### PR TITLE
Add Groq chat route and prescription checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+.DS_Store

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,28 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server';
-export async function POST(req: NextRequest){
-  const { question, role } = await req.json();
-  const base = process.env.LLM_BASE_URL;
-  const model = process.env.LLM_MODEL_ID || 'llama3-8b-instruct';
-  if(!base) return new NextResponse("LLM_BASE_URL not set", { status: 500 });
 
-  // OpenAI-compatible completion (v1/chat/completions)
-  const res = await fetch(`${base.replace(/\/$/,'')}/chat/completions`, {
+export async function POST(req: NextRequest) {
+  const { question, role } = await req.json();
+
+  const base  = process.env.LLM_BASE_URL;                  // e.g. https://api.groq.com/openai/v1
+  const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
+  const key   = process.env.LLM_API_KEY;                   // gsk_...
+
+  if (!base) return new NextResponse('LLM_BASE_URL not set', { status: 500 });
+  if (!key)  return new NextResponse('LLM_API_KEY not set',  { status: 500 });
+
+  const res = await fetch(`${base.replace(/\/$/, '')}/chat/completions`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
     body: JSON.stringify({
       model,
       messages: [
-        { role: 'system', content: role==='clinician' ? 'You are a clinical assistant. Be precise, cite sources if mentioned. Avoid medical advice; provide evidence and guideline pointers.' : 'You explain in simple, friendly language for patients. Avoid medical advice; encourage consulting a doctor.' },
+        { role: 'system', content: role === 'clinician'
+            ? 'You are a clinical assistant. Use markdown with headings and bullet points. Avoid medical advice.'
+            : 'You explain in simple language for patients. Use short paragraphs and markdown. Avoid medical advice.' },
         { role: 'user', content: question }
       ],
       temperature: 0.2
     })
   });
-  if(!res.ok){
-    const t = await res.text();
-    return new NextResponse(`LLM error: ${t}`, { status: 500 });
+
+  if (!res.ok) {
+    const err = await res.text();
+    return new NextResponse(`LLM error: ${err}`, { status: 500 });
   }
+
   const json = await res.json();
-  const text = json.choices?.[0]?.message?.content || "";
-  return new NextResponse(text, { headers: { 'Content-Type': 'text/plain; charset=utf-8' }});
+  const text = json.choices?.[0]?.message?.content || '';
+  return new NextResponse(text, { headers: { 'Content-Type': 'text/plain; charset=utf-8' } });
 }

--- a/app/api/diag/route.ts
+++ b/app/api/diag/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+export async function GET() {
+  return NextResponse.json({
+    LLM_BASE_URL: !!process.env.LLM_BASE_URL,
+    LLM_MODEL_ID: !!process.env.LLM_MODEL_ID,
+    LLM_API_KEY:  !!process.env.LLM_API_KEY,
+  });
+}

--- a/app/api/interactions/route.ts
+++ b/app/api/interactions/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { rxcuis } = await req.json();
+  if (!Array.isArray(rxcuis) || rxcuis.length < 2) {
+    return NextResponse.json({ interactions: [], note: 'Need at least 2 RXCUIs' });
+  }
+
+  const url = `https://rxnav.nlm.nih.gov/REST/interaction/list.json?rxcuis=${encodeURIComponent(rxcuis.join('+'))}`;
+  const res = await fetch(url);
+  if (!res.ok) return new NextResponse('RxNav interaction error', { status: 500 });
+  const data = await res.json();
+
+  const out: any[] = [];
+  for (const g of data.fullInteractionTypeGroup || []) {
+    for (const t of g.fullInteractionType || []) {
+      for (const p of t.interactionPair || []) {
+        out.push({ description: p.description, severity: p.severity, source: 'RxNav' });
+      }
+    }
+  }
+  return NextResponse.json({ interactions: out });
+}

--- a/app/api/rxnorm/normalize-pdf/route.ts
+++ b/app/api/rxnorm/normalize-pdf/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import pdf from 'pdf-parse';
+export const runtime = 'nodejs';
+
+async function rxcuiForName(name: string): Promise<string | null> {
+  const url = `https://rxnav.nlm.nih.gov/REST/rxcui.json?name=${encodeURIComponent(name)}&search=2`;
+  const res = await fetch(url);
+  if (!res.ok) return null;
+  const j = await res.json();
+  return j?.idGroup?.rxnormId?.[0] || null;
+}
+
+export async function POST(req: NextRequest) {
+  const form = await req.formData();
+  const file = form.get('file') as File | null;
+  if (!file) return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+  if (file.type !== 'application/pdf') return NextResponse.json({ error: 'File must be a PDF' }, { status: 400 });
+
+  const buf = Buffer.from(await file.arrayBuffer());
+
+  let text = '';
+  try {
+    const out = await pdf(buf);
+    text = out.text || '';
+  } catch (e: any) {
+    return NextResponse.json({ error: 'PDF parse failed', detail: String(e) }, { status: 500 });
+  }
+
+  if (!text.trim()) {
+    return NextResponse.json({ meds: [], note: 'No selectable text found; this PDF may be a scanned image. Use image upload (OCR) instead.' });
+  }
+
+  const tokens = Array.from(new Set(String(text).split(/[^A-Za-z0-9-]+/).filter(t => t.length > 2))).slice(0, 120);
+
+  const meds: { token: string; rxcui: string }[] = [];
+  for (const token of tokens) {
+    try {
+      const rxcui = await rxcuiForName(token);
+      if (rxcui) meds.push({ token, rxcui });
+    } catch {}
+  }
+
+  const dedup = Object.values(meds.reduce((acc: any, m) => { acc[m.rxcui] = m; return acc; }, {}));
+  return NextResponse.json({ text, meds: dedup });
+}

--- a/app/api/rxnorm/normalize/route.ts
+++ b/app/api/rxnorm/normalize/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+async function rxcuiForName(name: string): Promise<string | null> {
+  const url = `https://rxnav.nlm.nih.gov/REST/rxcui.json?name=${encodeURIComponent(name)}&search=2`;
+  const res = await fetch(url);
+  if (!res.ok) return null;
+  const j = await res.json();
+  return j?.idGroup?.rxnormId?.[0] || null;
+}
+
+export async function POST(req: NextRequest) {
+  const { text } = await req.json();
+  if (!text) return NextResponse.json({ meds: [] });
+
+  const tokens = Array.from(new Set(String(text).split(/[^A-Za-z0-9-]+/).filter(t => t.length > 2))).slice(0, 60);
+
+  const meds: { token: string; rxcui: string }[] = [];
+  for (const token of tokens) {
+    try {
+      const rxcui = await rxcuiForName(token);
+      if (rxcui) meds.push({ token, rxcui });
+    } catch {}
+  }
+
+  const dedup = Object.values(meds.reduce((acc: any, m) => { acc[m.rxcui] = m; return acc; }, {}));
+  return NextResponse.json({ meds: dedup });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
+import PrescriptionChecker from '../components/PrescriptionChecker';
 
 type BannerItem = { title:string; source:string; time:string; url:string };
 
@@ -56,8 +57,9 @@ export default function Home(){
           </select>
           <button className="btn primary" onClick={ask} disabled={loading}>{loading?'Thinking…':'Ask'}</button>
         </div>
-        <pre style={{whiteSpace:'pre-wrap', marginTop:12}}>{answer}</pre>
+        <div className="response" style={{whiteSpace:'pre-wrap', marginTop:12}}>{answer}</div>
       </section>
+      <PrescriptionChecker />
     </main>
   );
 }

--- a/components/PrescriptionChecker.tsx
+++ b/components/PrescriptionChecker.tsx
@@ -1,0 +1,88 @@
+'use client';
+import { useState } from 'react';
+import * as Tesseract from 'tesseract.js';
+
+type Med = { token: string; rxcui: string };
+
+export default function PrescriptionChecker() {
+  const [file, setFile] = useState<File | null>(null);
+  const [text, setText] = useState('');
+  const [meds, setMeds] = useState<Med[]>([]);
+  const [interactions, setInteractions] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  async function processFile() {
+    if (!file) return;
+    setLoading(true); setText(''); setMeds([]); setInteractions([]); setNote(null);
+
+    let extractedText = '';
+    let medsFound: Med[] = [];
+
+    try {
+      if (file.type === 'application/pdf') {
+        const fd = new FormData();
+        fd.append('file', file);
+        const r = await fetch('/api/rxnorm/normalize-pdf', { method: 'POST', body: fd });
+        const j = await r.json();
+        if (!r.ok) throw new Error(j?.error || 'PDF parse error');
+        extractedText = j.text || '';
+        medsFound = j.meds || [];
+        if (j.note) setNote(j.note);
+      } else {
+        const { data } = await Tesseract.recognize(file, 'eng', { logger: () => {} });
+        extractedText = data.text || '';
+        const rxRes = await fetch('/api/rxnorm/normalize', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text: extractedText })
+        });
+        const rx = await rxRes.json();
+        medsFound = rx.meds || [];
+      }
+
+      setText(extractedText);
+      setMeds(medsFound);
+
+      if (medsFound.length >= 2) {
+        const r = await fetch('/api/interactions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ rxcuis: medsFound.map(m => m.rxcui) })
+        });
+        const j = await r.json();
+        setInteractions(j.interactions || []);
+      }
+    } catch (e: any) {
+      setNote(String(e?.message || e) || 'Processing failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="response" style={{ marginTop: 16 }}>
+      <h3 style={{ marginTop: 0 }}>Prescription Checker (PDF/Image → Interactions)</h3>
+      <p className="muted" style={{ marginTop: -8 }}>
+        Upload a <strong>PDF</strong> prescription (preferred) or an <strong>image</strong>. Not medical advice.
+      </p>
+
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <input type="file" accept="application/pdf,image/*" onChange={e => setFile(e.target.files?.[0] || null)} />
+        <button className="btn" onClick={processFile} disabled={!file || loading}>
+          {loading ? 'Processing…' : 'Run checker'}
+        </button>
+      </div>
+
+      {note && <p className="muted" style={{ marginTop: 8 }}>{note}</p>}
+      {text && <><h4>Extracted text</h4><pre style={{ whiteSpace: 'pre-wrap' }}>{text.trim()}</pre></>}
+      {!!meds.length && (<>
+        <h4>Recognized medications</h4>
+        <ul>{meds.map((m,i)=>(<li key={i}>{m.token} — RXCUI <a target="_blank" rel="noreferrer" href={`https://rxnav.nlm.nih.gov/REST/rxcui/${m.rxcui}`}>{m.rxcui}</a></li>))}</ul>
+      </>)}
+      {!!interactions.length && (<>
+        <h4>Potential interactions</h4>
+        <ul>{interactions.map((it,i)=>(<li key={i}><strong>{it.severity||'Severity: N/A'}</strong> — {it.description}</li>))}</ul>
+      </>)}
+    </section>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -10,18 +10,20 @@
   },
   "dependencies": {
     "next": "14.2.4",
+    "next-themes": "0.3.0",
+    "pdf-parse": "^1.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "rss-parser": "3.13.0",
-    "xml2js": "0.6.2",
-    "next-themes": "0.3.0"
+    "tesseract.js": "^6.0.1",
+    "xml2js": "0.6.2"
   },
   "devDependencies": {
-    "typescript": "5.4.5",
     "@types/node": "20.11.30",
     "@types/react": "18.2.66",
     "@types/react-dom": "18.2.23",
     "eslint": "8.57.0",
-    "eslint-config-next": "14.2.4"
+    "eslint-config-next": "14.2.4",
+    "typescript": "5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- use Groq-compatible env vars for chat completions
- expose /api/diag to confirm env injection
- add PrescriptionChecker component with PDF/image OCR and interaction lookup
- implement RxNorm normalize and interaction API routes
- show prescription checker on home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(interactive ESLint prompt, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68b18c45e764832fa785cd80d140a7b3