### PR TITLE
feat: redesign interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+package-lock.json
+.DS_Store
+.next
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,63 +1,145 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import Sidebar from '../components/Sidebar';
+import Markdown from '../components/Markdown';
+import { Send, Sun, Moon, User, Stethoscope } from 'lucide-react';
 
-type BannerItem = { title:string; source:string; time:string; url:string };
+type ChatMsg = { role: 'user'|'assistant'; content: string };
 
 export default function Home(){
-  const [term,setTerm]=useState('thyroid cancer');
-  const [role,setRole]=useState<'patient'|'clinician'>('patient');
-  const [answer,setAnswer]=useState('');
-  const [loading,setLoading]=useState(false);
-  const [banner,setBanner]=useState<BannerItem[]>([]);
+  const [messages, setMessages] = useState<ChatMsg[]>([]);
+  const [input, setInput] = useState('');
+  const [mode, setMode] = useState<'patient'|'doctor'>('patient');
+  const [theme, setTheme] = useState<'dark'|'light'>('dark');
+  const chatRef = useRef<HTMLDivElement>(null);
 
-  useEffect(()=>{ fetch('/api/banner').then(r=>r.json()).then(setBanner).catch(()=>{}); },[]);
+  useEffect(()=>{ document.documentElement.className = theme==='light'?'light':''; },[theme]);
+  useEffect(()=>{ document.body.setAttribute('data-role', mode==='doctor'?'doctor':''); },[mode]);
+  useEffect(()=>{ chatRef.current?.scrollTo({ top: chatRef.current.scrollHeight }); },[messages]);
 
-  async function ask(){
-    setLoading(true);
-    setAnswer('');
-    const r = await fetch('/api/chat',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ role, question: term })});
-    const txt = await r.text();
-    setAnswer(txt);
-    setLoading(false);
+  const showHero = messages.length===0;
+
+  async function send(text: string){
+    if(!text.trim()) return;
+
+    // Ask orchestrator for structured sections
+    const planRes = await fetch('/api/medx', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ query: text, mode })
+    });
+    const plan = await planRes.json();
+
+    const sys = mode==='doctor'
+      ? `You are a clinical assistant. Write clean markdown with headings, lists, and short paragraphs.
+If CONTEXT includes codes, interactions, or trials, summarize and provide clickable links. No medical advice.`
+      : `You are a patient-friendly educator. Use simple language, short paragraphs, and gentle tone.
+If CONTEXT has codes or trials, explain in plain words and add links. No medical advice.`;
+
+    const contextBlock = "CONTEXT:\n" + JSON.stringify(plan.sections || {}, null, 2);
+
+    // push user + placeholder assistant
+    setMessages(prev=>[...prev, { role:'user', content:text }, { role:'assistant', content:'' }]);
+    setInput('');
+
+    // Stream SSE and render only delta.content
+    const res = await fetch('/api/chat/stream', {
+      method:'POST', headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify({
+        messages:[
+          { role:'system', content: sys },
+          { role:'user', content: `${text}\n\n${contextBlock}` }
+        ]
+      })
+    });
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let acc = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value, { stream:true });
+      // parse SSE: lines beginning with "data: "
+      const lines = chunk.split('\n').filter(l => l.startsWith('data: '));
+      for (const line of lines) {
+        if (line.trim() === 'data: [DONE]') continue;
+        try {
+          const payload = JSON.parse(line.replace(/^data:\s*/, ''));
+          const delta = payload?.choices?.[0]?.delta?.content;
+          if (delta) {
+            acc += delta;
+            setMessages(prev=>{
+              const copy = [...prev];
+              copy[copy.length-1] = { role:'assistant', content: acc };
+              return copy;
+            });
+          }
+        } catch {/* ignore */}
+      }
+    }
   }
 
   return (
-    <main className="container">
-      <div className="toggle">
-        <select onChange={e=>document.documentElement.className = e.target.value==='light'?'light':''} className="btn">
-          <option value="dark">Dark</option>
-          <option value="light">Light</option>
-        </select>
-      </div>
-      <h1>MedX</h1>
-      <p className="muted">Global medical companion • Patient/Clinician dual answers • Secure by design</p>
+    <div className="app">
+      <Sidebar onNew={()=>{setMessages([]); setInput('');}}
+               onSearch={()=>{}} />
 
-      <section className="card" style={{marginTop:12}}>
-        <div className="row" style={{justifyContent:'space-between'}}>
-          <div className="headline">Latest trusted updates</div>
-          <a className="muted" href="/api/banner" target="_blank">See JSON</a>
+      <main className="main">
+        <div className="header">
+          <button className="item" onClick={()=>setMode(mode==='patient'?'doctor':'patient')}>
+            {mode==='patient'? <><User size={16}/> Patient</> : <><Stethoscope size={16}/> Doctor</>}
+          </button>
+          <button className="item" onClick={()=>setTheme(theme==='dark'?'light':'dark')}>
+            {theme==='dark'? <><Sun size={16}/> Light</> : <><Moon size={16}/> Dark</>}
+          </button>
         </div>
-        <div className="row" style={{marginTop:8, overflowX:'auto'}}>
-          {banner.slice(0,6).map((b,i)=>(
-            <a key={i} href={b.url} target="_blank" className="card" style={{minWidth:260}}>
-              <div className="muted">{b.source} • {b.time}</div>
-              <div>{b.title}</div>
-            </a>
-          ))}
-        </div>
-      </section>
 
-      <section style={{marginTop:16}} className="card">
-        <div className="row">
-          <input value={term} onChange={e=>setTerm(e.target.value)} style={{flex:1, padding:12, borderRadius:8, border:'1px solid #22304a', background:'transparent', color:'inherit'}} placeholder="Ask MedX… (e.g., best trials for thyroid cancer in India)" />
-          <select value={role} onChange={e=>setRole(e.target.value as any)} className="btn">
-            <option value="patient">Patient view</option>
-            <option value="clinician">Clinician view</option>
-          </select>
-          <button className="btn primary" onClick={ask} disabled={loading}>{loading?'Thinking…':'Ask'}</button>
+        <div className="wrap">
+          {showHero ? (
+            <div className="hero">
+              <h1>MedX</h1>
+              <p>Ask anything medical. Switch to Doctor for clinical depth.</p>
+              <div className="inputRow" style={{ marginTop:16 }}>
+                <textarea
+                  placeholder="Type your question…"
+                  value={input}
+                  onChange={e=>setInput(e.target.value)}
+                  onKeyDown={e=>{ if(e.key==='Enter' && !e.shiftKey){ e.preventDefault(); send(input);} }}
+                />
+                <button className="iconBtn" onClick={()=>send(input)} aria-label="Send">➤</button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div ref={chatRef} className="chat">
+                {messages.map((m,i)=>(
+                  <div key={i} className={`msg ${m.role}`}>
+                    <div className="avatar">{m.role==='user'?'U':'M'}</div>
+                    <div className="bubble">
+                      <div className="role">{m.role==='user'?'You':'MedX'}</div>
+                      <div className="content markdown"><Markdown text={m.content}/></div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div className="inputDock">
+                <div className="inputRow">
+                  <textarea
+                    placeholder="Send a message…"
+                    value={input}
+                    onChange={e=>setInput(e.target.value)}
+                    onKeyDown={e=>{ if(e.key==='Enter' && !e.shiftKey){ e.preventDefault(); send(input);} }}
+                  />
+                  <button className="iconBtn" onClick={()=>send(input)} aria-label="Send">➤</button>
+                </div>
+              </div>
+            </>
+          )}
         </div>
-        <pre style={{whiteSpace:'pre-wrap', marginTop:12}}>{answer}</pre>
-      </section>
-    </main>
+      </main>
+    </div>
   );
 }

--- a/app/styles.css
+++ b/app/styles.css
@@ -1,15 +1,103 @@
-:root{ --bg:#0b1220; --fg:#e6f0ff; --muted:#9db1c7; --card:#121a2b; --accent:#41f0d2; }
-:root.light{ --bg:#f7fafc; --fg:#111827; --muted:#475569; --card:#ffffff; --accent:#0ea5e9; }
-html,body{ margin:0; padding:0; height:100%; }
-body{ background:var(--bg); color:var(--fg); font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-button,input,select{ font:inherit }
-.container{ max-width:1000px; margin:0 auto; padding:20px; }
-.row{ display:flex; gap:8px; flex-wrap:wrap; }
-.btn{ background:var(--card); color:var(--fg); border:1px solid #22304a; padding:10px 12px; border-radius:10px; cursor:pointer; }
-.btn.primary{ background:var(--accent); color:#001b1a; border:none; }
-.card{ background:var(--card); border:1px solid #1f2a44; border-radius:12px; padding:14px; }
-.headline{ color:var(--fg); font-weight:600; }
-.muted{ color:var(--muted); font-size:13px; }
-.toggle{ position:fixed; top:12px; right:12px; }
-.twoCol{ display:grid; grid-template-columns: 1fr 1fr; gap:12px; }
-@media (max-width:900px){ .twoCol{ grid-template-columns: 1fr; } }
+:root{
+  --bg:#0b0f18; --fg:#e7eefb; --muted:#9fb0c8;
+  --card:#111827; --card-2:#0f172a; --border:#23324d;
+  --accent:#22d3ee; --accent-ink:#002a32;
+}
+:root.light{
+  --bg:#f7fafc; --fg:#0b1526; --muted:#5a6b84;
+  --card:#ffffff; --card-2:#f2f6fb; --border:#e6eaf0;
+  --accent:#0ea5e9; --accent-ink:#002a32;
+}
+/* Doctor mode tint (body[data-role="doctor"] is set in page.tsx) */
+body[data-role="doctor"] { --accent:#7c3aed; }
+:root.light body[data-role="doctor"]{ --accent:#7c3aed; }
+
+/* Base */
+*{ box-sizing:border-box }
+html,body{ height:100%; margin:0; padding:0 }
+body{
+  background:var(--bg); color:var(--fg);
+  font:16px/1.55 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
+}
+
+/* Layout */
+.app{ display:flex; min-height:100vh }
+.sidebar{
+  width:260px; padding:14px; border-right:1px solid var(--border);
+  background:var(--card-2); display:flex; flex-direction:column; gap:10px;
+}
+.sidebar .title{ font-weight:700; letter-spacing:.2px; margin-bottom:2px }
+.sidebar .group{ display:flex; flex-direction:column; gap:8px }
+.sidebar .item{
+  display:flex; align-items:center; gap:8px;
+  padding:10px 10px; border:1px solid var(--border); border-radius:12px;
+  background:transparent; color:inherit; cursor:pointer;
+}
+.sidebar .item:hover{ background:rgba(255,255,255,.04) }
+.sidebar input{
+  width:100%; padding:10px 12px; border:1px solid var(--border); border-radius:12px;
+  background:transparent; color:inherit; outline:none;
+}
+
+.main{ flex:1; display:flex; flex-direction:column; }
+.header{
+  height:56px; border-bottom:1px solid var(--border);
+  display:flex; align-items:center; justify-content:space-between; padding:0 18px;
+  backdrop-filter:saturate(120%) blur(6px);
+}
+.wrap{ max-width:860px; margin:0 auto; width:100%; padding:0 18px; flex:1; display:flex; flex-direction:column }
+
+/* Toggle pill + buttons */
+.item{
+  display:flex; align-items:center; gap:8px; padding:8px 10px;
+  border:1px solid var(--border); border-radius:12px; background:var(--card-2);
+}
+.item:active{ transform:translateY(1px) }
+
+/* Hero */
+.hero{ margin:auto; max-width:720px; text-align:center; }
+.hero h1{ margin:10px 0 6px; font-size:36px; letter-spacing:.2px }
+.hero p{ color:var(--muted); margin:0 0 20px }
+
+/* Chat area */
+.chat{ flex:1; overflow:auto; padding:22px 0; }
+.msg{ display:flex; gap:12px; margin:14px 0; }
+.msg .avatar{
+  width:28px; height:28px; border-radius:50%; background:var(--card-2);
+  display:flex; align-items:center; justify-content:center; font-size:12px; color:var(--muted);
+  border:1px solid var(--border);
+}
+.msg .bubble{
+  border:1px solid var(--border); background:var(--card); border-radius:14px;
+  padding:12px 14px; width:100%;
+}
+.msg.user .bubble{ background:transparent }
+
+.role{ font-size:12px; color:var(--muted); margin-bottom:6px }
+.content a{ color:var(--accent); text-decoration:underline; word-break:break-word }
+
+/* Input dock */
+.inputDock{
+  padding:14px 0 20px; position:sticky; bottom:0;
+  background:linear-gradient(180deg, rgba(0,0,0,0), var(--bg) 30%);
+}
+.inputRow{
+  display:flex; align-items:center; gap:8px; border:1px solid var(--border);
+  border-radius:16px; padding:8px; background:var(--card);
+}
+.inputRow textarea{
+  flex:1; min-height:24px; max-height:160px; resize:vertical;
+  border:none; outline:none; background:transparent; color:inherit; padding:8px 10px;
+}
+.iconBtn{
+  width:40px; height:40px; border-radius:12px; display:flex; align-items:center; justify-content:center;
+  background:var(--accent); color:var(--accent-ink); border:none; cursor:pointer; font-weight:700;
+}
+.iconBtn:disabled{ opacity:.5; cursor:not-allowed }
+
+/* Markdown refinements */
+.markdown h1,.markdown h2,.markdown h3{ margin:12px 0 6px }
+.markdown p{ margin:8px 0 }
+.markdown ul, .markdown ol{ padding-left:22px; margin:8px 0 }
+.markdown code{ background:rgba(255,255,255,.06); padding:2px 6px; border-radius:6px; }

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,0 +1,8 @@
+'use client';
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+export default function Markdown({ text }: { text: string }){
+  return <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>;
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
+
+type Props = {
+  onNew: () => void;
+  onSearch: (query: string) => void;
+};
+
+export default function Sidebar({ onNew, onSearch }: Props){
+  const [query, setQuery] = useState('');
+  return (
+    <aside className="sidebar">
+      <div className="title">MedX</div>
+      <div className="group">
+        <button className="item" onClick={onNew}>
+          <Plus size={16}/> New Chat
+        </button>
+      </div>
+      <div className="group">
+        <input
+          type="text"
+          placeholder="Search..."
+          value={query}
+          onChange={e=>{
+            setQuery(e.target.value);
+            onSearch(e.target.value);
+          }}
+        />
+      </div>
+    </aside>
+  );
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-  experimental: { appDir: true }
+  reactStrictMode: true
 };
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "react-dom": "18.2.0",
     "rss-parser": "3.13.0",
     "xml2js": "0.6.2",
-    "next-themes": "0.3.0"
+    "next-themes": "0.3.0",
+    "lucide-react": "^0.424.0",
+    "react-markdown": "^9.0.0",
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
     "typescript": "5.4.5",


### PR DESCRIPTION
## Summary
- refresh UI with modern dark and light themes, chat layout, and input styling
- implement streaming chat page with mode and theme toggles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68b1cb536a9c832fb0ccd759ac8a7f6d