### PR TITLE
Add HTTP util, medx orchestrator, streaming and metrics APIs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { fetchWithTimeout } from '@/lib/http';
 export async function POST(req: NextRequest){
   const { question, role } = await req.json();
   const base = process.env.LLM_BASE_URL;
@@ -14,7 +15,7 @@ If CONTEXT contains codes or trials, add a "Sources" section with clickable link
 Do NOT provide medical advice; suggest speaking with a clinician.`;
 
   // OpenAI-compatible completion (v1/chat/completions)
-  const res = await fetch(`${base.replace(/\/$/,'')}/chat/completions`, {
+  const res = await fetchWithTimeout(`${base.replace(/\/$/,'')}/chat/completions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -25,7 +26,7 @@ Do NOT provide medical advice; suggest speaking with a clinician.`;
       ],
       temperature: 0.2
     })
-  });
+  }, { timeoutMs: 15000 });
   if(!res.ok){
     const t = await res.text();
     return new NextResponse(`LLM error: ${t}`, { status: 500 });

--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchWithTimeout } from '@/lib/http';
+export const runtime = 'edge';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { messages } = await req.json();
+    const base  = process.env.LLM_BASE_URL!;
+    const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
+    const key   = process.env.LLM_API_KEY!;
+    const url = `${base.replace(/\/$/,'')}/chat/completions`;
+
+    const upstream = await fetchWithTimeout(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
+      body: JSON.stringify({ model, stream: true, temperature: 0.2, messages })
+    }, { timeoutMs: 25000, retries: 1 });
+
+    if (!upstream.ok) {
+      const text = await upstream.text().catch(() => '');
+      return new NextResponse(`Upstream error: ${text}`, { status: upstream.status });
+    }
+
+    return new Response(upstream.body, {
+      headers: { 'Content-Type': 'text/event-stream; charset=utf-8' }
+    });
+  } catch (e:any) {
+    return new NextResponse(`Upstream error: ${e?.message || e}`, { status: 500 });
+  }
+}

--- a/app/api/medx/route.ts
+++ b/app/api/medx/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchWithTimeout } from '@/lib/http';
+
+const BASE = process.env.LLM_BASE_URL!;
+const MODEL = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
+const KEY   = process.env.LLM_API_KEY!;
+
+async function classifyIntent(query: string, mode: 'patient'|'doctor') {
+  const sys = `You are a router. Classify EXACTLY one intent:
+- DIAGNOSIS_QUERY      (map condition to codes; trials if doctor)
+- DRUGS_LIST           (medication list; interactions)
+- CLINICAL_TRIALS_QUERY(trials for condition)
+- GENERAL_HEALTH       (explain simply)
+
+Return STRICT JSON like: {"intent":"DIAGNOSIS_QUERY","keywords":["thyroid cancer"]}`;
+  const r = await fetchWithTimeout(`${BASE.replace(/\/$/,'')}/chat/completions`, {
+    method:'POST',
+    headers:{'Content-Type':'application/json',Authorization:`Bearer ${KEY}`},
+    body: JSON.stringify({ model: MODEL, temperature: 0, messages: [
+      { role:'system', content: sys },
+      { role:'user', content: `Mode=${mode}\nQuery=${query}\nJSON only:` }
+    ]})
+  }, { timeoutMs: 12000 });
+  const j = await r.json();
+  try { return JSON.parse(j.choices?.[0]?.message?.content || '{}'); }
+  catch { return { intent:'GENERAL_HEALTH', keywords:[] }; }
+}
+
+async function umlsSearch(term: string){
+  const res = await fetchWithTimeout(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/umls/search?q=${encodeURIComponent(term)}`);
+  return res.json();
+}
+async function umlsCrosswalk(cui: string, target:'ICD10CM'|'SNOMEDCT_US'|'RXNORM'){
+  const res = await fetchWithTimeout(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/umls/crosswalk?cui=${encodeURIComponent(cui)}&target=${target}`);
+  return res.json();
+}
+async function pubmedTrials(q: string){
+  const term = `${q} AND clinical trial[Publication Type]`;
+  const apiKey = process.env.NCBI_API_KEY || '';
+  const es = await fetchWithTimeout(
+    `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&retmax=5&sort=pub+date&term=${encodeURIComponent(term)}${apiKey?`&api_key=${apiKey}`:''}&retmode=json`,
+    {}, { timeoutMs: 12000 }
+  );
+  const ids = (await es.json())?.esearchresult?.idlist || [];
+  if (!ids.length) return [];
+  const sum = await fetchWithTimeout(
+    `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=${ids.join(',')}${apiKey?`&api_key=${apiKey}`:''}&retmode=json`,
+    {}, { timeoutMs: 12000 }
+  );
+  const j = await sum.json();
+  return ids.map((id:string)=>({ id, title: j.result?.[id]?.title, link: `https://pubmed.ncbi.nlm.nih.gov/${id}/`, source:'PubMed' }));
+}
+async function rxnormNormalize(text: string){
+  const r = await fetchWithTimeout(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/rxnorm/normalize`,{
+    method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ text })
+  });
+  return r.json();
+}
+async function rxnavInteractions(rxcuis: string[]){
+  const r = await fetchWithTimeout(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/interactions`,{
+    method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ rxcuis })
+  });
+  return r.json();
+}
+
+export async function POST(req: NextRequest){
+  const { query, mode } = await req.json();
+  if(!query) return NextResponse.json({ intent:'GENERAL_HEALTH', sections:{} });
+
+  const cls = await classifyIntent(query, mode==='doctor'?'doctor':'patient');
+  const intent = cls.intent || 'GENERAL_HEALTH';
+  const keywords: string[] = cls.keywords || [];
+  const sections: any = {};
+
+  try {
+    if (intent === 'DIAGNOSIS_QUERY') {
+      const term = keywords[0] || query;
+      const s = await umlsSearch(term);
+      const cui = s.results?.[0]?.ui || null;
+      if (cui) {
+        const icd = await umlsCrosswalk(cui,'ICD10CM');
+        const snomed = await umlsCrosswalk(cui,'SNOMEDCT_US');
+        sections.codes = { cui, icd: icd.mappings?.slice(0,6), snomed: snomed.mappings?.slice(0,6) };
+      }
+      if (mode==='doctor') sections.trials = await pubmedTrials(term);
+    } else if (intent === 'DRUGS_LIST') {
+      const rx = await rxnormNormalize(query);
+      sections.meds = rx.meds;
+      if ((rx.meds||[]).length >= 2) {
+        sections.interactions = (await rxnavInteractions(rx.meds.map((m:any)=>m.rxcui))).interactions;
+      }
+    } else if (intent === 'CLINICAL_TRIALS_QUERY') {
+      const term = keywords[0] || query;
+      sections.trials = await pubmedTrials(term);
+    }
+  } catch(e:any){ sections.error = String(e?.message || e); }
+
+  return NextResponse.json({ intent, sections });
+}

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// NOTE: On serverless this is per-instance and ephemeral.
+// Good enough for MVP; swap to a real store later.
+let counters: Record<string, number> = {};
+
+export async function POST(req: NextRequest) {
+  const { event, extra } = await req.json();
+  counters[event] = (counters[event] || 0) + 1;
+  console.log('[METRICS]', event, extra || {});
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET() {
+  return NextResponse.json({ counters });
+}

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,0 +1,26 @@
+// lib/http.ts
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  { timeoutMs = 15000, retries = 1 }: { timeoutMs?: number; retries?: number } = {}
+) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      const res = await fetch(input, { ...init, signal: ctrl.signal });
+      clearTimeout(t);
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`HTTP ${res.status}: ${text}`);
+      }
+      return res;
+    } catch (err) {
+      clearTimeout(t);
+      if (attempt === retries) throw err;
+      await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+    }
+  }
+  // Unreachable
+  throw new Error('fetchWithTimeout: exhausted retries');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,12 +20,24 @@
     "incremental": true,
     "types": [
       "node"
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
     ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- add reusable fetchWithTimeout utility with retry support
- introduce orchestrator route for intent classification and data aggregation
- add chat streaming proxy and basic metrics endpoint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint? prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b1df67241c832faaab2bf60ca910dd