### PR TITLE
feat: add nearby search feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+.next

--- a/addons/nearby/lib/geo.ts
+++ b/addons/nearby/lib/geo.ts
@@ -1,0 +1,17 @@
+export function haversineKm(lat1:number, lon1:number, lat2:number, lon2:number){
+  const R = 6371; // Earth radius in km
+  const toRad = (d:number)=>d*Math.PI/180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a = Math.sin(dLat/2)**2 + Math.cos(toRad(lat1))*Math.cos(toRad(lat2))*Math.sin(dLon/2)**2;
+  const c = 2*Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+  return R*c;
+}
+
+export function osmAmenityFor(term:string):string[]{
+  const t = term.toLowerCase();
+  if(t.includes('pharm')) return ['pharmacy'];
+  if(t.includes('doctor') || t.includes('physician') || t.includes('clinic') || t.includes('hospital')) return ['clinic','doctors','hospital'];
+  if(t.includes('dentist')) return ['dentist'];
+  return [];
+}

--- a/app/api/medx/route.ts
+++ b/app/api/medx/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function classify(q:string){
+  const l = (q||'').toLowerCase();
+  if(l.includes('near me') || l.includes('nearby')) return 'NEARBY';
+  return 'OTHER';
+}
+
+export async function POST(req: NextRequest){
+  const { q, role, coords } = await req.json();
+  const intent = classify(q);
+  if(intent === 'NEARBY'){
+    if(process.env.FEATURE_NEARBY !== 'on'){
+      return NextResponse.json({ intent, sections:{ nearby:{ disabled:true }}});
+    }
+    if(!coords || typeof coords.lat !== 'number' || typeof coords.lng !== 'number'){
+      return NextResponse.json({ intent, sections:{ needsLocation: true }});
+    }
+    const res = await fetch(`${req.nextUrl.origin}/api/nearby`,{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ lat: coords.lat, lng: coords.lng, kind: q })});
+    const list = await res.json();
+    return NextResponse.json({ intent, sections:{ nearby: list }});
+  }
+  const upstream = await fetch(`${req.nextUrl.origin}/api/chat`,{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ question: q, role })});
+  const text = await upstream.text();
+  return NextResponse.json({ intent, answer: text });
+}

--- a/app/api/nearby/route.ts
+++ b/app/api/nearby/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { haversineKm, osmAmenityFor } from '../../../addons/nearby/lib/geo';
+
+export async function POST(req: NextRequest){
+  if(process.env.FEATURE_NEARBY !== 'on'){
+    return NextResponse.json({ disabled: true });
+  }
+  const { lat, lng, kind } = await req.json();
+  if(typeof lat !== 'number' || typeof lng !== 'number'){
+    return NextResponse.json([], { status: 400 });
+  }
+  const amenities = osmAmenityFor(kind || '');
+  if(!amenities.length){
+    return NextResponse.json([]);
+  }
+  const query = `[out:json];node(around:3000,${lat},${lng})[amenity~"${amenities.join('|')}"];out;`;
+  const upstream = await fetch('https://overpass-api.de/api/interpreter',{ method:'POST', body: query, headers:{'Content-Type':'text/plain'} });
+  if(!upstream.ok){
+    return NextResponse.json([], { status: 500 });
+  }
+  const data = await upstream.json();
+  const places = (data.elements||[]).map((e:any)=>{
+    const dist = haversineKm(lat, lng, e.lat, e.lon);
+    const name = e.tags?.name || amenities[0];
+    const addr = [e.tags?.['addr:housenumber'], e.tags?.['addr:street'], e.tags?.['addr:city']].filter(Boolean).join(' ');
+    return {
+      name,
+      address: addr,
+      distanceKm: Math.round(dist*10)/10,
+      mapsUrl: `https://www.openstreetmap.org/${e.type}/${e.id}`,
+      navUrl: `https://www.google.com/maps/dir/?api=1&destination=${e.lat},${e.lon}`
+    };
+  }).sort((a:any,b:any)=>a.distanceKm - b.distanceKm);
+  return NextResponse.json(places);
+}


### PR DESCRIPTION
## Summary
- add geospatial helpers for distance and amenity mapping
- implement nearby API route backed by Overpass and feature flag
- extend orchestrator and client to support location-based queries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires manual configuration)*
- `npm run build` *(fails: fetch failed during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f9e3bd44832f800e3079483e2a60