### PR TITLE
feat: add ip-based location fallback and rxnorm normalization

### DIFF
--- a/app/api/locate/route.ts
+++ b/app/api/locate/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+export const runtime = 'edge';
+
+/**
+ * Returns { lat, lng, source } using client IP (via ipapi.co).
+ * Guarded by FEATURE_IP_LOCATE (default: on).
+ */
+export async function GET(_req: NextRequest) {
+  if ((process.env.FEATURE_IP_LOCATE || 'on') !== 'on') {
+    return NextResponse.json({ error: 'disabled' }, { status: 200 });
+  }
+  try {
+    // ipapi.co uses caller IP automatically
+    const r = await fetch('https://ipapi.co/json/');
+    const j = await r.json();
+    const lat = Number(j.latitude), lng = Number(j.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) throw new Error('No coords');
+    return NextResponse.json({ lat, lng, city: j.city, region: j.region, country: j.country_name, source: 'ipapi' });
+  } catch (e: any) {
+    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+  }
+}

--- a/app/api/medx/route.ts
+++ b/app/api/medx/route.ts
@@ -6,21 +6,48 @@ function classify(q:string){
   return 'OTHER';
 }
 
+function makeFollowups(intent:string, sections:any, mode:'patient'|'doctor', query:string): string[] {
+  const out: string[] = [];
+  if (intent === 'NEARBY') {
+    out.push('Show more within 10 km', 'Open now', 'Directions to the closest');
+  }
+  if (intent === 'DRUGS_LIST' && (sections?.interactions?.length || 0) > 0) {
+    out.push('Explain these interactions simply', 'Are there safer alternatives?', 'What should I ask my doctor?');
+  }
+  if (intent === 'DIAGNOSIS_QUERY') {
+    if (mode === 'doctor') {
+      out.push('Latest clinical trials', 'Common ICD-10 codes', 'SNOMED terms');
+    } else {
+      out.push('Simple explanation', 'What tests are usually done?', 'Questions to ask my doctor');
+    }
+  }
+  if ((sections?.trials?.length || 0) > 0) {
+    out.push('Summarize trial eligibility', 'Any phase 3 results?');
+  }
+  if (!out.length) out.push('Explain in simpler words', 'Show trusted sources');
+  return Array.from(new Set(out)).slice(0, 5);
+}
+
 export async function POST(req: NextRequest){
   const { q, role, coords } = await req.json();
   const intent = classify(q);
+  const mode = role === 'clinician' ? 'doctor' : 'patient';
+  let sections: any = {};
   if(intent === 'NEARBY'){
     if(process.env.FEATURE_NEARBY !== 'on'){
-      return NextResponse.json({ intent, sections:{ nearby:{ disabled:true }}});
+      sections.nearby = { disabled:true };
+      return NextResponse.json({ intent, sections, followups: makeFollowups(intent, sections, mode, q) });
     }
     if(!coords || typeof coords.lat !== 'number' || typeof coords.lng !== 'number'){
-      return NextResponse.json({ intent, sections:{ needsLocation: true }});
+      sections.needsLocation = true;
+      return NextResponse.json({ intent, sections, followups: makeFollowups(intent, sections, mode, q) });
     }
     const res = await fetch(`${req.nextUrl.origin}/api/nearby`,{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ lat: coords.lat, lng: coords.lng, kind: q })});
     const list = await res.json();
-    return NextResponse.json({ intent, sections:{ nearby: list }});
+    sections.nearby = list;
+    return NextResponse.json({ intent, sections, followups: makeFollowups(intent, sections, mode, q) });
   }
   const upstream = await fetch(`${req.nextUrl.origin}/api/chat`,{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ question: q, role })});
   const text = await upstream.text();
-  return NextResponse.json({ intent, answer: text });
+  return NextResponse.json({ intent, sections, answer: text, followups: makeFollowups(intent, sections, mode, q) });
 }

--- a/app/api/rxnorm/normalize/route.ts
+++ b/app/api/rxnorm/normalize/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchWithTimeout } from '../../../../lib/http';
+
+export const runtime = 'edge';
+
+function clean(text: string) {
+  return text
+    .replace(/[^\w\s\-\/\+\.]/g, ' ')
+    .replace(/\btab(?:let|)\b/gi, '')
+    .replace(/\bcap(?:sule|)\b/gi, '')
+    .replace(/\bmg\b/gi, '')
+    .replace(/\bmcg\b/gi, '')
+    .replace(/\bml\b/gi, '')
+    .replace(/\bq[d|h]|bid|tid|qhs|qam|prn/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function ngrams(words: string[], nMax = 3) {
+  const out: string[] = [];
+  for (let n = 1; n <= nMax; n++)
+    for (let i = 0; i + n <= words.length; i++) {
+      const g = words.slice(i, i + n).join(' ');
+      if (g.length >= 3) out.push(g);
+    }
+  return Array.from(new Set(out));
+}
+
+async function approx(term: string) {
+  const url = `https://rxnav.nlm.nih.gov/REST/approximateTerm.json?term=${encodeURIComponent(term)}&maxEntries=3`;
+  const r = await fetchWithTimeout(url, {}, { timeoutMs: 12000 });
+  const j = await r.json();
+  const cand = j?.approximateGroup?.candidate || [];
+  return cand
+    .filter((c: any) => Number(c?.score) >= 70)
+    .map((c: any) => ({ rxcui: c.rxcui, score: Number(c.score) }));
+}
+
+async function rxcuiToName(rxcui: string) {
+  const r = await fetchWithTimeout(`https://rxnav.nlm.nih.gov/REST/rxcui/${rxcui}/property.json?propName=RxNorm%20Name`, {}, { timeoutMs: 12000 });
+  const j = await r.json();
+  return j?.propConceptGroup?.propConcept?.[0]?.propValue || rxcui;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { text }: { text: string } = await req.json();
+    const cleaned = clean(text || '');
+    const grams = ngrams(cleaned.split(/\s+/).filter(Boolean));
+    const hits: Record<string, { rxcui: string; score: number; name?: string }> = {};
+
+    for (const g of grams) {
+      const list = await approx(g).catch(() => []);
+      for (const it of list) {
+        const ex = hits[it.rxcui];
+        if (!ex || it.score > ex.score) hits[it.rxcui] = it;
+      }
+    }
+
+    const meds = await Promise.all(
+      Object.values(hits)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 10)
+        .map(async (m) => ({ ...m, name: await rxcuiToName(m.rxcui) }))
+    );
+
+    return NextResponse.json({ meds });
+  } catch (e: any) {
+    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,34 +9,54 @@ export default function Home(){
   const [answer,setAnswer]=useState('');
   const [loading,setLoading]=useState(false);
   const [banner,setBanner]=useState<BannerItem[]>([]);
-  const [coords,setCoords]=useState<{lat:number,lng:number}|null>(null);
-  const [locNote,setLocNote]=useState('');
+  const [coords, setCoords] = useState<{lat:number; lng:number} | null>(null);
+  const [locNote, setLocNote] = useState<string | null>(null);
+  const [followups, setFollowups] = useState<string[]>([]);
 
   const nearbyOn = process.env.NEXT_PUBLIC_FEATURE_NEARBY === 'on';
 
   useEffect(()=>{ fetch('/api/banner').then(r=>r.json()).then(setBanner).catch(()=>{}); },[]);
 
-  function requestLocation(){
-    if(!navigator.geolocation){
-      setLocNote('Geolocation not supported');
-      return;
-    }
+  function saveCoords(c:{lat:number;lng:number}) {
+    setCoords(c);
+    try { localStorage.setItem('medx_coords', JSON.stringify(c)); } catch {}
+  }
+
+  async function loadSavedCoords() {
+    try {
+      const s = localStorage.getItem('medx_coords');
+      if (s) setCoords(JSON.parse(s));
+    } catch {}
+  }
+
+  async function requestLocation(auto=false) {
+    setLocNote(auto ? 'Setting location…' : null);
+    const useIPFallback = async () => {
+      try {
+        const r = await fetch('/api/locate'); const j = await r.json();
+        if (j?.lat && j?.lng) { saveCoords({ lat: j.lat, lng: j.lng }); setLocNote(`Location set${j.city ? `: ${j.city}` : ''}.`); return; }
+      } catch {}
+      setLocNote('Location unavailable. You can still type a place, e.g., "pharmacy near Connaught Place".');
+    };
+
+    if (!('geolocation' in navigator)) return useIPFallback();
     navigator.geolocation.getCurrentPosition(
-      pos=>{
-        setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude });
-        setLocNote('Location set');
-      },
-      ()=>setLocNote('Location denied')
+      (pos)=>{ saveCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude }); setLocNote('Location set.'); setTimeout(()=>setLocNote(null), 1500); },
+      async ()=>{ await useIPFallback(); },
+      { enableHighAccuracy: true, maximumAge: 60000, timeout: 8000 }
     );
   }
 
-  async function ask(){
+  useEffect(()=>{ loadSavedCoords().then(()=>requestLocation(true)); },[]);
+
+  async function ask(text=term){
     setLoading(true);
     setAnswer('');
-    const body:any = { q: term, role };
+    const body:any = { q: text, role };
     if(nearbyOn && coords) body.coords = coords;
     const r = await fetch('/api/medx',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
     const json = await r.json();
+    setFollowups(Array.isArray(json.followups) ? json.followups : []);
     if(json.sections?.nearby){
       setAnswer(JSON.stringify(json.sections.nearby, null, 2));
     }else if(json.answer){
@@ -84,15 +104,22 @@ export default function Home(){
             <option value="patient">Patient view</option>
             <option value="clinician">Clinician view</option>
           </select>
-          <button className="btn primary" onClick={ask} disabled={loading}>{loading?'Thinking…':'Ask'}</button>
+          <button className="btn primary" onClick={()=>ask()} disabled={loading}>{loading?'Thinking…':'Ask'}</button>
         </div>
         {nearbyOn && (
           <div style={{ marginTop:8, display:'flex', justifyContent:'space-between', alignItems:'center' }}>
-            <button className="item" onClick={requestLocation}>📍 Set location</button>
+            <button className="item" onClick={()=>requestLocation(false)}>📍 Set location</button>
             {locNote && <span style={{ color:'var(--muted)', fontSize:12 }}>{locNote}</span>}
           </div>
         )}
         <pre style={{whiteSpace:'pre-wrap', marginTop:12}}>{answer}</pre>
+        {followups.length > 0 && (
+          <div style={{ display:'flex', flexWrap:'wrap', gap:8, margin:'8px 0 4px 0' }}>
+            {followups.map((f,i)=>(
+              <button key={i} className="item" onClick={()=>{ setTerm(f); ask(f); }}>{f}</button>
+            ))}
+          </div>
+        )}
       </section>
     </main>
   );

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -1,0 +1,10 @@
+export async function fetchWithTimeout(input: RequestInfo | URL, init: RequestInit = {}, opts: { timeoutMs?: number } = {}) {
+  const { timeoutMs = 10000 } = opts;
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(id);
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/locate` endpoint to estimate user coordinates via ipapi.co
- normalize OCR prescription text using RxNorm approximate matches
- generate follow-up suggestions and client-side location helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive eslint config)*
- `npm run build` *(fails: fetch failed while prerendering /api/openfda and /api/who)*

------
https://chatgpt.com/codex/tasks/task_e_68b1feaf1884832f88a3f26d0c53937e