### PR TITLE
feat: add nearby location and followup features

### DIFF
--- a/addons/nearby/lib/geo.ts
+++ b/addons/nearby/lib/geo.ts
@@ -1,17 +1,3 @@
-export function haversineKm(lat1:number, lon1:number, lat2:number, lon2:number){
-  const R = 6371; // Earth radius in km
-  const toRad = (d:number)=>d*Math.PI/180;
-  const dLat = toRad(lat2 - lat1);
-  const dLon = toRad(lon2 - lon1);
-  const a = Math.sin(dLat/2)**2 + Math.cos(toRad(lat1))*Math.cos(toRad(lat2))*Math.sin(dLon/2)**2;
-  const c = 2*Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
-  return R*c;
-}
+export function haversineKm(a:{lat:number;lng:number}, b:{lat:number;lng:number}){const r=Math.PI/180,R=6371,dLat=(b.lat-a.lat)*r,dLng=(b.lng-a.lng)*r,la1=a.lat*r,la2=b.lat*r;const h=Math.sin(dLat/2)**2+Math.cos(la1)*Math.cos(la2)*Math.sin(dLng/2)**2;return 2*R*Math.asin(Math.min(1,Math.sqrt(h)));}
 
-export function osmAmenityFor(term:string):string[]{
-  const t = term.toLowerCase();
-  if(t.includes('pharm')) return ['pharmacy'];
-  if(t.includes('doctor') || t.includes('physician') || t.includes('clinic') || t.includes('hospital')) return ['clinic','doctors','hospital'];
-  if(t.includes('dentist')) return ['dentist'];
-  return [];
-}
+export function osmAmenityFor(kind:string){const k=(kind||'').toLowerCase();if(k.includes('pharm'))return['pharmacy'];if(k.includes('dent'))return['dentist'];if(k.includes('hospital'))return['hospital'];if(k.includes('ent'))return['clinic','doctors','hospital'];if(k.includes('doctor')||k.includes('physician')||k.includes('gp'))return['doctors','clinic','hospital'];if(k.includes('clinic'))return['clinic','doctors'];return['clinic','doctors','hospital','pharmacy'];}

--- a/app/api/medx/route.ts
+++ b/app/api/medx/route.ts
@@ -4,33 +4,12 @@ const BASE = process.env.LLM_BASE_URL!;
 const MODEL = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
 const KEY   = process.env.LLM_API_KEY!;
 
-function makeFollowups(intent:string, sections:any, mode:'patient'|'doctor', query:string): string[] {
-  const out: string[] = [];
-  if (intent === 'NEARBY') {
-    out.push('Show more within 10 km', 'Open now', 'Directions to the closest');
-  }
-  if (intent === 'DRUGS_LIST' && (sections?.interactions?.length || 0) > 0) {
-    out.push('Explain these interactions simply', 'Are there safer alternatives?', 'What should I ask my doctor?');
-  }
-  if (intent === 'DIAGNOSIS_QUERY') {
-    if (mode === 'doctor') {
-      out.push('Latest clinical trials', 'Common ICD-10 codes', 'SNOMED terms');
-    } else {
-      out.push('Simple explanation', 'What tests are usually done?', 'Questions to ask my doctor');
-    }
-  }
-  if ((sections?.trials?.length || 0) > 0) {
-    out.push('Summarize trial eligibility', 'Any phase 3 results?');
-  }
-  if (!out.length) out.push('Explain in simpler words', 'Show trusted sources');
-  return Array.from(new Set(out)).slice(0, 5);
-}
-
 async function classifyIntent(query: string, mode: 'patient'|'doctor') {
   const sys = `Classify a medical query into ONE:
 - DIAGNOSIS_QUERY (map to ICD-10, SNOMED; trials if doctor)
 - DRUGS_LIST (extract meds; check interactions)
 - CLINICAL_TRIALS_QUERY (fetch trials)
+- NEARBY                 (find nearby healthcare places like doctor/clinic/hospital/pharmacy)
 - GENERAL_HEALTH (explain simply)
 
 Return JSON: {"intent":"...","keywords":["..."]}`;
@@ -50,12 +29,12 @@ Return JSON: {"intent":"...","keywords":["..."]}`;
   catch { return { intent:'GENERAL_HEALTH', keywords:[] }; }
 }
 
-async function umlsSearch(term: string){
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/umls/search?q=${encodeURIComponent(term)}`);
+async function umlsSearch(api: (path:string)=>string, term: string){
+  const res = await fetch(api(`/api/umls/search?q=${encodeURIComponent(term)}`));
   return res.ok ? res.json() : { results: [] };
 }
-async function umlsCrosswalk(cui: string, target:'ICD10CM'|'SNOMEDCT_US'|'RXNORM'){
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/umls/crosswalk?cui=${encodeURIComponent(cui)}&target=${target}`);
+async function umlsCrosswalk(api: (path:string)=>string, cui: string, target:'ICD10CM'|'SNOMEDCT_US'|'RXNORM'){
+  const res = await fetch(api(`/api/umls/crosswalk?cui=${encodeURIComponent(cui)}&target=${target}`));
   return res.ok ? res.json() : { mappings: [] };
 }
 async function pubmedTrials(q: string){
@@ -68,50 +47,96 @@ async function pubmedTrials(q: string){
   const j = await sum.json();
   return ids.map((id:string)=>({ id, title: j.result?.[id]?.title, link: `https://pubmed.ncbi.nlm.nih.gov/${id}/`, source:'PubMed' }));
 }
-async function rxnormNormalize(text: string){
-  const r = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/rxnorm/normalize`,{
+async function rxnormNormalize(api: (path:string)=>string, text: string){
+  const r = await fetch(api('/api/rxnorm/normalize'),{
     method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ text })
   });
   return r.ok ? r.json() : { meds: [] };
 }
-async function rxnavInteractions(rxcuis: string[]){
-  const r = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/interactions`,{
+async function rxnavInteractions(api: (path:string)=>string, rxcuis: string[]){
+  const r = await fetch(api('/api/interactions'),{
     method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ rxcuis })
   });
   return r.ok ? r.json() : { interactions: [] };
 }
 
-export async function POST(req: NextRequest){
-  const { query, mode } = await req.json();
-  if(!query) return NextResponse.json({ intent:'GENERAL_HEALTH', sections:{} });
+function topicFrom(sections: any, fallback: string) {
+  return sections?.topic || sections?.codes?.icd?.[0]?.name || sections?.codes?.snomed?.[0]?.name || sections?.meds?.[0]?.name || fallback;
+}
+function makeFollowups(intent: string, sections: any, mode: 'patient'|'doctor', query: string): string[] {
+  const topic = topicFrom(sections, query || 'this condition');
+  const f: string[] = [];
+  if (intent === 'NEARBY') f.push(`Directions to the closest`, `Show more within 10 km`, `Open now`);
+  if (intent === 'DRUGS_LIST') {
+    if ((sections?.interactions?.length || 0) > 0) f.push(`Explain these interactions simply`, `Are there safer alternatives for ${topic}?`);
+    else f.push(`Check interactions for these medicines`);
+    f.push(`Trusted sources for ${topic} medicines`);
+  }
+  if (intent === 'DIAGNOSIS_QUERY' || intent === 'GENERAL_HEALTH') {
+    if (mode === 'doctor') f.push(`Latest clinical trials for ${topic}`, `Common ICD-10 codes for ${topic}`, `SNOMED terms for ${topic}`, `Trusted sources for ${topic}`);
+    else f.push(`What tests are usually done for ${topic}?`, `Trusted sources for ${topic}`, `Lifestyle changes that help ${topic}`, `Questions to ask my doctor about ${topic}`);
+  }
+  if ((sections?.trials?.length || 0) > 0) f.push(`Summarize trial eligibility for ${topic}`, `Any phase 3 results for ${topic}?`);
+  return Array.from(new Set(f)).slice(0, 6);
+}
 
-  const cls = await classifyIntent(query, mode==='doctor'?'doctor':'patient');
+export async function POST(req: NextRequest) {
+  // Edge-safe absolute URL builder for internal routes
+  const origin = req.nextUrl?.origin || process.env.NEXT_PUBLIC_BASE_URL || '';
+  const api = (path: string) => /^https?:\/\//i.test(path) ? path : new URL(path, origin).toString();
+
+  const { query, mode, coords, forceIntent, prior } = await req.json();
+  if (!query) return NextResponse.json({ intent: 'GENERAL_HEALTH', sections: {} });
+
+  const cls = forceIntent
+    ? { intent: forceIntent, keywords: [] }
+    : await classifyIntent(query, mode === 'doctor' ? 'doctor' : 'patient');
+
   const intent = cls.intent || 'GENERAL_HEALTH';
   const keywords: string[] = cls.keywords || [];
   const sections: any = {};
 
   try {
-    if (intent === 'DIAGNOSIS_QUERY') {
+    if (intent === 'NEARBY') {
+      const kind = (cls.keywords?.[0] || query || '').toString();
+      if (process.env.FEATURE_NEARBY !== 'on') {
+        sections.nearby = { disabled: true, reason: 'FEATURE_NEARBY is off' };
+      } else if (!coords || typeof coords.lat !== 'number' || typeof coords.lng !== 'number') {
+        sections.needsLocation = true; sections.kind = kind;
+      } else {
+        const r = await fetch(api('/api/nearby'), {
+          method:'POST', headers:{ 'Content-Type':'application/json' },
+          body: JSON.stringify({ lat: coords.lat, lng: coords.lng, kind })
+        });
+        sections.nearby = await r.json();
+      }
+    } else if (intent === 'DIAGNOSIS_QUERY') {
       const term = keywords[0] || query;
-      const s = await umlsSearch(term);
+      const s = await umlsSearch(api, term);
       const cui = s.results?.[0]?.ui || null;
       if (cui) {
-        const icd = await umlsCrosswalk(cui,'ICD10CM');
-        const snomed = await umlsCrosswalk(cui,'SNOMEDCT_US');
+        const icd = await umlsCrosswalk(api, cui, 'ICD10CM');
+        const snomed = await umlsCrosswalk(api, cui, 'SNOMEDCT_US');
         sections.codes = { cui, icd: icd.mappings?.slice(0,6), snomed: snomed.mappings?.slice(0,6) };
       }
-      if (mode==='doctor') sections.trials = await pubmedTrials(term);
+      if (mode === 'doctor') sections.trials = await pubmedTrials(term);
     } else if (intent === 'DRUGS_LIST') {
-      const rx = await rxnormNormalize(query);
+      const rx = await rxnormNormalize(api, query);
       sections.meds = rx.meds;
-      if ((rx.meds||[]).length >= 2) {
-        sections.interactions = (await rxnavInteractions(rx.meds.map((m:any)=>m.rxcui))).interactions;
+      if ((rx.meds || []).length >= 2) {
+        sections.interactions = (await rxnavInteractions(api, rx.meds.map((m:any)=>m.rxcui))).interactions;
       }
     } else if (intent === 'CLINICAL_TRIALS_QUERY') {
       const term = keywords[0] || query;
       sections.trials = await pubmedTrials(term);
     }
-  } catch(e:any){ sections.error = String(e?.message || e); }
+  } catch (e: any) { sections.error = String(e?.message || e); }
 
-  return NextResponse.json({ intent, sections, followups: makeFollowups(intent, sections, (mode==='doctor'?'doctor':'patient'), query) });
+  const mergedContext = { ...(prior || {}), ...(sections || {}) };
+
+  return NextResponse.json({
+    intent,
+    sections,
+    followups: makeFollowups(intent, mergedContext, (mode === 'doctor' ? 'doctor' : 'patient'), query)
+  });
 }

--- a/app/api/nearby/route.ts
+++ b/app/api/nearby/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { haversineKm, osmAmenityFor } from '@/addons/nearby/lib/geo';
+
+export const runtime = 'edge';
+
+export async function POST(req: NextRequest) {
+  if (process.env.FEATURE_NEARBY !== 'on')
+    return NextResponse.json({ disabled: true, reason: 'FEATURE_NEARBY is off' }, { status: 200 });
+
+  try {
+    const { lat, lng, kind, radiusMeters = 5000, limit = 20 } = await req.json();
+    if (typeof lat !== 'number' || typeof lng !== 'number')
+      return NextResponse.json({ error: 'Missing coords' }, { status: 400 });
+
+    const amenities = osmAmenityFor(String(kind||'')), around = Math.min(Math.max(500, +radiusMeters||5000), 20000);
+    const parts = amenities.map(a=>`
+      node["amenity"="${a}"](around:${around},${lat},${lng});
+      way["amenity"="${a}"](around:${around},${lat},${lng});
+      relation["amenity"="${a}"](around:${around},${lat},${lng});
+    `).join('\n');
+
+    const query = `[out:json][timeout:25];(${parts});out center ${limit};`;
+    const ua = process.env.OVERPASS_USER_AGENT || 'MedX/1.0';
+    const resp = await fetch('https://overpass-api.de/api/interpreter', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': ua },
+      body: new URLSearchParams({ data: query })
+    });
+    if (!resp.ok) return NextResponse.json({ error: `Overpass ${resp.status}`, detail: await resp.text() }, { status: 502 });
+
+    const json = await resp.json();
+    const here = { lat, lng };
+    const results = (json?.elements||[]).map((el:any)=>{
+      const c = el.center ? { lat: el.center.lat, lng: el.center.lon } : { lat: el.lat, lng: el.lon };
+      const tags = el.tags || {};
+      const name = tags.name || tags['name:en'] || (tags.amenity || 'Unknown');
+      const address = [tags['addr:housenumber'], tags['addr:street'], tags['addr:city']||tags['addr:town']||tags['addr:suburb'], tags['addr:state'], tags['addr:postcode']].filter(Boolean).join(', ');
+      return {
+        id: `${el.type}/${el.id}`, name, address, kind: tags.amenity, coords: c,
+        distanceKm: haversineKm(here, c),
+        mapsUrl: `https://www.openstreetmap.org/${el.type}/${el.id}`,
+        navUrl: `https://www.google.com/maps/dir/?api=1&destination=${c.lat},${c.lng}`
+      };
+    }).filter((r:any)=>Number.isFinite(r.distanceKm)).sort((a:any,b:any)=>a.distanceKm-b.distanceKm).slice(0, limit);
+
+    return NextResponse.json({ results, center: here, radiusMeters: around, source: 'OpenStreetMap Overpass' });
+  } catch (e:any) {
+    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add geospatial helpers and Overpass-powered `/api/nearby` endpoint
- integrate NEARBY intent, absolute URL helper, and follow-up generation in orchestrator
- enhance client with auto-location, context carry-forward, and follow-up chips

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b298b4f398832f8b5bd390b76b32d1