### PR TITLE
Improve NEARBY detection and Overpass resilience

### DIFF
--- a/app/api/diag/route.ts
+++ b/app/api/diag/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server';
+export const runtime = 'edge';
 export async function GET() {
   return NextResponse.json({
-    LLM_BASE_URL: !!process.env.LLM_BASE_URL,
-    LLM_MODEL_ID: !!process.env.LLM_MODEL_ID,
-    LLM_API_KEY:  !!process.env.LLM_API_KEY,
-    UMLS_API_KEY: !!process.env.UMLS_API_KEY,
-    OCRSPACE_API_KEY: !!process.env.OCRSPACE_API_KEY
+    featureNearby: process.env.FEATURE_NEARBY,
+    featureIpLocate: process.env.FEATURE_IP_LOCATE,
+    overpassUA: process.env.OVERPASS_USER_AGENT,
+    baseUrl: process.env.NEXT_PUBLIC_BASE_URL
   });
 }

--- a/app/api/medx/route.ts
+++ b/app/api/medx/route.ts
@@ -50,12 +50,12 @@ Return JSON: {"intent":"...","keywords":["..."]}`;
   catch { return { intent:'GENERAL_HEALTH', keywords:[] }; }
 }
 
-async function umlsSearch(term: string){
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/umls/search?q=${encodeURIComponent(term)}`);
+async function umlsSearch(term: string, api:(p:string)=>string){
+  const res = await fetch(api(`/api/umls/search?q=${encodeURIComponent(term)}`));
   return res.ok ? res.json() : { results: [] };
 }
-async function umlsCrosswalk(cui: string, target:'ICD10CM'|'SNOMEDCT_US'|'RXNORM'){
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/umls/crosswalk?cui=${encodeURIComponent(cui)}&target=${target}`);
+async function umlsCrosswalk(cui: string, target:'ICD10CM'|'SNOMEDCT_US'|'RXNORM', api:(p:string)=>string){
+  const res = await fetch(api(`/api/umls/crosswalk?cui=${encodeURIComponent(cui)}&target=${target}`));
   return res.ok ? res.json() : { mappings: [] };
 }
 async function pubmedTrials(q: string){
@@ -68,44 +68,52 @@ async function pubmedTrials(q: string){
   const j = await sum.json();
   return ids.map((id:string)=>({ id, title: j.result?.[id]?.title, link: `https://pubmed.ncbi.nlm.nih.gov/${id}/`, source:'PubMed' }));
 }
-async function rxnormNormalize(text: string){
-  const r = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/rxnorm/normalize`,{
+async function rxnormNormalize(text: string, api:(p:string)=>string){
+  const r = await fetch(api('/api/rxnorm/normalize'),{
     method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ text })
   });
   return r.ok ? r.json() : { meds: [] };
 }
-async function rxnavInteractions(rxcuis: string[]){
-  const r = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL || ''}/api/interactions`,{
+async function rxnavInteractions(rxcuis: string[], api:(p:string)=>string){
+  const r = await fetch(api('/api/interactions'),{
     method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ rxcuis })
   });
   return r.ok ? r.json() : { interactions: [] };
 }
 
 export async function POST(req: NextRequest){
-  const { query, mode } = await req.json();
+  const origin = req.nextUrl?.origin || process.env.NEXT_PUBLIC_BASE_URL || '';
+  const api = (path: string) => /^https?:\/\//i.test(path) ? path : new URL(path, origin).toString();
+
+  const { query, mode, coords, forceIntent, prior } = await req.json();
   if(!query) return NextResponse.json({ intent:'GENERAL_HEALTH', sections:{} });
 
-  const cls = await classifyIntent(query, mode==='doctor'?'doctor':'patient');
+  const cls = forceIntent ? { intent: forceIntent, keywords: [] } : await classifyIntent(query, mode==='doctor'?'doctor':'patient');
   const intent = cls.intent || 'GENERAL_HEALTH';
   const keywords: string[] = cls.keywords || [];
   const sections: any = {};
 
   try {
-    if (intent === 'DIAGNOSIS_QUERY') {
+    if (intent === 'NEARBY') {
+      const r = await fetch(api('/api/nearby'),{
+        method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ query, coords })
+      });
+      sections.nearby = r.ok ? (await r.json()).results : [];
+    } else if (intent === 'DIAGNOSIS_QUERY') {
       const term = keywords[0] || query;
-      const s = await umlsSearch(term);
+      const s = await umlsSearch(term, api);
       const cui = s.results?.[0]?.ui || null;
       if (cui) {
-        const icd = await umlsCrosswalk(cui,'ICD10CM');
-        const snomed = await umlsCrosswalk(cui,'SNOMEDCT_US');
+        const icd = await umlsCrosswalk(cui,'ICD10CM', api);
+        const snomed = await umlsCrosswalk(cui,'SNOMEDCT_US', api);
         sections.codes = { cui, icd: icd.mappings?.slice(0,6), snomed: snomed.mappings?.slice(0,6) };
       }
       if (mode==='doctor') sections.trials = await pubmedTrials(term);
     } else if (intent === 'DRUGS_LIST') {
-      const rx = await rxnormNormalize(query);
+      const rx = await rxnormNormalize(query, api);
       sections.meds = rx.meds;
       if ((rx.meds||[]).length >= 2) {
-        sections.interactions = (await rxnavInteractions(rx.meds.map((m:any)=>m.rxcui))).interactions;
+        sections.interactions = (await rxnavInteractions(rx.meds.map((m:any)=>m.rxcui), api)).interactions;
       }
     } else if (intent === 'CLINICAL_TRIALS_QUERY') {
       const term = keywords[0] || query;

--- a/app/api/nearby/route.ts
+++ b/app/api/nearby/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { haversineKm, osmAmenityFor } from '../../../addons/nearby/lib/geo';
+
+export const runtime = 'edge';
+
+async function fetchOverpass(query: string, ua: string) {
+  const endpoints = [
+    'https://overpass-api.de/api/interpreter',
+    'https://overpass.kumi.systems/api/interpreter',
+    'https://overpass.nchc.org.tw/api/interpreter'
+  ];
+  let lastText = '';
+  for (const url of endpoints) {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': ua },
+      body: new URLSearchParams({ data: query })
+    });
+    const ctype = resp.headers.get('content-type') || '';
+    const text = await resp.text();
+    if (!resp.ok) { lastText = text; continue; }
+    // Reject HTML error pages
+    if (ctype.includes('application/json') || text.trim().startsWith('{') || text.trim().startsWith('[')) {
+      try { return JSON.parse(text); } catch { /* fall through */ }
+    }
+    lastText = text;
+  }
+  throw new Error(`Overpass returned non-JSON/HTML error. Last body (truncated): ${lastText.slice(0,300)}`);
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { query, coords } = await req.json();
+    if (!query || !coords?.lat || !coords?.lng) {
+      return NextResponse.json({ results: [] });
+    }
+    const amenities = osmAmenityFor(query);
+    if (!amenities.length) return NextResponse.json({ results: [] });
+
+    const radius = 5000; // meters
+    const overpass = `
+      [out:json];
+      (
+        node["amenity"~"${amenities.join('|')}"](around:${radius},${coords.lat},${coords.lng});
+        way["amenity"~"${amenities.join('|')}"](around:${radius},${coords.lat},${coords.lng});
+        relation["amenity"~"${amenities.join('|')}"](around:${radius},${coords.lat},${coords.lng});
+      );
+      out center;
+    `;
+
+    const ua = process.env.OVERPASS_USER_AGENT || 'MedX/1.0';
+    const json = await fetchOverpass(overpass, ua);
+    const elements = Array.isArray(json.elements) ? json.elements : [];
+
+    const results = elements.map((el:any) => {
+      const lat = el.lat ?? el.center?.lat;
+      const lng = el.lon ?? el.center?.lon;
+      return {
+        id: el.id,
+        name: el.tags?.name || 'Unnamed',
+        lat,
+        lng,
+        distanceKm: haversineKm(coords.lat, coords.lng, lat, lng),
+        tags: el.tags || {}
+      };
+    }).sort((a:any,b:any)=>a.distanceKm-b.distanceKm);
+
+    return NextResponse.json({ results });
+  } catch (e:any) {
+    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,13 @@ import { Send, Sun, Moon, User, Stethoscope } from 'lucide-react';
 
 type ChatMsg = { role: 'user'|'assistant'; content: string };
 
+function isNearbyQuery(q: string) {
+  const s = q.toLowerCase();
+  const near = /\b(near me|around me|nearby)\b/.test(s);
+  const kind = /\b(doctor|doctors|dr|physician|clinic|clinics|hospital|hospitals|pharmacy|pharmacies|dentist|ent|gp|doc|docs)\b/.test(s);
+  return near && kind;
+}
+
 export default function Home(){
   const [messages, setMessages] = useState<ChatMsg[]>([]);
   const [input, setInput] = useState('');
@@ -59,9 +66,11 @@ export default function Home(){
     setBusy(true);
 
     try {
+      const payload:any = { query: text, mode, coords };
+      if (isNearbyQuery(text)) payload.forceIntent = 'NEARBY';
       const planRes = await fetch('/api/medx', {
         method:'POST', headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({ query: text, mode, coords })
+        body: JSON.stringify(payload)
       });
       if (!planRes.ok) throw new Error(`MedX API error ${planRes.status}`);
       const plan = await planRes.json();


### PR DESCRIPTION
## Summary
- map doc/doc/dr synonyms to doctor and force fast-path NEARBY search
- add resilient Overpass client and new `/api/nearby` endpoint
- use absolute URLs in edge API routes and expose diagnostics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b29d79362c832fa5b4e40905c9b597