### PR TITLE
feat: add nearby intent detection

### DIFF
--- a/components/NearbyCards.tsx
+++ b/components/NearbyCards.tsx
@@ -1,0 +1,18 @@
+export function NearbyCards({ items }: { items: Array<any> }) {
+  return (
+    <div className="grid gap-3 mt-2">
+      {items.map((it, i) => (
+        <div key={i} className="rounded-lg border p-3">
+          <div className="font-medium">{it.title}</div>
+          <div className="text-sm opacity-70">{it.subtitle}</div>
+          {it.address && <div className="text-sm mt-1">{it.address}</div>}
+          <div className="text-sm mt-2 flex gap-3">
+            {it.phone && <a className="underline" href={`tel:${it.phone}`}>Call</a>}
+            {it.website && <a className="underline" href={it.website} target="_blank">Website</a>}
+            <a className="underline" href={it.mapsUrl} target="_blank">Open in Maps</a>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/lib/intent.ts
+++ b/lib/intent.ts
@@ -1,0 +1,19 @@
+export type NearbyKind = 'doctor' | 'clinic' | 'hospital' | 'pharmacy' | 'any';
+
+export function parseNearbyIntent(q: string):
+  | { type: 'nearby'; kind: NearbyKind }
+  | { type: 'none' } {
+  const s = (q || '').toLowerCase().trim();
+
+  // common phrasings
+  const nearMe = /\b(near me|nearby|around me|closest|in my area)\b/;
+  if (!nearMe.test(s)) return { type: 'none' };
+
+  if (/\b(pharmacy|chemist|drug ?store)\b/.test(s)) return { type: 'nearby', kind: 'pharmacy' };
+  if (/\b(hospital|er|emergency)\b/.test(s)) return { type: 'nearby', kind: 'hospital' };
+  if (/\b(clinic|urgent care|polyclinic)\b/.test(s)) return { type: 'nearby', kind: 'clinic' };
+  if (/\b(doctor|doctors|physician|gp|dentist|dermatologist|cardiologist)\b/.test(s))
+    return { type: 'nearby', kind: 'doctor' };
+
+  return { type: 'nearby', kind: 'any' };
+}


### PR DESCRIPTION
## Summary
- detect "near me" queries and classify doctor/clinic/hospital/pharmacy/any
- intercept nearby intents in chat submit, lookup locations and render as cards
- add NearbyCards component for clean display of nearby results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b2d45b70fc832fbc6415cb7de9de5e