### PR TITLE
Add locale context and region-aware LLM prompts

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,9 +1,41 @@
 import { NextRequest, NextResponse } from 'next/server';
+
+function likelyMedicationQuery(text: string) {
+  const s = text.toLowerCase();
+  return /\b(cough|syrup|tablet|capsule|medication|medicine|dose|otc)\b/.test(s);
+}
+
+function regionGuard(country: string | null) {
+  const c = (country || '').toUpperCase();
+  if (!c) return { regulator: 'local regulator', otcNote: 'Availability may vary; check local pharmacist.' };
+  if (c === 'IN') return { regulator: 'CDSCO / ICMR', otcNote: 'Check with a pharmacist; products vary by state.' };
+  if (c === 'US') return { regulator: 'FDA', otcNote: 'Consider OTC monograph products if appropriate.' };
+  if (c === 'GB') return { regulator: 'NHS / BNF', otcNote: 'Follow NHS advice and consult a pharmacist.' };
+  if (c === 'AU') return { regulator: 'TGA', otcNote: 'Follow TGA scheduling; consult a pharmacist.' };
+  if (c === 'EU') return { regulator: 'EMA / national authority', otcNote: 'Country-specific rules apply.' };
+  return { regulator: 'local regulator', otcNote: 'Availability may vary; check local pharmacist.' };
+}
+
 export async function POST(req: NextRequest){
-  const { question, role } = await req.json();
+  const body = await req.json();
+  const { question, role } = body;
+  const countryCode: string | null = body?.meta?.countryCode ?? null;
   const base = process.env.LLM_BASE_URL;
   const model = process.env.LLM_MODEL_ID || 'llama3-8b-instruct';
   if(!base) return new NextResponse("LLM_BASE_URL not set", { status: 500 });
+
+  const { regulator, otcNote } = regionGuard(countryCode);
+
+  const regionBlock = `\nYou must tailor all medical and medication advice to the user's country: ${countryCode || 'Unknown'}.\nRules:\n- Prefer generic (INN) names first. Only list brand examples from that country.\n- Cite local regulators/guidelines: e.g., CDSCO/ICMR (IN), FDA/USP (US), NHS/BNF (UK), EMA (EU), TGA (AU).\n- If the drug is prescription-only in that country, say so.\n- If your sources are US-only but country is not US, say "Based on globally available data; local guidance may differ." and prefer generic guidance over US brand names.\n- Avoid recommending unavailable or unapproved products in the user's country.\n`;
+
+  const system = `You are MedX, a careful medical assistant. ${regionBlock}
+General safety: do not diagnose; encourage clinician review; highlight red-flag symptoms; avoid dosing unless asked with sufficient context. Keep responses concise and structured.`;
+
+  const medicationBlock = likelyMedicationQuery(question)
+    ? `For medication requests, answer with:\n- Generic ingredient first (e.g., "dextromethorphan"), then 2–3 brand examples **from ${countryCode || 'the user country'}** if widely available.\n- Regulatory note: ${regulator}. ${otcNote}\n- Warn about interactions and red-flag symptoms; avoid dosing unless explicitly needed and safe.`
+    : '';
+
+  const finalSystem = `${system}\n${medicationBlock}`;
 
   // OpenAI-compatible completion (v1/chat/completions)
   const res = await fetch(`${base.replace(/\/$/,'')}/chat/completions`, {
@@ -12,7 +44,7 @@ export async function POST(req: NextRequest){
     body: JSON.stringify({
       model,
       messages: [
-        { role: 'system', content: role==='clinician' ? 'You are a clinical assistant. Be precise, cite sources if mentioned. Avoid medical advice; provide evidence and guideline pointers.' : 'You explain in simple, friendly language for patients. Avoid medical advice; encourage consulting a doctor.' },
+        { role: 'system', content: finalSystem },
         { role: 'user', content: question }
       ],
       temperature: 0.2

--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -1,17 +1,53 @@
 import { NextRequest } from 'next/server';
 export const runtime = 'edge';
 
+function likelyMedicationQuery(text: string) {
+  const s = text.toLowerCase();
+  return /\b(cough|syrup|tablet|capsule|medication|medicine|dose|otc)\b/.test(s);
+}
+
+function regionGuard(country: string | null) {
+  const c = (country || '').toUpperCase();
+  if (!c) return { regulator: 'local regulator', otcNote: 'Availability may vary; check local pharmacist.' };
+  if (c === 'IN') return { regulator: 'CDSCO / ICMR', otcNote: 'Check with a pharmacist; products vary by state.' };
+  if (c === 'US') return { regulator: 'FDA', otcNote: 'Consider OTC monograph products if appropriate.' };
+  if (c === 'GB') return { regulator: 'NHS / BNF', otcNote: 'Follow NHS advice and consult a pharmacist.' };
+  if (c === 'AU') return { regulator: 'TGA', otcNote: 'Follow TGA scheduling; consult a pharmacist.' };
+  if (c === 'EU') return { regulator: 'EMA / national authority', otcNote: 'Country-specific rules apply.' };
+  return { regulator: 'local regulator', otcNote: 'Availability may vary; check local pharmacist.' };
+}
+
 export async function POST(req: NextRequest) {
-  const { messages } = await req.json();
+  const body = await req.json();
+  const messages = body?.messages || [];
+  const countryCode: string | null = body?.meta?.countryCode ?? null;
+
+  const userMsg = [...messages].reverse().find((m: any) => m.role === 'user');
+  const userText = userMsg?.content || '';
+  const clientSystem = messages.find((m: any) => m.role === 'system')?.content || '';
+  const { regulator, otcNote } = regionGuard(countryCode);
+
+  const regionBlock = `\nYou must tailor all medical and medication advice to the user's country: ${countryCode || 'Unknown'}.\nRules:\n- Prefer generic (INN) names first. Only list brand examples from that country.\n- Cite local regulators/guidelines: e.g., CDSCO/ICMR (IN), FDA/USP (US), NHS/BNF (UK), EMA (EU), TGA (AU).\n- If the drug is prescription-only in that country, say so.\n- If your sources are US-only but country is not US, say "Based on globally available data; local guidance may differ." and prefer generic guidance over US brand names.\n- Avoid recommending unavailable or unapproved products in the user's country.\n`;
+
+  const system = `You are MedX, a careful medical assistant. ${regionBlock}
+General safety: do not diagnose; encourage clinician review; highlight red-flag symptoms; avoid dosing unless asked with sufficient context. Keep responses concise and structured.`;
+
+  const medicationBlock = likelyMedicationQuery(userText)
+    ? `For medication requests, answer with:\n- Generic ingredient first (e.g., "dextromethorphan"), then 2–3 brand examples **from ${countryCode || 'the user country'}** if widely available.\n- Regulatory note: ${regulator}. ${otcNote}\n- Warn about interactions and red-flag symptoms; avoid dosing unless explicitly needed and safe.`
+    : '';
+
+  const finalSystem = `${clientSystem ? clientSystem + '\n' : ''}${system}\n${medicationBlock}`;
+
   const base  = process.env.LLM_BASE_URL!;
   const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
   const key   = process.env.LLM_API_KEY!;
   const url = `${base.replace(/\/$/,'')}/chat/completions`;
 
+  const filtered = messages.filter((m: any) => m.role !== 'system');
   const upstream = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
-    body: JSON.stringify({ model, stream: true, temperature: 0.2, messages })
+    body: JSON.stringify({ model, stream: true, temperature: 0.2, messages: [{ role: 'system', content: finalSystem }, ...filtered] })
   });
 
   if (!upstream.ok) {

--- a/app/api/whereami/route.ts
+++ b/app/api/whereami/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  try {
+    const ip =
+      req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      req.ip ||
+      '';
+    const r = await fetch(`https://ipapi.co/${ip}/json/`, { cache: 'no-store' });
+    const j = await r.json();
+    return NextResponse.json({
+      country_code: j?.country_code || null,
+      country_name: j?.country_name || null,
+      lat: j?.latitude ?? null,
+      lon: j?.longitude ?? null,
+    });
+  } catch (e) {
+    return NextResponse.json({ country_code: null, country_name: null }, { status: 200 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './styles.css';
 import { ThemeProvider } from 'next-themes';
+import { LocaleProvider } from '@/lib/locale';
 
 export const metadata = { title: 'MedX', description: 'Global medical AI' };
 
@@ -7,7 +8,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <ThemeProvider attribute="class" defaultTheme="system">{children}</ThemeProvider>
+        <LocaleProvider>
+          <ThemeProvider attribute="class" defaultTheme="system">{children}</ThemeProvider>
+        </LocaleProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState } from 'react';
 import Sidebar from '../components/Sidebar';
 import Markdown from '../components/Markdown';
 import { Send, Sun, Moon, User, Stethoscope } from 'lucide-react';
+import CountryPill from '../components/CountryPill';
+import { useLocale } from '@/lib/locale';
 
 type ChatMsg = { role: 'user'|'assistant'; content: string };
 
@@ -16,6 +18,7 @@ export default function Home(){
   const [locNote, setLocNote] = useState<string | null>(null);
   const [followups, setFollowups] = useState<string[]>([]);
   const chatRef = useRef<HTMLDivElement>(null);
+  const { locale } = useLocale();
 
   function saveCoords(c:{lat:number;lng:number}) {
     setCoords(c);
@@ -84,7 +87,8 @@ If CONTEXT has codes or trials, explain them in plain words and add links. Avoid
           messages:[
             { role:'system', content: sys },
             { role:'user', content: `${text}\n\n${contextBlock}` }
-          ]
+          ],
+          meta: { countryCode: locale.countryCode }
         })
       });
       if (!res.ok || !res.body) throw new Error(`Chat API error ${res.status}`);
@@ -206,6 +210,7 @@ If CONTEXT has codes or trials, explain them in plain words and add links. Avoid
           <button className="item" onClick={()=>setTheme(theme==='dark'?'light':'dark')}>
             {theme==='dark'? <><Sun size={16}/> Light</> : <><Moon size={16}/> Dark</>}
           </button>
+          <CountryPill />
         </div>
 
         <div className="wrap">

--- a/components/CountryPill.tsx
+++ b/components/CountryPill.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { useLocale } from '@/lib/locale';
+
+const COUNTRIES = [
+  { code: 'IN', name: 'India' },
+  { code: 'US', name: 'United States' },
+  { code: 'GB', name: 'United Kingdom' },
+  { code: 'AU', name: 'Australia' },
+  { code: 'EU', name: 'European Union' },
+  // add more as needed
+];
+
+export default function CountryPill() {
+  const { locale, setLocale } = useLocale();
+
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm">
+      <span>Country:</span>
+      <select
+        className="bg-transparent outline-none"
+        value={locale.countryCode || ''}
+        onChange={(e) => {
+          const code = e.target.value || null;
+          const item = COUNTRIES.find(c => c.code === code) || null;
+          setLocale({ countryCode: item?.code || null, countryName: item?.name || null });
+        }}
+      >
+        <option value="">Auto</option>
+        {COUNTRIES.map(c => (
+          <option key={c.code} value={c.code}>{c.name}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/lib/locale.tsx
+++ b/lib/locale.tsx
@@ -1,0 +1,53 @@
+'use client';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Locale = {
+  countryCode: string | null;   // "IN", "US", "GB", ...
+  countryName: string | null;   // "India"
+};
+
+type Ctx = {
+  locale: Locale;
+  setLocale: (l: Locale) => void;
+};
+
+const LocaleCtx = createContext<Ctx>({
+  locale: { countryCode: null, countryName: null },
+  setLocale: () => {},
+});
+
+export function LocaleProvider({ children }: { children: React.ReactNode }) {
+  const [locale, setLocale] = useState<Locale>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = window.localStorage.getItem('medx:locale');
+      if (saved) return JSON.parse(saved);
+    }
+    return { countryCode: null, countryName: null };
+  });
+
+  useEffect(() => {
+    if (!locale.countryCode) {
+      // detect once
+      fetch('/api/whereami')
+        .then(r => r.json())
+        .then((j) => {
+          const next = { countryCode: j.country_code, countryName: j.country_name };
+          setLocale(next);
+          try { localStorage.setItem('medx:locale', JSON.stringify(next)); } catch {}
+        })
+        .catch(() => {});
+    }
+  }, []);
+
+  useEffect(() => {
+    try { localStorage.setItem('medx:locale', JSON.stringify(locale)); } catch {}
+  }, [locale]);
+
+  return (
+    <LocaleCtx.Provider value={{ locale, setLocale }}>
+      {children}
+    </LocaleCtx.Provider>
+  );
+}
+
+export function useLocale() { return useContext(LocaleCtx); }


### PR DESCRIPTION
## Summary
- add `/api/whereami` endpoint for IP-based country detection
- provide Locale context and manual CountryPill override in UI
- inject country-specific guidance into chat routes and model prompts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2de479c9c832f83ede210ced4c16f