### PR TITLE
fix: relax specialty tag filter

### DIFF
--- a/app/api/nearby/route.ts
+++ b/app/api/nearby/route.ts
@@ -50,14 +50,8 @@ function buildFilters(kind?: string, specialty?: string) {
 
   const withSpecialty = (blocks: string[]) => {
     if (!specialty) return blocks;
-    const specTag = [
-      `["healthcare:specialty"~"${sp}", i]`,
-      `["healthcare:speciality"~"${sp}", i]`,
-      `["specialty"~"${sp}", i]`,
-      `["speciality"~"${sp}", i]`,
-      `["name"~"${sp}", i]`,
-    ];
-    return blocks.map((b) => `${b}${specTag.join('')}`);
+    const specTag = `[~"^(healthcare:specialty|healthcare:speciality|specialty|speciality|name)$"~"${sp}", i]`;
+    return blocks.map((b) => `${b}${specTag}`);
   };
 
   const k = (kind || 'any').toLowerCase();


### PR DESCRIPTION
## Summary
- relax nearby specialty filter to match any specialty-related tag

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2e294ad28832f816bb6ccc08a95d8