### PR TITLE
feat: add fuzzy match to nearby queries

### DIFF
--- a/lib/fuzzy.ts
+++ b/lib/fuzzy.ts
@@ -1,0 +1,33 @@
+// lib/fuzzy.ts
+// Lightweight Damerau–Levenshtein distance (good for small dictionaries)
+export function dlDistance(a: string, b: string): number {
+  a = a.toLowerCase(); b = b.toLowerCase();
+  const al = a.length, bl = b.length;
+  const dp = Array.from({ length: al + 1 }, () => new Array(bl + 1).fill(0));
+  for (let i = 0; i <= al; i++) dp[i][0] = i;
+  for (let j = 0; j <= bl; j++) dp[0][j] = j;
+  for (let i = 1; i <= al; i++) {
+    for (let j = 1; j <= bl; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,      // deletion
+        dp[i][j - 1] + 1,      // insertion
+        dp[i - 1][j - 1] + cost // substitution
+      );
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+        dp[i][j] = Math.min(dp[i][j], dp[i - 2][j - 2] + cost); // transposition
+      }
+    }
+  }
+  return dp[al][bl];
+}
+
+export function bestFuzzyMatch(input: string, candidates: string[], maxDist = 2) {
+  let best = { word: '', dist: Infinity };
+  for (const c of candidates) {
+    const d = dlDistance(input, c);
+    if (d < best.dist) best = { word: c, dist: d };
+    if (best.dist === 0) break;
+  }
+  return best.dist <= maxDist ? best.word : null;
+}

--- a/lib/intent.ts
+++ b/lib/intent.ts
@@ -1,19 +1,86 @@
+import { bestFuzzyMatch } from '@/lib/fuzzy';
+
 export type NearbyKind = 'doctor' | 'clinic' | 'hospital' | 'pharmacy' | 'any';
+export type NearbyIntent =
+  | { type: 'nearby'; kind: NearbyKind; specialty?: string; corrected?: boolean; suggestion?: string }
+  | { type: 'none' };
 
-export function parseNearbyIntent(q: string):
-  | { type: 'nearby'; kind: NearbyKind }
-  | { type: 'none' } {
-  const s = (q || '').toLowerCase().trim();
+// Canonical specialties we support + common aliases
+const SPECIALTY_CANON = [
+  'gynecology','cardiology','dermatology','urology','neurology','orthopedics',
+  'dentistry','pediatrics','psychiatry','ent','ophthalmology','endocrinology',
+  'gastroenterology','pulmonology','nephrology','rheumatology','oncology'
+];
 
-  // common phrasings
-  const nearMe = /\b(near me|nearby|around me|closest|in my area)\b/;
-  if (!nearMe.test(s)) return { type: 'none' };
+const SPECIALTY_ALIASES: Record<string, string> = {
+  // Gynecology (misspellings & synonyms)
+  'gyn': 'gynecology','gyno': 'gynecology','gyney': 'gynecology',
+  'gyne': 'gynecology','gynae': 'gynecology','gynaecologist': 'gynecology',
+  'gynecologist': 'gynecology','gynacologist': 'gynecology',
+  'obgyn': 'gynecology','ob-gyn': 'gynecology','ob/gyn': 'gynecology',
+  'obstetrician': 'gynecology','obstetrics': 'gynecology','women doctor': 'gynecology',
+  // A few more common ones (extend over time)
+  'skin doctor': 'dermatology','heart doctor': 'cardiology','kidney doctor': 'nephrology',
+  'lung doctor': 'pulmonology','bone doctor':'orthopedics','eye doctor':'ophthalmology',
+};
 
-  if (/\b(pharmacy|chemist|drug ?store)\b/.test(s)) return { type: 'nearby', kind: 'pharmacy' };
-  if (/\b(hospital|er|emergency)\b/.test(s)) return { type: 'nearby', kind: 'hospital' };
-  if (/\b(clinic|urgent care|polyclinic)\b/.test(s)) return { type: 'nearby', kind: 'clinic' };
-  if (/\b(doctor|doctors|physician|gp|dentist|dermatologist|cardiologist)\b/.test(s))
-    return { type: 'nearby', kind: 'doctor' };
+const NEAR_ME_RE = /\b(near me|nearby|around me|closest|in my area)\b/i;
 
-  return { type: 'nearby', kind: 'any' };
+function extractCandidateSpecialty(text: string) {
+  const s = text.toLowerCase();
+
+  // 1) Alias hits (includes common phrases)
+  for (const key of Object.keys(SPECIALTY_ALIASES)) {
+    if (s.includes(key)) return SPECIALTY_ALIASES[key];
+  }
+
+  // 2) Single token after stripping "near me"
+  // Try to grab likely token (e.g., "gynae", "dermatologist")
+  const tokens = s.replace(NEAR_ME_RE, '').split(/[^a-z/+-]+/i).filter(Boolean);
+
+  // Direct exact matches first
+  for (const t of tokens) {
+    if (SPECIALTY_CANON.includes(t)) return t;
+  }
+
+  // Fuzzy match against canon + known alias keys
+  const dict = [...SPECIALTY_CANON, ...Object.keys(SPECIALTY_ALIASES)];
+  for (const t of tokens) {
+    const m = bestFuzzyMatch(t, dict, 2); // edit distance <= 2
+    if (m) {
+      // map alias to canon
+      return SPECIALTY_ALIASES[m] || m;
+    }
+  }
+  return undefined;
+}
+
+export function parseNearbyIntent(q: string): NearbyIntent {
+  const s = (q || '').trim();
+  if (!NEAR_ME_RE.test(s)) return { type: 'none' };
+
+  // Base kind
+  let kind: NearbyKind = 'any';
+  const low = s.toLowerCase();
+  if (/\b(pharmacy|chemist|drug ?store)\b/.test(low)) kind = 'pharmacy';
+  else if (/\b(hospital|er|emergency)\b/.test(low)) kind = 'hospital';
+  else if (/\b(clinic|urgent care|polyclinic)\b/.test(low)) kind = 'clinic';
+  else if (/\b(doc|docs|doctor|doctors|physician|gp|dentist|dermatologist|cardiologist|gyn|gyno|gynae|gynecologist|gynaecologist|obgyn|ob-gyn|ob\/gyn)\b/.test(low))
+    kind = 'doctor';
+
+  // Specialty detection with autocorrect
+  const spec = extractCandidateSpecialty(s);
+  if (spec) {
+    // If the raw text doesn't literally include the canonical word, treat as correction
+    const corrected = !low.includes(spec);
+    let suggestion: string | undefined = undefined;
+    if (corrected) {
+      // Build a nice human suggestion term
+      const pretty = spec === 'ent' ? 'ENT' : spec.charAt(0).toUpperCase() + spec.slice(1);
+      suggestion = `${pretty} near me`;
+    }
+    return { type: 'nearby', kind: kind === 'pharmacy' ? 'pharmacy' : 'doctor', specialty: spec, corrected, suggestion };
+  }
+
+  return { type: 'nearby', kind }; // generic nearby
 }


### PR DESCRIPTION
## Summary
- add Damerau–Levenshtein fuzzy matcher for small dictionaries
- autocorrect specialties in nearby intent with suggestions
- show "Did you mean…?" note and run corrected nearby searches

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2e42a4010832fb3738b39a08eb99c