### PR TITLE
Expose facility distance and show nearby cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import Sidebar from '../components/Sidebar';
 import Markdown from '../components/Markdown';
 import { Send, Sun, Moon, User, Stethoscope } from 'lucide-react';
 import { parseNearbyIntent } from '@/lib/intent';
-import { NearbyCards } from '../components/NearbyCards';
+import NearbyCards from '@/components/NearbyCards';
 
 type ChatMsg = {
   role: 'user' | 'assistant';
@@ -110,11 +110,13 @@ Okay — searching ${intent.suggestion}…` } as ChatMsg]
           type: 'nearby-cards',
           payload: data.items.map((it: any) => ({
             title: it.name,
-            subtitle: it.type,
+            subtitle: prettyType(it.type),
             address: it.address,
             phone: it.phone,
             website: it.website,
             mapsUrl: `https://www.google.com/maps?q=${it.lat},${it.lon}`,
+            distanceKm:
+              typeof it.distance_km === 'number' ? it.distance_km : undefined,
           })),
         },
       ]);
@@ -366,4 +368,14 @@ If CONTEXT has codes or trials, explain them in plain words and add links. Avoid
       </main>
     </div>
   );
+}
+
+function prettyType(t?: string) {
+  if (!t) return '';
+  const s = String(t).toLowerCase();
+  if (s === 'doctors' || s === 'doctor') return 'Doctor';
+  if (s === 'clinic') return 'Clinic';
+  if (s === 'hospital') return 'Hospital';
+  if (s === 'pharmacy') return 'Pharmacy';
+  return s.charAt(0).toUpperCase() + s.slice(1);
 }

--- a/components/NearbyCards.tsx
+++ b/components/NearbyCards.tsx
@@ -1,18 +1,70 @@
-export function NearbyCards({ items }: { items: Array<any> }) {
+'use client';
+
+type Item = {
+  title: string;
+  subtitle?: string;
+  address?: string;
+  phone?: string | null;
+  website?: string | null;
+  mapsUrl: string;
+  distanceKm?: number;
+};
+
+export default function NearbyCards({ items }: { items: Item[] }) {
   return (
-    <div className="grid gap-3 mt-2">
+    <div className="grid gap-3 mt-3">
       {items.map((it, i) => (
-        <div key={i} className="rounded-lg border p-3">
-          <div className="font-medium">{it.title}</div>
-          <div className="text-sm opacity-70">{it.subtitle}</div>
-          {it.address && <div className="text-sm mt-1">{it.address}</div>}
-          <div className="text-sm mt-2 flex gap-3">
-            {it.phone && <a className="underline" href={`tel:${it.phone}`}>Call</a>}
-            {it.website && <a className="underline" href={it.website} target="_blank">Website</a>}
-            <a className="underline" href={it.mapsUrl} target="_blank">Open in Maps</a>
+        <div key={i} className="rounded-xl border p-4 bg-background">
+          {/* Name */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-base font-semibold leading-tight">
+              {it.title || 'Unknown'}
+            </div>
+            {typeof it.distanceKm === 'number' && (
+              <div className="text-xs px-2 py-1 rounded-full border opacity-80">
+                {it.distanceKm} km
+              </div>
+            )}
+          </div>
+
+          {/* Type */}
+          {it.subtitle && (
+            <div className="text-xs mt-1 opacity-70">
+              {it.subtitle}
+            </div>
+          )}
+
+          {/* Address */}
+          {it.address && (
+            <div className="text-sm mt-2">
+              {it.address}
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex flex-wrap items-center gap-3 mt-3 text-sm">
+            {it.phone && (
+              <a className="underline" href={`tel:${normalizePhone(it.phone)}`}>
+                Call
+              </a>
+            )}
+            {it.website && (
+              <a className="underline" href={it.website} target="_blank">
+                Website
+              </a>
+            )}
+            <a className="underline" href={it.mapsUrl} target="_blank">
+              Directions
+            </a>
           </div>
         </div>
       ))}
     </div>
   );
+}
+
+function normalizePhone(p?: string | null) {
+  if (!p) return '';
+  // remove spaces and dashes; keep + and digits
+  return p.replace(/[^\d+]/g, '');
 }


### PR DESCRIPTION
## Summary
- compute and expose distance_km for each nearby facility while preserving raw tags
- add NearbyCards component with distance badges, address, phone and directions link
- map API results to card props and render NearbyCards in chat

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b2ea285b18832fae8cf1683b109345