### PR TITLE
Refine nearby search and card display

### DIFF
--- a/components/NearbyCards.tsx
+++ b/components/NearbyCards.tsx
@@ -9,7 +9,14 @@ export function NearbyCards({ items }: { items: Array<any> }) {
           <div className="text-sm mt-2 flex gap-3">
             {it.phone && <a className="underline" href={`tel:${it.phone}`}>Call</a>}
             {it.website && <a className="underline" href={it.website} target="_blank">Website</a>}
-            <a className="underline" href={it.mapsUrl} target="_blank">Open in Maps</a>
+            <a
+              className="underline"
+              href={it.mapsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Directions
+            </a>
           </div>
         </div>
       ))}


### PR DESCRIPTION
## Summary
- Replace "Open in Maps" with "Directions" link and keep phone/address details on cards
- Add gynecology-specific regex, scoring, distance calculation, and result shaping in nearby API
- Enhance client payload to include formatted types, contact info, maps links, and distance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2f0c0c810832f8af6c51e9b444202