### PR TITLE
Harden MedX API and handle malformed responses

### DIFF
--- a/app/api/medx/route.ts
+++ b/app/api/medx/route.ts
@@ -1,53 +1,42 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-type MedxSuccess = {
-  ok: true;
-  data: {
-    role: 'assistant';
-    content: string; // markdown/plain
-    citations?: Array<{ title: string; url: string }>;
-  };
-};
+type MedxSuccess = { ok: true; data: { role: 'assistant'; content: string; citations?: Array<{title:string; url:string}> } };
+type MedxError   = { ok: false; error: { code: string; message: string } };
 
-type MedxError = {
-  ok: false;
-  error: { code: string; message: string };
-};
-
-function errorJSON(code: string, message: string, status = 200) {
-  const body: MedxError = { ok: false, error: { code, message } };
-  return NextResponse.json(body, { status });
+function jerror(code: string, message: string, status = 200) {
+  // 200 keeps client happy but payload.ok=false lets UI render a friendly note
+  return NextResponse.json({ ok:false, error:{ code, message } } as MedxError, { status });
 }
 
 async function callLLM(baseUrl: string, apiKey: string, body: any) {
-  const r = await fetch(`${baseUrl}/v1/chat/completions`, {
+  const endpoint = new URL('/v1/chat/completions', baseUrl).toString();
+  const res = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
     body: JSON.stringify(body),
   });
-  // Try to read text first, then parse
-  const text = await r.text();
+  const text = await res.text(); // always read text first to log on failure
   let json: any = null;
   try { json = JSON.parse(text); } catch {}
-  return { ok: r.ok, status: r.status, text, json };
+  return { ok: res.ok, status: res.status, text, json };
 }
 
 export async function POST(req: NextRequest) {
   try {
-    const { messages, meta } = await req.json();
+    const body = await req.json().catch(() => null);
+    if (!body) return jerror('bad_request', 'Invalid JSON payload');
 
     const BASE = process.env.LLM_BASE_URL?.trim();
     const KEY  = process.env.LLM_API_KEY?.trim();
-    const MODEL= process.env.LLM_MODEL || 'llama-3.1-8b-instant'; // or your default
+    const MODEL= process.env.LLM_MODEL?.trim() || 'llama-3.1-8b-instant';
+    if (!BASE) return jerror('missing_base_url', 'LLM_BASE_URL not set');
+    if (!KEY)  return jerror('missing_api_key', 'LLM_API_KEY not set');
 
-    if (!BASE) return errorJSON('missing_base_url', 'LLM_BASE_URL not set', 200);
-    if (!KEY)  return errorJSON('missing_api_key', 'LLM_API_KEY not set', 200);
-
-    // Build region/role-aware system message
-    const country = meta?.countryCode ?? 'Unknown';
-    const audience = meta?.mode === 'doctor'
+    const country = body?.meta?.countryCode ?? 'Unknown';
+    const audience = body?.meta?.mode === 'doctor'
       ? 'Audience is a clinician. Prefer codes, succinct bullets.'
       : 'Audience is a general user. Avoid jargon; keep it actionable and safe.';
+
     const system = `You are MedX, a careful medical assistant.
 Country: ${country}.
 ${audience}
@@ -55,42 +44,35 @@ Medication guidance: prefer generics; cite local regulators when useful; avoid d
 
     const llmBody = {
       model: MODEL,
-      messages: [
-        { role: 'system', content: system },
-        ...(messages ?? []),
-      ],
+      messages: [{ role: 'system', content: system }, ...(body?.messages || [])],
       temperature: 0.3,
     };
 
-    const resp = await callLLM(BASE, KEY, llmBody);
+    const r = await callLLM(BASE, KEY, llmBody);
 
-    if (!resp.ok) {
-      // Provider returned a non-2xx; bubble a clean error
-      const msg = resp.json?.error?.message || resp.text || 'LLM provider error';
-      return errorJSON('llm_upstream_error', msg.slice(0, 400));
+    // Log non-2xx details to Vercel logs for debugging
+    if (!r.ok) {
+      console.error('LLM upstream error:', { status: r.status, text: r.text?.slice(0, 500) });
+      const message = r.json?.error?.message || r.text || `HTTP ${r.status}`;
+      return jerror('llm_upstream_error', message.slice(0, 400));
     }
 
-    // Some providers put the completion in different fields; normalize:
     const content =
-      resp.json?.choices?.[0]?.message?.content ??
-      resp.json?.message?.content ??
-      resp.json?.output_text ??
+      r.json?.choices?.[0]?.message?.content ??
+      r.json?.message?.content ??
+      r.json?.output_text ??
       '';
 
     if (!content) {
-      return errorJSON('empty_completion', 'LLM returned empty content');
+      console.error('Empty completion from LLM:', r.json ?? r.text);
+      return jerror('empty_completion', 'LLM returned empty content');
     }
 
-    const out: MedxSuccess = {
-      ok: true,
-      data: {
-        role: 'assistant',
-        content,
-        citations: resp.json?.citations ?? undefined,
-      },
-    };
+    const out: MedxSuccess = { ok: true, data: { role: 'assistant', content, citations: r.json?.citations ?? undefined } };
     return NextResponse.json(out);
   } catch (e: any) {
-    return errorJSON('server_exception', e?.message || 'Unexpected server error');
+    console.error('MedX /api/medx handler exception:', e);
+    return jerror('server_exception', e?.message || 'Unexpected server error');
   }
 }
+


### PR DESCRIPTION
## Summary
- Wrap `/api/medx` upstream calls in robust error handling and log failures
- Guard chat client against invalid JSON payloads from the API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2ff26d124832fbfd15fc5b50ab051