### PR TITLE
Route follow-up chips through chat API

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,28 +1,68 @@
 import { NextRequest, NextResponse } from 'next/server';
-export async function POST(req: NextRequest){
-  const { question, role } = await req.json();
-  const base = process.env.LLM_BASE_URL;
-  const model = process.env.LLM_MODEL_ID || 'llama3-8b-instruct';
-  if(!base) return new NextResponse("LLM_BASE_URL not set", { status: 500 });
 
-  // OpenAI-compatible completion (v1/chat/completions)
-  const res = await fetch(`${base.replace(/\/$/,'')}/chat/completions`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      model,
-      messages: [
-        { role: 'system', content: role==='clinician' ? 'You are a clinical assistant. Be precise, cite sources if mentioned. Avoid medical advice; provide evidence and guideline pointers.' : 'You explain in simple, friendly language for patients. Avoid medical advice; encourage consulting a doctor.' },
-        { role: 'user', content: question }
-      ],
-      temperature: 0.2
-    })
-  });
-  if(!res.ok){
-    const t = await res.text();
-    return new NextResponse(`LLM error: ${t}`, { status: 500 });
-  }
-  const json = await res.json();
-  const text = json.choices?.[0]?.message?.content || "";
-  return new NextResponse(text, { headers: { 'Content-Type': 'text/plain; charset=utf-8' }});
+function jerr(code: string, message: string, status = 200) {
+  return NextResponse.json({ ok: false, error: { code, message } }, { status });
 }
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => null);
+    if (!body) return jerr('bad_request', 'Invalid JSON payload');
+
+    const BASE = process.env.LLM_BASE_URL;
+    const KEY = process.env.LLM_API_KEY;
+    const MODEL = process.env.LLM_MODEL_ID || process.env.LLM_MODEL || 'llama-3.1-8b-instant';
+
+    if (!BASE) return jerr('missing_base_url', 'LLM_BASE_URL not set');
+    if (!KEY) return jerr('missing_api_key', 'LLM_API_KEY not set');
+
+    const messages: any[] = body.messages || [];
+    if (!messages.length && body.question) {
+      const role = body.role;
+      messages.push({
+        role: 'system',
+        content:
+          role === 'clinician'
+            ? 'You are a clinical assistant. Be precise, cite sources if mentioned. Avoid medical advice; provide evidence and guideline pointers.'
+            : 'You explain in simple, friendly language for patients. Avoid medical advice; encourage consulting a doctor.',
+      });
+      messages.push({ role: 'user', content: body.question });
+    }
+
+    const endpoint = new URL('/v1/chat/completions', BASE).toString();
+
+    const upstream = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${KEY}`,
+      },
+      body: JSON.stringify({ model: MODEL, messages, temperature: 0.3 }),
+    });
+
+    const text = await upstream.text();
+    let json: any = null;
+    try {
+      json = JSON.parse(text);
+    } catch {}
+
+    if (!upstream.ok) {
+      const msg = json?.error?.message || text || `HTTP ${upstream.status}`;
+      return jerr('llm_upstream_error', msg.slice(0, 400));
+    }
+
+    const content =
+      json?.choices?.[0]?.message?.content ??
+      json?.message?.content ??
+      json?.output_text ??
+      '';
+
+    if (!content) return jerr('empty_completion', 'LLM returned empty content');
+
+    return NextResponse.json({ ok: true, data: { content } });
+  } catch (e: any) {
+    console.error('api/chat exception', e);
+    return jerr('server_exception', e?.message || 'Unexpected server error');
+  }
+}
+

--- a/components/FollowUpChips.tsx
+++ b/components/FollowUpChips.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+export default function FollowUpChips({
+  items,
+  onClick,
+}: {
+  items: Array<{ id: string; label: string }>;
+  onClick: (id: string, label?: string) => void;
+}) {
+  if (!items?.length) return null;
+  return (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {items.map((it) => (
+        <button
+          key={it.id}
+          onClick={() => onClick(it.id, it.label)}
+          className="px-3 py-1 text-sm rounded-full border"
+        >
+          {it.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Add FollowUpChips component for ID-based chip rendering
- Handle chip clicks via /api/chat with award search prompt when applicable
- Wrap /api/chat backend responses and errors in consistent JSON

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3180802a8832fbf574c45fab770ce