### PR TITLE
feat: add upload API and helper

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs'; // file uploads need node runtime
+
+// 10 MB default cap (adjust as needed)
+const MAX_BYTES = 10 * 1024 * 1024;
+const ALLOWED = [
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'text/plain'
+];
+
+export async function POST(req: NextRequest) {
+  try {
+    // IMPORTANT: for App Router route handlers, use formData() for multipart
+    const form = await req.formData();
+    const file = form.get('file') as File | null;
+
+    if (!file) {
+      return NextResponse.json({ ok: false, error: 'No file uploaded' }, { status: 400 });
+    }
+
+    if (!ALLOWED.includes(file.type)) {
+      return NextResponse.json({ ok: false, error: `Unsupported file type: ${file.type}` }, { status: 415 });
+    }
+
+    if (file.size > MAX_BYTES) {
+      return NextResponse.json({ ok: false, error: `File too large (> ${MAX_BYTES} bytes)` }, { status: 413 });
+    }
+
+    // Read into ArrayBuffer/Buffer
+    const buf = Buffer.from(await file.arrayBuffer());
+
+    // 👉 TODO: plug in your existing OCR/text-extraction here
+    // For now we just return metadata and a tiny preview of bytes
+    const preview = buf.subarray(0, 32).toString('hex');
+
+    // Example: you might route by type later
+    // if (file.type === 'application/pdf') { ...extractPdfText(buf) }
+    // if (file.type.startsWith('image/')) { ...ocrImage(buf) }
+
+    return NextResponse.json({
+      ok: true,
+      name: file.name,
+      type: file.type,
+      size: file.size,
+      previewHexFirst32: preview
+      // extractedText: '...', // <-- add when OCR hooked up
+    });
+  } catch (e: any) {
+    // Always return JSON so the client can parse without crashing
+    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 });
+  }
+}
+

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -1,0 +1,24 @@
+export async function safeJson(res: Response) {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { ok: res.ok, raw: text } as any;
+  }
+}
+
+export async function uploadFile(file: File) {
+  const fd = new FormData();
+  fd.append('file', file);
+
+  const res = await fetch('/api/upload', {
+    method: 'POST',
+    body: fd // DO NOT set Content-Type; the browser will set proper boundary
+  });
+
+  const data = await safeJson(res);
+  if (!res.ok || !data?.ok) {
+    throw new Error(data?.error || `Upload failed (${res.status})`);
+  }
+  return data;
+}

--- a/lib/upload.ts
+++ b/lib/upload.ts
@@ -13,7 +13,7 @@ export async function uploadFile(file: File) {
 
   const res = await fetch('/api/upload', {
     method: 'POST',
-    body: fd // DO NOT set Content-Type; the browser will set proper boundary
+    body: fd // DO NOT set Content-Type manually
   });
 
   const data = await safeJson(res);


### PR DESCRIPTION
## Summary
- implement `/api/upload` route for validating and previewing uploaded files
- add `uploadFile` and `safeJson` helper to send FormData and parse responses

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b40c0c11d4832f8d9aea4befc6aaf2