### PR TITLE
feat: add upload API route and client helper

### DIFF
--- a/app/api/ping/route.ts
+++ b/app/api/ping/route.ts
@@ -1,0 +1,3 @@
+import { NextResponse } from 'next/server';
+export const runtime = 'edge';
+export async function GET() { return NextResponse.json({ ok: true }); }

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'nodejs'; // required for file handling libs
+
+// Health check: GET /api/upload
+export async function GET() {
+  return NextResponse.json({ ok: true, route: '/api/upload', runtime: 'nodejs' });
+}
+
+// Upload: POST /api/upload (multipart/form-data)
+export async function POST(req: NextRequest) {
+  try {
+    // Important: App Router supports multipart via formData()
+    const form = await req.formData();
+    const file = form.get('file') as File | null;
+
+    if (!file) {
+      return NextResponse.json({ ok: false, error: 'No file uploaded' }, { status: 400 });
+    }
+
+    // Read bytes
+    const buf = Buffer.from(await file.arrayBuffer());
+
+    // TODO: (later) plug in pdf-parse / OCR here to produce extractedText
+    // For now, return metadata so client can safely parse JSON
+    return NextResponse.json({
+      ok: true,
+      name: file.name,
+      type: file.type,
+      size: file.size,
+      previewHexFirst32: buf.subarray(0, 32).toString('hex')
+    });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/upload` route for Node runtime file uploads
- wire an edge `/api/ping` health check
- simplify client upload logic with safe JSON parsing

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b41f9b70c4832fa5a167aec51e826a