### PR TITLE
Fix PDF parsing: replace legacy pdfjs import with dynamic pdfjs-dist

### DIFF
--- a/app/api/analyze-doc/route.ts
+++ b/app/api/analyze-doc/route.ts
@@ -1,3 +1,4 @@
+// app/api/analyze-doc/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { extractTextFromPDF } from '@/lib/pdftext';
 
@@ -6,59 +7,212 @@ export const maxDuration = 60;
 
 type DetectedType = 'blood' | 'prescription' | 'other';
 
-function looksLikeBloodReport(text: string) {
+function looksLikeBloodReport(text: string): boolean {
   const t = text.toLowerCase();
-  return (
-    t.includes('hemoglobin') ||
-    t.includes('hematocrit') ||
-    t.includes('wbc') ||
-    t.includes('platelet') ||
-    /\b\d+\s?(mg\/dL|g\/dL|mmol\/L)\b/i.test(text)
-  );
+  const labHints = [
+    'hemoglobin','hematocrit','hct','hb','wbc','rbc','platelet','platelets',
+    'mcv','mch','mchc','rdw','neutrophil','lymphocyte','monocyte','eosinophil','basophil',
+    'glucose','creatinine','bun','sodium','potassium','chloride','bicarbonate','calcium',
+    'alt','ast','alkaline phosphatase','bilirubin','tsh','t3','t4','ldl','hdl','triglycerides'
+  ];
+  let hits = 0;
+  for (const h of labHints) if (t.includes(h)) hits++;
+  const unitish = /\b(\d+(?:\.\d+)?)\s?(mg\/dL|g\/dL|mmol\/L|µIU\/mL|U\/L|fL|pg|%)\b/i;
+  return hits >= 2 || unitish.test(text);
 }
 
-function looksLikePrescription(text: string) {
-  return (
-    /\b\d+\s?(mg|mcg|ml|iu)\b/i.test(text) ||
-    /\b(bid|tid|prn|qd|od)\b/i.test(text)
-  );
+function looksLikePrescription(text: string): boolean {
+  const dose = /\b\d+(\.\d+)?\s?(mg|mcg|g|ml|iu)\b/i;
+  const freq = /\b(qd|od|bid|tid|qid|qhs|qam|prn|po|iv|im|sc|hs|ac|pc|once daily|twice daily|three times)\b/i;
+  const rxWords = /\bprescription\b|\brx\b|\bsig\b|\bdirection\b/i;
+  const medDose = /\b[A-Z][a-zA-Z\-]{2,}\s+\d+(?:\.\d+)?\s?(mg|mcg|g|ml)\b/;
+  let score = 0;
+  if (dose.test(text)) score++;
+  if (freq.test(text)) score++;
+  if (rxWords.test(text.toLowerCase())) score++;
+  if (medDose.test(text)) score++;
+  return score >= 2;
 }
 
+// ----------------- Prescription (RxNorm) helpers -----------------
+function cleanToken(t: string): string {
+  return t
+    .replace(/[^\w\s\-\+\/\.]/g, ' ')
+    .replace(/\b(?:tab(?:let)?|cap(?:sule)?|syrup|susp(?:ension)?|drop(?:s)?|inj(?:ection)?|cream|gel|ointment|soln|solution)\b/gi, ' ')
+    .replace(/\b(\d+(\.\d+)?)(mg|mcg|g|ml|iu)\b/gi, ' ')
+    .replace(/\b(qd|od|bid|tid|qid|qhs|qam|prn|po|iv|im|sc|hs|ac|pc)\b/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+async function rxcuiForName(name: string): Promise<string | null> {
+  const url = `https://rxnav.nlm.nih.gov/REST/rxcui.json?name=${encodeURIComponent(name)}&search=2`;
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) return null;
+  const j = await res.json();
+  const id = (j?.idGroup?.rxnormId?.[0] as string | undefined) ?? null;
+  return id;
+}
+
+async function analyzePrescription(text: string) {
+  const words: string[] = text.split(/[^A-Za-z0-9-]+/).filter((w: string) => w.length > 2);
+  const cleaned: string[] = words.map((w: string) => cleanToken(w)).filter((v: string) => Boolean(v));
+
+  const grams = new Set<string>();
+  for (let i = 0; i < cleaned.length; i++) {
+    grams.add(cleaned[i]);
+    if (i + 1 < cleaned.length) grams.add(`${cleaned[i]} ${cleaned[i + 1]}`);
+    if (i + 2 < cleaned.length) grams.add(`${cleaned[i]} ${cleaned[i + 1]} ${cleaned[i + 2]}`);
+  }
+  const candidates: string[] = Array.from(grams).slice(0, 200);
+
+  const found: Array<{ token: string; rxcui: string }> = [];
+  for (const token of candidates) {
+    try {
+      const rxcui = await rxcuiForName(token);
+      if (rxcui) found.push({ token, rxcui });
+    } catch {}
+  }
+  const meds = Object.values(
+    found.reduce<Record<string, { token: string; rxcui: string }>>((acc, m) => {
+      if (!acc[m.rxcui]) acc[m.rxcui] = m;
+      return acc;
+    }, {})
+  );
+  return { meds };
+}
+
+// ----------------- Blood report helpers -----------------
+const RANGES: Record<string, {unit: string, min: number, max: number, label: string}> = {
+  hemoglobin:{unit:'g/dL',min:12,max:17.5,label:'Hemoglobin'},
+  hb:{unit:'g/dL',min:12,max:17.5,label:'Hemoglobin'},
+  wbc:{unit:'/µL',min:4000,max:11000,label:'WBC'},
+  platelet:{unit:'/µL',min:150000,max:450000,label:'Platelet'},
+  platelets:{unit:'/µL',min:150000,max:450000,label:'Platelet'},
+  rbc:{unit:'M/µL',min:4,max:6,label:'RBC'},
+  hct:{unit:'%',min:36,max:52,label:'Hematocrit'},
+  mcv:{unit:'fL',min:80,max:100,label:'MCV'},
+  mch:{unit:'pg',min:27,max:34,label:'MCH'},
+  mchc:{unit:'g/dL',min:32,max:36,label:'MCHC'},
+  glucose:{unit:'mg/dL',min:70,max:100,label:'Fasting Glucose'},
+  creatinine:{unit:'mg/dL',min:0.6,max:1.3,label:'Creatinine'},
+  bun:{unit:'mg/dL',min:7,max:20,label:'BUN'},
+  sodium:{unit:'mmol/L',min:135,max:145,label:'Sodium'},
+  potassium:{unit:'mmol/L',min:3.5,max:5.1,label:'Potassium'},
+  chloride:{unit:'mmol/L',min:98,max:107,label:'Chloride'},
+  bicarbonate:{unit:'mmol/L',min:22,max:29,label:'Bicarbonate'},
+  calcium:{unit:'mg/dL',min:8.5,max:10.5,label:'Calcium'},
+  alt:{unit:'U/L',min:7,max:56,label:'ALT'},
+  ast:{unit:'U/L',min:10,max:40,label:'AST'},
+  'alkaline phosphatase':{unit:'U/L',min:44,max:147,label:'Alkaline phosphatase'},
+  bilirubin:{unit:'mg/dL',min:0.1,max:1.2,label:'Bilirubin (total)'},
+  tsh:{unit:'µIU/mL',min:0.4,max:4.5,label:'TSH'},
+  t3:{unit:'ng/dL',min:80,max:180,label:'T3'},
+  t4:{unit:'µg/dL',min:5,max:12,label:'T4'},
+  ldl:{unit:'mg/dL',min:0,max:100,label:'LDL (calc)'},
+  hdl:{unit:'mg/dL',min:40,max:100,label:'HDL'},
+  triglycerides:{unit:'mg/dL',min:0,max:150,label:'Triglycerides'},
+};
+
+const VAL_RE = /([A-Za-z][A-Za-z \-\/%()]*[A-Za-z])[^0-9\-]*(-?\d+(?:\.\d+)?)\s*([a-zA-Zµ\/%]+)?/g;
+const normKey = (k: string) => k.toLowerCase().replace(/[^a-z]/g, '');
+
+function labCandidates(text: string) {
+  const out: { name: string; value: number; unit?: string }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = VAL_RE.exec(text)) !== null) {
+    const name = m[1].trim();
+    const value = Number(m[2]);
+    const unit = m[3]?.trim();
+    if (Number.isFinite(value)) out.push({ name, value, unit });
+  }
+  return out;
+}
+
+function labMap(cs: ReturnType<typeof labCandidates>) {
+  return cs.map(c => {
+    const k = normKey(c.name);
+    const rk = Object.keys(RANGES).find(key => k.includes(normKey(key)));
+    if (!rk) return { label: c.name, key: k, value: c.value, unit: c.unit, status: 'unknown' as const };
+    const ref = RANGES[rk];
+    const unit = c.unit || ref.unit;
+    let status: 'low'|'normal'|'high' = 'normal';
+    if (c.value < ref.min) status = 'low'; else if (c.value > ref.max) status = 'high';
+    return { label: ref.label, key: rk, value: c.value, unit, ref: { min: ref.min, max: ref.max, unit: ref.unit }, status };
+  });
+}
+
+function labSummary(items: any[]) {
+  if (!items.length) return 'No recognizable lab values were found in the report text.';
+  const highs = items.filter(i => i.status === 'high').map(i => i.label);
+  const lows  = items.filter(i => i.status === 'low').map(i => i.label);
+  if (!highs.length && !lows.length) return 'All parsed lab values are within common adult reference ranges.';
+  const parts: string[] = [];
+  if (highs.length) parts.push(`High: ${highs.join(', ')}`);
+  if (lows.length)  parts.push(`Low: ${lows.join(', ')}`);
+  parts.push('Ranges vary by lab/age/sex; discuss with your clinician.');
+  return parts.join(' \u2022 ');
+}
+
+async function analyzeBlood(text: string) {
+  const items = labMap(labCandidates(text));
+  const summary = labSummary(items);
+  return { values: items, summary,
+    disclaimer: 'Automated summary for education only; not medical advice. Please consult your clinician.' };
+}
+
+// ----------------- Main handler -----------------
 export async function POST(req: NextRequest) {
   try {
     const form = await req.formData();
     const file = form.get('file') as File | null;
-    if (!file) return NextResponse.json({ ok: false, error: 'No file' }, { status: 400 });
+    if (!file) return NextResponse.json({ ok:false, error:'No file' }, { status: 400 });
     if (file.type !== 'application/pdf') {
-      return NextResponse.json({ ok: false, error: 'Only PDF supported' }, { status: 415 });
+      return NextResponse.json({ ok:false, error:'Only PDF supported' }, { status: 415 });
     }
 
     const buf = Buffer.from(await file.arrayBuffer());
+
     let text = '';
     try {
       text = await extractTextFromPDF(buf);
-    } catch (e: any) {
-      return NextResponse.json(
-        { ok: false, error: `PDF parse error: ${e?.message || e}` },
-        { status: 200 }
-      );
+    } catch (e:any) {
+      return NextResponse.json({ ok:false, error:`PDF parse error: ${e?.message||e}` }, { status: 200 });
     }
 
     if (!text) {
       return NextResponse.json({
         ok: true,
-        detectedType: 'other',
+        detectedType: 'other' as DetectedType,
         preview: '',
-        note: 'No selectable text found (may be scanned).',
+        note: 'No selectable text found (may be a scanned PDF). Enable OCR later.',
       });
     }
 
-    let detected: DetectedType = 'other';
-    if (looksLikeBloodReport(text)) detected = 'blood';
-    else if (looksLikePrescription(text)) detected = 'prescription';
+    let detectedType: DetectedType = 'other';
+    if (looksLikeBloodReport(text)) detectedType = 'blood';
+    else if (looksLikePrescription(text)) detectedType = 'prescription';
 
-    return NextResponse.json({ ok: true, detectedType: detected, preview: text.slice(0, 1000) });
-  } catch (e: any) {
-    return NextResponse.json({ ok: false, error: String(e.message) }, { status: 500 });
+    if (detectedType === 'blood') {
+      const blood = await analyzeBlood(text);
+      return NextResponse.json({ ok:true, detectedType, ...blood });
+    }
+
+    if (detectedType === 'prescription') {
+      const rx = await analyzePrescription(text);
+      return NextResponse.json({
+        ok:true,
+        detectedType,
+        ...rx,
+        note: rx.meds.length ? undefined : 'No clear medicines detected.'
+      });
+    }
+
+    // other
+    const preview = text.replace(/\s+/g, ' ').slice(0, 1000);
+    return NextResponse.json({ ok:true, detectedType, preview });
+  } catch (e:any) {
+    return NextResponse.json({ ok:false, error:String(e?.message||e) }, { status: 500 });
   }
 }
+

--- a/app/api/analyze-doc/route.ts
+++ b/app/api/analyze-doc/route.ts
@@ -33,12 +33,15 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ ok: false, error: 'Only PDF supported' }, { status: 415 });
     }
 
-    const buf = await file.arrayBuffer();
+    const buf = Buffer.from(await file.arrayBuffer());
     let text = '';
     try {
       text = await extractTextFromPDF(buf);
     } catch (e: any) {
-      return NextResponse.json({ ok: false, error: `PDF.js parse error: ${e?.message}` }, { status: 200 });
+      return NextResponse.json(
+        { ok: false, error: `PDF parse error: ${e?.message || e}` },
+        { status: 200 }
+      );
     }
 
     if (!text) {

--- a/lib/pdftext.ts
+++ b/lib/pdftext.ts
@@ -1,35 +1,45 @@
-[23:10:31.552] Running build in Washington, D.C., USA (East) – iad1
-[23:10:31.553] Build machine configuration: 4 cores, 8 GB
-[23:10:31.571] Cloning github.com/lakshay321123/medx (Branch: main, Commit: 616ab89)
-[23:10:31.810] Cloning completed: 237.000ms
-[23:10:33.755] Restored build cache from previous deployment (HmTkVxnNBDxc1CUQgWpKggrmaj8P)
-[23:10:34.312] Running "vercel build"
-[23:10:34.738] Vercel CLI 46.1.0
-[23:10:35.067] Installing dependencies...
-[23:10:36.543] 
-[23:10:36.543] up to date in 1s
-[23:10:36.543] 
-[23:10:36.544] 144 packages are looking for funding
-[23:10:36.544]   run `npm fund` for details
-[23:10:36.579] Detected Next.js version: 14.2.4
-[23:10:36.584] Running "npm run build"
-[23:10:36.713] 
-[23:10:36.713] > medx@3.0.0 build
-[23:10:36.713] > next build
-[23:10:36.713] 
-[23:10:37.455]   ▲ Next.js 14.2.4
-[23:10:37.456] 
-[23:10:37.527]    Creating an optimized production build ...
-[23:10:40.266] Failed to compile.
-[23:10:40.267] 
-[23:10:40.267] ./lib/pdftext.ts
-[23:10:40.267] Module not found: Can't resolve 'pdfjs-dist/legacy/build/pdf.js'
-[23:10:40.268] 
-[23:10:40.268] https://nextjs.org/docs/messages/module-not-found
-[23:10:40.268] 
-[23:10:40.269] Import trace for requested module:
-[23:10:40.269] ./app/api/analyze-doc/route.ts
-[23:10:40.269] 
-[23:10:40.291] 
-[23:10:40.301] > Build failed because of webpack errors
-[23:10:40.335] Error: Command "npm run build" exited with 1
+// lib/pdftext.ts
+// PDF text extraction using pdfjs-dist with a dynamic import
+// Works in Next.js API routes (Node runtime)
+
+export async function extractTextFromPDF(
+  buf: ArrayBuffer | Buffer | Uint8Array
+): Promise<string> {
+  // Dynamic import keeps Next.js bundler happy and avoids legacy paths
+  // @ts-ignore - no official TS types provided
+  const pdfjs: any = await import('pdfjs-dist');
+  const { getDocument } = pdfjs;
+
+  // Normalize input to Uint8Array
+  const uint8 =
+    buf instanceof Uint8Array
+      ? buf
+      : Buffer.isBuffer(buf)
+      ? new Uint8Array(buf)
+      : new Uint8Array(buf);
+
+  // Disable the worker in server routes
+  const task = getDocument({
+    data: uint8,
+    disableWorker: true,
+    isEvalSupported: false,
+    useSystemFonts: true,
+    disableFontFace: true,
+    disableRange: true,
+    disableStream: true,
+  });
+
+  const pdf = await task.promise;
+
+  let text = '';
+  for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+    const page = await pdf.getPage(pageNum);
+    const content = await page.getTextContent();
+    const line = (content.items as any[])
+      .map((it: any) => (typeof it?.str === 'string' ? it.str : ''))
+      .join(' ');
+    text += line + '\n';
+  }
+
+  return text.replace(/\s+\n/g, '\n').trim();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "14.2.4",
         "next-themes": "0.3.0",
         "pdf-parse": "1.1.1",
+        "pdfjs-dist": "^4.2.67",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tesseract.js": "5.0.5"
@@ -330,6 +331,191 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.78.tgz",
+      "integrity": "sha512-YaBHJvT+T1DoP16puvWM6w46Lq3VhwKIJ8th5m1iEJyGh7mibk5dT7flBvMQ1EH1LYmMzXJ+OUhu+8wQ9I6u7g==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.78",
+        "@napi-rs/canvas-darwin-arm64": "0.1.78",
+        "@napi-rs/canvas-darwin-x64": "0.1.78",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.78",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.78",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.78",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.78",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.78",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.78",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.78"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.78.tgz",
+      "integrity": "sha512-N1ikxztjrRmh8xxlG5kYm1RuNr8ZW1EINEDQsLhhuy7t0pWI/e7SH91uFVLZKCMDyjel1tyWV93b5fdCAi7ggw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.78.tgz",
+      "integrity": "sha512-FA3aCU3G5yGc74BSmnLJTObnZRV+HW+JBTrsU+0WVVaNyVKlb5nMvYAQuieQlRVemsAA2ek2c6nYtHh6u6bwFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.78.tgz",
+      "integrity": "sha512-xVij69o9t/frixCDEoyWoVDKgE3ksLGdmE2nvBWVGmoLu94MWUlv2y4Qzf5oozBmydG5Dcm4pRHFBM7YWa1i6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.78.tgz",
+      "integrity": "sha512-aSEXrLcIpBtXpOSnLhTg4jPsjJEnK7Je9KqUdAWjc7T8O4iYlxWxrXFIF8rV8J79h5jNdScgZpAUWYnEcutR3g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.78.tgz",
+      "integrity": "sha512-dlEPRX1hLGKaY3UtGa1dtkA1uGgFITn2mDnfI6YsLlYyLJQNqHx87D1YTACI4zFCUuLr/EzQDzuX+vnp9YveVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.78.tgz",
+      "integrity": "sha512-TsCfjOPZtm5Q/NO1EZHR5pwDPSPjPEttvnv44GL32Zn1uvudssjTLbvaG1jHq81Qxm16GTXEiYLmx4jOLZQYlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.78.tgz",
+      "integrity": "sha512-+cpTTb0GDshEow/5Fy8TpNyzaPsYb3clQIjgWRmzRcuteLU+CHEU/vpYvAcSo7JxHYPJd8fjSr+qqh+nI5AtmA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.78.tgz",
+      "integrity": "sha512-wxRcvKfvYBgtrO0Uy8OmwvjlnTcHpY45LLwkwVNIWHPqHAsyoTyG/JBSfJ0p5tWRzMOPDCDqdhpIO4LOgXjeyg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.78.tgz",
+      "integrity": "sha512-vQFOGwC9QDP0kXlhb2LU1QRw/humXgcbVp8mXlyBqzc/a0eijlLF9wzyarHC1EywpymtS63TAj8PHZnhTYN6hg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.78.tgz",
+      "integrity": "sha512-/eKlTZBtGUgpRKalzOzRr6h7KVSuziESWXgBcBnXggZmimwIJWPJlEcbrx5Tcwj8rPuZiANXQOG9pPgy9Q4LTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4426,6 +4612,18 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "marked": "12.0.2",
     "next": "14.2.4",
     "next-themes": "0.3.0",
+    "pdfjs-dist": "^4.2.67",
     "pdf-parse": "1.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "baseUrl": ".",
     "paths": { "@/*": ["*"] }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types"],
   "exclude": ["node_modules"]
 }

--- a/types/pdfjs-dist.d.ts
+++ b/types/pdfjs-dist.d.ts
@@ -1,0 +1,1 @@
+declare module 'pdfjs-dist';

--- a/types/pdfjs-legacy.d.ts
+++ b/types/pdfjs-legacy.d.ts
@@ -1,3 +1,0 @@
-// types/pdfjs-legacy.d.ts
-declare module 'pdfjs-dist/legacy/build/pdf.js';
-declare module 'pdfjs-dist/legacy/build/pdf';


### PR DESCRIPTION
## Summary
- replace legacy pdfjs code with dynamic `pdfjs-dist` helper for extracting PDF text
- update analyze-doc API route to use new helper
- add `pdfjs-dist` type stub and include project types in TypeScript config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b48cb60be0832fb008a0751ff4a79a