### PR TITLE
Add PDF analysis utilities and upload test

### DIFF
--- a/app/api/analyze-doc/route.ts
+++ b/app/api/analyze-doc/route.ts
@@ -13,40 +13,51 @@ function looksLikeBloodReport(text: string) {
     t.includes('hematocrit') ||
     t.includes('wbc') ||
     t.includes('platelet') ||
-    /\b\d+\s?(mg\/dL|g\/dL|mmol\/L)\b/i.test(text)
+    /\b\d+\s?(mg\/dL|g\/dL|mmol\/L|g\/L|µIU\/mL|U\/L|%|fL|pg)\b/i.test(text)
+  );
+}
+function looksLikePrescription(text: string) {
+  return (
+    /\b\d+\s?(mg|mcg|ml|iu|g)\b/i.test(text) ||
+    /\b(bid|tid|prn|qd|od|qhs|qam|po|iv|im|sc|ac|pc)\b/i.test(text)
   );
 }
 
-function looksLikePrescription(text: string) {
-  return (
-    /\b\d+\s?(mg|mcg|ml|iu)\b/i.test(text) ||
-    /\b(bid|tid|prn|qd|od)\b/i.test(text)
-  );
+export async function GET() {
+  // quick health check
+  return NextResponse.json({ ok: true, ping: 'analyze-doc-alive' });
 }
 
 export async function POST(req: NextRequest) {
   try {
     const form = await req.formData();
     const file = form.get('file') as File | null;
-    if (!file) return NextResponse.json({ ok: false, error: 'No file' }, { status: 400 });
+
+    if (!file) {
+      return NextResponse.json({ ok: false, error: 'No file' }, { status: 400 });
+    }
     if (file.type !== 'application/pdf') {
       return NextResponse.json({ ok: false, error: 'Only PDF supported' }, { status: 415 });
     }
 
-    const buf = await file.arrayBuffer();
     let text = '';
     try {
+      const buf = Buffer.from(await file.arrayBuffer());
       text = await extractTextFromPDF(buf);
-    } catch (e: any) {
-      return NextResponse.json({ ok: false, error: `PDF.js parse error: ${e?.message}` }, { status: 200 });
+    } catch (err: any) {
+      console.error('PDF parse error:', err);
+      return NextResponse.json(
+        { ok: false, error: `PDF parse error: ${err?.message || String(err)}` },
+        { status: 200 }
+      );
     }
 
     if (!text) {
       return NextResponse.json({
         ok: true,
-        detectedType: 'other',
+        detectedType: 'other' as DetectedType,
         preview: '',
-        note: 'No selectable text found (may be scanned).',
+        note: 'No selectable text found (may be a scanned PDF).',
       });
     }
 
@@ -54,8 +65,13 @@ export async function POST(req: NextRequest) {
     if (looksLikeBloodReport(text)) detected = 'blood';
     else if (looksLikePrescription(text)) detected = 'prescription';
 
-    return NextResponse.json({ ok: true, detectedType: detected, preview: text.slice(0, 1000) });
+    return NextResponse.json({
+      ok: true,
+      detectedType: detected,
+      preview: text.replace(/\s+/g, ' ').slice(0, 1200),
+    });
   } catch (e: any) {
-    return NextResponse.json({ ok: false, error: String(e.message) }, { status: 500 });
+    console.error('analyze-doc fatal:', e);
+    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 });
   }
 }

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,27 +1,27 @@
-// app/api/upload/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 
+export async function GET() {
+  // quick health check
+  return NextResponse.json({ ok: true, ping: 'upload-api-alive' });
+}
+
 export async function POST(req: NextRequest) {
   try {
-    // Forward the multipart/form-data to analyze-doc
     const origin = new URL(req.url).origin;
-
-    // Re-create the FormData, because req.body cannot be safely re-used
     const form = await req.formData();
+
     const upstream = await fetch(`${origin}/api/analyze-doc`, {
       method: 'POST',
-      body: form,            // pass the form directly
+      body: form,
       cache: 'no-store',
     });
 
-    // Always read text first
     let text = '';
     try { text = await upstream.text(); } catch { text = ''; }
 
-    // Guarantee a JSON object back to the client
     if (!text || !text.trim()) {
       return NextResponse.json(
         { ok: false, error: 'Empty response from /api/analyze-doc' },
@@ -29,17 +29,17 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // If upstream is JSON, forward it; else wrap as error
     try {
       const json = JSON.parse(text);
       return NextResponse.json(json, { status: upstream.status });
     } catch {
       return NextResponse.json(
-        { ok: false, error: 'Upstream not JSON', raw: text },
+        { ok: false, error: 'Upstream not JSON', raw: text.slice(0, 2000) },
         { status: upstream.status || 502 }
       );
     }
   } catch (e: any) {
+    console.error('upload proxy fatal:', e);
     return NextResponse.json(
       { ok: false, error: String(e?.message || e) },
       { status: 500 }

--- a/app/upload-test/page.tsx
+++ b/app/upload-test/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+import React, { useState } from 'react';
+
+export default function UploadTestPage() {
+  const [out, setOut] = useState<string>('');
+  const [busy, setBusy] = useState(false);
+
+  async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setBusy(true); setOut('');
+    try {
+      const fd = new FormData();
+      fd.append('file', f);
+      const res = await fetch('/api/upload', { method: 'POST', body: fd });
+      const txt = await res.text();
+      setOut(`HTTP ${res.status}\n\n${txt}`);
+    } catch (err: any) {
+      setOut(`CLIENT ERROR: ${String(err?.message || err)}`);
+    } finally {
+      setBusy(false);
+      e.currentTarget.value = '';
+    }
+  }
+
+  return (
+    <div style={{maxWidth:720, margin:'40px auto', padding:'16px', fontFamily:'system-ui, sans-serif'}}>
+      <h1>Upload Test</h1>
+      <input type="file" accept="application/pdf" onChange={onFile} disabled={busy}/>
+      <pre style={{whiteSpace:'pre-wrap', background:'#f7f7f7', padding:'12px', borderRadius:8, marginTop:16}}>
+        {out || 'Response will appear here...'}
+      </pre>
+      <p style={{color:'#666', fontSize:13}}>
+        Tip: Open <code>/api/upload</code> and <code>/api/analyze-doc</code> directly in browser to see health JSON.
+      </p>
+    </div>
+  );
+}

--- a/lib/pdftext.ts
+++ b/lib/pdftext.ts
@@ -1,35 +1,41 @@
-[23:10:31.552] Running build in Washington, D.C., USA (East) – iad1
-[23:10:31.553] Build machine configuration: 4 cores, 8 GB
-[23:10:31.571] Cloning github.com/lakshay321123/medx (Branch: main, Commit: 616ab89)
-[23:10:31.810] Cloning completed: 237.000ms
-[23:10:33.755] Restored build cache from previous deployment (HmTkVxnNBDxc1CUQgWpKggrmaj8P)
-[23:10:34.312] Running "vercel build"
-[23:10:34.738] Vercel CLI 46.1.0
-[23:10:35.067] Installing dependencies...
-[23:10:36.543] 
-[23:10:36.543] up to date in 1s
-[23:10:36.543] 
-[23:10:36.544] 144 packages are looking for funding
-[23:10:36.544]   run `npm fund` for details
-[23:10:36.579] Detected Next.js version: 14.2.4
-[23:10:36.584] Running "npm run build"
-[23:10:36.713] 
-[23:10:36.713] > medx@3.0.0 build
-[23:10:36.713] > next build
-[23:10:36.713] 
-[23:10:37.455]   ▲ Next.js 14.2.4
-[23:10:37.456] 
-[23:10:37.527]    Creating an optimized production build ...
-[23:10:40.266] Failed to compile.
-[23:10:40.267] 
-[23:10:40.267] ./lib/pdftext.ts
-[23:10:40.267] Module not found: Can't resolve 'pdfjs-dist/legacy/build/pdf.js'
-[23:10:40.268] 
-[23:10:40.268] https://nextjs.org/docs/messages/module-not-found
-[23:10:40.268] 
-[23:10:40.269] Import trace for requested module:
-[23:10:40.269] ./app/api/analyze-doc/route.ts
-[23:10:40.269] 
-[23:10:40.291] 
-[23:10:40.301] > Build failed because of webpack errors
-[23:10:40.335] Error: Command "npm run build" exited with 1
+// lib/pdftext.ts
+// PDF text extraction using pdfjs-dist with a dynamic import (Next.js safe)
+
+export async function extractTextFromPDF(
+  buf: ArrayBuffer | Buffer | Uint8Array
+): Promise<string> {
+  // @ts-ignore - pdfjs-dist types are partial
+  const pdfjs: any = await import('pdfjs-dist');
+  const { getDocument } = pdfjs;
+
+  const uint8 =
+    buf instanceof Uint8Array
+      ? buf
+      : Buffer.isBuffer(buf)
+      ? new Uint8Array(buf)
+      : new Uint8Array(buf);
+
+  const task = getDocument({
+    data: uint8,
+    disableWorker: true,
+    isEvalSupported: false,
+    useSystemFonts: true,
+    disableFontFace: true,
+    disableRange: true,
+    disableStream: true,
+  });
+
+  const pdf = await task.promise;
+
+  let text = '';
+  for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+    const page = await pdf.getPage(pageNum);
+    const content = await page.getTextContent();
+    const line = (content.items as any[])
+      .map((it: any) => (typeof it?.str === 'string' ? it.str : ''))
+      .join(' ');
+    text += line + '\n';
+  }
+
+  return text.replace(/\s+\n/g, '\n').trim();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "14.2.4",
         "next-themes": "0.3.0",
         "pdf-parse": "1.1.1",
+        "pdfjs-dist": "5.4.149",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tesseract.js": "5.0.5"
@@ -330,6 +331,191 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.78.tgz",
+      "integrity": "sha512-YaBHJvT+T1DoP16puvWM6w46Lq3VhwKIJ8th5m1iEJyGh7mibk5dT7flBvMQ1EH1LYmMzXJ+OUhu+8wQ9I6u7g==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.78",
+        "@napi-rs/canvas-darwin-arm64": "0.1.78",
+        "@napi-rs/canvas-darwin-x64": "0.1.78",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.78",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.78",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.78",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.78",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.78",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.78",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.78"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.78.tgz",
+      "integrity": "sha512-N1ikxztjrRmh8xxlG5kYm1RuNr8ZW1EINEDQsLhhuy7t0pWI/e7SH91uFVLZKCMDyjel1tyWV93b5fdCAi7ggw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.78.tgz",
+      "integrity": "sha512-FA3aCU3G5yGc74BSmnLJTObnZRV+HW+JBTrsU+0WVVaNyVKlb5nMvYAQuieQlRVemsAA2ek2c6nYtHh6u6bwFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.78.tgz",
+      "integrity": "sha512-xVij69o9t/frixCDEoyWoVDKgE3ksLGdmE2nvBWVGmoLu94MWUlv2y4Qzf5oozBmydG5Dcm4pRHFBM7YWa1i6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.78.tgz",
+      "integrity": "sha512-aSEXrLcIpBtXpOSnLhTg4jPsjJEnK7Je9KqUdAWjc7T8O4iYlxWxrXFIF8rV8J79h5jNdScgZpAUWYnEcutR3g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.78.tgz",
+      "integrity": "sha512-dlEPRX1hLGKaY3UtGa1dtkA1uGgFITn2mDnfI6YsLlYyLJQNqHx87D1YTACI4zFCUuLr/EzQDzuX+vnp9YveVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.78.tgz",
+      "integrity": "sha512-TsCfjOPZtm5Q/NO1EZHR5pwDPSPjPEttvnv44GL32Zn1uvudssjTLbvaG1jHq81Qxm16GTXEiYLmx4jOLZQYlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.78.tgz",
+      "integrity": "sha512-+cpTTb0GDshEow/5Fy8TpNyzaPsYb3clQIjgWRmzRcuteLU+CHEU/vpYvAcSo7JxHYPJd8fjSr+qqh+nI5AtmA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.78.tgz",
+      "integrity": "sha512-wxRcvKfvYBgtrO0Uy8OmwvjlnTcHpY45LLwkwVNIWHPqHAsyoTyG/JBSfJ0p5tWRzMOPDCDqdhpIO4LOgXjeyg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.78.tgz",
+      "integrity": "sha512-vQFOGwC9QDP0kXlhb2LU1QRw/humXgcbVp8mXlyBqzc/a0eijlLF9wzyarHC1EywpymtS63TAj8PHZnhTYN6hg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.78.tgz",
+      "integrity": "sha512-/eKlTZBtGUgpRKalzOzRr6h7KVSuziESWXgBcBnXggZmimwIJWPJlEcbrx5Tcwj8rPuZiANXQOG9pPgy9Q4LTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4426,6 +4612,18 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.149",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.149.tgz",
+      "integrity": "sha512-Xe8/1FMJEQPUVSti25AlDpwpUm2QAVmNOpFP0SIahaPIOKBKICaefbzogLdwey3XGGoaP4Lb9wqiw2e9Jqp0LA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.77"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "marked": "12.0.2",
     "next": "14.2.4",
     "next-themes": "0.3.0",
+    "pdfjs-dist": "5.4.149",
     "pdf-parse": "1.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,6 @@
     "baseUrl": ".",
     "paths": { "@/*": ["*"] }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "types/**/*.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]
 }

--- a/types/pdfjs-dist.d.ts
+++ b/types/pdfjs-dist.d.ts
@@ -1,0 +1,1 @@
+declare module 'pdfjs-dist';


### PR DESCRIPTION
## Summary
- add PDF.js-based helper for extracting text server-side
- add `/api/analyze-doc` and `/api/upload` endpoints with health checks and robust JSON handling
- add `/upload-test` page to exercise upload pipeline and view raw results
- include stub types and tsconfig support for pdfjs-dist

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b52b431790832f874ba9ab2eb6863f