### PR TITLE
Ensure upload APIs always return JSON

### DIFF
--- a/app/api/analyze-doc/route.ts
+++ b/app/api/analyze-doc/route.ts
@@ -13,40 +13,43 @@ function looksLikeBloodReport(text: string) {
     t.includes('hematocrit') ||
     t.includes('wbc') ||
     t.includes('platelet') ||
-    /\b\d+\s?(mg\/dL|g\/dL|mmol\/L)\b/i.test(text)
+    /\b\d+\s?(mg\/dL|g\/dL|mmol\/L|g\/L|µIU\/mL|U\/L|%|fL|pg)\b/i.test(text)
+  );
+}
+function looksLikePrescription(text: string) {
+  return (
+    /\b\d+\s?(mg|mcg|ml|iu|g)\b/i.test(text) ||
+    /\b(bid|tid|prn|qd|od|qhs|qam|po|iv|im|sc|ac|pc)\b/i.test(text)
   );
 }
 
-function looksLikePrescription(text: string) {
-  return (
-    /\b\d+\s?(mg|mcg|ml|iu)\b/i.test(text) ||
-    /\b(bid|tid|prn|qd|od)\b/i.test(text)
-  );
+export async function GET() {
+  return NextResponse.json({ ok: true, ping: 'analyze-doc-alive' });
 }
 
 export async function POST(req: NextRequest) {
   try {
     const form = await req.formData();
     const file = form.get('file') as File | null;
-    if (!file) return NextResponse.json({ ok: false, error: 'No file' }, { status: 400 });
-    if (file.type !== 'application/pdf') {
-      return NextResponse.json({ ok: false, error: 'Only PDF supported' }, { status: 415 });
-    }
 
-    const buf = await file.arrayBuffer();
+    if (!file) return NextResponse.json({ ok:false, error:'No file' }, { status:400 });
+    if (file.type !== 'application/pdf')
+      return NextResponse.json({ ok:false, error:'Only PDF supported' }, { status:415 });
+
     let text = '';
     try {
+      const buf = Buffer.from(await file.arrayBuffer());
       text = await extractTextFromPDF(buf);
-    } catch (e: any) {
-      return NextResponse.json({ ok: false, error: `PDF.js parse error: ${e?.message}` }, { status: 200 });
+    } catch (err: any) {
+      return NextResponse.json({ ok:false, error:`PDF parse error: ${err?.message || String(err)}` }, { status:200 });
     }
 
     if (!text) {
       return NextResponse.json({
-        ok: true,
-        detectedType: 'other',
-        preview: '',
-        note: 'No selectable text found (may be scanned).',
+        ok:true,
+        detectedType:'other' as DetectedType,
+        preview:'',
+        note:'No selectable text found (may be a scanned PDF).',
       });
     }
 
@@ -54,8 +57,12 @@ export async function POST(req: NextRequest) {
     if (looksLikeBloodReport(text)) detected = 'blood';
     else if (looksLikePrescription(text)) detected = 'prescription';
 
-    return NextResponse.json({ ok: true, detectedType: detected, preview: text.slice(0, 1000) });
+    return NextResponse.json({
+      ok:true,
+      detectedType: detected,
+      preview: text.replace(/\s+/g, ' ').slice(0, 1200),
+    });
   } catch (e: any) {
-    return NextResponse.json({ ok: false, error: String(e.message) }, { status: 500 });
+    return NextResponse.json({ ok:false, error:String(e?.message || e) }, { status:500 });
   }
 }

--- a/app/api/reports/blood/route.ts
+++ b/app/api/reports/blood/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { extractTextFromPDF } from '@/lib/pdftext';
 
 export const runtime = 'nodejs';
 
@@ -80,10 +81,8 @@ export async function POST(req: NextRequest) {
   if (file.type !== 'application/pdf') return NextResponse.json({ ok: false, error: 'File must be a PDF' }, { status: 415 });
 
   try {
-    const pdf = (await import('pdf-parse')).default;
     const buf = Buffer.from(await file.arrayBuffer());
-    const out = await pdf(buf);
-    const text = (out.text || '').replace(/\u0000/g, '').trim();
+    const text = (await extractTextFromPDF(buf)).replace(/\u0000/g, '').trim();
 
     if (!text) {
       return NextResponse.json({ ok: true, text: '', values: [], summary: 'No selectable text found (may be a scan).' });

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,48 +1,43 @@
-// app/api/upload/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 
+export async function GET() {
+  return NextResponse.json({ ok: true, ping: 'upload-api-alive' });
+}
+
 export async function POST(req: NextRequest) {
   try {
-    // Forward the multipart/form-data to analyze-doc
     const origin = new URL(req.url).origin;
-
-    // Re-create the FormData, because req.body cannot be safely re-used
     const form = await req.formData();
+
     const upstream = await fetch(`${origin}/api/analyze-doc`, {
       method: 'POST',
-      body: form,            // pass the form directly
+      body: form,
       cache: 'no-store',
     });
 
-    // Always read text first
     let text = '';
     try { text = await upstream.text(); } catch { text = ''; }
 
-    // Guarantee a JSON object back to the client
     if (!text || !text.trim()) {
       return NextResponse.json(
-        { ok: false, error: 'Empty response from /api/analyze-doc' },
+        { ok:false, error:'Empty response from /api/analyze-doc' },
         { status: upstream.status || 502 }
       );
     }
 
-    // If upstream is JSON, forward it; else wrap as error
     try {
       const json = JSON.parse(text);
       return NextResponse.json(json, { status: upstream.status });
     } catch {
       return NextResponse.json(
-        { ok: false, error: 'Upstream not JSON', raw: text },
+        { ok:false, error:'Upstream not JSON', raw: text.slice(0, 2000) },
         { status: upstream.status || 502 }
       );
     }
   } catch (e: any) {
-    return NextResponse.json(
-      { ok: false, error: String(e?.message || e) },
-      { status: 500 }
-    );
+    return NextResponse.json({ ok:false, error:String(e?.message || e) }, { status:500 });
   }
 }

--- a/components/UploadPanel.tsx
+++ b/components/UploadPanel.tsx
@@ -1,52 +1,34 @@
 'use client';
 import React, { useRef, useState } from 'react';
 
-type DetectedType = 'blood' | 'prescription' | 'other';
-
 async function safeJson(res: Response) {
-  const text = await res.text();           // never assume JSON
-  try { return JSON.parse(text); }
-  catch { return { ok: res.ok, status: res.status, raw: text }; }
+  const text = await res.text();
+  try { return JSON.parse(text); } catch { return { ok: res.ok, raw: text }; }
 }
 
 export default function UploadPanel() {
   const [busy, setBusy] = useState(false);
-  const [detected, setDetected] = useState<{type:DetectedType, preview?:string, note?:string} | null>(null);
-  const [result, setResult] = useState<any>(null);
+  const [out, setOut] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
   async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
-    const f = e.target.files?.[0];
-    if (!f) return;
+    const file = e.target.files?.[0];
+    if (!file) return;
 
-    setBusy(true);
-    setError(null);
-    setDetected(null);
-    setResult(null);
-
+    setBusy(true); setError(null); setOut('');
     try {
       const fd = new FormData();
-      fd.append('file', f);
+      fd.append('file', file);
 
-      // IMPORTANT: only call the proxy
       const res = await fetch('/api/upload', { method: 'POST', body: fd });
       const data = await safeJson(res);
 
       if (!data || data.ok === false) {
-        const msg = data?.error || `Upload failed (status ${data?.status ?? res.status})`;
-        setError(msg);
-        if (data?.raw) {
-          // surface raw upstream response for debugging
-          setResult({ raw: data.raw });
-        }
-        return;
+        throw new Error(data?.error || 'Upload failed');
       }
 
-      // best-effort UI fields
-      const dtype: DetectedType = (data.detectedType ?? 'other') as DetectedType;
-      setDetected({ type: dtype, preview: data.preview, note: data.note });
-      setResult(data);
+      setOut(JSON.stringify(data, null, 2));
     } catch (err: any) {
       setError(String(err?.message || err));
     } finally {
@@ -56,91 +38,10 @@ export default function UploadPanel() {
   }
 
   return (
-    <div style={{border:'1px solid var(--border,#ddd)', borderRadius:12, padding:16, display:'grid', gap:12}}>
-      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', gap:12 }}>
-        <div style={{ fontWeight:600 }}>Upload a medical PDF</div>
-        <label style={{
-          display:'inline-flex', alignItems:'center', gap:8, padding:'8px 12px',
-          border:'1px solid #ccc', borderRadius:8, cursor: busy ? 'default' : 'pointer',
-          background: busy ? '#f0f0f0' : 'white', opacity: busy ? 0.7 : 1
-        }}>
-          <span>{busy ? 'Processing…' : 'Choose PDF'}</span>
-          <input ref={fileRef} type="file" accept="application/pdf" onChange={onFile} style={{ display:'none' }} disabled={busy}/>
-        </label>
-      </div>
-
-      {error && <p style={{ color:'#b00', margin:0 }}>⚠️ {error}</p>}
-      {detected && <p style={{ margin:'0 0 8px' }}><strong>Detected:</strong> {detected.type}</p>}
-
-      {result && (
-        <div style={{ border:'1px solid #eee', borderRadius:8, padding:12, background:'var(--panel,#fafafa)' }}>
-          {/* Prescription */}
-          {Array.isArray(result.meds) && (
-            <>
-              <h3 style={{ margin:'0 0 8px' }}>Prescription analysis</h3>
-              {result.meds.length > 0 ? (
-                <ul style={{ margin:0, paddingLeft:18 }}>
-                  {result.meds.map((m: any, idx: number) => (
-                    <li key={`${m.rxcui || idx}`}>
-                      <strong>{m.token || m.name || m.rxcui}</strong>
-                      {m.rxcui ? <> → RXCUI: <code>{m.rxcui}</code></> : null}
-                    </li>
-                  ))}
-                </ul>
-              ) : <p style={{ margin:0 }}>No medications confidently recognized.</p>}
-              {result.note && <p style={{ marginTop:8, color:'#666' }}>{result.note}</p>}
-            </>
-          )}
-
-          {/* Blood */}
-          {Array.isArray(result.values) && (
-            <>
-              <h3 style={{ margin:'0 0 8px' }}>Blood report analysis</h3>
-              {result.summary && <p style={{ margin:'0 0 8px' }}>{result.summary}</p>}
-              <table style={{ width:'100%', borderCollapse:'collapse', fontSize:14 }}>
-                <thead>
-                  <tr>
-                    <th style={{textAlign:'left',borderBottom:'1px solid #eee',padding:'6px 4px'}}>Test</th>
-                    <th style={{textAlign:'left',borderBottom:'1px solid #eee',padding:'6px 4px'}}>Value</th>
-                    <th style={{textAlign:'left',borderBottom:'1px solid #eee',padding:'6px 4px'}}>Reference</th>
-                    <th style={{textAlign:'left',borderBottom:'1px solid #eee',padding:'6px 4px'}}>Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {result.values.map((v: any, idx: number) => (
-                    <tr key={idx}>
-                      <td style={{borderBottom:'1px solid #f2f2f2',padding:'6px 4px'}}>{v.label || v.key}</td>
-                      <td style={{borderBottom:'1px solid #f2f2f2',padding:'6px 4px'}}>{v.value} {v.unit || ''}</td>
-                      <td style={{borderBottom:'1px solid #f2f2f2',padding:'6px 4px',color:'#555'}}>
-                        {v.ref ? `${v.ref.min}–${v.ref.max} ${v.ref.unit}` : '—'}
-                      </td>
-                      <td style={{borderBottom:'1px solid #f2f2f2',padding:'6px 4px'}}>{v.status}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {result.disclaimer && <p style={{ marginTop:8, color:'#666', fontSize:12 }}>{result.disclaimer}</p>}
-            </>
-          )}
-
-          {/* Unknown / Other / Debug */}
-          {!Array.isArray(result.meds) && !Array.isArray(result.values) && (
-            <>
-              <h3 style={{ margin:'0 0 8px' }}>Document preview</h3>
-              {result.preview ? (
-                <p style={{ whiteSpace:'pre-wrap' }}>{result.preview}</p>
-              ) : result.raw ? (
-                <>
-                  <p style={{ margin:0, color:'#b00' }}>Server returned non-JSON. Raw response:</p>
-                  <pre style={{ whiteSpace:'pre-wrap', fontSize:12 }}>{String(result.raw)}</pre>
-                </>
-              ) : (
-                <p>(no preview)</p>
-              )}
-            </>
-          )}
-        </div>
-      )}
+    <div>
+      <input ref={fileRef} type="file" accept="application/pdf" onChange={onFile} disabled={busy}/>
+      {error && <pre>ERROR: {error}</pre>}
+      {out && <pre>{out}</pre>}
     </div>
   );
 }

--- a/lib/pdftext.ts
+++ b/lib/pdftext.ts
@@ -1,35 +1,33 @@
-[23:10:31.552] Running build in Washington, D.C., USA (East) – iad1
-[23:10:31.553] Build machine configuration: 4 cores, 8 GB
-[23:10:31.571] Cloning github.com/lakshay321123/medx (Branch: main, Commit: 616ab89)
-[23:10:31.810] Cloning completed: 237.000ms
-[23:10:33.755] Restored build cache from previous deployment (HmTkVxnNBDxc1CUQgWpKggrmaj8P)
-[23:10:34.312] Running "vercel build"
-[23:10:34.738] Vercel CLI 46.1.0
-[23:10:35.067] Installing dependencies...
-[23:10:36.543] 
-[23:10:36.543] up to date in 1s
-[23:10:36.543] 
-[23:10:36.544] 144 packages are looking for funding
-[23:10:36.544]   run `npm fund` for details
-[23:10:36.579] Detected Next.js version: 14.2.4
-[23:10:36.584] Running "npm run build"
-[23:10:36.713] 
-[23:10:36.713] > medx@3.0.0 build
-[23:10:36.713] > next build
-[23:10:36.713] 
-[23:10:37.455]   ▲ Next.js 14.2.4
-[23:10:37.456] 
-[23:10:37.527]    Creating an optimized production build ...
-[23:10:40.266] Failed to compile.
-[23:10:40.267] 
-[23:10:40.267] ./lib/pdftext.ts
-[23:10:40.267] Module not found: Can't resolve 'pdfjs-dist/legacy/build/pdf.js'
-[23:10:40.268] 
-[23:10:40.268] https://nextjs.org/docs/messages/module-not-found
-[23:10:40.268] 
-[23:10:40.269] Import trace for requested module:
-[23:10:40.269] ./app/api/analyze-doc/route.ts
-[23:10:40.269] 
-[23:10:40.291] 
-[23:10:40.301] > Build failed because of webpack errors
-[23:10:40.335] Error: Command "npm run build" exited with 1
+export async function extractTextFromPDF(
+  buf: ArrayBuffer | Buffer | Uint8Array
+): Promise<string> {
+  // @ts-ignore - partial types
+  const pdfjs: any = await import('pdfjs-dist');
+  const { getDocument } = pdfjs;
+
+  const uint8 =
+    buf instanceof Uint8Array ? buf
+    : Buffer.isBuffer(buf) ? new Uint8Array(buf)
+    : new Uint8Array(buf);
+
+  const task = getDocument({
+    data: uint8,
+    disableWorker: true,
+    isEvalSupported: false,
+    useSystemFonts: true,
+    disableFontFace: true,
+    disableRange: true,
+    disableStream: true,
+  });
+  const pdf = await task.promise;
+
+  let text = '';
+  for (let p = 1; p <= pdf.numPages; p++) {
+    const page = await pdf.getPage(p);
+    const content = await page.getTextContent();
+    text += (content.items as any[])
+      .map((it: any) => (typeof it?.str === 'string' ? it.str : ''))
+      .join(' ') + '\n';
+  }
+  return text.replace(/\s+\n/g, '\n').trim();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "marked": "12.0.2",
         "next": "14.2.4",
         "next-themes": "0.3.0",
-        "pdf-parse": "1.1.1",
+        "pdfjs-dist": "^5.4.149",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tesseract.js": "5.0.5"
@@ -330,6 +330,191 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.78.tgz",
+      "integrity": "sha512-YaBHJvT+T1DoP16puvWM6w46Lq3VhwKIJ8th5m1iEJyGh7mibk5dT7flBvMQ1EH1LYmMzXJ+OUhu+8wQ9I6u7g==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.78",
+        "@napi-rs/canvas-darwin-arm64": "0.1.78",
+        "@napi-rs/canvas-darwin-x64": "0.1.78",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.78",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.78",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.78",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.78",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.78",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.78",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.78"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.78.tgz",
+      "integrity": "sha512-N1ikxztjrRmh8xxlG5kYm1RuNr8ZW1EINEDQsLhhuy7t0pWI/e7SH91uFVLZKCMDyjel1tyWV93b5fdCAi7ggw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.78.tgz",
+      "integrity": "sha512-FA3aCU3G5yGc74BSmnLJTObnZRV+HW+JBTrsU+0WVVaNyVKlb5nMvYAQuieQlRVemsAA2ek2c6nYtHh6u6bwFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.78.tgz",
+      "integrity": "sha512-xVij69o9t/frixCDEoyWoVDKgE3ksLGdmE2nvBWVGmoLu94MWUlv2y4Qzf5oozBmydG5Dcm4pRHFBM7YWa1i6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.78.tgz",
+      "integrity": "sha512-aSEXrLcIpBtXpOSnLhTg4jPsjJEnK7Je9KqUdAWjc7T8O4iYlxWxrXFIF8rV8J79h5jNdScgZpAUWYnEcutR3g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.78.tgz",
+      "integrity": "sha512-dlEPRX1hLGKaY3UtGa1dtkA1uGgFITn2mDnfI6YsLlYyLJQNqHx87D1YTACI4zFCUuLr/EzQDzuX+vnp9YveVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.78.tgz",
+      "integrity": "sha512-TsCfjOPZtm5Q/NO1EZHR5pwDPSPjPEttvnv44GL32Zn1uvudssjTLbvaG1jHq81Qxm16GTXEiYLmx4jOLZQYlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.78.tgz",
+      "integrity": "sha512-+cpTTb0GDshEow/5Fy8TpNyzaPsYb3clQIjgWRmzRcuteLU+CHEU/vpYvAcSo7JxHYPJd8fjSr+qqh+nI5AtmA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.78.tgz",
+      "integrity": "sha512-wxRcvKfvYBgtrO0Uy8OmwvjlnTcHpY45LLwkwVNIWHPqHAsyoTyG/JBSfJ0p5tWRzMOPDCDqdhpIO4LOgXjeyg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.78.tgz",
+      "integrity": "sha512-vQFOGwC9QDP0kXlhb2LU1QRw/humXgcbVp8mXlyBqzc/a0eijlLF9wzyarHC1EywpymtS63TAj8PHZnhTYN6hg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.78.tgz",
+      "integrity": "sha512-/eKlTZBtGUgpRKalzOzRr6h7KVSuziESWXgBcBnXggZmimwIJWPJlEcbrx5Tcwj8rPuZiANXQOG9pPgy9Q4LTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4041,12 +4226,6 @@
         "react-dom": "^16.8 || ^17 || ^18"
       }
     },
-    "node_modules/node-ensure": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
-      "license": "MIT"
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -4406,26 +4585,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/pdf-parse": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
-      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.1.0",
-        "node-ensure": "^0.0.0"
-      },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.149",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.149.tgz",
+      "integrity": "sha512-Xe8/1FMJEQPUVSti25AlDpwpUm2QAVmNOpFP0SIahaPIOKBKICaefbzogLdwey3XGGoaP4Lb9wqiw2e9Jqp0LA==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=6.8.1"
-      }
-    },
-    "node_modules/pdf-parse/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.77"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -2,17 +2,21 @@
   "name": "medx",
   "version": "3.0.0",
   "private": true,
-  "scripts": { "dev": "next dev", "build": "next build", "start": "next start" },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
   "dependencies": {
     "isomorphic-dompurify": "2.13.0",
+    "lucide-react": "0.441.0",
     "marked": "12.0.2",
     "next": "14.2.4",
     "next-themes": "0.3.0",
-    "pdf-parse": "1.1.1",
+    "pdfjs-dist": "^5.4.149",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tesseract.js": "5.0.5",
-    "lucide-react": "0.441.0"
+    "tesseract.js": "5.0.5"
   },
   "devDependencies": {
     "@types/node": "20.11.30",

--- a/pdf-parse.d.ts
+++ b/pdf-parse.d.ts
@@ -1,1 +1,0 @@
-declare module 'pdf-parse';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -14,10 +18,28 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"],
+    "types": [
+      "node"
+    ],
     "baseUrl": ".",
-    "paths": { "@/*": ["*"] }
+    "paths": {
+      "@/*": [
+        "*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "types"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/types/pdfjs-dist.d.ts
+++ b/types/pdfjs-dist.d.ts
@@ -1,0 +1,1 @@
+declare module 'pdfjs-dist';

--- a/types/pdfjs-legacy.d.ts
+++ b/types/pdfjs-legacy.d.ts
@@ -1,3 +1,0 @@
-// types/pdfjs-legacy.d.ts
-declare module 'pdfjs-dist/legacy/build/pdf.js';
-declare module 'pdfjs-dist/legacy/build/pdf';


### PR DESCRIPTION
## Summary
- Add dynamic PDF text extraction helper with pdfjs-dist and TypeScript stub
- Wrap analyze and upload endpoints to always return JSON and expose health checks
- Simplify UploadPanel to use safe JSON parsing and proxy uploads via `/api/upload`

## Testing
- `npm run build`
- `curl -sS http://localhost:3000/api/upload`
- `curl -sS http://localhost:3000/api/analyze-doc`
- `curl -sS -F file=@sample.pdf http://localhost:3000/api/upload`

------
https://chatgpt.com/codex/tasks/task_e_68b536a28abc832fb3177f3d02acd7ff