### PR TITLE
feat: improve nearby search with geolocation and overpass

### DIFF
--- a/app/api/nearby/route.ts
+++ b/app/api/nearby/route.ts
@@ -1,132 +1,50 @@
-// app/api/nearby/route.ts
 import { NextRequest, NextResponse } from 'next/server';
+import { buildPOIQuery, overpassQuery, haversineKm } from '@/lib/geo';
 
 export const runtime = 'nodejs';
+export const maxDuration = 60;
 
-type Item = {
-  id: number;
-  title: string;
-  subtitle?: string;
-  address?: string;
-  phone?: string;
-  website?: string;
-  mapsUrl: string;
-  lat: number;
-  lon: number;
-  distanceKm: number;
-};
-
-function haversineKm(aLat: number, aLon: number, bLat: number, bLon: number) {
-  const R = 6371;
-  const dLat = (bLat - aLat) * Math.PI / 180;
-  const dLon = (bLon - aLon) * Math.PI / 180;
-  const sa =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(aLat * Math.PI / 180) *
-      Math.cos(bLat * Math.PI / 180) *
-      Math.sin(dLon / 2) ** 2;
-  return 2 * R * Math.asin(Math.sqrt(sa));
+export async function GET() {
+  return NextResponse.json({ ok: true, ping: 'nearby-alive' });
 }
 
-function pickName(tags: any) {
-  return tags?.name || tags?.['alt_name'] || tags?.['official_name'] || '';
-}
-
-function pickAddress(tags: any) {
-  const parts = [
-    tags?.['addr:housenumber'],
-    tags?.['addr:street'],
-    tags?.['addr:city'],
-    tags?.['addr:state'],
-    tags?.['addr:postcode'],
-    tags?.['addr:country'],
-  ].filter(Boolean);
-  return parts.join(', ');
-}
-
-function cleanPhone(p?: string) {
-  if (!p) return undefined;
-  return String(p).replace(/;/g, ', ').trim();
-}
-
-function mapsUrl(lat: number, lon: number) {
-  return `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lon}#map=18/${lat}/${lon}`;
-}
-
-export async function GET(req: NextRequest) {
+export async function POST(req: NextRequest) {
   try {
-    const { searchParams } = new URL(req.url);
-    const kind = (searchParams.get('kind') || 'doctor').toLowerCase(); // 'doctor' | 'pharmacy'
-    const lat = Number(searchParams.get('lat'));
-    const lon = Number(searchParams.get('lon'));
-    const q = (searchParams.get('q') || '').trim(); // optional name filter
-    const radius = Math.min(Number(searchParams.get('radius') || 5000), 20000); // meters
-    const limit = Math.min(Number(searchParams.get('limit') || 20), 50);
-
-    if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
-      return NextResponse.json({ ok: false, error: 'lat/lon required' }, { status: 400 });
+    const { lat, lon, kind = 'hospital', radius = 2000 } = await req.json();
+    if (typeof lat !== 'number' || typeof lon !== 'number') {
+      return NextResponse.json({ ok:false, error:'Missing lat/lon' }, { status: 400 });
     }
 
-    let filters = '';
-    if (kind === 'pharmacy') {
-      filters = '(node["amenity"="pharmacy"];way["amenity"="pharmacy"];relation["amenity"="pharmacy"];);';
-    } else {
-      filters = '('
-        + 'node["amenity"="doctors"];way["amenity"="doctors"];relation["amenity"="doctors"];'
-        + 'node["amenity"="clinic"];way["amenity"="clinic"];relation["amenity"="clinic"];'
-        + 'node["amenity"="hospital"];way["amenity"="hospital"];relation["amenity"="hospital"];'
-        + ');';
+    // Try increasing radii until we find something
+    const radii = [radius, Math.max(radius * 2, 4000), Math.max(radius * 4, 8000)];
+    let elements: any[] = [];
+    for (const r of radii) {
+      const q = buildPOIQuery(kind, lat, lon, r);
+      try {
+        const json = await overpassQuery(q);
+        elements = Array.isArray(json?.elements) ? json.elements : [];
+        if (elements.length) break;
+      } catch { /* try next radius/mirror */ }
     }
 
-    const overpassQL =
-`[out:json][timeout:25];
-(
-  ${filters}
-)(around:${radius},${lat},${lon});
-out center ${limit};
-`;
-
-    const res = await fetch('https://overpass-api.de/api/interpreter', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8' },
-      body: new URLSearchParams({ data: overpassQL }),
-      cache: 'no-store',
-    });
-
-    if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      return NextResponse.json({ ok: false, error: `Overpass error ${res.status}`, detail: text.slice(0, 2000) }, { status: 502 });
-    }
-
-    const json = await res.json() as { elements?: any[] };
-    const elements = json.elements || [];
-
-    const items: Item[] = [];
-    for (const el of elements) {
-      const tags = el.tags || {};
-      const name = pickName(tags);
-      const center = el.center || el;
-      const eLat = center.lat, eLon = center.lon;
-      if (!Number.isFinite(eLat) || !Number.isFinite(eLon)) continue;
-      if (q && name && !name.toLowerCase().includes(q.toLowerCase())) continue;
-
-      items.push({
+    // Normalize + sort by distance
+    const items = elements.map((el: any) => {
+      const center = el.center || el; // node has lat/lon, way/relation has center
+      const pos = { lat: center.lat, lon: center.lon };
+      const distKm = haversineKm({ lat, lon }, pos);
+      return {
         id: el.id,
-        title: name || (kind === 'pharmacy' ? 'Pharmacy' : (tags['amenity'] || 'Clinic')),
-        subtitle: tags['operator'] || tags['brand'] || undefined,
-        address: pickAddress(tags) || undefined,
-        phone: cleanPhone(tags['phone'] || tags['contact:phone']),
-        website: tags['website'] || tags['contact:website'] || undefined,
-        mapsUrl: mapsUrl(eLat, eLon),
-        lat: eLat,
-        lon: eLon,
-        distanceKm: Math.round(haversineKm(lat, lon, eLat, eLon) * 10) / 10,
-      });
-    }
+        type: el.type,
+        name: el.tags?.name || el.tags?.['name:en'] || '(Unnamed)',
+        tags: el.tags || {},
+        lat: pos.lat,
+        lon: pos.lon,
+        distanceKm: Number(distKm.toFixed(2)),
+      };
+    }).sort((a, b) => a.distanceKm - b.distanceKm);
 
-    items.sort((a, b) => a.distanceKm - b.distanceKm);
-    return NextResponse.json({ ok: true, items: items.slice(0, limit) });
+    return NextResponse.json({ ok:true, count: items.length, items });
   } catch (e: any) {
-    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 });
+    return NextResponse.json({ ok:false, error: String(e?.message || e) }, { status: 500 });
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -310,7 +310,7 @@ Okay — searching ${intent.suggestion}…` } as ChatMsg]
                       <div className="role">{m.role==='user'?'You':'MedX'}</div>
                       <div className="content">
                         {m.type === 'nearby-cards' ? (
-                          <NearbyCards items={m.payload} />
+                          <NearbyCards />
                         ) : (
                           <div className="markdown"><Markdown text={m.content || ''}/></div>
                         )}

--- a/components/NearbyCards.tsx
+++ b/components/NearbyCards.tsx
@@ -1,70 +1,134 @@
 'use client';
+import React, { useEffect, useRef, useState } from 'react';
+import { getClientLocation, loadLocation, saveLocation } from '@/lib/geo';
+import { safeJson } from '@/lib/safeJson';
 
-type Item = {
-  title: string;
-  subtitle?: string;
-  address?: string;
-  phone?: string | null;
-  website?: string | null;
-  mapsUrl: string;
-  distanceKm?: number;
+type Place = {
+  id: number | string;
+  name: string;
+  lat: number;
+  lon: number;
+  distanceKm: number;
+  tags: Record<string, string>;
 };
 
-export default function NearbyCards({ items }: { items: Item[] }) {
+export default function NearbyCards({ kind = 'hospital' }: { kind?: 'hospital'|'clinic'|'pharmacy'|'doctor' }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [places, setPlaces] = useState<Place[]>([]);
+  const [loc, setLoc] = useState<{ lat:number; lon:number } | null>(null);
+  const [manual, setManual] = useState('');
+  const did = useRef(false);
+
+  useEffect(() => {
+    if (did.current) return;
+    did.current = true;
+
+    (async () => {
+      setBusy(true); setError(null);
+      // 1) cached?
+      const cached = loadLocation();
+      if (cached) setLoc(cached);
+
+      // 2) try browser geolocation (fast timeout)
+      try {
+        const here = await getClientLocation({ enableHighAccuracy:false, timeout: 6000, maximumAge: 60000 });
+        setLoc(here);
+        saveLocation(here);
+      } catch (e:any) {
+        // do nothing; user can set manually
+        setError('Location permission denied or unavailable. You can set location manually.');
+      } finally {
+        setBusy(false);
+      }
+    })();
+  }, []);
+
+  async function fetchNearby(current: { lat:number; lon:number }) {
+    setBusy(true); setError(null);
+    try {
+      const res = await fetch('/api/nearby', {
+        method: 'POST',
+        headers: { 'content-type':'application/json' },
+        body: JSON.stringify({ lat: current.lat, lon: current.lon, kind, radius: 2000 })
+      });
+      const data = await safeJson(res) as any;
+      if (!data || data.ok === false) throw new Error(data?.error || 'Nearby failed');
+      setPlaces(data.items || []);
+    } catch (e:any) {
+      setError(String(e?.message || e));
+      setPlaces([]);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onUseLocation() {
+    if (!loc) return;
+    await fetchNearby(loc);
+  }
+
+  async function onSetManual() {
+    const m = manual.trim();
+    // support "lat,lon" format quickly
+    const mMatch = m.match(/^\s*(-?\d+(\.\d+)?)\s*,\s*(-?\d+(\.\d+)?)\s*$/);
+    if (mMatch) {
+      const lat = parseFloat(mMatch[1]);
+      const lon = parseFloat(mMatch[3]);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) {
+        const here = { lat, lon };
+        setLoc(here); saveLocation(here);
+        await fetchNearby(here);
+        return;
+      }
+    }
+    setError('Enter coordinates as "lat,lon" (e.g., 28.6139,77.2090)');
+  }
+
   return (
-    <div className="grid gap-3 mt-3">
-      {items.map((it, i) => (
-        <div key={i} className="rounded-xl border p-4 bg-background">
-          {/* Name */}
-          <div className="flex items-center justify-between gap-3">
-            <div className="text-base font-semibold leading-tight">
-              {it.title || 'Unknown'}
-            </div>
-            {typeof it.distanceKm === 'number' && (
-              <div className="text-xs px-2 py-1 rounded-full border opacity-80">
-                {it.distanceKm} km
-              </div>
-            )}
-          </div>
-
-          {/* Type */}
-          {it.subtitle && (
-            <div className="text-xs mt-1 opacity-70">
-              {it.subtitle}
-            </div>
-          )}
-
-          {/* Address */}
-          {it.address && (
-            <div className="text-sm mt-2">
-              {it.address}
-            </div>
-          )}
-
-          {/* Actions */}
-          <div className="flex flex-wrap items-center gap-3 mt-3 text-sm">
-            {it.phone && (
-              <a className="underline" href={`tel:${normalizePhone(it.phone)}`}>
-                Call
-              </a>
-            )}
-            {it.website && (
-              <a className="underline" href={it.website} target="_blank">
-                Website
-              </a>
-            )}
-            <a className="underline" href={it.mapsUrl} target="_blank">
-              Directions
-            </a>
-          </div>
+    <div style={{border:'1px solid var(--border,#ddd)', borderRadius:12, padding:16, display:'grid', gap:12}}>
+      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', gap:12 }}>
+        <div style={{ fontWeight:600 }}>Nearby: {kind}</div>
+        <div style={{ display:'flex', gap:8, alignItems:'center' }}>
+          <button onClick={onUseLocation} disabled={busy || !loc}
+            style={{ padding:'8px 12px', border:'1px solid #ccc', borderRadius:8 }}>
+            {busy ? 'Searching…' : 'Use my location'}
+          </button>
         </div>
-      ))}
+      </div>
+
+      {!loc && (
+        <div style={{ display:'flex', gap:8, alignItems:'center' }}>
+          <input value={manual} onChange={e=>setManual(e.target.value)} placeholder='Set location (lat,lon)'
+            style={{ flex:1, padding:'8px', border:'1px solid #ccc', borderRadius:8 }} />
+          <button onClick={onSetManual} style={{ padding:'8px 12px', border:'1px solid #ccc', borderRadius:8 }}>Set</button>
+        </div>
+      )}
+
+      {error && <p style={{ color:'#b00', margin:0, whiteSpace:'pre-wrap' }}>⚠️ {error}</p>}
+
+      {places.length > 0 ? (
+        <ul style={{ listStyle:'none', padding:0, margin:0, display:'grid', gap:8 }}>
+          {places.map((p) => (
+            <li key={p.id} style={{ border:'1px solid #eee', borderRadius:8, padding:12 }}>
+              <div style={{ fontWeight:600 }}>{p.name}</div>
+              <div style={{ color:'#555', fontSize:13 }}>
+                {p.tags?.amenity || ''} • {p.distanceKm} km
+                {p.tags?.phone ? ` • ${p.tags.phone}` : ''}
+              </div>
+              <div style={{ fontSize:12, marginTop:6 }}>
+                {p.tags?.addr_full || [p.tags?.['addr:housenumber'], p.tags?.['addr:street'], p.tags?.['addr:city']].filter(Boolean).join(', ')}
+              </div>
+              <a target='_blank' href={`https://www.openstreetmap.org/?mlat=${p.lat}&mlon=${p.lon}#map=17/${p.lat}/${p.lon}`} rel='noreferrer'
+                 style={{ display:'inline-block', marginTop:8, fontSize:13 }}>
+                View on OpenStreetMap ↗
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p style={{ color:'#555', margin:0 }}>{busy ? 'Searching…' : 'No results yet. Use location or set coordinates.'}</p>
+      )}
     </div>
   );
-}
-
-function normalizePhone(p?: string | null) {
-  if (!p) return '';
-  // remove spaces and dashes; keep + and digits
-  return p.replace(/[^\d+]/g, '');
 }

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -1,0 +1,106 @@
+export type LatLng = { lat: number; lon: number };
+
+const LS_KEY = 'medx.userLocation.v1';
+
+export function saveLocation(loc: LatLng) {
+  try { localStorage.setItem(LS_KEY, JSON.stringify(loc)); } catch {}
+}
+export function loadLocation(): LatLng | null {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return null;
+    const obj = JSON.parse(raw);
+    if (typeof obj?.lat === 'number' && typeof obj?.lon === 'number') return obj as LatLng;
+  } catch {}
+  return null;
+}
+
+export function haversineKm(a: LatLng, b: LatLng) {
+  const R = 6371;
+  const dLat = ((b.lat - a.lat) * Math.PI) / 180;
+  const dLon = ((b.lon - a.lon) * Math.PI) / 180;
+  const lat1 = (a.lat * Math.PI) / 180;
+  const lat2 = (b.lat * Math.PI) / 180;
+  const x =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(x));
+}
+
+// Client-side geolocation with timeouts & clear errors
+export function getClientLocation(
+  opts: PositionOptions = { enableHighAccuracy: false, timeout: 6000, maximumAge: 60000 }
+): Promise<LatLng> {
+  return new Promise((resolve, reject) => {
+    if (typeof window === 'undefined' || !('geolocation' in navigator)) {
+      reject(new Error('Geolocation not available'));
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (p) => resolve({ lat: p.coords.latitude, lon: p.coords.longitude }),
+      (err) => reject(new Error(err.message || 'Geolocation error')),
+      opts
+    );
+  });
+}
+
+// Overpass mirror rotation + fetch with timeout
+const DEFAULT_MIRRORS = [
+  (process.env.OVERPASS_URL as string) || '', // env preferred (may be empty)
+  'https://overpass-api.de/api/interpreter',
+  'https://overpass.kumi.systems/api/interpreter',
+  'https://overpass.openstreetmap.ru/api/interpreter',
+  'https://overpass.nchc.org.tw/api/interpreter',
+].filter(Boolean);
+
+async function fetchWithTimeout(url: string, body: string, ms = 12000): Promise<Response> {
+  const ctrl = new AbortController();
+  const id = setTimeout(() => ctrl.abort(), ms);
+  try {
+    return await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+      body: `data=${encodeURIComponent(body)}`,
+      signal: ctrl.signal,
+      cache: 'no-store',
+    });
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+export async function overpassQuery(body: string, mirrors = DEFAULT_MIRRORS, attempts = 3) {
+  let lastErr: any;
+  for (let i = 0; i < Math.min(attempts, mirrors.length); i++) {
+    const url = mirrors[i % mirrors.length];
+    try {
+      const res = await fetchWithTimeout(url, body, 12000 + i * 3000);
+      if (!res.ok) { lastErr = new Error(`HTTP ${res.status}`); continue; }
+      const json = await res.json();
+      return json;
+    } catch (e) { lastErr = e; }
+  }
+  throw lastErr || new Error('Overpass failed');
+}
+
+// Build an Overpass query for kinds: hospital/clinic/pharmacy/doctor
+export function buildPOIQuery(kind: string, lat: number, lon: number, radiusMeters: number) {
+  // Map UI kinds to OSM tags
+  const tag = (() => {
+    switch (kind) {
+      case 'hospital': return 'amenity=hospital';
+      case 'clinic': return 'amenity=clinic';
+      case 'pharmacy': return 'amenity=pharmacy';
+      case 'doctor': return 'amenity=doctors';
+      default: return 'amenity=hospital';
+    }
+  })();
+  // nwr = nodes, ways, relations
+  return `
+    [out:json][timeout:25];
+    (
+      nwr[${tag}](around:${radiusMeters},${lat},${lon});
+    );
+    out center tags;
+  `;
+}

--- a/lib/safeJson.ts
+++ b/lib/safeJson.ts
@@ -1,9 +1,4 @@
-// lib/safeJson.ts
-export async function safeJson(res: Response) {
-  const text = await res.text();     // always read full body
-  try {
-    return JSON.parse(text);         // return parsed JSON if valid
-  } catch {
-    return { ok: res.ok, raw: text }; // fallback safe object
-  }
+export async function safeJson<T = any>(res: Response): Promise<T | { ok: boolean; raw: string }> {
+  const text = await res.text();
+  try { return JSON.parse(text) as T; } catch { return { ok: res.ok, raw: text }; }
 }


### PR DESCRIPTION
## Summary
- add geo utilities for client caching, haversine distance, and Overpass mirror handling
- expose `/api/nearby` endpoint that widens radius and sorts locations by distance
- refresh NearbyCards component with geolocation, manual coordinate input, and safe JSON parsing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5592ba520832f9edb1fb2c6b6bfc4