### PR TITLE
fix: add pdf parse types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+.DS_Store

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@types/node": "20.11.30",
+        "@types/pdf-parse": "^1.1.5",
         "@types/react": "18.2.66",
         "@types/react-dom": "18.2.23",
         "eslint": "8.57.0",
@@ -629,6 +630,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {

--- a/package.json
+++ b/package.json
@@ -2,20 +2,25 @@
   "name": "medx",
   "version": "3.0.0",
   "private": true,
-  "scripts": { "dev": "next dev", "build": "next build", "start": "next start" },
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
   "dependencies": {
     "isomorphic-dompurify": "2.13.0",
+    "lucide-react": "0.441.0",
     "marked": "12.0.2",
     "next": "14.2.4",
     "next-themes": "0.3.0",
     "pdf-parse": "1.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "tesseract.js": "5.0.5",
-    "lucide-react": "0.441.0"
+    "tesseract.js": "5.0.5"
   },
   "devDependencies": {
     "@types/node": "20.11.30",
+    "@types/pdf-parse": "^1.1.5",
     "@types/react": "18.2.66",
     "@types/react-dom": "18.2.23",
     "eslint": "8.57.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,38 @@
+{
+    "compilerOptions": {
+      "lib": [
+        "dom",
+        "dom.iterable",
+        "esnext"
+      ],
+      "allowJs": true,
+      "skipLibCheck": true,
+      "strict": false,
+      "noEmit": true,
+      "incremental": true,
+      "module": "esnext",
+      "esModuleInterop": true,
+      "moduleResolution": "node",
+      "resolveJsonModule": true,
+      "isolatedModules": true,
+      "jsx": "preserve",
+      "baseUrl": ".",
+      "paths": {
+        "@/*": ["./*"]
+      },
+      "plugins": [
+        {
+          "name": "next"
+        }
+      ]
+    },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add `@types/pdf-parse` to fix TypeScript build failure
- configure TypeScript baseUrl and `@/*` path alias
- ignore generated and dependency directories

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b57d89b1cc832f950cc911fc448eda