### PR TITLE
feat: summarize uploads and parse lab values

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,22 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server';
+
 export async function POST(req: NextRequest){
-  const { question, role } = await req.json();
+  const body = await req.json();
   const base = process.env.LLM_BASE_URL;
   const model = process.env.LLM_MODEL_ID || 'llama3-8b-instruct';
   if(!base) return new NextResponse("LLM_BASE_URL not set", { status: 500 });
+
+  // Allow either a raw question/role pair or full chat messages
+  let messages = body.messages;
+  if(!messages){
+    const { question, role } = body;
+    const sys = role==='clinician'
+      ? 'You are a clinical assistant. Be precise, cite sources if mentioned. Avoid medical advice; provide evidence and guideline pointers.'
+      : role==='admin'
+        ? 'You help administrative staff with medical documents. Summarize logistics and coding info. Avoid medical advice.'
+        : 'You explain in simple, friendly language for patients. Avoid medical advice; encourage consulting a doctor.';
+    messages = [
+      { role: 'system', content: sys },
+      { role: 'user', content: question }
+    ];
+  }
 
   // OpenAI-compatible completion (v1/chat/completions)
   const res = await fetch(`${base.replace(/\/$/,'')}/chat/completions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      model,
-      messages: [
-        { role: 'system', content: role==='clinician' ? 'You are a clinical assistant. Be precise, cite sources if mentioned. Avoid medical advice; provide evidence and guideline pointers.' : 'You explain in simple, friendly language for patients. Avoid medical advice; encourage consulting a doctor.' },
-        { role: 'user', content: question }
-      ],
-      temperature: 0.2
-    })
+    body: JSON.stringify({ model, messages, temperature: 0.2 })
   });
   if(!res.ok){
     const t = await res.text();

--- a/lib/parseLabs.ts
+++ b/lib/parseLabs.ts
@@ -1,0 +1,61 @@
+export type LabResult = {
+  name: string;
+  value: number;
+  unit: string;
+  normalLow: number;
+  normalHigh: number;
+  flag: 'low' | 'high' | 'normal';
+};
+
+// Reference ranges for a few common labs
+const LABS: { name: string; regex: RegExp; unit: string; low: number; high: number }[] = [
+  {
+    name: 'Hemoglobin',
+    regex: /Hemoglobin\s*(\d+(?:\.\d+)?)\s*g\/dL/i,
+    unit: 'g/dL',
+    low: 12,
+    high: 16,
+  },
+  {
+    name: 'WBC',
+    regex: /WBC\s*(\d+(?:\.\d+)?)\s*10\^3\/?\s*?\u03bc?L/i,
+    unit: '10^3/uL',
+    low: 4,
+    high: 11,
+  },
+  {
+    name: 'Platelets',
+    regex: /Platelets?\s*(\d+(?:\.\d+)?)\s*10\^3\/?\s*?\u03bc?L/i,
+    unit: '10^3/uL',
+    low: 150,
+    high: 450,
+  },
+  {
+    name: 'Glucose',
+    regex: /Glucose\s*(\d+(?:\.\d+)?)\s*mg\/dL/i,
+    unit: 'mg/dL',
+    low: 70,
+    high: 99,
+  },
+];
+
+export function parseLabValues(text: string): LabResult[] {
+  const results: LabResult[] = [];
+  for (const lab of LABS) {
+    let match: RegExpExecArray | null;
+    const re = new RegExp(lab.regex.source, 'gi');
+    while ((match = re.exec(text))) {
+      const value = parseFloat(match[1]);
+      const flag: LabResult['flag'] = value < lab.low ? 'low' : value > lab.high ? 'high' : 'normal';
+      results.push({
+        name: lab.name,
+        value,
+        unit: lab.unit,
+        normalLow: lab.low,
+        normalHigh: lab.high,
+        flag,
+      });
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary
- classify uploaded documents and request a mode-aware summary
- add lab value parser with reference ranges
- support patient, doctor, and admin modes with tailored document summaries

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5820e4868832f91fb336abdff2324