### PR TITLE
Fix PDF analysis to parse all pages and clean text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+
+.next

--- a/app/api/rxnorm/normalize-pdf/route.ts
+++ b/app/api/rxnorm/normalize-pdf/route.ts
@@ -4,8 +4,15 @@ export const runtime = 'nodejs';
 
 async function rxcuiForName(name: string): Promise<string | null> {
   const url = `https://rxnav.nlm.nih.gov/REST/rxcui.json?name=${encodeURIComponent(name)}&search=2`;
-  const res = await fetch(url, { headers: { Accept: 'application/json' } });
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { Accept: 'application/json' } });
+  } catch {
+    return null;
+  }
   if (!res.ok) return null;
+  const ct = res.headers.get('content-type') || '';
+  if (!ct.includes('application/json')) return null;
   try {
     const j = await res.json();
     return j?.idGroup?.rxnormId?.[0] || null;

--- a/app/api/rxnorm/normalize-pdf/route.ts
+++ b/app/api/rxnorm/normalize-pdf/route.ts
@@ -4,10 +4,14 @@ export const runtime = 'nodejs';
 
 async function rxcuiForName(name: string): Promise<string | null> {
   const url = `https://rxnav.nlm.nih.gov/REST/rxcui.json?name=${encodeURIComponent(name)}&search=2`;
-  const res = await fetch(url);
+  const res = await fetch(url, { headers: { Accept: 'application/json' } });
   if (!res.ok) return null;
-  const j = await res.json();
-  return j?.idGroup?.rxnormId?.[0] || null;
+  try {
+    const j = await res.json();
+    return j?.idGroup?.rxnormId?.[0] || null;
+  } catch {
+    return null;
+  }
 }
 
 export async function POST(req: NextRequest) {
@@ -23,9 +27,20 @@ export async function POST(req: NextRequest) {
 
   if (!text.trim()) return NextResponse.json({ meds: [], note: 'No selectable text found.' });
 
-  const tokens = Array.from(new Set(String(text).split(/[^A-Za-z0-9-]+/).filter(t => t.length > 2))).slice(0, 120);
+  const tokens = Array.from(
+    new Set(String(text).split(/[^A-Za-z0-9-]+/).filter(t => t.length > 2))
+  ).slice(0, 120);
   const meds: { token: string; rxcui: string }[] = [];
-  for (const token of tokens) { try { const rxcui = await rxcuiForName(token); if (rxcui) meds.push({ token, rxcui }); } catch {} }
-  const dedup = Object.values(meds.reduce((acc: any, m) => (acc[m.rxcui] = m, acc), {}));
+  for (const token of tokens) {
+    try {
+      const rxcui = await rxcuiForName(token);
+      if (rxcui) meds.push({ token, rxcui });
+    } catch {
+      // ignore failed lookups
+    }
+  }
+  const dedup = Object.values(
+    meds.reduce((acc: any, m) => ((acc[m.rxcui] = m), acc), {})
+  );
   return NextResponse.json({ text, meds: dedup });
 }

--- a/app/api/rxnorm/normalize-pdf/route.ts
+++ b/app/api/rxnorm/normalize-pdf/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import pdfText from '@/lib/pdftext';
 export const runtime = 'nodejs';
 
 async function rxcuiForName(name: string): Promise<string | null> {
@@ -15,10 +16,9 @@ export async function POST(req: NextRequest) {
   if (!file) return NextResponse.json({ error: 'No file provided' }, { status: 400 });
   if (file.type !== 'application/pdf') return NextResponse.json({ error: 'File must be a PDF' }, { status: 400 });
 
-  const pdf = (await import('pdf-parse')).default;
   const buf = Buffer.from(await file.arrayBuffer());
   let text = '';
-  try { const out = await pdf(buf); text = out.text || ''; }
+  try { text = await pdfText(buf); }
   catch (e:any){ return NextResponse.json({ error: 'PDF parse failed', detail: String(e) }, { status: 500 }); }
 
   if (!text.trim()) return NextResponse.json({ meds: [], note: 'No selectable text found.' });

--- a/app/api/rxnorm/normalize-pdf/route.ts
+++ b/app/api/rxnorm/normalize-pdf/route.ts
@@ -36,14 +36,17 @@ export async function POST(req: NextRequest) {
 
   const tokens = Array.from(
     new Set(String(text).split(/[^A-Za-z0-9-]+/).filter(t => t.length > 2))
-  ).slice(0, 120);
+  );
   const meds: { token: string; rxcui: string }[] = [];
-  for (const token of tokens) {
-    try {
-      const rxcui = await rxcuiForName(token);
-      if (rxcui) meds.push({ token, rxcui });
-    } catch {
-      // ignore failed lookups
+  for (let i = 0; i < tokens.length; i += 120) {
+    const batch = tokens.slice(i, i + 120);
+    for (const token of batch) {
+      try {
+        const rxcui = await rxcuiForName(token);
+        if (rxcui) meds.push({ token, rxcui });
+      } catch {
+        // ignore failed lookups
+      }
     }
   }
   const dedup = Object.values(

--- a/app/api/rxnorm/normalize/route.ts
+++ b/app/api/rxnorm/normalize/route.ts
@@ -2,10 +2,21 @@ import { NextRequest, NextResponse } from 'next/server';
 
 async function rxcuiForName(name: string): Promise<string | null> {
   const url = `https://rxnav.nlm.nih.gov/REST/rxcui.json?name=${encodeURIComponent(name)}&search=2`;
-  const res = await fetch(url);
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: { Accept: 'application/json' } });
+  } catch {
+    return null;
+  }
   if (!res.ok) return null;
-  const j = await res.json();
-  return j?.idGroup?.rxnormId?.[0] || null;
+  const ct = res.headers.get('content-type') || '';
+  if (!ct.includes('application/json')) return null;
+  try {
+    const j = await res.json();
+    return j?.idGroup?.rxnormId?.[0] || null;
+  } catch {
+    return null;
+  }
 }
 
 export async function POST(req: NextRequest) {

--- a/lib/pdftext.ts
+++ b/lib/pdftext.ts
@@ -1,50 +1,53 @@
+import pdf from 'pdf-parse/lib/pdf-parse.js';
+
 export default async function pdfText(data: Buffer): Promise<string> {
-  // @ts-ignore - pdf.js has no type definitions
-  const pdfjs: any = await import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js');
-  const doc = await pdfjs.getDocument({ data, disableWorker: true }).promise;
   const allLines: string[] = [];
   let prevHeader: string[] = [];
   let prevFooter: string[] = [];
 
-  for (let i = 1; i <= doc.numPages; i++) {
-    try {
-      const page = await doc.getPage(i);
-      const content = await page.getTextContent();
+  await pdf(data, {
+    max: 0,
+    pagerender: async (page: any) => {
+      try {
+        const content = await page.getTextContent();
+        const lineMap = new Map<number, { x: number; str: string }[]>();
+        for (const item of content.items) {
+          const str = (item.str || '').trim();
+          if (!str) continue;
+          const [x, y] = item.transform.slice(4, 6);
+          const key = Math.round(y);
+          if (!lineMap.has(key)) lineMap.set(key, []);
+          lineMap.get(key)!.push({ x, str });
+        }
 
-      const lineMap = new Map<number, { x: number; str: string }[]>();
-      for (const item of content.items) {
-        const str = (item.str || '').trim();
-        if (!str) continue;
-        const [x, y] = item.transform.slice(4, 6);
-        const key = Math.round(y);
-        if (!lineMap.has(key)) lineMap.set(key, []);
-        lineMap.get(key)!.push({ x, str });
+        const pageLines = Array.from(lineMap.entries())
+          .sort((a, b) => b[0] - a[0])
+          .map(([_, items]) =>
+            items.sort((a, b) => a.x - b.x).map(i => i.str).join(' ').trim()
+          )
+          .filter(Boolean);
+
+        const header = pageLines
+          .slice(0, 3)
+          .map(l => l.replace(/\s+/g, ' ').toLowerCase());
+        const footer = pageLines
+          .slice(-3)
+          .map(l => l.replace(/\s+/g, ' ').toLowerCase());
+
+        for (const line of pageLines) {
+          const norm = line.replace(/\s+/g, ' ').toLowerCase();
+          if (prevHeader.includes(norm) || prevFooter.includes(norm)) continue;
+          allLines.push(line);
+        }
+
+        prevHeader = header;
+        prevFooter = footer;
+      } catch (err) {
+        console.error('Failed to parse page', page.pageNumber, err);
       }
-
-      const pageLines = Array.from(lineMap.entries())
-        .sort((a, b) => b[0] - a[0])
-        .map(([_, items]) =>
-          items.sort((a, b) => a.x - b.x).map(i => i.str).join(' ').trim()
-        )
-        .filter(Boolean);
-
-      const header = pageLines.slice(0, 3).map(l => l.replace(/\s+/g, ' ').toLowerCase());
-      const footer = pageLines.slice(-3).map(l => l.replace(/\s+/g, ' ').toLowerCase());
-
-      for (const line of pageLines) {
-        const norm = line.replace(/\s+/g, ' ').toLowerCase();
-        if (prevHeader.includes(norm) || prevFooter.includes(norm)) continue;
-        allLines.push(line);
-      }
-
-      prevHeader = header;
-      prevFooter = footer;
-    } catch (err) {
-      console.error('Failed to parse page', i, err);
+      return '';
     }
-  }
-
-  doc.destroy?.();
+  });
 
   const cleanedLines = allLines.map(line => {
     const tokens = line.split(/[^A-Za-z0-9.-]+/).filter(Boolean);

--- a/lib/pdftext.ts
+++ b/lib/pdftext.ts
@@ -16,19 +16,27 @@ export default async function pdfText(data: Buffer): Promise<string> {
   doc.destroy?.();
   let text = pages.join('\n');
   const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
-  const unique: string[] = [];
+  const uniqueLines: string[] = [];
   const seen = new Set<string>();
   for (const line of lines) {
     const key = line.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
-    unique.push(line);
+    uniqueLines.push(line);
   }
-  text = unique.join(' ');
-  text = text.replace(/(\b[a-zA-Z]+)(\1)+/g, '$1');
-  text = text.replace(/(\b\d+(?:\.\d+)?)(\1)+/g, '$1');
+  text = uniqueLines.join(' ');
+
+  // remove repeated tokens stuck together (e.g. InvestigationInvestigation)
+  text = text.replace(/([A-Za-z]+)\1+/gi, '$1');
+  text = text.replace(/(\d+(?:\.\d+)?)\1+/g, '$1');
+
+  // normalize whitespace
   text = text.replace(/\s+/g, ' ').trim();
+
+  // remove consecutive duplicate words/numbers
   const tokens = text.split(' ');
-  text = tokens.filter((t, i) => i === 0 || t !== tokens[i - 1]).join(' ');
+  text = tokens
+    .filter((t, i) => i === 0 || t.toLowerCase() !== tokens[i - 1].toLowerCase())
+    .join(' ');
   return text;
 }

--- a/lib/pdftext.ts
+++ b/lib/pdftext.ts
@@ -1,0 +1,34 @@
+export default async function pdfText(data: Buffer): Promise<string> {
+  // @ts-ignore - pdf.js has no type definitions
+  const pdfjs: any = await import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js');
+  const doc = await pdfjs.getDocument({ data, disableWorker: true }).promise;
+  const pages: string[] = [];
+  for (let i = 1; i <= doc.numPages; i++) {
+    try {
+      const page = await doc.getPage(i);
+      const content = await page.getTextContent();
+      const pageText = content.items.map((item: any) => item.str || '').join(' ');
+      pages.push(pageText);
+    } catch (err) {
+      console.error('Failed to parse page', i, err);
+    }
+  }
+  doc.destroy?.();
+  let text = pages.join('\n');
+  const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  const unique: string[] = [];
+  const seen = new Set<string>();
+  for (const line of lines) {
+    const key = line.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(line);
+  }
+  text = unique.join(' ');
+  text = text.replace(/(\b[a-zA-Z]+)(\1)+/g, '$1');
+  text = text.replace(/(\b\d+(?:\.\d+)?)(\1)+/g, '$1');
+  text = text.replace(/\s+/g, ' ').trim();
+  const tokens = text.split(' ');
+  text = tokens.filter((t, i) => i === 0 || t !== tokens[i - 1]).join(' ');
+  return text;
+}

--- a/lib/pdftext.ts
+++ b/lib/pdftext.ts
@@ -2,41 +2,60 @@ export default async function pdfText(data: Buffer): Promise<string> {
   // @ts-ignore - pdf.js has no type definitions
   const pdfjs: any = await import('pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js');
   const doc = await pdfjs.getDocument({ data, disableWorker: true }).promise;
-  const pages: string[] = [];
+  const allLines: string[] = [];
+
   for (let i = 1; i <= doc.numPages; i++) {
     try {
       const page = await doc.getPage(i);
       const content = await page.getTextContent();
-      const pageText = content.items.map((item: any) => item.str || '').join(' ');
-      pages.push(pageText);
+
+      const lineMap = new Map<number, { x: number; str: string }[]>();
+      for (const item of content.items) {
+        const str = (item.str || '').trim();
+        if (!str) continue;
+        const [x, y] = item.transform.slice(4, 6);
+        const key = Math.round(y);
+        if (!lineMap.has(key)) lineMap.set(key, []);
+        lineMap.get(key)!.push({ x, str });
+      }
+
+      const pageLines = Array.from(lineMap.entries())
+        .sort((a, b) => b[0] - a[0])
+        .map(([_, items]) =>
+          items.sort((a, b) => a.x - b.x).map(i => i.str).join(' ').trim()
+        )
+        .filter(Boolean);
+
+      allLines.push(...pageLines);
     } catch (err) {
       console.error('Failed to parse page', i, err);
     }
   }
+
   doc.destroy?.();
-  let text = pages.join('\n');
-  const lines = text.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+
   const uniqueLines: string[] = [];
   const seen = new Set<string>();
-  for (const line of lines) {
-    const key = line.toLowerCase();
+  for (const line of allLines) {
+    const key = line.replace(/\s+/g, ' ').toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
     uniqueLines.push(line);
   }
-  text = uniqueLines.join(' ');
 
-  // remove repeated tokens stuck together (e.g. InvestigationInvestigation)
-  text = text.replace(/([A-Za-z]+)\1+/gi, '$1');
-  text = text.replace(/(\d+(?:\.\d+)?)\1+/g, '$1');
+  const rawTokens = uniqueLines
+    .join(' ')
+    .split(/[^A-Za-z0-9.-]+/)
+    .filter(Boolean);
 
-  // normalize whitespace
-  text = text.replace(/\s+/g, ' ').trim();
+  const cleanedTokens: string[] = [];
+  for (let token of rawTokens) {
+    token = token.replace(/([A-Za-z]+)\1+/gi, '$1');
+    token = token.replace(/(\d+(?:\.\d+)?)(?:\1)+/g, '$1');
+    const last = cleanedTokens[cleanedTokens.length - 1];
+    if (last && last.toLowerCase() === token.toLowerCase()) continue;
+    cleanedTokens.push(token);
+  }
 
-  // remove consecutive duplicate words/numbers
-  const tokens = text.split(' ');
-  text = tokens
-    .filter((t, i) => i === 0 || t.toLowerCase() !== tokens[i - 1].toLowerCase())
-    .join(' ');
-  return text;
+  return cleanedTokens.join(' ');
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,42 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "preserve",
+    "strict": false,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "incremental": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- parse every page of uploaded PDFs and skip pages that fail
- clean parsed text by removing repeated tokens, normalizing whitespace and deduplicating headers
- wire PDF text extraction into RxNorm PDF normalization endpoint
- add TypeScript config for root path imports

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b59ea9c4fc832fa23344a3a17c62fa