### PR TITLE
Return object from PDF text extraction

### DIFF
--- a/lib/pdftext.ts
+++ b/lib/pdftext.ts
@@ -3,7 +3,7 @@
 
 export async function extractTextFromPDF(
   buf: ArrayBuffer | Buffer | Uint8Array
-): Promise<string> {
+): Promise<{ text: string; ocr?: boolean }> {
   // @ts-ignore - pdfjs-dist types are partial
   const pdfjs: any = await import('pdfjs-dist');
   const { getDocument } = pdfjs;
@@ -37,5 +37,5 @@ export async function extractTextFromPDF(
     text += line + '\n';
   }
 
-  return text.replace(/\s+\n/g, '\n').trim();
+  return { text: text.replace(/\s+\n/g, '\n').trim() };
 }


### PR DESCRIPTION
## Summary
- Update `extractTextFromPDF` to return an object with text field (and optional OCR flag)
- Allows API routes to access `res.text` without TypeScript errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5eae07f18832fafd6113bc22f0b72