### PR TITLE
Fix LLM URL normalization and auth for Groq API

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -4,7 +4,8 @@ export async function POST(req: NextRequest){
   const body = await req.json();
   const base = process.env.LLM_BASE_URL;
   const model = process.env.LLM_MODEL_ID || 'llama3-8b-instruct';
-  if(!base) return new NextResponse("LLM_BASE_URL not set", { status: 500 });
+  const key = process.env.LLM_API_KEY;
+  if(!base || !key) return new NextResponse("LLM_BASE_URL or LLM_API_KEY not set", { status: 500 });
 
   // Allow either a raw question/role pair or full chat messages
   let messages = body.messages;
@@ -22,9 +23,9 @@ export async function POST(req: NextRequest){
   }
 
   // OpenAI-compatible completion (v1/chat/completions)
-  const res = await fetch(`${base.replace(/\/$/,'')}/chat/completions`, {
+  const res = await fetch(`${base.replace(/\/+$/,'')}/chat/completions`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
     body: JSON.stringify({ model, messages, temperature: 0.2 })
   });
   if(!res.ok){

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -8,12 +8,10 @@ export function chunkText(text: string, maxChars = 12000) {
 }
 
 function pickEnv() {
-  const base =
-    (process.env.LLM_BASE_URL?.replace(/\/+$/, '') || 'https://api.groq.com'); // default to Groq
-  const model =
-    (process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant'); // your default
-  const key =
-    (process.env.LLM_API_KEY || '');
+  const rawBase = process.env.LLM_BASE_URL || 'https://api.groq.com/openai/v1';
+  const base = rawBase.replace(/\/+$/, '').replace(/\/openai\/v1$/, '') + '/openai/v1';
+  const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
+  const key = process.env.LLM_API_KEY || '';
 
   return { base, model, key };
 }
@@ -43,7 +41,7 @@ export async function summarizeChunks(chunks: string[], systemPrompt: string): P
   // If key or base/model missing, skip summarization quietly.
   if (!key || !base || !model || !Array.isArray(chunks) || chunks.length === 0) return '';
 
-  const url = `${base}/v1/chat/completions`;
+  const url = `${base}/chat/completions`;
   const parts: string[] = [];
 
   for (const c of chunks) {
@@ -51,8 +49,8 @@ export async function summarizeChunks(chunks: string[], systemPrompt: string): P
       const r = await withTimeout(fetch(url, {
         method: 'POST',
         headers: {
-          'content-type': 'application/json',
-          authorization: `Bearer ${key}`,
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${key}`,
         },
         body: JSON.stringify({
           model,


### PR DESCRIPTION
## Summary
- normalize LLM base URL to avoid duplicated `/v1`
- always send Authorization header in document summarizer
- add Authorization header and API key check to chat route

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5fcabb090832fb22129d33b715493