### PR TITLE
Enable OCR fallback for PDFs

### DIFF
--- a/app/api/ocr/route.ts
+++ b/app/api/ocr/route.ts
@@ -1,24 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { ocrBuffer } from '@/lib/ocr';
+
 export async function POST(req: NextRequest) {
   const form = await req.formData();
   const file = form.get('file') as File | null;
   if (!file) return NextResponse.json({ error: 'No file uploaded' }, { status: 400 });
-  const apiKey = process.env.OCRSPACE_API_KEY || 'helloworld';
-  const buffer = Buffer.from(await file.arrayBuffer());
 
-  const fd = new FormData();
-  fd.append("file", new Blob([buffer], { type: file.type || 'image/jpeg' }), file.name || 'image.jpg');
-  fd.append("language", "eng");
-  fd.append("OCREngine", "2");
-  fd.append("scale", "true");
-  fd.append("isTable", "false");
-
-  const resp = await fetch("https://api.ocr.space/parse/image", { method: "POST", headers: { apikey: apiKey }, body: fd });
-  if (!resp.ok) {
-    const t = await resp.text();
-    return NextResponse.json({ error: `OCR error ${resp.status}`, detail: t }, { status: 500 });
+  try {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const { text } = await ocrBuffer(buffer);
+    return NextResponse.json({ text });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'OCR failed' }, { status: 500 });
   }
-  const j = await resp.json();
-  const text = j?.ParsedResults?.[0]?.ParsedText || '';
-  return NextResponse.json({ text });
 }

--- a/lib/ocr.ts
+++ b/lib/ocr.ts
@@ -1,8 +1,31 @@
-import Tesseract from 'tesseract.js';
+export async function ocrBuffer(buf: Buffer | ArrayBuffer | Uint8Array) {
+  const apiKey = process.env.OCRSPACE_API_KEY;
+  if (!apiKey) throw new Error('OCRSPACE_API_KEY not set');
 
-export async function runOCR(buffer: Buffer) {
-  const {
-    data: { text },
-  } = await Tesseract.recognize(buffer, 'eng');
-  return text.replace(/\s+/g, ' ').trim();
+  const buffer =
+    buf instanceof Uint8Array
+      ? Buffer.from(buf)
+      : Buffer.isBuffer(buf)
+      ? buf
+      : Buffer.from(buf);
+
+  const fd = new FormData();
+  fd.append('file', new Blob([buffer], { type: 'application/pdf' }), 'file.pdf');
+  fd.append('language', 'eng');
+  fd.append('OCREngine', '2');
+  fd.append('scale', 'true');
+  fd.append('isTable', 'false');
+
+  const resp = await fetch('https://api.ocr.space/parse/image', {
+    method: 'POST',
+    headers: { apikey: apiKey },
+    body: fd,
+  });
+  if (!resp.ok) {
+    const t = await resp.text();
+    throw new Error(`OCR error ${resp.status}: ${t}`);
+  }
+  const j = await resp.json();
+  const text = j?.ParsedResults?.[0]?.ParsedText || '';
+  return { text };
 }


### PR DESCRIPTION
## Summary
- use OCRSpace-based ocrBuffer helper
- enable OCR fallback in PDF analysis route
- centralize OCR route on shared helper and require OCRSPACE_API_KEY

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5febae28c832f8b37e03e796c0dd5