### PR TITLE
feat: detect and route medical document types

### DIFF
--- a/lib/detect.ts
+++ b/lib/detect.ts
@@ -1,0 +1,33 @@
+export type DocumentType = 'prescription' | 'lab' | 'imaging' | 'clinical' | 'other';
+
+/**
+ * Simple rule-based document type detector.  It inspects the raw text for
+ * common keywords or structures associated with typical medical documents.
+ * A more advanced implementation could add ML classification when the
+ * heuristic confidence is low.
+ */
+export function detectDocumentType(text: string, mime: string, fileName: string): DocumentType {
+  const lower = text.toLowerCase();
+
+  // --- Prescription ---
+  if (/\b(rx|tab\.|cap\.|inj\.|od|bd|tds|sig)\b/.test(lower) && /\b(mg|ml|mcg)\b/.test(lower)) {
+    return 'prescription';
+  }
+
+  // --- Lab Report ---
+  if (/test name|reference range|mg\/dl|mmol\/l|cbc|hemoglobin|cholesterol|thyroid/.test(lower)) {
+    return 'lab';
+  }
+
+  // --- Imaging Report ---
+  if (/x-ray|ct\b|mri|ultrasound|impression|findings/.test(lower)) {
+    return 'imaging';
+  }
+
+  // --- Clinical Note / Discharge Summary ---
+  if (/admitted|discharge|diagnosis|treatment|plan/.test(lower)) {
+    return 'clinical';
+  }
+
+  return 'other';
+}


### PR DESCRIPTION
## Summary
- add rule-based document type detector for prescription, lab, imaging, clinical, and other documents
- expand `/api/analyze-doc` to route text through dedicated pipelines and return unified JSON

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b60d7e5e00832fbfe5d405dadaad9c