### PR TITLE
feat: add Hugging Face imaging analyzer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -213,18 +213,20 @@ If CONTEXT has codes or trials, explain them in plain words and add links. Avoid
 
   async function handleImaging(file: File) {
     if (!file) return;
+    const hint = window.prompt('Hint (e.g., "chest", "wrist", "tibia")') || '';
     setBusy(true);
     try {
       const idx = messages.length;
       setMessages(prev=>[...prev, { role:'assistant', content:`Analyzing "${file.name}"…` }]);
       const fd = new FormData();
       fd.append('file', file);
+      if (hint) fd.append('hint', hint);
       const res = await fetch('/api/imaging/analyze', { method:'POST', body: fd });
       const data = await res.json();
       if (!res.ok || data.ok === false) throw new Error(data?.error || 'Imaging analysis failed');
       const lines: string[] = [];
       lines.push(`**${data.documentType || 'Imaging Report'} – ${file.name}**`);
-      if (data.region) lines.push(`**Region:** ${data.region}`);
+      if (data.family) lines.push(`**Family:** ${data.family}`);
       if (Array.isArray(data.predictions) && data.predictions.length) {
         lines.push('**Predictions:**');
         data.predictions.forEach((p:any)=>{


### PR DESCRIPTION
## Summary
- add `/api/imaging/analyze` route to call Hugging Face X-ray models with hint or override
- normalize predictions and build an impression string for UI
- prompt for optional hint on upload and display family, predictions, and disclaimer

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6b844cb50832fbdc7e96deba4865c