### PR TITLE
feat: add imaging narrative interpretation

### DIFF
--- a/app/api/imaging/analyze/route.ts
+++ b/app/api/imaging/analyze/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { composeImagingReport } from '@/lib/imagingReport';
 
 export const runtime = "nodejs";
 
@@ -64,6 +63,94 @@ function normalize(out: any): {label:string; score:number}[] {
   return [{ label:"Unknown", score:0 }];
 }
 
+function band(p: number) {
+  if (p >= 0.85) return { band: "high", text: "High" } as const;
+  if (p >= 0.60) return { band: "moderate", text: "Moderate" } as const;
+  if (p >= 0.40) return { band: "borderline", text: "Borderline" } as const;
+  return { band: "low", text: "Low" } as const;
+}
+
+function boneSignals(preds: {label:string;score:number}[]) {
+  const m = Object.fromEntries(preds.map(p => [p.label.toLowerCase(), p.score]));
+  const frac = m["fracture"] ?? m["fractured"] ?? 0;
+  const normal = m["normal"] ?? (1 - frac);
+  return { frac, normal };
+}
+
+function humanTemplate(family: "bone"|"chest", preds: {label:string;score:number}[], hint?: string) {
+  const top = [...preds].sort((a,b)=>b.score-a.score)[0];
+  if (family === "bone") {
+    const { frac } = boneSignals(preds);
+    const b = band(frac);
+    const site = (hint || "bone").toLowerCase();
+    if (b.band === "high") {
+      return {
+        patientSummary: `The ${site} X-ray strongly suggests a fracture.`,
+        clinicianNote: `• Binary classifier indicates fracture ≈${Math.round(frac*100)}% (High confidence)\n• Consider immobilization and orthopaedic review as clinically indicated`
+      };
+    }
+    if (b.band === "moderate") {
+      return {
+        patientSummary: `The ${site} X-ray may show a fracture.`,
+        clinicianNote: `• Suspicious for fracture ≈${Math.round(frac*100)}%\n• Consider additional views/CT based on exam`
+      };
+    }
+    if (b.band === "borderline") {
+      return {
+        patientSummary: `The ${site} X-ray is inconclusive for a fracture.`,
+        clinicianNote: `• Equivocal probability ≈${Math.round(frac*100)}%\n• Correlate with focal tenderness; repeat imaging if needed`
+      };
+    }
+    return {
+      patientSummary: `No obvious fracture is seen in the ${site} X-ray.`,
+      clinicianNote: `• Model favors no fracture (top: ${top.label} ${Math.round(top.score*100)}%)`
+    };
+  }
+  const strong = preds.filter(p => p.score >= 0.15).slice(0,5);
+  if (!strong.length) {
+    return {
+      patientSummary: "No strong abnormality seen on the chest X-ray by the AI model.",
+      clinicianNote: "• No label ≥15%. Consider clinical context."
+    };
+  }
+  const list = strong.map(p => `${p.label} ${Math.round(p.score*100)}%`).join(", ");
+  return {
+    patientSummary: `The chest X-ray AI highlights: ${list}.`,
+    clinicianNote: `• Top chest labels (≥15%): ${list}\n• Correlate clinically`
+  };
+}
+
+async function llmPolish(ctx: {
+  family: "bone"|"chest", hint?: string, model: string,
+  preds: {label:string;score:number}[], base: {patientSummary:string; clinicianNote:string}
+}) {
+  if (!process.env.LLM_BASE_URL || !process.env.LLM_API_KEY) return null;
+  const pred_lines = ctx.preds.slice(0,5).map(p=>`• ${p.label}: ${p.score.toFixed(2)}`).join("\n");
+  const prompt = `Context:\n- Modality: X-ray\n- Family: ${ctx.family}\n- Region/Hint: ${ctx.hint || "unspecified"}\n- Model: ${ctx.model}\n\nModel outputs (top 5):\n${pred_lines}\n\nInitial draft:\nPatient: ${ctx.base.patientSummary}\nClinician:\n${ctx.base.clinicianNote}\n\nRewrite both sections concisely (2–3 sentences for patient, 2–3 short bullets for clinician). Keep probabilities and avoid overreach.`;
+
+  const r = await fetch(process.env.LLM_BASE_URL!, {
+    method: "POST",
+    headers: { "Authorization": `Bearer ${process.env.LLM_API_KEY!}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: process.env.LLM_MODEL_ID || "llama-3.1-8b-instant",
+      messages: [
+        { role: "system", content: "You are a clinical reporting assistant. Be concise, safe, factual." },
+        { role: "user", content: prompt }
+      ],
+      temperature: 0.2,
+      max_tokens: 220
+    })
+  });
+  const j = await r.json();
+  const text = j?.choices?.[0]?.message?.content || "";
+  if (!text) return null;
+  const parts = text.split(/\n{2,}/);
+  return {
+    patientSummary: parts[0]?.trim() || ctx.base.patientSummary,
+    clinicianNote: (parts[1] || ctx.base.clinicianNote).trim()
+  };
+}
+
 
 export async function POST(req: NextRequest) {
   try {
@@ -116,16 +203,21 @@ export async function POST(req: NextRequest) {
 
     const preds = normalize(out);
 
-    const report = await composeImagingReport({
-      family: pickFamily(hint, file.name),
-      region: hint,
+    const family = pickFamily(hint, file.name);
+    const baseInterp = humanTemplate(family, preds, hint);
+    const polished = await llmPolish({ family, hint, model: modelId, preds, base: baseInterp }) || baseInterp;
+
+    return NextResponse.json({
+      ok: true,
+      documentType: "Imaging Report",
+      modality: "X-ray",
+      family,
+      region: hint || "unspecified",
       model: modelId,
       predictions: preds,
-      hint,
-      fileName: file.name,
+      interpretation: polished,
+      disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician."
     });
-
-    return NextResponse.json(report);
   } catch (e:any) {
     return NextResponse.json({ ok:false, error: e?.message || String(e) }, { status: 500 });
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -226,15 +226,18 @@ If CONTEXT has codes or trials, explain them in plain words and add links. Avoid
       if (!res.ok || data.ok === false) throw new Error(data?.error || 'Imaging analysis failed');
       const lines: string[] = [];
       lines.push(`**${data.documentType || 'Imaging Report'} – ${file.name}**`);
-      if (data.family) lines.push(`**Family:** ${data.family}`);
+      lines.push(`**Patient-friendly summary**`);
+      lines.push(data.interpretation?.patientSummary || '(none)');
+      lines.push('');
+      lines.push(`**Clinician note**`);
+      lines.push(data.interpretation?.clinicianNote || '(none)');
       if (Array.isArray(data.predictions) && data.predictions.length) {
         lines.push('**Predictions:**');
-        data.predictions.forEach((p:any)=>{
+        data.predictions.slice(0,5).forEach((p:any)=>{
           const pct = Math.round((p.score || 0)*100);
-          lines.push(`- ${p.label} (${pct}%)`);
+          lines.push(`- ${p.label}: ${pct}%`);
         });
       }
-      if (data.impression) lines.push(`**Impression:** ${data.impression}`);
       if (data.disclaimer) lines.push(`_${data.disclaimer}_`);
       setMessages(prev=>{ const copy=[...prev]; copy[idx] = { role:'assistant', content: lines.join('\n') }; return copy; });
     } catch(e:any) {


### PR DESCRIPTION
## Summary
- add rule-based narrative helpers and optional LLM polish for imaging analysis
- return structured interpretation with patient and clinician sections
- update imaging upload flow to render new interpretation and predictions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6c5c97cec832f9240dea44041f6a7