### PR TITLE
feat: dual-model document analysis pipeline

### DIFF
--- a/app/api/analyze-doc/route.ts
+++ b/app/api/analyze-doc/route.ts
@@ -1,103 +1,112 @@
-import { NextResponse } from "next/server";
-import { extractTextFromPDF } from "@/lib/pdftext";
-import { detectDocumentType } from "@/lib/detectDocumentType";
-import { parseLabValues } from "@/lib/parseLabs";
+import { NextResponse } from 'next/server';
+import { extractPages } from '@/lib/pdf';
+import { chunkPages } from '@/lib/chunk';
+import { SCHEMA_PROMPT, askGroq, askOpenAI } from '@/lib/llm';
+import { detectDocumentType } from '@/lib/detectDocumentType';
+import { reduceChunks, fuseResults, emptyData, DataSet } from '@/lib/ensemble';
 
-export const runtime = "nodejs";
+export const runtime = 'nodejs';
 export const maxDuration = 60;
 
-// Simple prescription parser placeholder using RxNorm lookup
-async function parsePrescription(text: string) {
-  return { meds: await rxFromText(text) };
+const DEBUG = process.env.DOC_ENABLE_DEBUG === 'true';
+
+function parseOutput(text: string, range: string): DataSet {
+  try {
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) return emptyData();
+    const data = JSON.parse(match[0]);
+    const cats = ['labs', 'medications', 'diagnoses', 'impressions', 'red_flags', 'followups'];
+    for (const c of cats) {
+      for (const item of data[c] || []) {
+        if (!item.page_range) item.page_range = range;
+      }
+    }
+    return data;
+  } catch {
+    return emptyData();
+  }
 }
 
-// Use existing lab parser
-async function parseLabReport(text: string) {
-  return { labs: parseLabValues(text) };
-}
-
-async function parseImaging(text: string) {
-  return { rawText: text };
-}
-
-async function parseClinicalNotes(text: string) {
-  return { rawText: text };
+async function summarize(data: DataSet, mode: 'patient' | 'doctor'): Promise<string> {
+  const prompt =
+    mode === 'patient'
+      ? 'Provide 5-8 bullet points in plain language based on this data:'
+      : 'Provide 10-14 bullet points with clinical detail based on this data:';
+  const provider = process.env.OPENAI_API_KEY ? askOpenAI : process.env.LLM_API_KEY ? askGroq : null;
+  if (!provider) return '';
+  try {
+    const res = await provider(
+      `You are a clinical summarization assistant. ${prompt}`,
+      JSON.stringify(data)
+    );
+    return res.trim();
+  } catch (e) {
+    if (DEBUG) console.error('summary-error', e);
+    return '';
+  }
 }
 
 export async function POST(req: Request) {
-  const form = await req.formData();
-  const file = form.get("file") as File | null;
-
-  if (!file) {
-    return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
-  }
-
-  const buf = Buffer.from(await file.arrayBuffer());
-  const { text } = await extractTextFromPDF(buf);
-
-  if (!text.trim()) {
-    return NextResponse.json({ error: "Empty text extracted" }, { status: 400 });
-  }
-
-  // 🔍 Detect type
-  const docType = detectDocumentType(text, file.type, file.name);
-
-  // 🔀 Route to pipelines
-  switch (docType) {
-    case "prescription":
-      return NextResponse.json({ documentType: docType, content: await parsePrescription(text) });
-    case "lab":
-      return NextResponse.json({ documentType: docType, content: await parseLabReport(text) });
-    case "imaging":
-      return NextResponse.json({ documentType: docType, content: await parseImaging(text) });
-    case "clinical":
-      return NextResponse.json({ documentType: docType, content: await parseClinicalNotes(text) });
-    default:
-      return NextResponse.json({ documentType: "other", rawText: text });
-  }
-}
-
-function cleanToken(t: string): string {
-  return t
-    .replace(/[^\w\s\-\+\/\.]/g, " ")
-    .replace(/\b(tab(?:let)?|cap(?:sule)?|syrup|susp(?:ension)?|drop(?:s)?|inj(?:ection)?|cream|gel|ointment|soln|solution)\b/gi, " ")
-    .replace(/\b(\d+(?:\.\d+)?)(mg|mcg|g|ml|iu)\b/gi, " ")
-    .replace(/\b(qd|od|bid|tid|qid|qhs|qam|prn|po|iv|im|sc|hs|ac|pc)\b/gi, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-async function rxcuiForName(name: string): Promise<string | null> {
   try {
-    const res = await fetch(`https://rxnav.nlm.nih.gov/REST/rxcui.json?name=${encodeURIComponent(name)}&search=2`, { cache: 'no-store' });
-    if (!res.ok) return null;
-    const j = await res.json().catch(() => null);
-    return j?.idGroup?.rxnormId?.[0] ?? null;
-  } catch {
-    return null;
-  }
-}
+    const form = await req.formData();
+    const file = form.get('file') as File | null;
+    if (!file) return NextResponse.json({ error: 'No file uploaded' }, { status: 400 });
 
-async function rxFromText(text: string) {
-  const words: string[] = text.split(/[^A-Za-z0-9-]+/).filter((w: string) => w.length > 2);
-  const cleaned: string[] = words.map(cleanToken).filter(Boolean);
-  const grams = new Set<string>();
-  for (let i = 0; i < cleaned.length; i++) {
-    grams.add(cleaned[i]);
-    if (i + 1 < cleaned.length) grams.add(`${cleaned[i]} ${cleaned[i + 1]}`);
-    if (i + 2 < cleaned.length) grams.add(`${cleaned[i]} ${cleaned[i + 1]} ${cleaned[i + 2]}`);
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const pages = await extractPages(buffer);
+    if (!pages.length) return NextResponse.json({ error: 'Empty text extracted' }, { status: 400 });
+
+    const fullText = pages.map((p) => p.text).join('\n');
+    const docType = detectDocumentType(fullText, file.type, file.name);
+
+    const chunks = chunkPages(pages);
+    const groqChunks: DataSet[] = [];
+    const openaiChunks: DataSet[] = [];
+
+    for (const ch of chunks) {
+      const user = `Pages ${ch.page_range}:\n${ch.text}`;
+      const tasks: Promise<void>[] = [];
+      if (process.env.LLM_API_KEY) {
+        tasks.push(
+          askGroq(SCHEMA_PROMPT, user)
+            .then((out) => {
+              groqChunks.push(parseOutput(out, ch.page_range));
+            })
+            .catch((e) => {
+              if (DEBUG) console.error('groq-chunk-error', e);
+            })
+        );
+      }
+      if (process.env.OPENAI_API_KEY) {
+        tasks.push(
+          askOpenAI(SCHEMA_PROMPT, user)
+            .then((out) => {
+              openaiChunks.push(parseOutput(out, ch.page_range));
+            })
+            .catch((e) => {
+              if (DEBUG) console.error('openai-chunk-error', e);
+            })
+        );
+      }
+      if (tasks.length) await Promise.all(tasks);
+    }
+
+    const groqReduced = reduceChunks(groqChunks);
+    const openaiReduced = reduceChunks(openaiChunks);
+    const fused = fuseResults(groqReduced, openaiReduced);
+
+    const patient = await summarize(fused, 'patient');
+    const doctor = await summarize(fused, 'doctor');
+
+    return NextResponse.json({
+      meta: { pages: pages.length, doc_type: docType },
+      raw: { groq_chunks: groqChunks, openai_chunks: openaiChunks },
+      fused,
+      summaries: { patient, doctor },
+      disclaimer: 'AI assistance only — not a medical diagnosis. Confirm with a clinician.',
+    });
+  } catch (e: any) {
+    if (DEBUG) console.error('analyze-doc-error', e);
+    return NextResponse.json({ error: 'Failed to analyze document' }, { status: 500 });
   }
-  const tokens = Array.from(grams).slice(0, 200);
-  const found: Array<{ token: string; rxcui: string }> = [];
-  for (const token of tokens) {
-    const r = await rxcuiForName(token);
-    if (r) found.push({ token, rxcui: r });
-  }
-  const meds = Object.values(
-    found.reduce<Record<string, { token: string; rxcui: string }>>((acc, m) => {
-      if (!acc[m.rxcui]) acc[m.rxcui] = m;
-      return acc;
-    }, {})
-  );
-  return meds;
 }

--- a/lib/chunk.ts
+++ b/lib/chunk.ts
@@ -1,0 +1,40 @@
+export interface PageChunk {
+  text: string;
+  page_range: string;
+}
+
+interface PageText {
+  page: number;
+  text: string;
+}
+
+const MAX_DOC_TOKENS = parseInt(process.env.DOC_MAX_TOKENS || '8192', 10);
+const CHUNK_TOKENS = parseInt(process.env.DOC_CHUNK_TOKENS || '1200', 10);
+const CHUNK_OVERLAP = parseInt(process.env.DOC_CHUNK_OVERLAP || '120', 10);
+const DEBUG = process.env.DOC_ENABLE_DEBUG === 'true';
+
+// Naive whitespace tokenization chunker with overlap and page range tracking
+export function chunkPages(pages: PageText[]): PageChunk[] {
+  const tokens: Array<{ token: string; page: number }> = [];
+  for (const p of pages) {
+    const words = p.text.split(/\s+/).filter(Boolean);
+    for (const w of words) tokens.push({ token: w, page: p.page });
+  }
+  if (tokens.length > MAX_DOC_TOKENS) tokens.splice(MAX_DOC_TOKENS);
+
+  const chunks: PageChunk[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const end = Math.min(i + CHUNK_TOKENS, tokens.length);
+    const slice = tokens.slice(i, end);
+    const text = slice.map((t) => t.token).join(' ');
+    const pStart = slice[0].page;
+    const pEnd = slice[slice.length - 1].page;
+    const range = pStart === pEnd ? `p${pStart}` : `p${pStart}-p${pEnd}`;
+    chunks.push({ text, page_range: range });
+    if (DEBUG) console.log('chunk', chunks.length, range, 'tokens', slice.length);
+    if (end === tokens.length) break;
+    i = Math.max(0, end - CHUNK_OVERLAP);
+  }
+  return chunks;
+}

--- a/lib/ensemble.ts
+++ b/lib/ensemble.ts
@@ -1,0 +1,114 @@
+export interface Lab {
+  name: string;
+  value?: string;
+  units?: string;
+  ref_low?: string;
+  ref_high?: string;
+  flag?: string;
+  page_range?: string;
+  [k: string]: any;
+}
+
+export interface Medication {
+  drug: string;
+  dose?: string;
+  route?: string;
+  frequency?: string;
+  duration?: string;
+  page_range?: string;
+  [k: string]: any;
+}
+
+export interface Named {
+  name: string;
+  page_range?: string;
+  [k: string]: any;
+}
+
+export interface TextEntry {
+  text: string;
+  page_range?: string;
+  [k: string]: any;
+}
+
+export interface DataSet {
+  labs: Lab[];
+  medications: Medication[];
+  diagnoses: Named[];
+  impressions: TextEntry[];
+  red_flags: TextEntry[];
+  followups: TextEntry[];
+}
+
+export function emptyData(): DataSet {
+  return { labs: [], medications: [], diagnoses: [], impressions: [], red_flags: [], followups: [] };
+}
+
+export function reduceChunks(chunks: DataSet[]): DataSet {
+  const out = emptyData();
+  for (const c of chunks) {
+    out.labs.push(...(c.labs || []));
+    out.medications.push(...(c.medications || []));
+    out.diagnoses.push(...(c.diagnoses || []));
+    out.impressions.push(...(c.impressions || []));
+    out.red_flags.push(...(c.red_flags || []));
+    out.followups.push(...(c.followups || []));
+  }
+  return out;
+}
+
+function normLabName(n: string) {
+  const k = n.toLowerCase();
+  if (k.includes('hba1c') || k.includes('hemoglobin a1c')) return 'HbA1c';
+  if (k.includes('ldl')) return 'LDL';
+  if (k.includes('tsh')) return 'TSH';
+  return n.trim();
+}
+
+function normDrug(n: string) {
+  return n.toLowerCase().trim();
+}
+
+function normText(t: string) {
+  return t.toLowerCase().trim();
+}
+
+function fuseCategory<T extends { [k: string]: any }>(
+  groq: T[],
+  openai: T[],
+  keyFn: (x: T) => string
+) {
+  const map = new Map<string, { g?: T; o?: T }>();
+  for (const g of groq || []) {
+    const k = keyFn(g);
+    map.set(k, { ...(map.get(k) || {}), g });
+  }
+  for (const o of openai || []) {
+    const k = keyFn(o);
+    map.set(k, { ...(map.get(k) || {}), o });
+  }
+  const out: any[] = [];
+  for (const { g, o } of map.values()) {
+    if (g && o) {
+      const same = JSON.stringify(g) === JSON.stringify(o);
+      if (same) out.push({ ...g, confidence: 1 });
+      else {
+        out.push({ ...g, source: 'Groq', confidence: -1 });
+        out.push({ ...o, source: 'OpenAI', confidence: -1 });
+      }
+    } else if (g) out.push({ ...g, source: 'Groq', confidence: 0 });
+    else if (o) out.push({ ...o, source: 'OpenAI', confidence: 0 });
+  }
+  return out;
+}
+
+export function fuseResults(groq: DataSet, openai: DataSet): DataSet {
+  return {
+    labs: fuseCategory(groq.labs, openai.labs, (x) => normLabName(x.name)),
+    medications: fuseCategory(groq.medications, openai.medications, (x) => normDrug(x.drug)),
+    diagnoses: fuseCategory(groq.diagnoses, openai.diagnoses, (x) => normText(x.name)),
+    impressions: fuseCategory(groq.impressions, openai.impressions, (x) => normText(x.text)),
+    red_flags: fuseCategory(groq.red_flags, openai.red_flags, (x) => normText(x.text)),
+    followups: fuseCategory(groq.followups, openai.followups, (x) => normText(x.text)),
+  };
+}

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -7,21 +7,10 @@ export function chunkText(text: string, maxChars = 12000) {
   return out;
 }
 
-function pickEnv() {
-  const rawBase = process.env.LLM_BASE_URL || 'https://api.groq.com/openai/v1';
-  const base = rawBase.replace(/\/+$/, '').replace(/\/openai\/v1$/, '') + '/openai/v1';
-  const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
-  const key = process.env.LLM_API_KEY || '';
+const DEFAULT_TIMEOUT = parseInt(process.env.DOC_TIMEOUT_MS || '30000', 10);
+const DEBUG = process.env.DOC_ENABLE_DEBUG === 'true';
 
-  return { base, model, key };
-}
-
-async function safeJson(res: Response) {
-  const txt = await res.text();
-  try { return JSON.parse(txt); } catch { return { ok: res.ok, raw: txt }; }
-}
-
-async function withTimeout<T>(p: Promise<T>, ms = 20000, label = 'timeout'): Promise<T> {
+async function withTimeout<T>(p: Promise<T>, ms = DEFAULT_TIMEOUT, label = 'timeout'): Promise<T> {
   let t: NodeJS.Timeout | null = null;
   return await Promise.race([
     p.then((v) => { if (t) clearTimeout(t); return v; }),
@@ -29,54 +18,122 @@ async function withTimeout<T>(p: Promise<T>, ms = 20000, label = 'timeout'): Pro
   ]);
 }
 
+function normalizeBase(rawBase: string) {
+  return rawBase.replace(/\/+$/, '').replace(/\/openai\/v1$/, '') + '/openai/v1';
+}
+
+async function callLLM(
+  base: string,
+  model: string,
+  key: string | undefined,
+  systemPrompt: string,
+  userContent: string
+): Promise<string> {
+  if (!key || !base || !model) throw new Error('missing-credentials');
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT);
+  try {
+    const res = await fetch(`${base}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userContent },
+        ],
+        temperature: 0.2,
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`http-${res.status}`);
+    const j: any = await res.json().catch(() => ({}));
+    return j?.choices?.[0]?.message?.content || '';
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+export const SCHEMA_PROMPT = `You are a clinical summarization assistant.\nReturn STRICT JSON first, then 2–3 sentences explanation.\n\nSchema expected:\n{\n  "labs": [ { "name":"", "value":"", "units":"", "ref_low":"", "ref_high":"", "flag":"", "page_range":"" } ],\n  "medications": [ { "drug":"", "dose":"", "route":"", "frequency":"", "duration":"", "page_range":"" } ],\n  "diagnoses": [ { "name":"", "page_range":"" } ],\n  "impressions": [ { "text":"", "page_range":"" } ],\n  "red_flags": [ { "text":"", "page_range":"" } ],\n  "followups": [ { "text":"", "page_range":"" } ]\n}`;
+
+export async function askGroq(systemPrompt: string, userContent: string): Promise<string> {
+  try {
+    const base = normalizeBase(process.env.LLM_BASE_URL || 'https://api.groq.com');
+    const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
+    const key = process.env.LLM_API_KEY;
+    return await callLLM(base, model, key, systemPrompt, userContent);
+  } catch (e) {
+    if (DEBUG) console.error('groq-error', e);
+    throw e;
+  }
+}
+
+export async function askOpenAI(systemPrompt: string, userContent: string): Promise<string> {
+  try {
+    const base = normalizeBase('https://api.openai.com');
+    const model = process.env.OPENAI_TEXT_MODEL || 'gpt-4o-mini';
+    const key = process.env.OPENAI_API_KEY;
+    return await callLLM(base, model, key, systemPrompt, userContent);
+  } catch (e) {
+    if (DEBUG) console.error('openai-error', e);
+    throw e;
+  }
+}
+
+async function safeJson(res: Response) {
+  const txt = await res.text();
+  try {
+    return JSON.parse(txt);
+  } catch {
+    return { ok: res.ok, raw: txt };
+  }
+}
+
 /**
  * Summarize an array of text chunks. Uses only LLM_* env vars.
- * - If any env var is missing, returns '' (does not throw).
- * - Uses safe JSON parsing so bad payloads never crash.
- * - Adds a per-request timeout to avoid hanging uploads.
+ * Retained for backwards compatibility with previous code paths.
  */
 export async function summarizeChunks(chunks: string[], systemPrompt: string): Promise<string> {
-  const { base, model, key } = pickEnv();
+  const rawBase = process.env.LLM_BASE_URL || 'https://api.groq.com/openai/v1';
+  const base = normalizeBase(rawBase);
+  const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
+  const key = process.env.LLM_API_KEY || '';
 
-  // If key or base/model missing, skip summarization quietly.
   if (!key || !base || !model || !Array.isArray(chunks) || chunks.length === 0) return '';
 
   const url = `${base}/chat/completions`;
   const parts: string[] = [];
-
   for (const c of chunks) {
     try {
-      const r = await withTimeout(fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${key}`,
-        },
-        body: JSON.stringify({
-          model,
-          messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: c },
-          ],
-          temperature: 0.2,
+      const r = await withTimeout(
+        fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${key}`,
+          },
+          body: JSON.stringify({
+            model,
+            messages: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: c },
+            ],
+            temperature: 0.2,
+          }),
         }),
-      }), 20000, 'llm-timeout');
-
-      // Don’t assume JSON; parse safely
+        DEFAULT_TIMEOUT,
+        'llm-timeout'
+      );
       const j: any = await safeJson(r);
       const content = j?.choices?.[0]?.message?.content;
-
-      if (typeof content === 'string' && content.trim()) {
-        parts.push(content.trim());
-      } else {
-        // If provider returns an error (e.g., invalid_api_key), just skip this chunk
-        // You can optionally log: console.error('LLM error payload:', j);
-      }
+      if (typeof content === 'string' && content.trim()) parts.push(content.trim());
     } catch (e) {
-      // Swallow request/timeout errors to keep the upload flow resilient
-      // Optionally: console.error('LLM request failed:', e);
+      if (DEBUG) console.error('summarize-error', e);
     }
   }
-
   return parts.join('\n\n').trim();
 }
+

--- a/lib/pdf.ts
+++ b/lib/pdf.ts
@@ -1,0 +1,49 @@
+import { runOCR } from './ocr';
+
+export interface PDFPage {
+  page: number;
+  text: string;
+}
+
+// Extract text per page from PDF buffer. If a page has little/no text, run OCR.
+export async function extractPages(buf: Buffer): Promise<PDFPage[]> {
+  const pages: PDFPage[] = [];
+  const buffer = Buffer.isBuffer(buf)
+    ? buf
+    : Buffer.from(buf as any);
+
+  try {
+    const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+    const loadingTask = pdfjs.getDocument({
+      data: new Uint8Array(buffer),
+      disableWorker: true,
+      isEvalSupported: false,
+      useSystemFonts: true,
+      disableFontFace: true,
+      disableRange: true,
+      disableStream: true,
+    } as any);
+    const pdf = await loadingTask.promise;
+    for (let i = 1; i <= pdf.numPages; i++) {
+      const page = await pdf.getPage(i);
+      const content = await page.getTextContent();
+      const txt = (content.items as any[])
+        .map((it: any) => (typeof it?.str === 'string' ? it.str : ''))
+        .join(' ')
+        .replace(/\s+\n/g, '\n')
+        .trim();
+      if (txt && txt.length > 10) {
+        pages.push({ page: i, text: txt });
+      } else {
+        // OCR fallback for scanned pages
+        const ocr = await runOCR(buffer);
+        pages.push({ page: i, text: ocr });
+      }
+    }
+  } catch {
+    // If PDF parsing fails, attempt OCR on entire document
+    const text = await runOCR(buffer);
+    if (text) pages.push({ page: 1, text });
+  }
+  return pages;
+}


### PR DESCRIPTION
## Summary
- add PDF text extractor with page-level OCR fallback
- implement token-based chunking and dual LLM calls
- merge Groq and OpenAI outputs with confidence scoring

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b6e51f40b4832fbf27b0697665bf44