### PR TITLE
feat: add unified analyze endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project includes:
 - **Banner aggregator** (WHO, ClinicalTrials, openFDA, PubMed)
 - **Chat** that proxies to a **self-hosted LLM** (OpenAI-compatible endpoint like vLLM/Ollama)
+- **/api/analyze** endpoint that sends PDFs or images to OpenAI for summarization
 - Dark/Light theme, PWA manifest
 - Minimal UI with Patient/Clinician toggle
 - API wrappers for PubMed, openFDA, ClinicalTrials, DailyMed, RxNorm, ICD-11
@@ -15,6 +16,7 @@ This project includes:
    - `LLM_MODEL_ID` (e.g., `llama3-8b-instruct`)
    - `HF_API_TOKEN`
    - optional: `HF_CHEST_MODEL` `HF_BONE_MODEL`
+   - for OpenAI summaries: `OPENAI_API_KEY`, `OPENAI_TEXT_MODEL`, `OPENAI_VISION_MODEL`
 2. `npm install`
 3. `npm run dev`
 
@@ -24,8 +26,9 @@ This project includes:
 ## Endpoints
 - `GET /api/banner` — aggregated headlines
 - `POST /api/chat` — body: `{question, role: "patient"|"clinician"}`
+- `POST /api/analyze` — multipart form-data with `file` and optional `doctorMode`
 - Plus wrappers: `/api/clinicaltrials`, `/api/pubmed`, `/api/who`, `/api/openfda`, `/api/dailymed`, `/api/rxnorm`, `/api/icd11`
 
 ## Notes
-- No OpenAI/Gemini dependency. Use your own LLM endpoint.
+- OpenAI models power the `/api/analyze` endpoint for PDF and image summaries.
 - Images for banner should follow source licenses; this demo just returns text/meta.

--- a/app/analyze/page.tsx
+++ b/app/analyze/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+import { useState } from 'react';
+import Markdown from '@/components/Markdown';
+
+export default function AnalyzePage(){
+  const [doctorMode, setDoctorMode] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState('');
+
+  async function handleFile(file: File){
+    setBusy(true);
+    setResult('Analyzing...');
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      if (doctorMode) fd.append('doctorMode', 'true');
+      const res = await fetch('/api/analyze', { method:'POST', body: fd });
+      const j = await res.json();
+      if (!res.ok) throw new Error(j?.error || 'analysis failed');
+      if (j.type === 'pdf') {
+        let txt = `### Patient Summary\n${j.patient}`;
+        if (j.doctor) txt += `\n\n### Doctor Summary\n${j.doctor}`;
+        txt += `\n\n_${j.disclaimer}_`;
+        setResult(txt);
+      } else if (j.type === 'image') {
+        setResult(`${j.report}\n\n_${j.disclaimer}_`);
+      }
+    } catch(e:any){
+      setResult(`⚠️ ${String(e?.message || e)}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div style={{ padding:20, maxWidth:600, margin:'0 auto' }}>
+      <h1>MedX</h1>
+      <label style={{ display:'block', marginTop:20 }}>
+        <input type="file" accept=".pdf,image/*" disabled={busy}
+          onChange={e=>{ const f=e.target.files?.[0]; if(f) handleFile(f); e.target.value=''; }} />
+      </label>
+      <div style={{ marginTop:8, fontSize:14, color:'#555' }}>
+        Upload lab reports, prescriptions, discharge summaries, or X-rays (PDF or image).
+      </div>
+      <label style={{ display:'block', marginTop:12, fontSize:14 }}>
+        <input type="checkbox" checked={doctorMode} onChange={e=>setDoctorMode(e.target.checked)} /> Doctor Mode
+      </label>
+      <div style={{ marginTop:20 }} className="markdown"><Markdown text={result} /></div>
+    </div>
+  );
+}
+

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { openaiVision } from '@/lib/llm';
+
+export const runtime = 'nodejs';
+
+const SYS_PATIENT = 'You are a medical explainer. Use clear, calm, non-alarming language (8th–10th grade).';
+const SYS_DOCTOR = 'You are a clinician. Write structured notes. Be concise and evidence-based.';
+const SYS_RAD = 'You are a radiologist. Write a structured X-ray report (Technique, Findings, Impression \u22643 bullets with cautious language, Recommendations, Limitations).';
+
+function fileToDataUrl(file: File): Promise<string> {
+  return file.arrayBuffer().then(buf => {
+    const b64 = Buffer.from(buf).toString('base64');
+    return `data:${file.type};base64,${b64}`;
+  });
+}
+
+export async function POST(req: Request) {
+  try {
+    const fd = await req.formData();
+    const file = fd.get('file') as File | null;
+    const doctorMode = (fd.get('doctorMode') || 'false').toString() === 'true';
+    if (!file) return NextResponse.json({ error: 'file missing' }, { status: 400 });
+
+    const mime = file.type || '';
+    const dataUrl = await fileToDataUrl(file);
+
+    if (mime.includes('pdf')) {
+      const patient = await openaiVision({
+        system: SYS_PATIENT,
+        prompt: 'Please summarize this medical report for a patient.',
+        imageDataUrl: dataUrl,
+        model: process.env.OPENAI_TEXT_MODEL,
+      });
+      let doctor: string | null = null;
+      if (doctorMode) {
+        doctor = await openaiVision({
+          system: SYS_DOCTOR,
+          prompt: 'Summarize for a doctor with headings: HPI/Context, Key Results, Interpretation, Plan, Red Flags, Limitations.',
+          imageDataUrl: dataUrl,
+          model: process.env.OPENAI_TEXT_MODEL,
+        });
+      }
+      return NextResponse.json({
+        type: 'pdf',
+        patient,
+        doctor,
+        disclaimer: 'AI assistance only — not a medical diagnosis. Confirm with a clinician.',
+      });
+    }
+
+    // default: treat as image
+    const report = await openaiVision({
+      system: SYS_RAD,
+      prompt: 'Analyze this X-ray and generate a radiology-style report.',
+      imageDataUrl: dataUrl,
+      model: process.env.OPENAI_VISION_MODEL,
+    });
+    return NextResponse.json({
+      type: 'image',
+      report,
+      disclaimer: 'AI assistance only — not a medical diagnosis. Confirm with a clinician.',
+    });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'analyze failed' }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `/api/analyze` that sends PDFs or images to OpenAI for patient and doctor summaries
- build simple `/analyze` page with single upload and Doctor Mode toggle
- document new environment variables and endpoint in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7087be85c832f9335450534345bdd