### PR TITLE
feat: add pdf report summarization

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -20,8 +20,10 @@ export async function POST(req: Request) {
     const doctorMode = (fd.get("doctorMode") || "true").toString() === "true";
     const buf = Buffer.from(await file.arrayBuffer());
     const mime = file.type || "application/octet-stream";
+    const filename = file.name || "file";
+    const isPdf = mime.includes("pdf") || filename.toLowerCase().endsWith(".pdf");
 
-    if (mime.includes("pdf")) {
+    if (isPdf) {
       const dataUrl = `data:application/pdf;base64,${buf.toString("base64")}`;
 
       const pResp = await fetch("https://api.openai.com/v1/chat/completions", {
@@ -59,8 +61,9 @@ export async function POST(req: Request) {
 
       return NextResponse.json({
         type: "pdf",
+        filename,
         patient,
-        doctor: doctorMode ? doctor : null,
+        ...(doctorMode ? { doctor } : {}),
         disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
       });
     }


### PR DESCRIPTION
## Summary
- support PDF uploads in `/api/analyze`
- detect PDF via mime or filename
- return patient and optional doctor summaries with filename and disclaimer

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b713ea3274832f892881b6ee088458