### PR TITLE
Handle PDF uploads in analyze route

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 
 const OAI_KEY = process.env.OPENAI_API_KEY!;
-const MODEL_TEXT = process.env.OPENAI_TEXT_MODEL || "gpt-5";
-const MODEL_VISION = process.env.OPENAI_VISION_MODEL || "gpt-5";
+const MODEL_TEXT   = process.env.OPENAI_TEXT_MODEL   || "gpt-5"; // PDFs
+const MODEL_VISION = process.env.OPENAI_VISION_MODEL || "gpt-5"; // X-rays/images
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -14,18 +14,23 @@ function toDataUrl(buf: Buffer, mime: string) {
 export async function POST(req: Request) {
   try {
     const fd = await req.formData();
+
+    // unified single field (tolerate legacy names too)
     const file = (fd.get("file") || fd.get("pdf") || fd.get("image") || fd.get("document")) as File | null;
     if (!file) return NextResponse.json({ error: "file missing" }, { status: 400 });
 
     const doctorMode = (fd.get("doctorMode") || "true").toString() === "true";
-    const buf = Buffer.from(await file.arrayBuffer());
-    const mime = file.type || "application/octet-stream";
-    const filename = file.name || "file";
-    const isPdf = mime.includes("pdf") || filename.toLowerCase().endsWith(".pdf");
+    const name = (file as any).name || "upload";
+    const buf  = Buffer.from(await file.arrayBuffer());
+    let mime   = file.type || "application/octet-stream";
+    const lowerName = name.toLowerCase();
 
-    if (isPdf) {
+    // ---------- PDF BRANCH (handle first, then return) ----------
+    const looksLikePdf = mime.includes("pdf") || lowerName.endsWith(".pdf");
+    if (looksLikePdf) {
       const dataUrl = `data:application/pdf;base64,${buf.toString("base64")}`;
 
+      // Patient summary (OpenAI only; no temperature)
       const pResp = await fetch("https://api.openai.com/v1/chat/completions", {
         method: "POST",
         headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
@@ -33,14 +38,20 @@ export async function POST(req: Request) {
           model: MODEL_TEXT,
           messages: [
             { role: "system", content: "You are a medical explainer. Summarize reports for patients in clear, calm, non-alarming language (8th–10th grade)." },
-            { role: "user", content: [{ type: "text", text: "Please summarize this medical report for a patient." }, { type: "image_url", image_url: { url: dataUrl } }] }
+            { role: "user", content: [
+              { type: "text", text: "Please summarize this medical report for a patient." },
+              { type: "image_url", image_url: { url: dataUrl } }
+            ] }
           ],
         }),
       });
       const pJson = await pResp.json();
-      if (!pResp.ok) throw new Error(pJson?.error?.message || pResp.statusText);
+      if (!pResp.ok) {
+        return NextResponse.json({ error: pJson?.error?.message || pResp.statusText }, { status: 502 });
+      }
       const patient = pJson.choices?.[0]?.message?.content || "";
 
+      // Doctor summary (optional)
       let doctor: string | null = null;
       if (doctorMode) {
         const dResp = await fetch("https://api.openai.com/v1/chat/completions", {
@@ -50,49 +61,75 @@ export async function POST(req: Request) {
             model: MODEL_TEXT,
             messages: [
               { role: "system", content: "You are a clinician. Write a structured summary with headings: HPI/Context, Key Results, Interpretation, Plan, Red Flags, Limitations. Be concise and evidence-based." },
-              { role: "user", content: [{ type: "text", text: "Summarize this report for a doctor." }, { type: "image_url", image_url: { url: dataUrl } }] }
+              { role: "user", content: [
+                { type: "text", text: "Summarize this report for a doctor." },
+                { type: "image_url", image_url: { url: dataUrl } }
+              ] }
             ],
           }),
         });
         const dJson = await dResp.json();
-        if (!dResp.ok) throw new Error(dJson?.error?.message || dResp.statusText);
+        if (!dResp.ok) {
+          return NextResponse.json({ error: dJson?.error?.message || dResp.statusText }, { status: 502 });
+        }
         doctor = dJson.choices?.[0]?.message?.content || "";
       }
 
       return NextResponse.json({
         type: "pdf",
-        filename,
+        filename: name,
         patient,
-        ...(doctorMode ? { doctor } : {}),
+        doctor: doctorMode ? doctor : null,
         disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
       });
     }
+    // ---------- END PDF BRANCH ----------
 
-    if (mime.startsWith("image/")) {
-      const dataUrl = toDataUrl(buf, mime);
-      const resp = await fetch("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: MODEL_VISION,
-          messages: [
-            { role: "system", content: "You are a radiologist. Write a structured X-ray report: Technique, Findings, Impression (≤3 bullets, cautious language), Recommendations, Limitations." },
-            { role: "user", content: [{ type: "text", text: "Analyze this X-ray and generate a radiology-style report." }, { type: "image_url", image_url: { url: dataUrl } }] }
-          ],
-        }),
-      });
-      const j = await resp.json();
-      if (!resp.ok) throw new Error(j?.error?.message || resp.statusText);
-      const report = j.choices?.[0]?.message?.content || "";
+    // ---------- IMAGE / X-RAY BRANCH (leave behavior as-is) ----------
+    const looksLikeImage =
+      mime.startsWith("image/") || /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(lowerName);
 
-      return NextResponse.json({
-        type: "image",
-        report,
-        disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
-      });
+    if (!looksLikeImage) {
+      return NextResponse.json(
+        { error: `Unsupported MIME type: ${mime} (name: ${name}). Upload a PDF or image.` },
+        { status: 415 }
+      );
     }
 
-    return NextResponse.json({ error: `Unsupported MIME type: ${mime}` }, { status: 415 });
+    // Normalize mime for octet-stream images by extension
+    if (!mime || mime === "application/octet-stream") {
+      const ext = lowerName.split(".").pop() || "";
+      mime = ext ? `image/${ext === "jpg" ? "jpeg" : ext}` : "image/jpeg";
+    }
+
+    const dataUrl = toDataUrl(buf, mime);
+
+    const resp = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: MODEL_VISION,
+        messages: [
+          { role: "system", content: "You are a radiologist. Write a structured X-ray report: Technique, Findings, Impression (≤3 bullets, cautious language), Recommendations, Limitations." },
+          { role: "user", content: [
+            { type: "text", text: "Analyze this X-ray and generate a radiology-style report." },
+            { type: "image_url", image_url: { url: dataUrl } }
+          ] }
+        ],
+      }),
+    });
+
+    const j = await resp.json();
+    if (!resp.ok) return NextResponse.json({ error: j?.error?.message || resp.statusText }, { status: 502 });
+
+    const report = j.choices?.[0]?.message?.content || "";
+
+    return NextResponse.json({
+      type: "image",
+      filename: name,
+      report,
+      disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
+    });
   } catch (e: any) {
     return NextResponse.json({ error: e.message || "analyze failed" }, { status: 500 });
   }


### PR DESCRIPTION
## Summary
- Detect PDFs by MIME type or filename and send them directly to OpenAI for patient and doctor summaries
- Preserve existing X-ray/image handling while normalizing octet-stream image MIME types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(incomplete: build started but did not finish in allotted time)*

------
https://chatgpt.com/codex/tasks/task_e_68b71be3479c832f94e5d559936020c9