### PR TITLE
feat: handle PDFs in imaging analyzer

### DIFF
--- a/app/api/imaging/analyze/route.ts
+++ b/app/api/imaging/analyze/route.ts
@@ -11,6 +11,18 @@ function toDataUrl(buf: Buffer, mime = "image/jpeg") {
   return `data:${mime};base64,${buf.toString("base64")}`;
 }
 
+function looksLikePdfByMagic(buf: Buffer): boolean {
+  // %PDF-  => 0x25 0x50 0x44 0x46 0x2D
+  return (
+    buf.length >= 5 &&
+    buf[0] === 0x25 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x44 &&
+    buf[3] === 0x46 &&
+    buf[4] === 0x2d
+  );
+}
+
 export async function POST(req: Request) {
   try {
     const fd = await req.formData();
@@ -27,15 +39,24 @@ export async function POST(req: Request) {
     }
 
     const name = (file as any).name || "upload";
-    const buf  = Buffer.from(await file.arrayBuffer());
-    let mime   = file.type || "application/octet-stream";
+    let mime = file.type || "application/octet-stream";
     const lowerName = name.toLowerCase();
 
-    // --- PDF FIRST: handle PDFs here so images code below is untouched ---
-    const looksLikePdf = mime.includes("pdf") || lowerName.endsWith(".pdf");
-    if (looksLikePdf) {
+    // Read once so we can check the PDF signature reliably
+    const buf = Buffer.from(await file.arrayBuffer());
+
+    // ---- PDF FIRST (robust detection) ----
+    const isPdf =
+      mime.includes("pdf") ||
+      lowerName.endsWith(".pdf") ||
+      looksLikePdfByMagic(buf);
+
+    if (isPdf) {
       const doctorMode = (fd.get("doctorMode") || "true").toString() === "true";
       const dataUrl = `data:application/pdf;base64,${buf.toString("base64")}`;
+
+      // Optional: server log to confirm branch
+      console.log("[/api/imaging/analyze] PDF branch →", { name, mime, byMagic: looksLikePdfByMagic(buf) });
 
       // Patient summary (OpenAI only; no temperature)
       const pResp = await fetch("https://api.openai.com/v1/chat/completions", {
@@ -73,7 +94,8 @@ export async function POST(req: Request) {
             messages: [
               {
                 role: "system",
-                content: "You are a clinician. Write a structured summary with headings: HPI/Context, Key Results, Interpretation, Plan, Red Flags, Limitations. Be concise and evidence-based.",
+                content:
+                  "You are a clinician. Write a structured summary with headings: HPI/Context, Key Results, Interpretation, Plan, Red Flags, Limitations. Be concise and evidence-based.",
               },
               {
                 role: "user",
@@ -90,20 +112,24 @@ export async function POST(req: Request) {
         doctor = dJson.choices?.[0]?.message?.content || "";
       }
 
-      return NextResponse.json({
+      const res = NextResponse.json({
         type: "pdf",
         filename: name,
         patient,
         doctor: doctorMode ? doctor : null,
         disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
       });
+      res.headers.set("x-branch", "pdf");
+      return res;
     }
-    // --- END PDF ---
+    // ---- END PDF ----
 
     // --- EXISTING IMAGE / X-RAY FLOW (leave this as-is) ---
     const looksLikeImage =
       mime.startsWith("image/") || /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(lowerName);
     if (!looksLikeImage) {
+      // Optional: log unsupported to debug
+      console.warn("[/api/imaging/analyze] unsupported MIME", { name, mime, size: buf.length });
       return NextResponse.json(
         { error: `Unsupported MIME type for imaging: ${mime} (name: ${name})` },
         { status: 415 }
@@ -145,12 +171,14 @@ export async function POST(req: Request) {
 
     const report = j.choices?.[0]?.message?.content || "";
 
-    return NextResponse.json({
+    const res = NextResponse.json({
       type: "image",
       filename: name,
       report,
       disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
     });
+    res.headers.set("x-branch", "image");
+    return res;
   } catch (e: any) {
     return NextResponse.json({ error: e.message || "imaging analyze failed" }, { status: 500 });
   }

--- a/components/UnifiedUpload.tsx
+++ b/components/UnifiedUpload.tsx
@@ -10,7 +10,20 @@ export default function UnifiedUpload() {
   async function onChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
-    setLoading(true); setErr(null); setOut(null);
+
+    const name = file.name?.toLowerCase() || "";
+    const isPdf = file.type === "application/pdf" || name.endsWith(".pdf");
+    const isImage =
+      file.type.startsWith("image/") ||
+      /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(name);
+    if (!isPdf && !isImage) {
+      setErr(`Unsupported file type: ${file.type || name}. Upload a PDF or an image.`);
+      return;
+    }
+
+    setLoading(true);
+    setErr(null);
+    setOut(null);
 
     const fd = new FormData();
     fd.append("file", file);


### PR DESCRIPTION
## Summary
- detect PDFs by MIME, extension, or magic bytes in imaging analyzer
- return `x-branch` header and log unsupported file types
- validate uploads for PDF/image on client side

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7203ddb08832fbbb9a49bb74cd3c8