### PR TITLE
Separate PDF and image analysis endpoints

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,132 +1,89 @@
 import { NextResponse } from "next/server";
 
 const OAI_KEY = process.env.OPENAI_API_KEY!;
-const MODEL_TEXT   = process.env.OPENAI_TEXT_MODEL   || "gpt-5"; // PDFs
-const MODEL_VISION = process.env.OPENAI_VISION_MODEL || "gpt-5"; // X-rays/images
+const MODEL_TEXT = process.env.OPENAI_TEXT_MODEL || "gpt-5";
+const MODEL_VISION = process.env.OPENAI_VISION_MODEL || "gpt-5";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-function toDataUrl(buf: Buffer, mime: string) {
-  return `data:${mime};base64,${buf.toString("base64")}`;
-}
-
 export async function POST(req: Request) {
   try {
     const fd = await req.formData();
-
-    // unified single field (tolerate legacy names too)
-    const file = (fd.get("file") || fd.get("pdf") || fd.get("image") || fd.get("document")) as File | null;
+    const file = fd.get("file") as File;
+    const instruction = (fd.get("instruction") as string) || "";
+    const audience = ((fd.get("audience") as string) || "patient") as "patient" | "clinician";
     if (!file) return NextResponse.json({ error: "file missing" }, { status: 400 });
 
-    const doctorMode = (fd.get("doctorMode") || "true").toString() === "true";
-    const name = (file as any).name || "upload";
-    const buf  = Buffer.from(await file.arrayBuffer());
-    let mime   = file.type || "application/octet-stream";
-    const lowerName = name.toLowerCase();
-
-    // ---------- PDF BRANCH (handle first, then return) ----------
-    const looksLikePdf = mime.includes("pdf") || lowerName.endsWith(".pdf");
-    if (looksLikePdf) {
-      const dataUrl = `data:application/pdf;base64,${buf.toString("base64")}`;
-
-      // Patient summary (OpenAI only; no temperature)
-      const pResp = await fetch("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: MODEL_TEXT,
-          messages: [
-            { role: "system", content: "You are a medical explainer. Summarize reports for patients in clear, calm, non-alarming language (8th–10th grade)." },
-            { role: "user", content: [
-              { type: "text", text: "Please summarize this medical report for a patient." },
-              { type: "image_url", image_url: { url: dataUrl } }
-            ] }
-          ],
-        }),
-      });
-      const pJson = await pResp.json();
-      if (!pResp.ok) {
-        return NextResponse.json({ error: pJson?.error?.message || pResp.statusText }, { status: 502 });
-      }
-      const patient = pJson.choices?.[0]?.message?.content || "";
-
-      // Doctor summary (optional)
-      let doctor: string | null = null;
-      if (doctorMode) {
-        const dResp = await fetch("https://api.openai.com/v1/chat/completions", {
-          method: "POST",
-          headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
-          body: JSON.stringify({
-            model: MODEL_TEXT,
-            messages: [
-              { role: "system", content: "You are a clinician. Write a structured summary with headings: HPI/Context, Key Results, Interpretation, Plan, Red Flags, Limitations. Be concise and evidence-based." },
-              { role: "user", content: [
-                { type: "text", text: "Summarize this report for a doctor." },
-                { type: "image_url", image_url: { url: dataUrl } }
-              ] }
-            ],
-          }),
-        });
-        const dJson = await dResp.json();
-        if (!dResp.ok) {
-          return NextResponse.json({ error: dJson?.error?.message || dResp.statusText }, { status: 502 });
-        }
-        doctor = dJson.choices?.[0]?.message?.content || "";
-      }
-
-      return NextResponse.json({
-        type: "pdf",
-        filename: name,
-        patient,
-        doctor: doctorMode ? doctor : null,
-        disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
-      });
-    }
-    // ---------- END PDF BRANCH ----------
-
-    // ---------- IMAGE / X-RAY BRANCH (leave behavior as-is) ----------
-    const looksLikeImage =
-      mime.startsWith("image/") || /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(lowerName);
-
-    if (!looksLikeImage) {
-      return NextResponse.json(
-        { error: `Unsupported MIME type: ${mime} (name: ${name}). Upload a PDF or image.` },
-        { status: 415 }
-      );
+    const name = (file.name || "").toLowerCase();
+    const mime = file.type || "";
+    const isPdf = mime === "application/pdf" || name.endsWith(".pdf");
+    const isImage =
+      mime.startsWith("image/") || /\.(png|jpe?g|gif|bmp|webp)$/i.test(name);
+    if (!isPdf && !isImage) {
+      return NextResponse.json({ error: "Please upload a PDF or image." }, { status: 400 });
     }
 
-    // Normalize mime for octet-stream images by extension
-    if (!mime || mime === "application/octet-stream") {
-      const ext = lowerName.split(".").pop() || "";
-      mime = ext ? `image/${ext === "jpg" ? "jpeg" : ext}` : "image/jpeg";
+    const baseStyle =
+      audience === "clinician"
+        ? "Write like a clinician for colleagues: findings, differentials, red flags, recommended next steps."
+        : "Explain in simple language: plain English, short sentences, key points and next steps.";
+    const custom = instruction ? `User instruction: ${instruction}` : "";
+    const systemPrompt = [
+      "You are a careful medical assistant. Never provide a diagnosis; provide support and clarity.",
+      baseStyle,
+      custom,
+      "Always include a brief disclaimer that this is not a medical diagnosis.",
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+
+    let userContent: any[] = [];
+    let model = MODEL_TEXT;
+
+    if (isPdf) {
+      const arrayBuffer = await file.arrayBuffer();
+      const pdfParse = (await import("pdf-parse")).default;
+      const data = await pdfParse(Buffer.from(arrayBuffer));
+      const text = data.text || "";
+      userContent = [{ type: "text", text }];
+    } else {
+      model = MODEL_VISION;
+      const arrayBuffer = await file.arrayBuffer();
+      const mimeType = mime || "image/jpeg";
+      const dataUrl = `data:${mimeType};base64,${Buffer.from(arrayBuffer).toString("base64")}`;
+      userContent = [
+        { type: "text", text: "Analyze this image and provide a report." },
+        { type: "image_url", image_url: { url: dataUrl } },
+      ];
     }
 
-    const dataUrl = toDataUrl(buf, mime);
-
-    const resp = await fetch("https://api.openai.com/v1/chat/completions", {
+    const r = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
       headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
       body: JSON.stringify({
-        model: MODEL_VISION,
+        model,
         messages: [
-          { role: "system", content: "You are a radiologist. Write a structured X-ray report: Technique, Findings, Impression (≤3 bullets, cautious language), Recommendations, Limitations." },
-          { role: "user", content: [
-            { type: "text", text: "Analyze this X-ray and generate a radiology-style report." },
-            { type: "image_url", image_url: { url: dataUrl } }
-          ] }
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userContent },
         ],
       }),
     });
 
-    const j = await resp.json();
-    if (!resp.ok) return NextResponse.json({ error: j?.error?.message || resp.statusText }, { status: 502 });
+    if (!r.ok) {
+      const errData = await r.json().catch(() => null);
+      return NextResponse.json(
+        { error: errData?.error?.message || `OpenAI error ${r.status}` },
+        { status: r.status }
+      );
+    }
 
-    const report = j.choices?.[0]?.message?.content || "";
+    const data = await r.json();
+    const report = data.choices?.[0]?.message?.content || "";
 
     return NextResponse.json({
-      type: "image",
-      filename: name,
+      type: isPdf ? "pdf" : "image",
+      filename: file.name || "upload",
       report,
       disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
     });

--- a/app/api/imaging/analyze/route.ts
+++ b/app/api/imaging/analyze/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 
 const OAI_KEY = process.env.OPENAI_API_KEY!;
 const MODEL_VISION = process.env.OPENAI_VISION_MODEL || "gpt-5"; // images
-const MODEL_TEXT   = process.env.OPENAI_TEXT_MODEL   || "gpt-5"; // PDFs
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -11,138 +10,43 @@ function toDataUrl(buf: Buffer, mime = "image/jpeg") {
   return `data:${mime};base64,${buf.toString("base64")}`;
 }
 
-function looksLikePdfByMagic(buf: Buffer): boolean {
-  // %PDF-  => 0x25 0x50 0x44 0x46 0x2D
-  return (
-    buf.length >= 5 &&
-    buf[0] === 0x25 &&
-    buf[1] === 0x50 &&
-    buf[2] === 0x44 &&
-    buf[3] === 0x46 &&
-    buf[4] === 0x2d
-  );
-}
-
 export async function POST(req: Request) {
   try {
     const fd = await req.formData();
+    const f = fd.get("file") as File;
+    if (!f) throw new Error("No file uploaded");
 
-    // Accept both legacy and unified field names
-    const multi = fd.getAll("files[]").filter(Boolean) as File[];
-    const single = (fd.get("file") || fd.get("image") || fd.get("pdf") || fd.get("document")) as File | null;
-    const file = multi[0] ?? single;
-    if (!file) {
+    const name = (f.name || "").toLowerCase();
+    const mime = f.type || "";
+
+    // Reject PDFs explicitly
+    if (mime === "application/pdf" || name.endsWith(".pdf")) {
       return NextResponse.json(
-        { error: "No file found. Send as 'file' (preferred) or 'files[]'." },
+        { error: "This endpoint only supports images. Send PDFs to /api/analyze." },
         { status: 400 }
       );
     }
 
-    const name = (file as any).name || "upload";
-    let mime = file.type || "application/octet-stream";
-    const lowerName = name.toLowerCase();
+    const buf = Buffer.from(await f.arrayBuffer());
 
-    // Read once so we can check the PDF signature reliably
-    const buf = Buffer.from(await file.arrayBuffer());
-
-    // ---- PDF FIRST (robust detection) ----
-    const isPdf =
-      mime.includes("pdf") ||
-      lowerName.endsWith(".pdf") ||
-      looksLikePdfByMagic(buf);
-
-    if (isPdf) {
-      const doctorMode = (fd.get("doctorMode") || "true").toString() === "true";
-      const dataUrl = `data:application/pdf;base64,${buf.toString("base64")}`;
-
-      // Optional: server log to confirm branch
-      console.log("[/api/imaging/analyze] PDF branch →", { name, mime, byMagic: looksLikePdfByMagic(buf) });
-
-      // Patient summary (OpenAI only; no temperature)
-      const pResp = await fetch("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: MODEL_TEXT,
-          messages: [
-            {
-              role: "system",
-              content: "You are a medical explainer. Summarize reports for patients in clear, calm, non-alarming language (8th–10th grade).",
-            },
-            {
-              role: "user",
-              content: [
-                { type: "text", text: "Please summarize this medical report for a patient." },
-                { type: "image_url", image_url: { url: dataUrl } },
-              ],
-            },
-          ],
-        }),
-      });
-      const pJson = await pResp.json();
-      if (!pResp.ok) throw new Error(pJson?.error?.message || pResp.statusText);
-      const patient = pJson.choices?.[0]?.message?.content || "";
-
-      // Doctor summary (optional)
-      let doctor: string | null = null;
-      if (doctorMode) {
-        const dResp = await fetch("https://api.openai.com/v1/chat/completions", {
-          method: "POST",
-          headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
-          body: JSON.stringify({
-            model: MODEL_TEXT,
-            messages: [
-              {
-                role: "system",
-                content:
-                  "You are a clinician. Write a structured summary with headings: HPI/Context, Key Results, Interpretation, Plan, Red Flags, Limitations. Be concise and evidence-based.",
-              },
-              {
-                role: "user",
-                content: [
-                  { type: "text", text: "Summarize this report for a doctor." },
-                  { type: "image_url", image_url: { url: dataUrl } },
-                ],
-              },
-            ],
-          }),
-        });
-        const dJson = await dResp.json();
-        if (!dResp.ok) throw new Error(dJson?.error?.message || dResp.statusText);
-        doctor = dJson.choices?.[0]?.message?.content || "";
-      }
-
-      const res = NextResponse.json({
-        type: "pdf",
-        filename: name,
-        patient,
-        doctor: doctorMode ? doctor : null,
-        disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
-      });
-      res.headers.set("x-branch", "pdf");
-      return res;
-    }
-    // ---- END PDF ----
-
-    // --- EXISTING IMAGE / X-RAY FLOW (leave this as-is) ---
     const looksLikeImage =
-      mime.startsWith("image/") || /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(lowerName);
+      mime.startsWith("image/") || /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(name);
     if (!looksLikeImage) {
-      // Optional: log unsupported to debug
-      console.warn("[/api/imaging/analyze] unsupported MIME", { name, mime, size: buf.length });
       return NextResponse.json(
         { error: `Unsupported MIME type for imaging: ${mime} (name: ${name})` },
         { status: 415 }
       );
     }
 
-    // Normalize mime if needed
-    if (!mime || mime === "application/octet-stream") {
-      const ext = lowerName.split(".").pop() || "";
-      mime = ext ? `image/${ext === "jpg" ? "jpeg" : ext}` : "image/jpeg";
-    }
+    const finalMime =
+      mime && mime !== "application/octet-stream"
+        ? mime
+        : (() => {
+            const ext = name.split(".").pop() || "";
+            return ext ? `image/${ext === "jpg" ? "jpeg" : ext}` : "image/jpeg";
+          })();
 
-    const dataUrl = toDataUrl(buf, mime);
+    const dataUrl = toDataUrl(buf, finalMime);
 
     const resp = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
@@ -171,15 +75,14 @@ export async function POST(req: Request) {
 
     const report = j.choices?.[0]?.message?.content || "";
 
-    const res = NextResponse.json({
+    return NextResponse.json({
       type: "image",
       filename: name,
       report,
       disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
     });
-    res.headers.set("x-branch", "image");
-    return res;
   } catch (e: any) {
     return NextResponse.json({ error: e.message || "imaging analyze failed" }, { status: 500 });
   }
 }
+

--- a/components/UnifiedUpload.tsx
+++ b/components/UnifiedUpload.tsx
@@ -2,78 +2,91 @@
 import { useState } from "react";
 
 export default function UnifiedUpload() {
+  const [file, setFile] = useState<File | null>(null);
+  const [instruction, setInstruction] = useState("");
+  const [audience, setAudience] = useState<"patient"|"clinician">("patient");
   const [loading, setLoading] = useState(false);
-  const [doctorMode, setDoctorMode] = useState(true);
   const [out, setOut] = useState<any>(null);
   const [err, setErr] = useState<string | null>(null);
 
-  async function onChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    const name = file.name?.toLowerCase() || "";
-    const isPdf = file.type === "application/pdf" || name.endsWith(".pdf");
-    const isImage =
-      file.type.startsWith("image/") ||
-      /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(name);
-    if (!isPdf && !isImage) {
-      setErr(`Unsupported file type: ${file.type || name}. Upload a PDF or an image.`);
-      return;
-    }
-
-    setLoading(true);
-    setErr(null);
+  function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setFile(e.target.files?.[0] || null);
     setOut(null);
+    setErr(null);
+  }
 
-    const fd = new FormData();
-    fd.append("file", file);
-    fd.append("doctorMode", String(doctorMode));
+  async function onAnalyze() {
+    try {
+      if (!file) return setErr("Please choose a file first.");
+      setLoading(true); setErr(null); setOut(null);
 
-    const r = await fetch("/api/analyze", { method: "POST", body: fd });
-    const j = await r.json();
-    setLoading(false);
-    if (!r.ok) return setErr(j.error || "Upload failed");
-    setOut(j);
+      const name = (file.name || "").toLowerCase();
+      const mime = file.type || ""; // sometimes blank
+      const isPdf   = mime === "application/pdf" || name.endsWith(".pdf");
+      const isImage = mime.startsWith("image/") ||
+                      /\.(png|jpe?g|gif|bmp|webp)$/i.test(name);
+
+      const endpoint = isPdf ? "/api/analyze" : isImage ? "/api/imaging/analyze" : null;
+      if (!endpoint) throw new Error("Unsupported file type. Please upload a PDF or an image.");
+
+      const fd = new FormData();
+      fd.append("file", file);
+      fd.append("instruction", instruction);
+      fd.append("audience", audience);
+
+      const res = await fetch(endpoint, { method: "POST", body: fd });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || "Analyze failed");
+      setOut(data);
+    } catch (e:any) {
+      setErr(e.message || String(e));
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (
     <div className="space-y-3">
+      <input type="file" accept=".pdf,image/*" onChange={onFileChange} />
+
+      <label className="block text-sm font-medium">Command (optional)</label>
+      <textarea
+        rows={3}
+        placeholder='e.g., "Explain in simple language" or "Clinician note with differentials and next steps"'
+        value={instruction}
+        onChange={(e)=>setInstruction(e.target.value)}
+        className="w-full p-2 border rounded"
+      />
+
       <div className="flex items-center gap-3">
-        <label className="px-4 py-2 rounded bg-black text-white cursor-pointer">
-          <span>Upload</span>
-          <input type="file" accept="application/pdf,image/*" onChange={onChange} className="hidden" />
-        </label>
-        <label className="flex items-center gap-2 text-sm">
-          <input type="checkbox" checked={doctorMode} onChange={e=>setDoctorMode(e.target.checked)} />
-          <span>Doctor Mode</span>
-        </label>
+        <label className="text-sm">Audience:</label>
+        <select
+          value={audience}
+          onChange={(e)=>setAudience(e.target.value as any)}
+          className="p-1 border rounded"
+        >
+          <option value="patient">Patient-friendly</option>
+          <option value="clinician">Clinician detail</option>
+        </select>
+
+        <button disabled={loading || !file} onClick={onAnalyze} className="px-3 py-1 border rounded">
+          {loading ? "Analyzing…" : "Analyze"}
+        </button>
       </div>
 
-      <p className="text-xs text-gray-500">
-        (Upload medical reports, prescriptions, discharge summaries, or X-rays — PDF or image.)
-      </p>
-
-      {loading && <p>Analyzing…</p>}
-      {err && <p className="text-red-600">⚠️ {err}</p>}
+      {err && <p className="text-red-600 text-sm">⚠️ {err}</p>}
 
       {out && (
-        <div className="space-y-3">
+        <div className="p-3 border rounded space-y-2">
+          <div className="text-sm text-gray-500">Filename: {out.filename}</div>
           {out.type === "pdf" && (
-            <>
-              <section className="p-3 border rounded">
-                <h3 className="font-semibold mb-1">Patient Summary</h3>
-                <p className="whitespace-pre-wrap text-sm">{out.patient}</p>
-              </section>
-              {out.doctor && (
-                <section className="p-3 border rounded">
-                  <h3 className="font-semibold mb-1">Doctor Summary</h3>
-                  <p className="whitespace-pre-wrap text-sm">{out.doctor}</p>
-                </section>
-              )}
-            </>
+            <section>
+              <h3 className="font-semibold mb-1">Document Analysis</h3>
+              <p className="whitespace-pre-wrap text-sm">{out.report}</p>
+            </section>
           )}
           {out.type === "image" && (
-            <section className="p-3 border rounded">
+            <section>
               <h3 className="font-semibold mb-1">Imaging Report</h3>
               <p className="whitespace-pre-wrap text-sm">{out.report}</p>
             </section>


### PR DESCRIPTION
## Summary
- Route PDF uploads through `/api/analyze` and images through `/api/imaging/analyze`
- Reject PDFs in the imaging endpoint with a clear 400 error
- Enhance `/api/analyze` to accept instruction and audience fields and call OpenAI accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7262bce8c832f8a27f217083dbe02