### PR TITLE
feat(pdf): route PDFs to /api/analyze, add instruction+audience UX; keep imaging flow unchanged

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,137 +1,100 @@
 import { NextResponse } from "next/server";
+import { extractTextFromPDF } from "@/lib/pdftext";
 
 const OAI_KEY = process.env.OPENAI_API_KEY!;
-const MODEL_TEXT   = process.env.OPENAI_TEXT_MODEL   || "gpt-5"; // PDFs
-const MODEL_VISION = process.env.OPENAI_VISION_MODEL || "gpt-5"; // X-rays/images
+const MODEL_TEXT = process.env.OPENAI_TEXT_MODEL || "gpt-5";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-function toDataUrl(buf: Buffer, mime: string) {
-  return `data:${mime};base64,${buf.toString("base64")}`;
-}
-
 export async function POST(req: Request) {
   try {
     const fd = await req.formData();
-
-    // unified single field (tolerate legacy names too)
-    const file = (fd.get("file") || fd.get("pdf") || fd.get("image") || fd.get("document")) as File | null;
-    if (!file) return NextResponse.json({ error: "file missing" }, { status: 400 });
-
-    const doctorMode = (fd.get("doctorMode") || "true").toString() === "true";
-    const name = (file as any).name || "upload";
-    const buf  = Buffer.from(await file.arrayBuffer());
-    let mime   = file.type || "application/octet-stream";
-    const lowerName = name.toLowerCase();
-
-    // ---------- PDF BRANCH (handle first, then return) ----------
-    const looksLikePdf = mime.includes("pdf") || lowerName.endsWith(".pdf");
-    if (looksLikePdf) {
-      const dataUrl = `data:application/pdf;base64,${buf.toString("base64")}`;
-
-      // Patient summary (OpenAI only; no temperature)
-      const pResp = await fetch("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: MODEL_TEXT,
-          messages: [
-            { role: "system", content: "You are a medical explainer. Summarize reports for patients in clear, calm, non-alarming language (8th–10th grade)." },
-            { role: "user", content: [
-              { type: "text", text: "Please summarize this medical report for a patient." },
-              { type: "image_url", image_url: { url: dataUrl } }
-            ] }
-          ],
-        }),
-      });
-      const pJson = await pResp.json();
-      if (!pResp.ok) {
-        return NextResponse.json({ error: pJson?.error?.message || pResp.statusText }, { status: 502 });
-      }
-      const patient = pJson.choices?.[0]?.message?.content || "";
-
-      // Doctor summary (optional)
-      let doctor: string | null = null;
-      if (doctorMode) {
-        const dResp = await fetch("https://api.openai.com/v1/chat/completions", {
-          method: "POST",
-          headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
-          body: JSON.stringify({
-            model: MODEL_TEXT,
-            messages: [
-              { role: "system", content: "You are a clinician. Write a structured summary with headings: HPI/Context, Key Results, Interpretation, Plan, Red Flags, Limitations. Be concise and evidence-based." },
-              { role: "user", content: [
-                { type: "text", text: "Summarize this report for a doctor." },
-                { type: "image_url", image_url: { url: dataUrl } }
-              ] }
-            ],
-          }),
-        });
-        const dJson = await dResp.json();
-        if (!dResp.ok) {
-          return NextResponse.json({ error: dJson?.error?.message || dResp.statusText }, { status: 502 });
-        }
-        doctor = dJson.choices?.[0]?.message?.content || "";
-      }
-
-      return NextResponse.json({
-        type: "pdf",
-        filename: name,
-        patient,
-        doctor: doctorMode ? doctor : null,
-        disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
-      });
+    const file = fd.get("file") as File | null;
+    if (!file) {
+      return NextResponse.json({ error: "file missing" }, { status: 400 });
     }
-    // ---------- END PDF BRANCH ----------
 
-    // ---------- IMAGE / X-RAY BRANCH (leave behavior as-is) ----------
-    const looksLikeImage =
-      mime.startsWith("image/") || /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(lowerName);
+    const instruction = (fd.get("instruction") || "").toString();
+    const audience = (fd.get("audience") || "patient").toString();
 
-    if (!looksLikeImage) {
+    const name = (file as any).name || "upload";
+    const mime = file.type || "";
+    const lower = name.toLowerCase();
+    const isPdf = mime === "application/pdf" || lower.endsWith(".pdf");
+    const isImage = mime.startsWith("image/") || /\.(png|jpe?g|gif|bmp|webp)$/i.test(lower);
+
+    if (!isPdf) {
+      if (isImage) {
+        return NextResponse.json(
+          { error: "Images are handled by /api/imaging/analyze." },
+          { status: 400 }
+        );
+      }
       return NextResponse.json(
-        { error: `Unsupported MIME type: ${mime} (name: ${name}). Upload a PDF or image.` },
+        { error: `Unsupported file type: ${mime || name}` },
         { status: 415 }
       );
     }
 
-    // Normalize mime for octet-stream images by extension
-    if (!mime || mime === "application/octet-stream") {
-      const ext = lowerName.split(".").pop() || "";
-      mime = ext ? `image/${ext === "jpg" ? "jpeg" : ext}` : "image/jpeg";
-    }
+    const buf = Buffer.from(await file.arrayBuffer());
+    const { text } = await extractTextFromPDF(buf);
+    const trimmed = text.slice(0, 20_000);
 
-    const dataUrl = toDataUrl(buf, mime);
+    const baseStyle =
+      audience === "clinician"
+        ? "Write like a clinician for colleagues: findings, differentials, red flags, recommended next steps."
+        : "Explain in simple language: plain English, short sentences, key points and next steps.";
+    const custom = instruction ? `User instruction: ${instruction}` : "";
+    const systemPrompt = [
+      "You are a careful medical assistant. Never provide a diagnosis; provide support and clarity.",
+      baseStyle,
+      custom,
+      "Always include a brief disclaimer that this is not a medical diagnosis.",
+    ]
+      .filter(Boolean)
+      .join("\n\n");
 
     const resp = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
-      headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
+      headers: {
+        Authorization: `Bearer ${OAI_KEY}`,
+        "Content-Type": "application/json",
+      },
       body: JSON.stringify({
-        model: MODEL_VISION,
+        model: MODEL_TEXT,
+        temperature: 0.2,
         messages: [
-          { role: "system", content: "You are a radiologist. Write a structured X-ray report: Technique, Findings, Impression (≤3 bullets, cautious language), Recommendations, Limitations." },
-          { role: "user", content: [
-            { type: "text", text: "Analyze this X-ray and generate a radiology-style report." },
-            { type: "image_url", image_url: { url: dataUrl } }
-          ] }
+          { role: "system", content: systemPrompt },
+          {
+            role: "user",
+            content: `Here is PDF text content:\n\n${trimmed}`,
+          },
         ],
       }),
     });
-
     const j = await resp.json();
-    if (!resp.ok) return NextResponse.json({ error: j?.error?.message || resp.statusText }, { status: 502 });
+    if (!resp.ok) {
+      return NextResponse.json(
+        { error: j?.error?.message || resp.statusText },
+        { status: resp.status }
+      );
+    }
 
     const report = j.choices?.[0]?.message?.content || "";
 
     return NextResponse.json({
-      type: "image",
+      type: "pdf",
       filename: name,
       report,
-      disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
+      disclaimer:
+        "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
     });
   } catch (e: any) {
-    return NextResponse.json({ error: e.message || "analyze failed" }, { status: 500 });
+    return NextResponse.json(
+      { error: e.message || "analyze failed" },
+      { status: 500 }
+    );
   }
 }
 

--- a/app/api/imaging/analyze/route.ts
+++ b/app/api/imaging/analyze/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 
 const OAI_KEY = process.env.OPENAI_API_KEY!;
 const MODEL_VISION = process.env.OPENAI_VISION_MODEL || "gpt-5"; // images
-const MODEL_TEXT   = process.env.OPENAI_TEXT_MODEL   || "gpt-5"; // PDFs
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -45,84 +44,16 @@ export async function POST(req: Request) {
     // Read once so we can check the PDF signature reliably
     const buf = Buffer.from(await file.arrayBuffer());
 
-    // ---- PDF FIRST (robust detection) ----
     const isPdf =
       mime.includes("pdf") ||
       lowerName.endsWith(".pdf") ||
       looksLikePdfByMagic(buf);
-
     if (isPdf) {
-      const doctorMode = (fd.get("doctorMode") || "true").toString() === "true";
-      const dataUrl = `data:application/pdf;base64,${buf.toString("base64")}`;
-
-      // Optional: server log to confirm branch
-      console.log("[/api/imaging/analyze] PDF branch →", { name, mime, byMagic: looksLikePdfByMagic(buf) });
-
-      // Patient summary (OpenAI only; no temperature)
-      const pResp = await fetch("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: MODEL_TEXT,
-          messages: [
-            {
-              role: "system",
-              content: "You are a medical explainer. Summarize reports for patients in clear, calm, non-alarming language (8th–10th grade).",
-            },
-            {
-              role: "user",
-              content: [
-                { type: "text", text: "Please summarize this medical report for a patient." },
-                { type: "image_url", image_url: { url: dataUrl } },
-              ],
-            },
-          ],
-        }),
-      });
-      const pJson = await pResp.json();
-      if (!pResp.ok) throw new Error(pJson?.error?.message || pResp.statusText);
-      const patient = pJson.choices?.[0]?.message?.content || "";
-
-      // Doctor summary (optional)
-      let doctor: string | null = null;
-      if (doctorMode) {
-        const dResp = await fetch("https://api.openai.com/v1/chat/completions", {
-          method: "POST",
-          headers: { Authorization: `Bearer ${OAI_KEY}`, "Content-Type": "application/json" },
-          body: JSON.stringify({
-            model: MODEL_TEXT,
-            messages: [
-              {
-                role: "system",
-                content:
-                  "You are a clinician. Write a structured summary with headings: HPI/Context, Key Results, Interpretation, Plan, Red Flags, Limitations. Be concise and evidence-based.",
-              },
-              {
-                role: "user",
-                content: [
-                  { type: "text", text: "Summarize this report for a doctor." },
-                  { type: "image_url", image_url: { url: dataUrl } },
-                ],
-              },
-            ],
-          }),
-        });
-        const dJson = await dResp.json();
-        if (!dResp.ok) throw new Error(dJson?.error?.message || dResp.statusText);
-        doctor = dJson.choices?.[0]?.message?.content || "";
-      }
-
-      const res = NextResponse.json({
-        type: "pdf",
-        filename: name,
-        patient,
-        doctor: doctorMode ? doctor : null,
-        disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
-      });
-      res.headers.set("x-branch", "pdf");
-      return res;
+      return NextResponse.json(
+        { error: "This endpoint only supports images. Send PDFs to /api/analyze." },
+        { status: 400 }
+      );
     }
-    // ---- END PDF ----
 
     // --- EXISTING IMAGE / X-RAY FLOW (leave this as-is) ---
     const looksLikeImage =

--- a/app/api/imaging/openai-selftest/route.ts
+++ b/app/api/imaging/openai-selftest/route.ts
@@ -22,8 +22,19 @@ export async function GET() {
     const ok = r.ok;
     const data = await r.json();
 
-    return NextResponse.json({ ok, model, status: r.status, snippet: (data?.choices?.[0]?.message?.content||"").slice(0,120) });
-  } catch (e:any) {
-    return NextResponse.json({ ok:false, error:String(e?.message||e) }, { status: 500 });
+    if (ok) {
+      return NextResponse.json({
+        ok,
+        model,
+        status: r.status,
+        snippet: (data?.choices?.[0]?.message?.content || "").slice(0, 120),
+      });
+    }
+    return NextResponse.json(
+      { ok, model, status: r.status, rawError: data },
+      { status: r.status }
+    );
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- Add instruction box and audience selector, route uploads by file type
- Handle PDF uploads in new `/api/analyze` with OpenAI GPT-5 text model
- Guard imaging endpoint against PDFs and improve self-test diagnostics

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b72a7a851c832f977fcbde3fe3ee4b