### PR TITLE
Fix first click theme toggle and improve dark-mode header

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,22 @@
-import './styles.css';
-import { ThemeProvider } from 'next-themes';
+import "./styles.css";
+import { ThemeProvider } from "next-themes";
+import Header from "../components/Header";
+import { ThemeMetaColor } from "../components/ThemeMetaColor";
 
-export const metadata = { title: 'MedX', description: 'Global medical AI' };
+export const metadata = { title: "MedX", description: "Global medical AI" };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <meta name="theme-color" content="#ffffff" />
+      </head>
       <body>
-        <ThemeProvider attribute="class" defaultTheme="system">{children}</ThemeProvider>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+          <ThemeMetaColor />
+          <Header />
+          {children}
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState } from 'react';
 import Sidebar from '../components/Sidebar';
 import Markdown from '../components/Markdown';
-import { Send, Sun, Moon, User, Stethoscope, ClipboardList, FlaskConical } from 'lucide-react';
+import { Send, User, Stethoscope, ClipboardList, FlaskConical } from 'lucide-react';
 
 type ChatMsg = { role: 'user'|'assistant'; content: string };
 
@@ -10,12 +10,10 @@ export default function Home(){
   const [messages, setMessages] = useState<ChatMsg[]>([]);
   const [input, setInput] = useState('');
   const [mode, setMode] = useState<'patient'|'doctor'|'admin'>('patient');
-  const [theme, setTheme] = useState<'dark'|'light'>('dark');
   const [busy, setBusy] = useState(false);
   const [researchMode, setResearchMode] = useState(false);
   const chatRef = useRef<HTMLDivElement>(null);
 
-  useEffect(()=>{ document.documentElement.className = theme==='light'?'light':''; },[theme]);
   useEffect(()=>{ document.body.setAttribute('data-role', mode==='doctor'? 'doctor' : mode==='admin' ? 'admin' : ''); },[mode]);
   useEffect(()=>{ chatRef.current?.scrollTo({ top: chatRef.current.scrollHeight }); },[messages]);
 
@@ -137,9 +135,6 @@ If CONTEXT has codes or trials, explain them in plain words and add links. Avoid
               : mode==='doctor'
                 ? <><Stethoscope size={16}/> Doctor</>
                 : <><ClipboardList size={16}/> Admin</>}
-          </button>
-          <button className="item" onClick={()=>setTheme(theme==='dark'?'light':'dark')}>
-            {theme==='dark'? <><Sun size={16}/> Light</> : <><Moon size={16}/> Dark</>}
           </button>
           <button className="item" onClick={()=>setResearchMode(r=>!r)}>
             {researchMode ? <><FlaskConical size={16}/> Research On</> : <><FlaskConical size={16}/> Research Off</>}

--- a/app/styles.css
+++ b/app/styles.css
@@ -3,6 +3,10 @@
   --card:#111827; --card-2:#0f172a; --border:#23324d;
   --accent:#22d3ee; --accent-ink:#002a32;
 }
+:root, .dark {
+  --tw-transition-colors: color 150ms ease, background-color 150ms ease, border-color 150ms ease, fill 150ms ease, stroke 150ms ease;
+}
+* { transition: var(--tw-transition-colors); }
 :root.light{
   --bg:#f7fafc; --fg:#0b1526; --muted:#5a6b84;
   --card:#ffffff; --card-2:#f2f6fb; --border:#e6eaf0;
@@ -44,6 +48,7 @@ body{
   height:56px; border-bottom:1px solid var(--border);
   display:flex; align-items:center; justify-content:space-between; padding:0 18px;
   backdrop-filter:saturate(120%) blur(6px);
+  background:var(--card-2);
 }
 .wrap{ max-width:860px; margin:0 auto; width:100%; padding:0 18px; flex:1; display:flex; flex-direction:column }
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,40 @@
+import ThemeToggle from "./ThemeToggle";
+
+export default function Header() {
+  return (
+    <header
+      className="
+        sticky top-0 z-40 w-full border-b
+        bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60
+        text-gray-900
+        dark:bg-gray-900/80 dark:supports-[backdrop-filter]:bg-gray-900/60
+        dark:text-gray-100 dark:border-gray-800
+      "
+    >
+      <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
+        <div className="font-semibold tracking-tight">
+          MedX
+        </div>
+
+        <nav className="flex items-center gap-4">
+          <a
+            href="#"
+            className="text-sm text-gray-600 hover:text-gray-900
+                       dark:text-gray-300 dark:hover:text-white"
+          >
+            Docs
+          </a>
+          <a
+            href="#"
+            className="text-sm text-gray-600 hover:text-gray-900
+                       dark:text-gray-300 dark:hover:text-white"
+          >
+            Support
+          </a>
+
+          <ThemeToggle />
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/components/ThemeMetaColor.tsx
+++ b/components/ThemeMetaColor.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { useEffect } from "react";
+import { useTheme } from "next-themes";
+
+export function ThemeMetaColor() {
+  const { theme } = useTheme();
+  useEffect(() => {
+    const meta = document.querySelector(
+      'meta[name="theme-color"]'
+    ) as HTMLMetaElement | null;
+    if (!meta) return;
+    meta.content = theme === "dark" ? "#0a0a0a" : "#ffffff";
+  }, [theme]);
+  return null;
+}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+
+  const next = theme === "dark" ? "light" : "dark";
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={() => setTheme(next)}
+      className="inline-flex items-center gap-2 rounded-lg px-3 py-1.5
+                 bg-gray-100 text-gray-900 hover:bg-gray-200
+                 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700
+                 transition-colors"
+    >
+      {theme === "dark" ? "Light" : "Dark"}
+    </button>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,6 @@
+export default {
+  darkMode: "class",
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"],
+  theme: { extend: {} },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- wrap app with `ThemeProvider` and add `ThemeMetaColor` for dynamic address bar tint
- add `ThemeToggle` client component that waits for mount before rendering
- add site `Header` with dark-mode aware styles and contrast-safe banner
- enable class-based dark mode in Tailwind config and smooth global color transitions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Can't resolve '@napi-rs/canvas')*

------
https://chatgpt.com/codex/tasks/task_e_68b748c14e70832fbfe76c68bd62964d