### PR TITLE
feat(refine): wire Explain/Doctor/Next to refine last analysis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "marked": "12.0.2",
         "next": "14.2.4",
         "next-themes": "0.3.0",
+        "openai": "^5.18.1",
         "pdf-lib": "^1.17.1",
         "pdf-parse": "^1.1.1",
         "pdfjs-dist": "^4.6.82",
@@ -5198,6 +5199,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.18.1.tgz",
+      "integrity": "sha512-iXSOfLlOL+jgnFr5CGrB2SEZw5C92o1nrFW2SasoAXj4QxGhfeJPgg8zkX+vaCfX80cT6CWjgaGnq7z9XzbyRw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/opencollective-postinstall": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "marked": "12.0.2",
     "next": "14.2.4",
     "next-themes": "0.3.0",
+    "openai": "^5.18.1",
     "pdf-lib": "^1.17.1",
     "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^4.6.82",


### PR DESCRIPTION
## Summary
- add `/api/actions/refine` endpoint that refines an existing analysis via OpenAI
- add frontend quick action flow with optimistic "Analyzing…" card and replacement on success or error
- disable quick action buttons while a refinement is loading and ensure buttons don't submit forms

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Missing OPENAI_API_KEY)


------
https://chatgpt.com/codex/tasks/task_e_68b77c71505c832fb39d42e9a3c1a401