### PR TITLE
fix(ui): sanitize external links in assistant messages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -189,12 +189,16 @@ export default function Home() {
       if (!planRes.ok) throw new Error(`MedX API error ${planRes.status}`);
       const plan = await planRes.json();
 
+      const linkNudge =
+        'When adding a reference, always format as [title](https://full.url) with the full absolute URL. Never output Learn more without a URL, and never use relative links.';
       const sys =
         mode === 'doctor'
           ? `You are a clinical assistant. Write clean markdown with headings and bullet lists.
-If CONTEXT has codes, interactions, or trials, summarize and add clickable links. Avoid medical advice.`
+If CONTEXT has codes, interactions, or trials, summarize and add clickable links. Avoid medical advice.
+${linkNudge}`
           : `You are a patient-friendly explainer. Use simple markdown and short paragraphs.
-If CONTEXT has codes or trials, explain them in plain words and add links. Avoid medical advice.`;
+If CONTEXT has codes or trials, explain them in plain words and add links. Avoid medical advice.
+${linkNudge}`;
 
       const contextBlock = 'CONTEXT:\n' + JSON.stringify(plan.sections || {}, null, 2);
 

--- a/components/AutoLink.ts
+++ b/components/AutoLink.ts
@@ -1,0 +1,13 @@
+import { normalizeExternalHref } from "./SafeLink";
+
+export function linkify(text: string): string {
+  return text.replace(
+    /\b(https?:\/\/[^\s)]+|www\.[^\s)]+)/gi,
+    (m) => {
+      const safe = normalizeExternalHref(m);
+      return safe
+        ? `<a href="${safe}" target="_blank" rel="noopener noreferrer">${m}</a>`
+        : m;
+    }
+  );
+}

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,10 +1,22 @@
 'use client';
 import { marked } from 'marked';
 import DOMPurify from 'isomorphic-dompurify';
+import { normalizeExternalHref } from './SafeLink';
+import { linkify } from './AutoLink';
 
 export default function Markdown({ text }: { text: string }) {
   marked.setOptions({ gfm: true, breaks: true });
-  const withLinks = text.replace(/(https?:\/\/[^\s)]+)/g, '[$1]($1)');
-  const html = DOMPurify.sanitize(marked.parse(withLinks) as string);
-  return <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />;
+  const raw = linkify(text);
+  const sanitized = DOMPurify.sanitize(marked.parse(raw) as string, {
+    ADD_ATTR: ['target', 'rel'],
+  });
+  const withSafeLinks = sanitized.replace(/<a\s+[^>]*>(.*?)<\/a>/gi, (match, inner) => {
+    const hrefMatch = match.match(/href="([^"]+)"/i);
+    const safe = normalizeExternalHref(hrefMatch ? hrefMatch[1] : undefined);
+    if (!safe) {
+      return `<span class="text-slate-500 dark:text-slate-400 cursor-not-allowed" title="Link unavailable">${inner}</span>`;
+    }
+    return `<a href="${safe}" target="_blank" rel="noopener noreferrer" class="underline underline-offset-2 decoration-slate-400 hover:decoration-slate-600 dark:decoration-slate-500 dark:hover:decoration-slate-300">${inner}</a>`;
+  });
+  return <div className="markdown" dangerouslySetInnerHTML={{ __html: withSafeLinks }} />;
 }

--- a/components/SafeLink.tsx
+++ b/components/SafeLink.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+const ALLOW = [
+  "nih.gov",
+  "ncbi.nlm.nih.gov",
+  "cancer.gov",
+  "who.int",
+  "cdc.gov",
+  "nhs.uk",
+  "mayoclinic.org",
+  "uptodate.com",
+];
+
+export function normalizeExternalHref(input?: string): string | null {
+  if (!input) return null;
+  let href = input.trim();
+
+  // If model returned "[Learn more](www.nhs.uk/...)" (no protocol), add https
+  if (/^www\./i.test(href)) href = "https://" + href;
+
+  // If relative or missing protocol → invalid
+  if (!/^https?:\/\//i.test(href)) return null;
+
+  try {
+    const url = new URL(href);
+    // encode spaces etc.
+    url.pathname = url.pathname.split("/").map(encodeURIComponent).join("/");
+    const hostOk = ALLOW.some(
+      d => url.hostname === d || url.hostname.endsWith(`.${d}`)
+    );
+    if (!hostOk) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export const SafeAnchor: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({ href, children, ...rest }) => {
+  const safe = normalizeExternalHref(href);
+  if (!safe) {
+    return (
+      <span
+        className="text-slate-500 dark:text-slate-400 cursor-not-allowed"
+        title="Link unavailable"
+      >
+        {children}
+      </span>
+    );
+  }
+  return (
+    <a
+      href={safe}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline underline-offset-2 decoration-slate-400 hover:decoration-slate-600 dark:decoration-slate-500 dark:hover:decoration-slate-300"
+      {...rest}
+    >
+      {children}
+    </a>
+  );
+};
+


### PR DESCRIPTION
## Summary
- sanitize and validate outgoing assistant links
- enforce absolute https links with SafeAnchor fallback
- instruct model to output only fully qualified references

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Module not found: Can't resolve 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b77ec811fc832fb2c8d16ad21d6bca