### PR TITLE
feat: add country selector and localization

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { COUNTRIES } from '@/data/countries';
 
 export async function POST(req: NextRequest){
   const body = await req.json();
@@ -10,12 +11,14 @@ export async function POST(req: NextRequest){
   // Allow either a raw question/role pair or full chat messages
   let messages = body.messages;
   if(!messages){
-    const { question, role } = body;
-    const sys = role==='clinician'
+    const { question, role, country: code } = body;
+    const country = COUNTRIES.find(c => c.code3 === code) || COUNTRIES.find(c => c.code3 === 'USA')!;
+    const base = role==='clinician'
       ? 'You are a clinical assistant. Be precise, cite sources if mentioned. Avoid medical advice; provide evidence and guideline pointers.'
       : role==='admin'
         ? 'You help administrative staff with medical documents. Summarize logistics and coding info. Avoid medical advice.'
         : 'You explain in simple, friendly language for patients. Avoid medical advice; encourage consulting a doctor.';
+    const sys = `You are MedX. User country: ${country.code3}.\nPrefer local guidelines, availability, dosing units, and OTC product examples used in ${country.name}.\nIf country-specific examples are uncertain, give generic names and note availability varies by region.\n` + base;
     messages = [
       { role: 'system', content: sys },
       { role: 'user', content: question }

--- a/app/api/nearby/route.ts
+++ b/app/api/nearby/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const { lat, lng, type = 'pharmacy', radiusKm = 5, countryCode2 } = await req.json();
+    const overpass = 'https://overpass-api.de/api/interpreter';
+
+    let query: string;
+    if (lat != null && lng != null) {
+      query = `
+[out:json];
+(
+  node[amenity="${type}"](around:${radiusKm * 1000},${lat},${lng});
+  way[amenity="${type}"](around:${radiusKm * 1000},${lat},${lng});
+  relation[amenity="${type}"](around:${radiusKm * 1000},${lat},${lng});
+);
+out center tags;`;
+    } else if (countryCode2) {
+      query = `
+[out:json];
+area["ISO3166-1"="${countryCode2}"][admin_level=2]->.searchArea;
+(
+  node[amenity="${type}"](area.searchArea);
+  way[amenity="${type}"](area.searchArea);
+  relation[amenity="${type}"](area.searchArea);
+);
+out center tags;`;
+    } else {
+      return NextResponse.json({ error: 'lat/lng or countryCode2 required' }, { status: 400 });
+    }
+
+    const res = await fetch(overpass, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: query,
+    });
+    const data = await res.json();
+    const results = (data.elements || []).map((el: any) => ({
+      id: el.id,
+      lat: el.lat || el.center?.lat,
+      lng: el.lon || el.center?.lon,
+      name: el.tags?.name || '',
+      tags: el.tags || {},
+    }));
+    return NextResponse.json({ results });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'nearby failed' }, { status: 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { ThemeProvider } from "next-themes";
 import Sidebar from "../components/Sidebar";
+import { CountryProvider } from "@/lib/country";
 
 export const metadata = { title: "MedX", description: "Global medical AI" };
 
@@ -8,16 +9,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen bg-white dark:bg-slate-950 text-slate-900 dark:text-gray-100">
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-          <div className="flex">
-            <aside className="hidden md:block fixed inset-y-0 left-0 w-64 border-r border-slate-200 dark:border-gray-800 bg-white dark:bg-gray-900">
-              <Sidebar />
-            </aside>
-            <main className="flex-1 md:ml-64 min-h-dvh flex flex-col">
-              {children}
-            </main>
-          </div>
-        </ThemeProvider>
+        <CountryProvider>
+          <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            <div className="flex">
+              <aside className="hidden md:block fixed inset-y-0 left-0 w-64 border-r border-slate-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+                <Sidebar />
+              </aside>
+              <main className="flex-1 md:ml-64 min-h-dvh flex flex-col">
+                {children}
+              </main>
+            </div>
+          </ThemeProvider>
+        </CountryProvider>
       </body>
     </html>
   );

--- a/components/CountryGlobe.tsx
+++ b/components/CountryGlobe.tsx
@@ -1,0 +1,75 @@
+"use client";
+import { useMemo, useState } from "react";
+import { useCountry } from "@/lib/country";
+import { COUNTRIES } from "@/data/countries";
+import { Globe2, Check } from "lucide-react";
+
+export default function CountryGlobe() {
+  const { country, setCountry } = useCountry();
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+
+  const list = useMemo(() => {
+    const query = q.trim().toLowerCase();
+    if (!query) return COUNTRIES;
+    return COUNTRIES.filter(
+      c =>
+        c.name.toLowerCase().includes(query) ||
+        c.code3.toLowerCase().includes(query)
+    );
+  }, [q]);
+
+  return (
+    <div className="relative">
+      <button
+        aria-label="Choose country"
+        title={`Country: ${country.name} (${country.code3}) — click to change`}
+        onClick={() => setOpen(v => !v)}
+        className="inline-flex items-center gap-1 rounded-full border border-slate-300 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 px-3 py-1.5 text-sm shadow-sm hover:bg-white/80 dark:hover:bg-gray-900"
+      >
+        <Globe2 className="h-4 w-4" />
+        <span className="font-medium">{country.code3}</span>
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Select country"
+          className="absolute right-0 mt-2 w-80 rounded-xl border border-slate-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-xl p-3 z-50"
+        >
+          <div className="mb-2">
+            <input
+              autoFocus
+              value={q}
+              onChange={e => setQ(e.target.value)}
+              placeholder="Search country or code…"
+              className="w-full rounded-lg border border-slate-300 dark:border-gray-700 bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-teal-500/50"
+            />
+          </div>
+
+          <div className="max-h-64 overflow-auto pr-1">
+            {list.map(c => (
+              <button
+                key={c.code3}
+                onClick={() => {
+                  setCountry(c.code3);
+                  setOpen(false);
+                }}
+                className="w-full flex items-center justify-between rounded-lg px-2 py-2 hover:bg-slate-50 dark:hover:bg-gray-800"
+              >
+                <span className="flex items-center gap-2">
+                  <span className="text-base">{c.flag}</span>
+                  <span className="text-sm">{c.name}</span>
+                </span>
+                <span className="text-xs font-semibold tabular-nums">{c.code3}</span>
+                {country.code3 === c.code3 && (
+                  <Check className="h-4 w-4 text-teal-500" />
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@
 import { User, Stethoscope } from 'lucide-react';
 import ThemeToggle from './ThemeToggle';
 import { ResearchToggle } from './ResearchToggle';
+import CountryGlobe from '@/components/CountryGlobe';
 
 export default function Header({
   mode,
@@ -17,7 +18,10 @@ export default function Header({
   return (
     <header className="sticky top-0 z-40 h-14 md:h-16 bg-white/80 dark:bg-gray-900/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:supports-[backdrop-filter]:bg-gray-900/60 border-b border-slate-200 dark:border-gray-800">
       <div className="max-w-6xl mx-auto h-full px-4 sm:px-6 flex items-center justify-between">
-        <div className="text-base md:text-lg font-semibold">MedX</div>
+        <div className="flex items-center gap-2 text-base md:text-lg font-semibold">
+          <div>MedX</div>
+          <CountryGlobe />
+        </div>
         <div className="flex items-center gap-2">
           <button
             onClick={() => onModeChange(mode === 'patient' ? 'doctor' : 'patient')}

--- a/data/countries.ts
+++ b/data/countries.ts
@@ -1,0 +1,17 @@
+export type Country = { code2: string; code3: string; name: string; flag: string };
+
+export const COUNTRIES: Country[] = [
+  { code2: "IN", code3: "IND", name: "India", flag: "🇮🇳" },
+  { code2: "US", code3: "USA", name: "United States", flag: "🇺🇸" },
+  { code2: "GB", code3: "GBR", name: "United Kingdom", flag: "🇬🇧" },
+  { code2: "AE", code3: "ARE", name: "United Arab Emirates", flag: "🇦🇪" },
+  { code2: "SG", code3: "SGP", name: "Singapore", flag: "🇸🇬" },
+  { code2: "CA", code3: "CAN", name: "Canada", flag: "🇨🇦" },
+  { code2: "AU", code3: "AUS", name: "Australia", flag: "🇦🇺" },
+  { code2: "DE", code3: "DEU", name: "Germany", flag: "🇩🇪" },
+  { code2: "FR", code3: "FRA", name: "France", flag: "🇫🇷" },
+  { code2: "ZA", code3: "ZAF", name: "South Africa", flag: "🇿🇦" }
+];
+
+export const byCode2 = (c2: string) => COUNTRIES.find(c => c.code2 === c2.toUpperCase());
+export const byCode3 = (c3: string) => COUNTRIES.find(c => c.code3 === c3.toUpperCase());

--- a/lib/country.tsx
+++ b/lib/country.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { createContext, useContext, useState } from "react";
+import { COUNTRIES, byCode2 } from "@/data/countries";
+
+const STORAGE_KEY = "medx.country.code3";
+
+type Ctx = {
+  country: { code3: string; code2: string; name: string; flag: string };
+  setCountry: (code3: string) => void;
+};
+
+const CountryContext = createContext<Ctx | null>(null);
+
+function inferFromLocale(): string {
+  try {
+    const locale =
+      Intl.DateTimeFormat().resolvedOptions().locale ||
+      navigator.language ||
+      "";
+    const c2 = locale.split("-")[1]?.toUpperCase();
+    const hit = c2 && byCode2(c2);
+    return hit?.code3 ?? "USA";
+  } catch {
+    return "USA";
+  }
+}
+
+export function CountryProvider({ children }: { children: React.ReactNode }) {
+  const [code3, setCode3] = useState<string>(() => {
+    if (typeof window === "undefined") return "USA";
+    return localStorage.getItem(STORAGE_KEY) || inferFromLocale();
+  });
+
+  const setCountry = (newCode3: string) => {
+    setCode3(newCode3);
+    if (typeof window !== "undefined")
+      localStorage.setItem(STORAGE_KEY, newCode3);
+  };
+
+  const cur =
+    COUNTRIES.find(c => c.code3 === code3) ||
+    COUNTRIES.find(c => c.code3 === "USA")!;
+  return (
+    <CountryContext.Provider value={{ country: cur, setCountry }}>
+      {children}
+    </CountryContext.Provider>
+  );
+}
+
+export function useCountry() {
+  const ctx = useContext(CountryContext);
+  if (!ctx) throw new Error("useCountry must be used within CountryProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add globe selector with ISO-3 codes and persistence
- localize chat, analysis, and refine prompts based on selected country
- support optional country filter for nearby searches

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b786ef35ec832f913e558e109324af