### PR TITLE
feat(upload): allow attaching a note before analyzing documents

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -86,6 +86,7 @@ export async function POST(req: Request) {
     const file = fd.get("file") as File | null;
     const doctorMode = fd.get("doctorMode") === "true";
     const code = (fd.get("country") as string) || "USA";
+    const note = (fd.get("note") as string | null)?.trim() || "";
     const country =
       COUNTRIES.find(c => c.code3 === code) ||
       COUNTRIES.find(c => c.code3 === "USA")!;
@@ -116,7 +117,10 @@ export async function POST(req: Request) {
             model: MODEL_TEXT,
             messages: [
               { role: "system", content: systemPrompt },
-              { role: "user", content: text.slice(0, 15000) },
+              {
+                role: "user",
+                content: `User note (optional): ${note || "not provided"}\n---\n${text.slice(0, 15000)}`,
+              },
             ],
           }),
         });
@@ -146,7 +150,13 @@ export async function POST(req: Request) {
           model: MODEL_VISION,
           messages: [
             { role: "system", content: systemPrompt },
-            { role: "user", content: [{ type: "image_url", image_url: { url: dataUrl } }] },
+            {
+              role: "user",
+              content: [
+                ...(note ? [{ type: "text", text: note }] : []),
+                { type: "image_url", image_url: { url: dataUrl } },
+              ],
+            },
           ],
         }),
       });


### PR DESCRIPTION
## Summary
- stop auto-analysis on file select and let users add an optional note
- send multipart file+note on submit; show a single pending card
- imaging analyze endpoint accepts optional `note` and forwards it to the model

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Module not found: Can't resolve 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68b78f90f5d8832fa9c87868eef0ec82