### PR TITLE
feat(nearby): restore 'pharmacy/hospitals near me' with geolocation (≤5 km)

### DIFF
--- a/app/api/nearby/route.ts
+++ b/app/api/nearby/route.ts
@@ -4,35 +4,26 @@ type Body = {
   lat: number;
   lng: number;
   radiusKm?: number;
-  category: "pharmacy"|"hospital"|"lab"|"doctor"|"gynecologist"|"chiropractor";
+  category?: string; // e.g. "pharmacy", "doctor", "gynecologist"
 };
 
-const CATEGORY_TAGS: Record<Body["category"], string[]> = {
-  pharmacy: ['amenity="pharmacy"'],
-  hospital: ['amenity="hospital"', 'healthcare="hospital"'],
-  lab: ['healthcare="laboratory"', 'amenity="clinic"[name~"(?i)lab|diagnostic|patholog|blood|test"]'],
-  doctor: ['amenity="doctors"', 'healthcare="doctor"', 'amenity="clinic"'],
-  gynecologist: [
-    'amenity="doctors"[healthcare:speciality~"(?i)gyn|ob.?gyn|obstetric|gynaec"]',
-    'healthcare="clinic"[healthcare:speciality~"(?i)gyn|ob.?gyn|obstetric|gynaec"]',
-    'amenity="doctors"[name~"(?i)gyn|ob.?gyn|women|maternity|obstetric"]',
-  ],
-  chiropractor: [
-    'healthcare="chiropractor"',
-    'amenity="doctors"[healthcare:speciality~"(?i)chiro"]',
-    'amenity="clinic"[name~"(?i)chiro"]',
-  ],
-};
+const BASE_SELECTORS = [
+  'amenity="doctors"',
+  'healthcare="doctor"',
+  'amenity="clinic"',
+  'amenity="hospital"',
+  'healthcare="hospital"',
+];
 
-function haversineKm(a:{lat:number;lng:number}, b:{lat:number;lng:number}) {
-  const R = 6371, toRad = (d:number)=>d*Math.PI/180;
+function haversineKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }) {
+  const R = 6371, toRad = (d: number) => d * Math.PI / 180;
   const dLat = toRad(b.lat - a.lat), dLon = toRad(b.lng - a.lng);
   const la1 = toRad(a.lat), la2 = toRad(b.lat);
-  const h = Math.sin(dLat/2)**2 + Math.cos(la1)*Math.cos(la2)*Math.sin(dLon/2)**2;
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(la1) * Math.cos(la2) * Math.sin(dLon / 2) ** 2;
   return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
 }
 
-function buildAddress(tags:any): string|null {
+function buildAddress(tags: any): string | null {
   if (!tags) return null;
   const parts = [
     tags["addr:housename"],
@@ -45,54 +36,59 @@ function buildAddress(tags:any): string|null {
   return parts.length ? parts.join(", ") : null;
 }
 
+function pickPhone(tags: any): string | null {
+  const cands = [tags?.phone, tags?.["contact:phone"], tags?.["contact:mobile"], tags?.["contact:tel"]];
+  return cands.find(Boolean) || null;
+}
+
 function tidyName(raw?: string): string {
   if (!raw) return "(Unnamed)";
-  const s = raw.replace(/\s+/g, " ").trim();
-  return s.replace(/\b([A-Za-z][a-z']*)\b/g, m => m[0].toUpperCase() + m.slice(1));
-}
-
-function pickPhone(tags:any): string|null {
-  const cands = [tags?.phone, tags?.["contact:phone"], tags?.["contact:mobile"], tags?.["contact:tel"]];
-  const v = cands.find(Boolean);
-  if (!v) return null;
-  return String(v).split(";")[0].trim();
-}
-
-function dedupe(items:any[]) {
-  const out:any[] = [];
-  for (const it of items) {
-    const dup = out.find(o =>
-      o.name.toLowerCase() === it.name.toLowerCase() &&
-      Math.abs(o.lat - it.lat) < 0.001 && Math.abs(o.lng - it.lng) < 0.001
-    );
-    if (!dup) out.push(it);
-  }
-  return out;
+  return raw
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b([A-Za-z][a-z']*)\b/g, m => m[0].toUpperCase() + m.slice(1));
 }
 
 export async function POST(req: Request) {
   try {
     const { lat, lng, category, radiusKm = 5 } = (await req.json()) as Body;
-    if (typeof lat !== "number" || typeof lng !== "number" || !CATEGORY_TAGS[category]) {
+    if (typeof lat !== "number" || typeof lng !== "number") {
       return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
 
     const radiusM = Math.round(radiusKm * 1000);
-    const selectors = CATEGORY_TAGS[category];
-    const around = `around:${radiusM},${lat},${lng}`;
-    const union = selectors.map(sel => `
+    let q: string;
+
+    if (category === "pharmacy") {
+      const around = `around:${radiusM},${lat},${lng}`;
+      const sel = 'amenity="pharmacy"';
+      const union = `
+  node[${sel}](${around});
+  way[${sel}](${around});
+  relation[${sel}](${around});
+`;
+      q = `
+  [out:json][timeout:25];
+  (
+    ${union}
+  );
+  out center tags;
+`.trim();
+    } else {
+      const around = `around:${radiusM},${lat},${lng}`;
+      const union = BASE_SELECTORS.map(sel => `
   node[${sel}](${around});
   way[${sel}](${around});
   relation[${sel}](${around});
 `).join("\n");
-
-    const q = `
-      [out:json][timeout:25];
-      (
-        ${union}
-      );
-      out center tags;
-    `.trim();
+      q = `
+  [out:json][timeout:25];
+  (
+    ${union}
+  );
+  out center tags;
+`.trim();
+    }
 
     const endpoint = process.env.OVERPASS_ENDPOINT?.trim() || "https://overpass-api.de/api/interpreter";
     const apiKey = process.env.OVERPASS_API_KEY?.trim();
@@ -108,33 +104,63 @@ export async function POST(req: Request) {
 
     if (!res.ok) {
       const txt = await res.text();
-      return NextResponse.json({ error: `Overpass error ${res.status}: ${txt.slice(0,200)}` }, { status: 502 });
+      return NextResponse.json({ error: `Overpass error ${res.status}: ${txt.slice(0, 200)}` }, { status: 502 });
     }
 
     const json = await res.json();
-    const els = Array.isArray(json?.elements) ? json.elements : [];
+    const elements = Array.isArray(json?.elements) ? json.elements : [];
 
-    let items = els.map((e:any) => {
-      const center = e.center || (e.lat && e.lon ? { lat: e.lat, lon: e.lon } : null);
-      if (!center) return null;
-      const name = tidyName(e.tags?.name);
-      const address = buildAddress(e.tags);
-      const phone = pickPhone(e.tags);
-      const lat2 = center.lat, lng2 = center.lon;
-      const distKm = haversineKm({lat,lng},{lat:lat2,lng:lng2});
-      const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${lat2},${lng2}`;
-      return { id: `${e.type}/${e.id}`, name, address, phone, lat: lat2, lng: lng2, distanceKm: distKm, mapsUrl };
-    })
-    .filter(Boolean)
-    .sort((a:any,b:any)=>a.distanceKm-b.distanceKm);
+    function mapOverpassResults(els: any[]) {
+      return els
+        .map(e => {
+          const center = e.center || (e.lat && e.lon ? { lat: e.lat, lon: e.lon } : null);
+          if (!center) return null;
+          const name = tidyName(e.tags?.name);
+          const address = buildAddress(e.tags);
+          const phone = pickPhone(e.tags);
+          const lat2 = center.lat, lng2 = center.lon;
+          const distKm = haversineKm({ lat, lng }, { lat: lat2, lng: lng2 });
+          const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${lat2},${lng2}`;
+          return { name, address, phone, distanceKm: distKm, mapsUrl, tags: e.tags || {} };
+        })
+        .filter(Boolean)
+        .sort((a: any, b: any) => a.distanceKm - b.distanceKm)
+        .slice(0, 10);
+    }
 
-    items = dedupe(items);
-    const named = items.filter((x:any)=>x.name !== "(Unnamed)");
-    const unnamed = items.filter((x:any)=>x.name === "(Unnamed)").slice(0,2);
-    items = [...named, ...unnamed].slice(0,10);
+    let results = mapOverpassResults(elements);
+
+    const specialityMap: Record<string, RegExp> = {
+      gynecologist: /\b(gyn|obgyn|ob[-\s]?gyn|obstetric|maternity|women)\b/i,
+      chiropractor: /\b(chiro|chiropractic)\b/i,
+      cardiovascular: /\b(cardio|heart|vascular|angioplasty)\b/i,
+      pediatrician: /\b(pediatric|paediatric|child)\b/i,
+      dermatologist: /\b(derma|skin)\b/i,
+      neurologist: /\b(neuro|brain|nerve)\b/i,
+    };
+
+    if (category && specialityMap[category]) {
+      const regex = specialityMap[category];
+      const filtered = results.filter(r =>
+        regex.test(r.name) ||
+        regex.test(r.tags?.speciality || "") ||
+        regex.test(r.tags?.description || "")
+      );
+      if (filtered.length > 0) results = filtered;
+    } else if (category === "hospital") {
+      const regex = /hospital/i;
+      const filtered = results.filter(r =>
+        regex.test(r.name) ||
+        regex.test(r.tags?.amenity || "") ||
+        regex.test(r.tags?.healthcare || "")
+      );
+      if (filtered.length > 0) results = filtered;
+    }
+
+    const items = results.map(({ tags, ...rest }) => rest);
 
     return NextResponse.json({ items, center: { lat, lng }, radiusKm });
-  } catch (e:any) {
+  } catch (e: any) {
     return NextResponse.json({ error: e?.message || "nearby failed" }, { status: 500 });
   }
 }

--- a/app/api/nearby/route.ts
+++ b/app/api/nearby/route.ts
@@ -1,49 +1,84 @@
-import { NextResponse } from 'next/server';
+import { NextResponse } from "next/server";
+
+type Body = { lat: number; lng: number; type: "pharmacy"|"hospital"; radiusKm?: number };
+
+const TAGS: Record<Body["type"], string> = {
+  pharmacy: 'amenity="pharmacy"',
+  hospital: 'amenity="hospital"',
+};
+
+function haversineKm(a:{lat:number;lng:number}, b:{lat:number;lng:number}) {
+  const R = 6371, toRad = (d:number)=>d*Math.PI/180;
+  const dLat = toRad(b.lat - a.lat), dLon = toRad(b.lng - a.lng);
+  const la1 = toRad(a.lat), la2 = toRad(b.lat);
+  const h = Math.sin(dLat/2)**2 + Math.cos(la1)*Math.cos(la2)*Math.sin(dLon/2)**2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(h)));
+}
 
 export async function POST(req: Request) {
   try {
-    const { lat, lng, type = 'pharmacy', radiusKm = 5, countryCode2 } = await req.json();
-    const overpass = 'https://overpass-api.de/api/interpreter';
-
-    let query: string;
-    if (lat != null && lng != null) {
-      query = `
-[out:json];
-(
-  node[amenity="${type}"](around:${radiusKm * 1000},${lat},${lng});
-  way[amenity="${type}"](around:${radiusKm * 1000},${lat},${lng});
-  relation[amenity="${type}"](around:${radiusKm * 1000},${lat},${lng});
-);
-out center tags;`;
-    } else if (countryCode2) {
-      query = `
-[out:json];
-area["ISO3166-1"="${countryCode2}"][admin_level=2]->.searchArea;
-(
-  node[amenity="${type}"](area.searchArea);
-  way[amenity="${type}"](area.searchArea);
-  relation[amenity="${type}"](area.searchArea);
-);
-out center tags;`;
-    } else {
-      return NextResponse.json({ error: 'lat/lng or countryCode2 required' }, { status: 400 });
+    const { lat, lng, type, radiusKm = 5 } = (await req.json()) as Body;
+    if (typeof lat !== "number" || typeof lng !== "number" || !TAGS[type]) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
 
-    const res = await fetch(overpass, {
-      method: 'POST',
-      headers: { 'Content-Type': 'text/plain' },
-      body: query,
+    const radiusM = Math.round(radiusKm * 1000);
+    const tag = TAGS[type];
+
+    const q = `
+      [out:json][timeout:25];
+      (
+        node[${tag}](around:${radiusM},${lat},${lng});
+        way[${tag}](around:${radiusM},${lat},${lng});
+        relation[${tag}](around:${radiusM},${lat},${lng});
+      );
+      out center tags;
+    `.trim();
+
+    const endpoint = process.env.OVERPASS_ENDPOINT?.trim() || "https://overpass-api.de/api/interpreter";
+    const apiKey = process.env.OVERPASS_API_KEY?.trim(); // if your provider uses one
+
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        ...(apiKey ? { "x-api-key": apiKey } : {}),
+      },
+      body: new URLSearchParams({ data: q }).toString(),
+      // Do not forward cookies; keep server-side to avoid CORS issues.
     });
-    const data = await res.json();
-    const results = (data.elements || []).map((el: any) => ({
-      id: el.id,
-      lat: el.lat || el.center?.lat,
-      lng: el.lon || el.center?.lon,
-      name: el.tags?.name || '',
-      tags: el.tags || {},
-    }));
-    return NextResponse.json({ results });
-  } catch (e: any) {
-    return NextResponse.json({ error: e?.message || 'nearby failed' }, { status: 500 });
+
+    if (!res.ok) {
+      const txt = await res.text();
+      return NextResponse.json({ error: `Overpass error ${res.status}: ${txt.slice(0,200)}` }, { status: 502 });
+    }
+
+    const json = await res.json();
+    const els = Array.isArray(json?.elements) ? json.elements : [];
+
+    const items = els.map((e:any) => {
+      const center = e.center || (e.lat && e.lon ? { lat: e.lat, lon: e.lon } : null);
+      if (!center) return null;
+      const name = e.tags?.name || e.tags?.["addr:housename"] || "(Unnamed)";
+      const addr = [
+        e.tags?.["addr:housenumber"],
+        e.tags?.["addr:street"],
+        e.tags?.["addr:suburb"] || e.tags?.["addr:district"],
+        e.tags?.["addr:city"] || e.tags?.["addr:town"],
+      ].filter(Boolean).join(", ") || null;
+
+      const lat2 = center.lat, lng2 = center.lon;
+      const distKm = haversineKm({lat,lng}, {lat:lat2, lng:lng2});
+      const osmUrl = e.type && e.id ? `https://www.openstreetmap.org/${e.type}/${e.id}` : null;
+      const mapsUrl = `https://www.google.com/maps/search/?api=1&query=${lat2},${lng2}`;
+      return { id: `${e.type}/${e.id}`, name, address: addr, lat: lat2, lng: lng2, distanceKm: distKm, osmUrl, mapsUrl };
+    })
+    .filter(Boolean)
+    .sort((a:any,b:any) => a.distanceKm - b.distanceKm)
+    .slice(0, 10);
+
+    return NextResponse.json({ items, center: { lat, lng }, radiusKm });
+  } catch (e:any) {
+    return NextResponse.json({ error: e?.message || "nearby failed" }, { status: 500 });
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,6 +32,10 @@ const CATEGORY_LABELS: Record<NearCategory, string> = {
   doctor: 'doctors',
   gynecologist: 'gynecologists',
   chiropractor: 'chiropractors',
+  cardiovascular: 'cardiologists',
+  pediatrician: 'pediatricians',
+  dermatologist: 'dermatologists',
+  neurologist: 'neurologists',
 };
 
 function getLastAnalysis(list: ChatMessage[]) {

--- a/hooks/useGeolocate.ts
+++ b/hooks/useGeolocate.ts
@@ -1,0 +1,13 @@
+export function useGeolocate() {
+  async function getCoords(): Promise<{ lat: number; lng: number }> {
+    if (!("geolocation" in navigator)) throw new Error("Geolocation not supported.");
+    return new Promise((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => resolve({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+        (err) => reject(new Error(err.message || "Location permission denied.")),
+        { enableHighAccuracy: true, timeout: 15000, maximumAge: 60000 }
+      );
+    });
+  }
+  return { getCoords };
+}

--- a/lib/nearIntents.ts
+++ b/lib/nearIntents.ts
@@ -1,28 +1,12 @@
-export type NearCategory =
-  | "pharmacy"
-  | "hospital"
-  | "lab"
-  | "doctor"
-  | "gynecologist"
-  | "chiropractor"
-  | "cardiovascular"
-  | "pediatrician"
-  | "dermatologist"
-  | "neurologist";
+export type NearPayload = {
+  radiusKm: number;
+  specialtyQuery?: string;
+};
 
-export function detectNearIntent(text: string): NearCategory | null {
-  const q = text.toLowerCase().trim();
-  if (!/\bnear me\b/.test(q)) return null;
-  if (/\b(pharma|pharmacy|chemist|drug ?store)\b/.test(q)) return "pharmacy";
-  if (/\b(hospital|emergency|er)\b/.test(q)) return "hospital";
-  if (/\b(lab|laboratory|blood test|pathology|diagnostic)\b/.test(q)) return "lab";
-  if (/\b(gyn|gyno|gyne|gynecologist|gynaecologist|ob[-\s]?gyn|obgyn)\b/.test(q)) return "gynecologist";
-  if (/\b(chiro|chiropractor|chiropractic)\b/.test(q)) return "chiropractor";
-  if (/\b(cardio|cardiologist|heart|vascular)\b/.test(q)) return "cardiovascular";
-  if (/\b(pediatric|paediatric|pediatri|child|kids?)\b/.test(q)) return "pediatrician";
-  if (/\b(derma|dermatologist|skin)\b/.test(q)) return "dermatologist";
-  if (/\b(neuro|neurologist|brain|nerve)\b/.test(q)) return "neurologist";
-  if (/\b(doctor|gp|clinic|physician)\b/.test(q)) return "doctor";
-  return "doctor";
+export function parseNearIntent(text: string): NearPayload | null {
+  const q = text.trim();
+  if (!/\bnear me\b/i.test(q)) return null;
+  const specialty = q.replace(/\bnear me\b/i, "").trim();
+  return { radiusKm: 5, specialtyQuery: specialty || undefined };
 }
 

--- a/lib/nearIntents.ts
+++ b/lib/nearIntents.ts
@@ -1,10 +1,20 @@
-export type NearType = "pharmacy" | "hospital" | null;
+export type NearCategory =
+  | "pharmacy"
+  | "hospital"
+  | "lab"
+  | "doctor"
+  | "gynecologist"
+  | "chiropractor";
 
-export function detectNearIntent(text: string): NearType {
-  const q = text.toLowerCase();
-  if (/\b(pharma|pharmacy|chemist|drug ?store)\b.*\bnear me\b|\bnear me\b.*\b(pharma|pharmacy|chemist|drug ?store)\b/.test(q))
-    return "pharmacy";
-  if (/\b(hospital|hospitals|clinic|er|emergency)\b.*\bnear me\b|\bnear me\b.*\b(hospital|hospitals|clinic|er|emergency)\b/.test(q))
-    return "hospital";
-  return null;
+export function detectNearIntent(text: string): NearCategory | null {
+  const q = text.toLowerCase().trim();
+  if (!/\bnear me\b/.test(q)) return null;
+  if (/\b(pharma|pharmacy|chemist|drug ?store)\b/.test(q)) return "pharmacy";
+  if (/\b(hospital|emergency|er)\b/.test(q)) return "hospital";
+  if (/\b(lab|laboratory|blood test|pathology|diagnostic)\b/.test(q)) return "lab";
+  if (/\b(gyn|gyno|gyne|gynecologist|gynaecologist|ob[-\s]?gyn|obgyn)\b/.test(q)) return "gynecologist";
+  if (/\b(chiro|chiropractor|chiropractic)\b/.test(q)) return "chiropractor";
+  if (/\b(doctor|gp|clinic|physician)\b/.test(q)) return "doctor";
+  return "doctor";
 }
+

--- a/lib/nearIntents.ts
+++ b/lib/nearIntents.ts
@@ -1,0 +1,10 @@
+export type NearType = "pharmacy" | "hospital" | null;
+
+export function detectNearIntent(text: string): NearType {
+  const q = text.toLowerCase();
+  if (/\b(pharma|pharmacy|chemist|drug ?store)\b.*\bnear me\b|\bnear me\b.*\b(pharma|pharmacy|chemist|drug ?store)\b/.test(q))
+    return "pharmacy";
+  if (/\b(hospital|hospitals|clinic|er|emergency)\b.*\bnear me\b|\bnear me\b.*\b(hospital|hospitals|clinic|er|emergency)\b/.test(q))
+    return "hospital";
+  return null;
+}

--- a/lib/nearIntents.ts
+++ b/lib/nearIntents.ts
@@ -4,7 +4,11 @@ export type NearCategory =
   | "lab"
   | "doctor"
   | "gynecologist"
-  | "chiropractor";
+  | "chiropractor"
+  | "cardiovascular"
+  | "pediatrician"
+  | "dermatologist"
+  | "neurologist";
 
 export function detectNearIntent(text: string): NearCategory | null {
   const q = text.toLowerCase().trim();
@@ -14,6 +18,10 @@ export function detectNearIntent(text: string): NearCategory | null {
   if (/\b(lab|laboratory|blood test|pathology|diagnostic)\b/.test(q)) return "lab";
   if (/\b(gyn|gyno|gyne|gynecologist|gynaecologist|ob[-\s]?gyn|obgyn)\b/.test(q)) return "gynecologist";
   if (/\b(chiro|chiropractor|chiropractic)\b/.test(q)) return "chiropractor";
+  if (/\b(cardio|cardiologist|heart|vascular)\b/.test(q)) return "cardiovascular";
+  if (/\b(pediatric|paediatric|pediatri|child|kids?)\b/.test(q)) return "pediatrician";
+  if (/\b(derma|dermatologist|skin)\b/.test(q)) return "dermatologist";
+  if (/\b(neuro|neurologist|brain|nerve)\b/.test(q)) return "neurologist";
   if (/\b(doctor|gp|clinic|physician)\b/.test(q)) return "doctor";
   return "doctor";
 }


### PR DESCRIPTION
## Summary
- detect "near me" queries for pharmacies or hospitals
- geolocate users or prompt for manual location, display nearby results within 5 km
- Overpass-powered `/api/nearby` endpoint with env-configurable endpoint/key

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7fe465250832f94da4b338f9c5f97