### PR TITLE
feat: enforce auth via middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const PUBLIC_PATHS = [
+  "/api/auth",
+  "/api/health",
+  "/api/diag",
+  "/favicon.ico",
+  "/_next",
+  "/assets",
+];
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+    return NextResponse.next();
+  }
+
+  const hasSession =
+    req.cookies.has("next-auth.session-token") ||
+    req.cookies.has("__Secure-next-auth.session-token");
+
+  if (!hasSession) {
+    const url = req.nextUrl.clone();
+    url.pathname = "/api/auth/signin";
+    url.searchParams.set("callbackUrl", req.nextUrl.href);
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next|assets|.*\\..*).*)"],
+};
+


### PR DESCRIPTION
## Summary
- add middleware to redirect unauthenticated users to Google sign-in

## Testing
- `npm test`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68b8908c312c832f9a0474c7c4c3059a