### PR TITLE
Use shallow tab routing and persist chat panel

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+import { useEffect, useRef } from "react";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
 import Timeline from "@/components/panels/Timeline";
@@ -8,19 +10,35 @@ type Search = { panel?: string; threadId?: string };
 
 export default function Page({ searchParams }: { searchParams: Search }) {
   const panel = (searchParams.panel ?? "chat").toLowerCase();
+  const chatInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
 
-  switch (panel) {
-    case "chat":
-      return <ChatPane />;
-    case "profile":
-      return <MedicalProfile />;
-    case "timeline":
-      return <Timeline threadId={searchParams.threadId} />;
-    case "alerts":
-      return <AlertsPane />;
-    case "settings":
-      return <SettingsPane />;
-    default:
-      return <ChatPane />;
-  }
+  useEffect(() => {
+    const handler = () => chatInputRef.current?.focus();
+    window.addEventListener("focus-chat-input", handler);
+    return () => window.removeEventListener("focus-chat-input", handler);
+  }, []);
+
+  return (
+    <>
+      <section className={panel === "chat" ? "block h-full" : "hidden"}>
+        <ChatPane inputRef={chatInputRef} />
+      </section>
+
+      <section className={panel === "profile" ? "block" : "hidden"}>
+        <MedicalProfile />
+      </section>
+
+      <section className={panel === "timeline" ? "block" : "hidden"}>
+        <Timeline threadId={searchParams.threadId} />
+      </section>
+
+      <section className={panel === "alerts" ? "block" : "hidden"}>
+        <AlertsPane />
+      </section>
+
+      <section className={panel === "settings" ? "block" : "hidden"}>
+        <SettingsPane />
+      </section>
+    </>
+  );
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, RefObject } from 'react';
 import Header from '../Header';
 import Markdown from '../Markdown';
 import { Send } from 'lucide-react';
@@ -192,7 +192,7 @@ function AssistantMessage({ m, researchOn, onQuickAction, busy }: { m: ChatMessa
   );
 }
 
-export default function ChatPane() {
+export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: RefObject<HTMLInputElement | HTMLTextAreaElement> } = {}) {
 
   const { country } = useCountry();
   const { active, setFromAnalysis, setFromChat, clear: clearContext } = useActiveContext();
@@ -206,7 +206,7 @@ export default function ChatPane() {
   const [therapyMode, setTherapyMode] = useState(false);
   const [loadingAction, setLoadingAction] = useState<null | 'simpler' | 'doctor' | 'next'>(null);
   const chatRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = externalInputRef ?? useRef<HTMLInputElement | HTMLTextAreaElement>(null);
 
   useEffect(()=>{ chatRef.current?.scrollTo({ top: chatRef.current.scrollHeight }); },[messages]);
   useEffect(() => {

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 const tabs = [
   { key: 'chat', label: 'Chat' },
@@ -12,24 +12,21 @@ const tabs = [
 
 export default function Tabs() {
   const router = useRouter();
-  const [current, setCurrent] = useState("chat");
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const [current, setCurrent] = useState(params.get("panel") ?? "chat");
 
   useEffect(() => {
-    const updateCurrent = () => {
-      const params = new URLSearchParams(window.location.search);
-      setCurrent((params.get("panel") ?? "chat").toLowerCase());
-    };
-    updateCurrent();
-    window.addEventListener("popstate", updateCurrent);
-    return () => window.removeEventListener("popstate", updateCurrent);
-  }, []);
+    setCurrent(params.get("panel") ?? "chat");
+  }, [params]);
 
-  const onSelect = (key: string) => {
-    const params = new URLSearchParams(window.location.search);
-    params.set("panel", key);
-    router.push("?" + params.toString());
+  function onSelect(key: string) {
+    const usp = new URLSearchParams(params);
+    usp.set("panel", key);
+    router.replace(`${pathname}?${usp.toString()}`, { scroll: false });
     setCurrent(key);
-  };
+    if (key === "chat") window.dispatchEvent(new Event("focus-chat-input"));
+  }
 
   return (
     <ul className="mt-3 space-y-1">


### PR DESCRIPTION
## Summary
- preserve chat state by keeping ChatPane mounted and toggling panel visibility
- use shallow router.replace in sidebar tabs to avoid remounts
- allow ChatPane to accept external input ref for focus when returning to chat

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b95bd0ddcc832f96f7831906a61a34