### PR TITLE
Add risk scoring utilities and compute endpoint

### DIFF
--- a/app/api/predictions/compute/route.ts
+++ b/app/api/predictions/compute/route.ts
@@ -1,0 +1,51 @@
+export const runtime = 'nodejs';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase/admin';
+import { deriveInputs } from '@/lib/predict/derive';
+import { scoreRisk } from '@/lib/predict/score';
+
+const TEST_USER = process.env.MEDX_TEST_USER_ID!;
+
+export async function POST(req: NextRequest) {
+  try {
+    const { threadId } = await req.json().catch(() => ({} as any));
+    if (!threadId) return NextResponse.json({ error: 'threadId required' }, { status: 400 });
+
+    // 1) derive inputs from latest observations
+    const inputs = await deriveInputs(TEST_USER, threadId);
+
+    // 2) score
+    const result = scoreRisk(inputs);
+
+    // 3) save prediction
+    const sb = supabaseAdmin();
+    const { data: pred, error: perr } = await sb.from('predictions').insert({
+      user_id: TEST_USER,
+      thread_id: threadId,
+      model: 'medx-heuristic-v1',
+      risk_score: result.riskScore,
+      band: result.band,
+      factors: result.factors,
+      recommendations: result.recommendations,
+      inputs_snapshot: inputs,
+    }).select().single();
+    if (perr) throw new Error(perr.message);
+
+    // 4) alert on thresholds
+    if (result.band === 'Red' || (result.band === 'Yellow' && result.riskScore >= 50)) {
+      await sb.from('alerts').insert({
+        user_id: TEST_USER,
+        thread_id: threadId,
+        severity: result.band === 'Red' ? 'high' : 'medium',
+        title: result.band === 'Red' ? 'High Risk Alert' : 'Moderate Risk Alert',
+        body: `Latest risk score ${result.riskScore} (${result.band}). Review timeline.`,
+        meta: { factors: result.factors }
+      });
+    }
+
+    return NextResponse.json({ ok: true, prediction: pred, inputs, result });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || 'compute failed' }, { status: 500 });
+  }
+}

--- a/lib/predict/derive.ts
+++ b/lib/predict/derive.ts
@@ -1,0 +1,63 @@
+import { supabaseAdmin } from '@/lib/supabase/admin';
+import type { RiskInputs } from './score';
+
+type ObsRow = {
+  kind: string;
+  value_num: number | null;
+  value_text: string | null;
+  unit: string | null;
+  observed_at: string;
+};
+
+const K = {
+  HBA1C: 'hba1c',
+  FPG: 'fasting_glucose',
+  BMI: 'bmi',
+  EGFR: 'egfr',
+  SMOKING: 'smoking',
+  FHX: 'family_history',
+} as const;
+
+export async function deriveInputs(userId: string, threadId?: string): Promise<RiskInputs> {
+  const sb = supabaseAdmin();
+  let q = sb.from('observations')
+    .select('kind,value_num,value_text,unit,observed_at')
+    .eq('user_id', userId)
+    .order('observed_at', { ascending: false })
+    .limit(200);
+  if (threadId) q = q.eq('thread_id', threadId);
+
+  const { data, error } = await q;
+  if (error) throw new Error(error.message);
+
+  // pick first occurrence by kind (latest due to ordering)
+  const pick = (kind: string): ObsRow | undefined => data?.find(r => r.kind === kind);
+
+  const hba1c = num(pick(K.HBA1C));
+  const fpg   = num(pick(K.FPG));
+  const bmi   = num(pick(K.BMI));
+  const egfr  = num(pick(K.EGFR));
+
+  const smoking       = bool(pick(K.SMOKING));
+  const familyHistory = bool(pick(K.FHX));
+
+  return { hba1c, fastingGlucose: fpg, bmi, egfr, smoking, familyHistory };
+}
+
+function num(row?: ObsRow): number | undefined {
+  if (!row) return undefined;
+  if (row.value_num !== null && !Number.isNaN(row.value_num)) return row.value_num;
+  const n = parseFloat((row.value_text || '').replace(/[^\d.]/g, ''));
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function bool(row?: ObsRow): boolean | undefined {
+  if (!row) return undefined;
+  if (row.value_text != null) {
+    const t = row.value_text.toString().toLowerCase();
+    if (['yes','true','1','y'].includes(t)) return true;
+    if (['no','false','0','n'].includes(t)) return false;
+  }
+  if (row.value_num != null) return row.value_num !== 0;
+  return undefined;
+}

--- a/lib/predict/score.ts
+++ b/lib/predict/score.ts
@@ -1,0 +1,65 @@
+export type RiskInputs = {
+  hba1c?: number;           // %
+  fastingGlucose?: number;  // mg/dL
+  bmi?: number;             // kg/m^2
+  familyHistory?: boolean;
+  smoking?: boolean;
+  egfr?: number;            // mL/min/1.73m²
+};
+
+export type RiskBand = 'Green' | 'Yellow' | 'Red';
+export interface RiskResult {
+  riskScore: number; // 0-100
+  band: RiskBand;
+  factors: { name: string; contribution: number }[];
+  recommendations: string[];
+}
+
+function band(score: number): RiskBand {
+  if (score >= 70) return 'Red';
+  if (score >= 35) return 'Yellow';
+  return 'Green';
+}
+
+/** Simple, explainable heuristic. Tweak weights later. */
+export function scoreRisk(i: RiskInputs): RiskResult {
+  let score = 0;
+  const factors: { name: string; contribution: number }[] = [];
+
+  if (i.hba1c !== undefined) {
+    if (i.hba1c >= 8.5) { score += 30; factors.push({ name: 'HbA1c ≥ 8.5%', contribution: 30 }); }
+    else if (i.hba1c >= 7.0) { score += 20; factors.push({ name: 'HbA1c 7.0–8.4%', contribution: 20 }); }
+    else if (i.hba1c >= 6.5) { score += 10; factors.push({ name: 'HbA1c 6.5–6.9%', contribution: 10 }); }
+  }
+
+  if (i.fastingGlucose !== undefined) {
+    if (i.fastingGlucose >= 180) { score += 20; factors.push({ name: 'FPG ≥ 180 mg/dL', contribution: 20 }); }
+    else if (i.fastingGlucose >= 126) { score += 10; factors.push({ name: 'FPG 126–179 mg/dL', contribution: 10 }); }
+  }
+
+  if (i.bmi !== undefined) {
+    if (i.bmi >= 35) { score += 15; factors.push({ name: 'BMI ≥ 35', contribution: 15 }); }
+    else if (i.bmi >= 30) { score += 10; factors.push({ name: 'BMI 30–34.9', contribution: 10 }); }
+  }
+
+  if (i.egfr !== undefined && i.egfr < 60) {
+    score += 25; factors.push({ name: 'eGFR < 60', contribution: 25 });
+  }
+
+  if (i.familyHistory) { score += 10; factors.push({ name: 'Family history', contribution: 10 }); }
+  if (i.smoking)      { score += 10; factors.push({ name: 'Smoking', contribution: 10 }); }
+
+  if (score > 100) score = 100;
+  const b = band(score);
+
+  const recommendations: string[] = [];
+  if (b !== 'Green') {
+    recommendations.push('Follow up with clinician for optimization.');
+    if (i.hba1c && i.hba1c >= 7.0) recommendations.push('Tighten glycemic control; review meds/insulin.');
+    if (i.egfr !== undefined && i.egfr < 60) recommendations.push('Renal protection (ACEi/ARB/SGLT2 if appropriate).');
+    if (i.smoking) recommendations.push('Offer smoking cessation support.');
+    if (i.bmi && i.bmi >= 30) recommendations.push('Weight management plan and dietician referral.');
+  }
+
+  return { riskScore: Math.round(score), band: b, factors, recommendations };
+}


### PR DESCRIPTION
## Summary
- add heuristic risk scoring util with recommendations
- derive risk inputs from latest observations
- compute and store predictions with alerting API route

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Module not found: Can't resolve '@supabase/supabase-js')*


------
https://chatgpt.com/codex/tasks/task_e_68b9786e8b10832fb5b58f887fdc44f1