### PR TITLE
Align API routes to Supabase columns

### DIFF
--- a/app/api/alerts/[id]/ack/route.ts
+++ b/app/api/alerts/[id]/ack/route.ts
@@ -1,21 +1,21 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
-import { supabaseAdmin } from '@/lib/supabase/admin';
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase/admin";
 
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
 export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
   const session = await getServerSession(authOptions);
   const userId = (session?.user as { id?: string })?.id;
-  if (!userId) return new NextResponse('Unauthorized', { status: 401 });
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
 
-  const id = params.id;
   const { error } = await supabaseAdmin()
-    .from('alerts')
-    .update({ status: 'ack' })
-    .eq('id', id)
-    .eq('userId', userId);
+    .from("alerts")
+    .update({ status: "acknowledged", ack_at: new Date().toISOString() })
+    .eq("id", params.id)
+    .eq("user_id", userId);
+
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ ok: true });
 }

--- a/app/api/alerts/route.ts
+++ b/app/api/alerts/route.ts
@@ -1,26 +1,36 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
-import { supabaseAdmin } from '@/lib/supabase/admin';
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase/admin";
 
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   const userId = (session?.user as { id?: string })?.id;
-  if (!userId) return new NextResponse('Unauthorized', { status: 401 });
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
 
   const { searchParams } = new URL(req.url);
-  const status = searchParams.get('status') || undefined;
+  const status = (searchParams.get("status") || "open").toLowerCase();
 
   const sb = supabaseAdmin();
-  let query = sb
-    .from('alerts')
-    .select('id, severity, title, createdAt, status')
-    .eq('userId', userId)
-    .order('createdAt', { ascending: false });
-  if (status) query = query.eq('status', status);
-  const { data, error } = await query;
+  const { data, error } = await sb
+    .from("alerts")
+    .select("id, severity, title, created_at, status")
+    .eq("user_id", userId)
+    .eq("status", status)
+    .order("created_at", { ascending: false });
+
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data ?? []);
+
+  // Map to UI shape expected by AlertsPane.tsx
+  const out = (data ?? []).map((r) => ({
+    id: r.id,
+    severity: r.severity,
+    title: r.title,
+    createdAt: r.created_at,
+    status: r.status,
+  }));
+
+  return NextResponse.json(out);
 }

--- a/app/api/observations/route.ts
+++ b/app/api/observations/route.ts
@@ -1,25 +1,38 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
-import { supabaseAdmin } from '@/lib/supabase/admin';
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase/admin";
 
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   const userId = (session?.user as { id?: string })?.id;
-  if (!userId) return new NextResponse('Unauthorized', { status: 401 });
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
 
   const { searchParams } = new URL(req.url);
-  const limit = parseInt(searchParams.get('limit') || '100', 10);
+  const limit = Math.min(parseInt(searchParams.get("limit") || "100", 10), 1000);
+  const threadId = searchParams.get("threadId") || undefined;
 
   const sb = supabaseAdmin();
-  const { data, error } = await sb
-    .from('observations')
-    .select('kind, value, observedAt')
-    .eq('userId', userId)
-    .order('observedAt', { ascending: false })
-    .limit(Math.min(limit, 1000));
+  let q = sb
+    .from("observations")
+    .select("kind, value_num, value_text, unit, observed_at")
+    .eq("user_id", userId)
+    .order("observed_at", { ascending: false })
+    .limit(limit);
+  if (threadId) q = q.eq("thread_id", threadId);
+
+  const { data, error } = await q;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data ?? []);
+
+  // Map to UI shape expected by MedicalProfile
+  const out = (data ?? []).map((r) => ({
+    kind: r.kind,
+    value: r.value_num ?? r.value_text ?? null,
+    observedAt: r.observed_at,
+    unit: r.unit ?? null,
+  }));
+
+  return NextResponse.json(out);
 }

--- a/app/api/predictions/compute/route.ts
+++ b/app/api/predictions/compute/route.ts
@@ -1,51 +1,67 @@
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
-import { NextRequest, NextResponse } from 'next/server';
-import { supabaseAdmin } from '@/lib/supabase/admin';
-import { deriveInputs } from '@/lib/predict/derive';
-import { scoreRisk } from '@/lib/predict/score';
-
-const TEST_USER = process.env.MEDX_TEST_USER_ID!;
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { deriveInputs } from "@/lib/predict/derive";
+import { scoreRisk } from "@/lib/predict/score";
 
 export async function POST(req: NextRequest) {
   try {
-    const { threadId } = await req.json().catch(() => ({} as any));
-    if (!threadId) return NextResponse.json({ error: 'threadId required' }, { status: 400 });
+    const session = await getServerSession(authOptions);
+    const userId = (session?.user as { id?: string })?.id;
+    if (!userId) return new NextResponse("Unauthorized", { status: 401 });
 
-    // 1) derive inputs from latest observations
-    const inputs = await deriveInputs(TEST_USER, threadId);
+    const { threadId } = await req.json().catch(() => ({} as any));
+    if (!threadId) return NextResponse.json({ error: "threadId required" }, { status: 400 });
+
+    // 1) derive inputs from latest observations (snake_case fields)
+    const inputs = await deriveInputs(userId, threadId);
 
     // 2) score
     const result = scoreRisk(inputs);
 
     // 3) save prediction
     const sb = supabaseAdmin();
-    const { data: pred, error: perr } = await sb.from('predictions').insert({
-      user_id: TEST_USER,
-      thread_id: threadId,
-      model: 'medx-heuristic-v1',
-      risk_score: result.riskScore,
-      band: result.band,
-      factors: result.factors,
-      recommendations: result.recommendations,
-      inputs_snapshot: inputs,
-    }).select().single();
+    const { data: pred, error: perr } = await sb
+      .from("predictions")
+      .insert({
+        user_id: userId,
+        thread_id: threadId,
+        model: "medx-heuristic-v1",
+        risk_score: result.riskScore,
+        band: result.band,
+        factors: result.factors,
+        recommendations: result.recommendations,
+        inputs_snapshot: inputs,
+      })
+      .select("id, created_at, risk_score, band")
+      .single();
     if (perr) throw new Error(perr.message);
 
     // 4) alert on thresholds
-    if (result.band === 'Red' || (result.band === 'Yellow' && result.riskScore >= 50)) {
-      await sb.from('alerts').insert({
-        user_id: TEST_USER,
+    if (result.band === "Red" || (result.band === "Yellow" && result.riskScore >= 50)) {
+      await sb.from("alerts").insert({
+        user_id: userId,
         thread_id: threadId,
-        severity: result.band === 'Red' ? 'high' : 'medium',
-        title: result.band === 'Red' ? 'High Risk Alert' : 'Moderate Risk Alert',
+        severity: result.band === "Red" ? "high" : "medium",
+        title: result.band === "Red" ? "High Risk Alert" : "Moderate Risk Alert",
         body: `Latest risk score ${result.riskScore} (${result.band}). Review timeline.`,
-        meta: { factors: result.factors }
+        meta: { factors: result.factors },
       });
     }
 
-    return NextResponse.json({ ok: true, prediction: pred, inputs, result });
+    // Map to UI shape on response (optional)
+    const out = {
+      id: pred.id,
+      createdAt: pred.created_at,
+      riskScore: pred.risk_score,
+      band: pred.band,
+    };
+
+    return NextResponse.json({ ok: true, prediction: out, inputs, result });
   } catch (e: any) {
-    return NextResponse.json({ error: e?.message || 'compute failed' }, { status: 500 });
+    return NextResponse.json({ error: e?.message || "compute failed" }, { status: 500 });
   }
 }

--- a/app/api/predictions/route.ts
+++ b/app/api/predictions/route.ts
@@ -1,27 +1,37 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
-import { supabaseAdmin } from '@/lib/supabase/admin';
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/supabase/admin";
 
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
   const userId = (session?.user as { id?: string })?.id;
-  if (!userId) return new NextResponse('Unauthorized', { status: 401 });
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
 
   const { searchParams } = new URL(req.url);
-  const threadId = searchParams.get('threadId');
-  if (!threadId) return new NextResponse('Missing threadId', { status: 400 });
+  const threadId = searchParams.get("threadId");
+  if (!threadId) return new NextResponse("Missing threadId", { status: 400 });
 
   const sb = supabaseAdmin();
   const { data, error } = await sb
-    .from('predictions')
-    .select('id, createdAt, riskScore, band')
-    .eq('threadId', threadId)
-    .eq('userId', userId)
-    .order('createdAt', { ascending: false })
+    .from("predictions")
+    .select("id, created_at, risk_score, band")
+    .eq("user_id", userId)
+    .eq("thread_id", threadId)
+    .order("created_at", { ascending: false })
     .limit(50);
+
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data ?? []);
+
+  // Map to UI shape expected by Timeline.tsx
+  const out = (data ?? []).map((r) => ({
+    id: r.id,
+    createdAt: r.created_at,
+    riskScore: r.risk_score,
+    band: r.band,
+  }));
+
+  return NextResponse.json(out);
 }


### PR DESCRIPTION
## Summary
- Align observations, predictions, and alerts APIs with Supabase snake_case columns and map results to UI shapes
- Update alert acknowledgement to mark status "acknowledged" with timestamp
- Switch predictions compute route to use NextAuth user and return camelCase response

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b97d3a69b0832fb91ced2596af52e4