### PR TITLE
feat: add timeline recompute risk button

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,20 +1,51 @@
-import { NextResponse } from "next/server";
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/supabase/admin";
 
-export const runtime = "nodejs";
+// surface these kinds on Profile
+const LAB_KINDS = ["hba1c", "fasting_glucose", "bmi", "egfr", "blood_group", "smoking", "family_history"] as const;
 
-export async function GET() {
+export async function GET(_req: NextRequest) {
   const session = await getServerSession(authOptions);
   const userId = (session?.user as { id?: string })?.id;
   if (!userId) return new NextResponse("Unauthorized", { status: 401 });
 
-  const { data, error } = await supabaseAdmin()
+  const sb = supabaseAdmin();
+
+  // 1) canonical profile row
+  const { data: profile, error: perr } = await sb
     .from("profiles")
     .select("*")
     .eq("id", userId)
-    .single();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data);
+    .maybeSingle();
+  if (perr) return NextResponse.json({ error: perr.message }, { status: 500 });
+
+  // 2) latest observation per kind
+  const { data: obs, error: oerr } = await sb
+    .from("observations")
+    .select("kind, value_num, value_text, unit, observed_at")
+    .eq("user_id", userId)
+    .in("kind", LAB_KINDS as unknown as string[])
+    .order("observed_at", { ascending: false })
+    .limit(200);
+  if (oerr) return NextResponse.json({ error: oerr.message }, { status: 500 });
+
+  const latest: Record<string, { value: string | number | null; unit: string | null; observedAt: string } | null> = {};
+  for (const k of LAB_KINDS) latest[k] = null;
+
+  const seen = new Set<string>();
+  for (const r of obs ?? []) {
+    if (seen.has(r.kind)) continue; // first = latest due to DESC order
+    latest[r.kind] = {
+      value: r.value_num ?? r.value_text ?? null,
+      unit: r.unit ?? null,
+      observedAt: r.observed_at,
+    };
+    seen.add(r.kind);
+  }
+
+  return NextResponse.json({ profile, latest });
 }

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -1,48 +1,105 @@
-'use client';
-import { useEffect, useState } from 'react';
-import { safeJson } from '@/lib/safeJson';
+"use client";
+import { useEffect, useState } from "react";
+import { safeJson } from "@/lib/safeJson";
 
+// Existing observation type for legacy profile sections
 type Observation = { kind: string; value: any; observedAt: string };
+
+// Types for latest labs card
+type LatestRow = { value: string | number | null; unit: string | null; observedAt: string } | null;
+type Latest = Record<string, LatestRow>;
+type ProfilePayload = { profile: any; latest: Latest };
 
 export default function MedicalProfile() {
   const [obs, setObs] = useState<Observation[]>([]);
+  const [data, setData] = useState<ProfilePayload | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function loadProfile() {
+    setErr(null);
+    try {
+      const r = await fetch("/api/profile", { cache: "no-store" });
+      if (!r.ok) throw new Error(await r.text());
+      setData(await r.json());
+    } catch (e: any) {
+      setErr(e.message || "Failed to load profile");
+    }
+  }
 
   useEffect(() => {
-    safeJson(fetch('/api/observations?userId=me'))
+    safeJson(fetch("/api/observations?userId=me"))
       .then(setObs)
       .catch(() => setObs([]));
+    loadProfile();
+    const h = () => loadProfile();
+    window.addEventListener("observations-updated", h);
+    return () => window.removeEventListener("observations-updated", h);
   }, []);
 
-  const latest = (kind: string) => obs.find(o => o.kind === kind);
+  const latestLabs = data?.latest;
+  const latestObs = (kind: string) => obs.find((o) => o.kind === kind);
 
   return (
     <div className="p-4 space-y-4">
+      {/* Existing profile sections */}
       <section className="rounded-xl border p-4">
         <h2 className="font-semibold mb-2">Vitals</h2>
         <ul className="text-sm space-y-1">
-          {['bp','hr','bmi'].map(k => {
-            const o = latest(k);
-            return <li key={k}>{k.toUpperCase()}: {o ? JSON.stringify(o.value) : '—'}</li>;
+          {["bp", "hr", "bmi"].map((k) => {
+            const o = latestObs(k);
+            return <li key={k}>{k.toUpperCase()}: {o ? JSON.stringify(o.value) : "—"}</li>;
           })}
         </ul>
       </section>
       <section className="rounded-xl border p-4">
         <h2 className="font-semibold mb-2">Labs</h2>
         <ul className="text-sm space-y-1">
-          {['HbA1c','FPG','eGFR'].map(k => {
-            const o = latest(k);
-            return <li key={k}>{k}: {o ? JSON.stringify(o.value) : '—'}</li>;
+          {["HbA1c", "FPG", "eGFR"].map((k) => {
+            const o = latestObs(k);
+            return <li key={k}>{k}: {o ? JSON.stringify(o.value) : "—"}</li>;
           })}
         </ul>
       </section>
       <section className="rounded-xl border p-4">
         <h2 className="font-semibold mb-2">Symptoms/notes</h2>
         <ul className="text-sm space-y-1">
-          {obs.filter(o => typeof o.value === 'string').slice(0,5).map(o => (
+          {obs.filter((o) => typeof o.value === "string").slice(0, 5).map((o) => (
             <li key={o.observedAt}>{o.value}</li>
           ))}
         </ul>
       </section>
+
+      {latestLabs && (
+        <div className="rounded-lg border p-4">
+          <div className="mb-2 font-medium">Latest Labs (from uploads)</div>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
+            {([
+              ["HbA1c", "hba1c"],
+              ["Fasting Glucose", "fasting_glucose"],
+              ["BMI", "bmi"],
+              ["eGFR", "egfr"],
+              ["Blood Group", "blood_group"],
+              ["Smoking", "smoking"],
+              ["Family History", "family_history"],
+            ] as const).map(([label, key]) => {
+              const row = latestLabs[key];
+              return (
+                <div key={key} className="flex items-center justify-between rounded-md bg-muted/40 px-3 py-2">
+                  <span>{label}</span>
+                  <span className="font-medium">
+                    {row?.value ?? "—"}{row?.unit ? ` ${row.unit}` : ""}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          <div className="mt-2 text-xs text-muted-foreground">
+            Values shown are the latest parsed from your uploads. Timeline has full history.
+          </div>
+        </div>
+      )}
+
+      {err && <div className="text-sm text-red-600">{err}</div>}
     </div>
   );
 }

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -1,42 +1,98 @@
 "use client";
-import { useEffect, useState } from "react";
-import { safeJson } from "@/lib/safeJson";
-import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
 type Prediction = { id: string; createdAt: string; riskScore: number; band: string };
 
-export default function Timeline({ threadId = "" }: { threadId?: string }) {
-  const router = useRouter();
-  const [data, setData] = useState<Prediction[]>([]);
+export default function Timeline(props: { threadId?: string }) {
+  const params = useSearchParams();
+  const urlThreadId = params.get("threadId") || undefined;
+  const threadId = props.threadId || urlThreadId || "";
 
-  useEffect(() => {
+  const router = useRouter();
+  const [preds, setPreds] = useState<Prediction[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [recomputing, setRecomputing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPredictions = useCallback(async () => {
     if (!threadId) return;
-    safeJson(fetch(`/api/predictions?threadId=${threadId}`))
-      .then(setData)
-      .catch(() => setData([]));
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await fetch(`/api/predictions?threadId=${encodeURIComponent(threadId)}`, { cache: "no-store" });
+      if (!r.ok) throw new Error(await r.text());
+      const data = await r.json();
+      setPreds(data || []);
+    } catch (e: any) {
+      setError(e.message || "Failed to load predictions");
+    } finally {
+      setLoading(false);
+    }
   }, [threadId]);
 
-  const scores = data.map(p => p.riskScore);
+  useEffect(() => {
+    if (threadId) fetchPredictions();
+  }, [threadId, fetchPredictions]);
+
+  const onRecompute = useCallback(async () => {
+    if (!threadId) return;
+    setRecomputing(true);
+    setError(null);
+    try {
+      const r = await fetch("/api/predictions/compute", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ threadId }),
+      });
+      if (!r.ok) throw new Error(await r.text());
+      await fetchPredictions();
+    } catch (e: any) {
+      setError(e.message || "Recompute failed");
+    } finally {
+      setRecomputing(false);
+    }
+  }, [threadId, fetchPredictions]);
+
+  const scores = useMemo(() => preds.map((p) => p.riskScore), [preds]);
   const max = Math.max(100, ...scores);
-  const points = data.map((p, i) => `${(i / Math.max(data.length - 1, 1)) * 100},${100 - (p.riskScore / max) * 100}`).join(' ');
+  const points = useMemo(
+    () => preds.map((p, i) => `${(i / Math.max(preds.length - 1, 1)) * 100},${100 - (p.riskScore / max) * 100}`).join(" "),
+    [preds, max]
+  );
 
   const goChat = (id: string) => {
-    const params = new URLSearchParams(window.location.search);
-    if (threadId) params.set("threadId", threadId);
-    params.set("panel", "chat");
-    router.push("?" + params.toString());
-    // scroll logic could be added here
+    const search = new URLSearchParams(window.location.search);
+    if (threadId) search.set("threadId", threadId);
+    search.set("panel", "chat");
+    router.push("?" + search.toString());
   };
 
   return (
     <div className="p-4 space-y-4">
-      {data.length > 0 ? (
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Timeline</h2>
+        <button
+          onClick={onRecompute}
+          disabled={recomputing || !threadId}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+          aria-busy={recomputing}
+        >
+          {recomputing ? "Recomputing…" : "Recompute Risk"}
+        </button>
+      </div>
+
+      {error && <div className="text-sm text-red-600">{error}</div>}
+
+      {loading ? (
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      ) : preds.length > 0 ? (
         <>
           <svg viewBox="0 0 100 100" className="w-full h-24" preserveAspectRatio="none">
             <polyline points={points} fill="none" stroke="currentColor" strokeWidth="2" />
           </svg>
           <ul className="text-sm space-y-1">
-            {data.map(p => (
+            {preds.map((p) => (
               <li key={p.id} className="flex items-center gap-2">
                 <button onClick={() => goChat(p.id)} className="underline">
                   {new Date(p.createdAt).toLocaleDateString()}
@@ -47,7 +103,7 @@ export default function Timeline({ threadId = "" }: { threadId?: string }) {
           </ul>
         </>
       ) : (
-        <p className="text-sm text-slate-500">No predictions yet.</p>
+        <p className="text-sm text-muted-foreground">No predictions yet.</p>
       )}
     </div>
   );

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -47,6 +47,9 @@ export default function Timeline(props: { threadId?: string }) {
       });
       if (!r.ok) throw new Error(await r.text());
       await fetchPredictions();
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event("observations-updated"));
+      }
     } catch (e: any) {
       setError(e.message || "Recompute failed");
     } finally {


### PR DESCRIPTION
## Summary
- add Recompute Risk button to timeline panel that calls compute API and refreshes predictions

## Testing
- `npm test`
- `npx eslint components/panels/Timeline.tsx --no-eslintrc`


------
https://chatgpt.com/codex/tasks/task_e_68b97fd07b40832fb368c470c1016033