### PR TITLE
Ensure observations POST uses authenticated user

### DIFF
--- a/app/api/observations/route.ts
+++ b/app/api/observations/route.ts
@@ -37,7 +37,7 @@ export async function POST(req: Request) {
   const body = await req.json();
   const { data, error } = await supabaseAdmin()
     .from("observations")
-    .insert({ user_id: userId, ...body })
+    .insert({ ...body, user_id: userId })
     .select()
     .single();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });


### PR DESCRIPTION
## Summary
- prevent clients from overriding `user_id` in observations API

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b9912fb91c832fa3b6cc10653a2324