### PR TITLE
feat: auto ingest uploaded medical text

### DIFF
--- a/app/api/observations/bulk/route.ts
+++ b/app/api/observations/bulk/route.ts
@@ -1,0 +1,42 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { getUserId } from "@/lib/getUserId";
+
+type InObs = {
+  kind: string;
+  value_num?: number | null;
+  value_text?: string | null;
+  unit?: string | null;
+  observed_at?: string | null;   // ISO
+  thread_id?: string | null;
+  meta?: any;                    // jsonb
+};
+
+export async function POST(req: NextRequest) {
+  const userId = await getUserId();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  const { items } = await req.json().catch(() => ({ items: [] as InObs[] }));
+  if (!Array.isArray(items) || items.length === 0) {
+    return NextResponse.json({ error: "items[] required" }, { status: 400 });
+  }
+
+  const now = new Date().toISOString();
+  const rows = items.map((x) => ({
+    user_id: userId,
+    kind: x.kind.toLowerCase(),
+    value_num: x.value_num ?? null,
+    value_text: x.value_text ?? null,
+    unit: x.unit ?? null,
+    observed_at: x.observed_at ?? now,
+    thread_id: x.thread_id ?? null,
+    meta: x.meta ?? null,
+  }));
+
+  const { error, count } = await supabaseAdmin().from("observations").insert(rows, { count: "exact" });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true, inserted: count ?? rows.length });
+}

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -458,6 +458,11 @@ ${linkNudge}`;
       fd.append('doctorMode', String(mode === 'doctor'));
       fd.append('country', country.code3);
       if (note.trim()) fd.append('note', note.trim());
+      const search = new URLSearchParams(window.location.search);
+      const threadId = search.get('threadId');
+      if (threadId) fd.append('threadId', threadId);
+      const sourceHash = `${file?.name ?? 'doc'}:${file?.size ?? ''}:${(file as any)?.lastModified ?? ''}`;
+      fd.append('sourceHash', sourceHash);
       const data = await safeJson(
         fetch('/api/analyze', { method: 'POST', body: fd })
       );


### PR DESCRIPTION
## Summary
- add bulk observations API for trusted inserts
- parse medical text into observations with OpenAI or deterministic regex fallback
- ingest uploads earlier and include thread/source hash metadata

## Testing
- `npm test`
- `npm run lint` *(fails: Interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a5dae218832fbd24724ab25945b6