### PR TITLE
feat: improve profile observation grouping

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -27,7 +27,7 @@ type Item = {
 
 type Groups = Record<GroupKey, Item[]>;
 
-// Optional friendly labels (fallback: startCase(kind))
+// --- labels (extendable) ---
 const LABELS: Record<string, string> = {
   bp: "BP",
   hr: "HR",
@@ -39,33 +39,117 @@ const LABELS: Record<string, string> = {
   ast: "AST",
   alp: "ALP",
   ggt: "GGT",
-  total_bilirubin: "Total Bilirubin",
+  total_bilirubin: "Bilirubin Total",
+  direct_bilirubin: "Bilirubin Direct",
+  indirect_bilirubin: "Bilirubin Indirect",
   hemoglobin: "Hemoglobin",
   wbc: "WBC",
   platelets: "Platelets",
   esr: "ESR",
+  uibc: "UIBC",
+  tibc: "TIBC",
+  transferrin_saturation: "Transferrin Saturation",
+  total_cholesterol: "Total Cholesterol",
+  triglycerides: "Triglycerides",
+  ldl: "LDL",
+  hdl: "HDL",
+  vitamin_d: "Vitamin D",
+  vitamin_b12: "Vitamin B12",
+  creatinine: "Serum Creatinine",
+  lipase: "Serum Lipase",
+  amylase: "Serum Amylase",
+  fsh: "FSH",
+  lh: "LH",
+  rheumatoid_factor: "Rheumatoid Factor",
+  rbc_count: "Erythrocyte Count",
 };
 
-const RX_WORDS = ["med", "rx", "drug", "dose", "tablet", "capsule", "syrup"];
+// --- normalization for common synonyms/kinds ---
+function normalizeKind(raw: string) {
+  const k = String(raw || "").trim().toLowerCase().replace(/\s+/g, "_");
+  // exact matches or common synonyms
+  if (["erythrocyte_count", "rbc", "rbc_count"].includes(k)) return "rbc_count";
+  if (["total_chol", "cholesterol", "cholesterol_total"].includes(k)) return "total_cholesterol";
+  if (["bilirubin", "tbil", "tbil_total"].includes(k)) return "total_bilirubin";
+  if (["vit_b12", "b12"].includes(k)) return "vitamin_b12";
+  if (["vitamin_d3", "25_oh_vitamin_d", "25-oh-vitamin-d"].includes(k)) return "vitamin_d";
+  if (["serum_creatinine"].includes(k)) return "creatinine";
+  if (["rf", "ra_factor"].includes(k)) return "rheumatoid_factor";
+  return k;
+}
+
+// --- deterministic overrides (canonical kind -> group) ---
+const KIND_CATEGORY_OVERRIDES: Record<string, GroupKey> = {
+  // always labs:
+  rbc_count: "labs",
+  hemoglobin: "labs",
+  wbc: "labs",
+  platelets: "labs",
+  esr: "labs",
+  uibc: "labs",
+  tibc: "labs",
+  transferrin_saturation: "labs",
+  egfr: "labs",
+  creatinine: "labs",
+  fasting_glucose: "labs",
+  hba1c: "labs",
+  total_cholesterol: "labs",
+  triglycerides: "labs",
+  ldl: "labs",
+  hdl: "labs",
+  total_bilirubin: "labs",
+  direct_bilirubin: "labs",
+  indirect_bilirubin: "labs",
+  alt: "labs",
+  ast: "labs",
+  alp: "labs",
+  ggt: "labs",
+  vitamin_d: "labs",
+  vitamin_b12: "labs",
+  lipase: "labs",
+  amylase: "labs",
+  fsh: "labs",
+  lh: "labs",
+  rheumatoid_factor: "labs",
+
+  // real vitals:
+  bp: "vitals",
+  hr: "vitals",
+  bmi: "vitals",
+  height: "vitals",
+  weight: "vitals",
+  spo2: "vitals",
+  pulse: "vitals",
+};
+
+// imaging trigger words, but require 'report' or meta.imaging to avoid false positives
 const IMG_WORDS = ["xray", "xr", "cxr", "ct", "mri", "usg", "ultrasound", "echo"];
-const VITAL_WORDS = ["bp", "hr", "pulse", "temp", "spo2", "bmi", "height", "weight"];
+const RX_WORDS  = ["med", "rx", "drug", "dose", "tablet", "capsule", "syrup"];
+
+// broader lab hints
 const LAB_HINT = [
   "glucose","cholesterol","triglycer","hba1c","egfr","creatinine","bun",
   "bilirubin","ast","alt","alp","ggt","hb","hemoglobin","wbc","platelet","esr",
-  "ferritin","tibc","uibc","transferrin","sodium","potassium","ldl","hdl"
+  "ferritin","tibc","uibc","transferrin","sodium","potassium","ldl","hdl",
+  "vitamin","lipase","amylase","fsh","lh","rheumatoid"
 ];
 
 function startCase(s: string) {
   return s.replaceAll("_", " ").replace(/(^|\s)\S/g, c => c.toUpperCase());
 }
 
-function classify(kind: string, meta: any): GroupKey {
-  const k = kind.toLowerCase();
+function classify(kindRaw: string, meta: any): GroupKey {
+  const kind = normalizeKind(kindRaw);
+  // 1) explicit override
+  if (KIND_CATEGORY_OVERRIDES[kind]) return KIND_CATEGORY_OVERRIDES[kind];
+
+  const k = kind;
   const cat = (meta?.category as string | undefined)?.toLowerCase();
   const modality = (meta?.modality as string | undefined)?.toLowerCase();
   const src = (meta?.source_type as string | undefined)?.toLowerCase();
+  const textHas = (arr: string[]) => arr.some(w => k.includes(w));
 
-  // Prefer explicit metadata from the parser
+  // 2) explicit meta from parser
   if (cat === "vital") return "vitals";
   if (cat === "lab") return "labs";
   if (cat === "imaging") return "imaging";
@@ -75,11 +159,13 @@ function classify(kind: string, meta: any): GroupKey {
   if (cat === "immunization" || cat === "vaccine") return "immunizations";
   if (cat === "note" || cat === "symptom") return "notes";
 
-  // Heuristics
-  if (IMG_WORDS.some(w => k.includes(w)) || (modality && IMG_WORDS.some(w => modality.includes(w)))) return "imaging";
-  if (RX_WORDS.some(w => k.includes(w))) return "medications";
-  if (VITAL_WORDS.some(w => k.includes(w))) return "vitals";
-  if (LAB_HINT.some(w => k.includes(w))) return "labs";
+  // 3) heuristics (tightened)
+  const looksImaging = textHas(IMG_WORDS) || (modality && IMG_WORDS.some(w => modality.includes(w)));
+  if (looksImaging && (k.includes("report") || cat === "imaging")) return "imaging";
+
+  if (textHas(RX_WORDS)) return "medications";
+  if (textHas(["bp","hr","pulse","temp","spo2","bmi","height","weight"])) return "vitals";
+  if (textHas(LAB_HINT)) return "labs";
   if (src === "note" || src === "text" || k.includes("note") || k.includes("symptom")) return "notes";
 
   return "other";
@@ -136,7 +222,8 @@ export async function GET(_req: NextRequest) {
     other: [],
   };
 
-  for (const [kind, info] of latestByKind.entries()) {
+  for (const [rawKind, info] of latestByKind.entries()) {
+    const kind = normalizeKind(rawKind);
     const group = classify(kind, info.meta);
     const label = LABELS[kind] ?? startCase(kind);
 


### PR DESCRIPTION
## Summary
- enhance /api/profile grouping with canonical labels and synonyms
- add deterministic kind to category overrides and stricter heuristics
- normalize kinds before labeling and grouping

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ae1ebfbc832f959af4378121ca8b