### PR TITLE
Add patient profile editing and reset endpoints

### DIFF
--- a/app/api/admin/reset/route.ts
+++ b/app/api/admin/reset/route.ts
@@ -1,0 +1,62 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { getUserId } from "@/lib/getUserId";
+
+type Scope = "observations" | "all";
+type Mode = "clear" | "zero";
+
+export async function POST(req: NextRequest) {
+  const userId = await getUserId();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  const { scope, mode, threadId } = await req
+    .json()
+    .catch(() => ({}) as { scope?: Scope; mode?: Mode; threadId?: string | null });
+  const sb = supabaseAdmin();
+
+  // 1) clear observations (optionally per threadId)
+  if (scope === "observations" || scope === "all") {
+    let q = sb.from("observations").delete().eq("user_id", userId);
+    if (threadId) q = q.eq("thread_id", threadId);
+    const { error } = await q;
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // 2) optionally zero-out demo values (re-insert zeros)
+  if (mode === "zero") {
+    const now = new Date().toISOString();
+    const demo = [
+      { kind: "bp", value_text: "0/0", unit: null },
+      { kind: "hr", value_num: 0, unit: "bpm" },
+      { kind: "bmi", value_num: 0, unit: "kg/m²" },
+      { kind: "hba1c", value_num: 0, unit: "%" },
+      { kind: "fasting_glucose", value_num: 0, unit: "mg/dL" },
+      { kind: "egfr", value_num: 0, unit: "mL/min/1.73m²" },
+    ].map((x) => ({
+      user_id: userId,
+      thread_id: threadId ?? null,
+      kind: x.kind,
+      value_num: (x as any).value_num ?? null,
+      value_text: (x as any).value_text ?? null,
+      unit: x.unit ?? null,
+      observed_at: now,
+      meta: { source_type: "reset" },
+    }));
+
+    const { error } = await sb.from("observations").insert(demo);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // 3) if scope = all, clear predictions + alerts too
+  if (scope === "all") {
+    const p = await sb.from("predictions").delete().eq("user_id", userId);
+    if (p.error) return NextResponse.json({ error: p.error.message }, { status: 500 });
+    const a = await sb.from("alerts").delete().eq("user_id", userId);
+    if (a.error) return NextResponse.json({ error: a.error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -256,3 +256,29 @@ export async function GET(_req: NextRequest) {
   return NextResponse.json({ profile, groups, latest });
 }
 
+export async function PUT(req: NextRequest) {
+  const userId = await getUserId();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  const body = await req.json().catch(() => ({}));
+  const allowed = [
+    "full_name",
+    "dob",
+    "sex",
+    "blood_group",
+    "conditions_predisposition",
+    "chronic_conditions",
+  ] as const;
+
+  const patch: Record<string, any> = {};
+  for (const k of allowed) if (k in body) patch[k] = body[k];
+
+  const { error } = await supabaseAdmin()
+    .from("profiles")
+    .update(patch)
+    .eq("id", userId);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true });
+}
+


### PR DESCRIPTION
## Summary
- add PUT `/api/profile` to save patient demographics
- create admin reset API to clear or zero demo data
- expand MedicalProfile panel with patient info form and reset controls

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b248c19c832fa0ecc5bf20f389cd