### PR TITLE
Add patient profile editing and reset API

### DIFF
--- a/app/api/admin/reset/route.ts
+++ b/app/api/admin/reset/route.ts
@@ -1,0 +1,62 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { getUserId } from "@/lib/getUserId";
+
+type Scope = "observations" | "all";
+type Mode = "clear" | "zero";
+
+export async function POST(req: NextRequest) {
+  const userId = await getUserId();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  const { scope, mode, threadId } = await req.json().catch(() => ({} as {
+    scope?: Scope; mode?: Mode; threadId?: string | null;
+  }));
+  const sb = supabaseAdmin();
+
+  // 1) clear observations (optionally by thread)
+  if (scope === "observations" || scope === "all") {
+    let q = sb.from("observations").delete().eq("user_id", userId);
+    if (threadId) q = q.eq("thread_id", threadId);
+    const { error } = await q;
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // 2) optional: zero-out demo values
+  if (mode === "zero") {
+    const now = new Date().toISOString();
+    const demo = [
+      { kind: "bp", value_text: "0/0", unit: null },
+      { kind: "hr", value_num: 0, unit: "bpm" },
+      { kind: "bmi", value_num: 0, unit: "kg/m²" },
+      { kind: "hba1c", value_num: 0, unit: "%" },
+      { kind: "fasting_glucose", value_num: 0, unit: "mg/dL" },
+      { kind: "egfr", value_num: 0, unit: "mL/min/1.73m²" },
+    ].map(x => ({
+      user_id: userId,
+      thread_id: threadId ?? null,
+      kind: x.kind,
+      value_num: (x as any).value_num ?? null,
+      value_text: (x as any).value_text ?? null,
+      unit: x.unit ?? null,
+      observed_at: now,
+      meta: { source_type: "reset" },
+    }));
+
+    const { error } = await sb.from("observations").insert(demo);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // 3) if scope = all, clear predictions + alerts
+  if (scope === "all") {
+    const p = await sb.from("predictions").delete().eq("user_id", userId);
+    if (p.error) return NextResponse.json({ error: p.error.message }, { status: 500 });
+    const a = await sb.from("alerts").delete().eq("user_id", userId);
+    if (a.error) return NextResponse.json({ error: a.error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -256,3 +256,25 @@ export async function GET(_req: NextRequest) {
   return NextResponse.json({ profile, groups, latest });
 }
 
+export async function PUT(req: NextRequest) {
+  const userId = await getUserId();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+
+  const body = await req.json().catch(() => ({}));
+  const allowed = [
+    "full_name",
+    "dob",
+    "sex",
+    "blood_group",
+    "conditions_predisposition",
+    "chronic_conditions",
+  ] as const;
+
+  const patch: Record<string, any> = {};
+  for (const k of allowed) if (k in body) patch[k] = body[k];
+
+  const { error } = await supabaseAdmin().from("profiles").update(patch).eq("id", userId);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}
+

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -2,6 +2,22 @@
 import { useEffect, useState } from "react";
 import { safeJson } from "@/lib/safeJson";
 
+const SEXES = ["male", "female", "other"] as const;
+const BLOOD_GROUPS = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
+const PRESET_CONDITIONS = [
+  "Diabetes mellitus","Hypertension","Coronary artery disease","Asthma",
+  "COPD","Hypothyroidism","Hyperthyroidism","CKD","Anemia","Arthritis",
+  "Depression","Anxiety","Obesity","Dyslipidemia",
+];
+
+function ageFromDob(dob?: string | null) {
+  if (!dob) return "";
+  const d = new Date(dob);
+  if (isNaN(d.getTime())) return "";
+  const diff = Date.now() - d.getTime();
+  return String(Math.floor(diff / (365.25 * 24 * 3600 * 1000)));
+}
+
 type Observation = { kind: string; value: any; observedAt: string };
 
 type Item = {
@@ -22,6 +38,27 @@ export default function MedicalProfile() {
   const [obs, setObs] = useState<Observation[]>([]);
   const [data, setData] = useState<ProfilePayload | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [resetting, setResetting] = useState<null | "obs" | "all" | "zero">(null);
+
+  // derive from profile
+  const prof = data?.profile || {};
+  const [fullName, setFullName] = useState("");
+  const [dob, setDob] = useState("");
+  const [sex, setSex] = useState("");
+  const [bloodGroup, setBloodGroup] = useState("");
+  const [predis, setPredis] = useState<string[]>([]);
+  const [chronic, setChronic] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!prof) return;
+    setFullName(prof.full_name || "");
+    setDob(prof.dob || "");
+    setSex(prof.sex || "");
+    setBloodGroup(prof.blood_group || "");
+    setPredis(prof.conditions_predisposition || []);
+    setChronic(prof.chronic_conditions || []);
+  }, [prof]);
 
   async function loadProfile() {
     setErr(null);
@@ -61,6 +98,164 @@ export default function MedicalProfile() {
 
   return (
     <div className="p-4 space-y-4">
+      <section className="rounded-xl border p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="font-semibold">Patient Info</h2>
+          <div className="flex items-center gap-2">
+
+            {/* RESET button — type="button" is REQUIRED for sidebar safety */}
+            <button
+              type="button"
+              className="text-sm rounded-md border px-3 py-1.5 hover:bg-muted"
+              onClick={async () => {
+                const pick = window.prompt(
+                  "Reset:\n1 = Clear observations\n2 = Clear everything (obs+pred+alerts)\n3 = Zero-out demo values\n\nEnter 1/2/3 or Cancel"
+                );
+                const map: any = { "1": "obs", "2": "all", "3": "zero" };
+                const sel = map[pick || ""];
+                if (!sel) return;
+                setResetting(sel);
+                try {
+                  const body =
+                    sel === "obs" ? { scope: "observations", mode: "clear" } :
+                    sel === "all" ? { scope: "all", mode: "clear" } :
+                                    { scope: "observations", mode: "zero" };
+                  const r = await fetch("/api/admin/reset", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(body),
+                  });
+                  if (!r.ok) throw new Error(await r.text());
+                  if (typeof window !== "undefined") {
+                    window.dispatchEvent(new Event("observations-updated"));
+                  }
+                  await loadProfile();
+                } catch (e: any) {
+                  alert(e.message || "Reset failed");
+                } finally {
+                  setResetting(null);
+                }
+              }}
+            >
+              {resetting ? "Resetting…" : "Reset"}
+            </button>
+
+            {/* SAVE button — type="button" is REQUIRED for sidebar safety */}
+            <button
+              type="button"
+              className="text-sm rounded-md border px-3 py-1.5 hover:bg-muted disabled:opacity-50"
+              disabled={saving}
+              onClick={async () => {
+                setSaving(true);
+                try {
+                  const r = await fetch("/api/profile", {
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      full_name: fullName || null,
+                      dob: dob || null,
+                      sex: sex || null,
+                      blood_group: bloodGroup || null,
+                      conditions_predisposition: predis,
+                      chronic_conditions: chronic,
+                    }),
+                  });
+                  if (!r.ok) throw new Error(await r.text());
+                  await loadProfile();
+                } catch (e: any) {
+                  alert(e.message || "Save failed");
+                } finally {
+                  setSaving(false);
+                }
+              }}
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+          <label className="flex flex-col gap-1">
+            <span>Name</span>
+            <input className="rounded-md border px-3 py-2"
+                   value={fullName} onChange={e => setFullName(e.target.value)}
+                   placeholder="Full name" />
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span>DOB</span>
+            <input type="date" className="rounded-md border px-3 py-2"
+                   value={dob || ""} onChange={e => setDob(e.target.value)} />
+            <span className="text-xs text-muted-foreground">Age: {ageFromDob(dob)}</span>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span>Sex</span>
+            <select className="rounded-md border px-3 py-2" value={sex} onChange={e => setSex(e.target.value)}>
+              <option value="">—</option>
+              {SEXES.map(s => <option key={s} value={s}>{s}</option>)}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span>Blood Group</span>
+            <select className="rounded-md border px-3 py-2" value={bloodGroup} onChange={e => setBloodGroup(e.target.value)}>
+              <option value="">—</option>
+              {BLOOD_GROUPS.map(bg => <option key={bg} value={bg}>{bg}</option>)}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 md:col-span-1">
+            <span>Predispositions</span>
+            <input
+              className="rounded-md border px-3 py-2"
+              placeholder="Type to add (Enter)…"
+              onKeyDown={(e) => {
+                const v = (e.target as HTMLInputElement).value.trim();
+                if (e.key === "Enter" && v) {
+                  setPredis(Array.from(new Set([...predis, v])));
+                  (e.target as HTMLInputElement).value = "";
+                }
+              }}
+              list="condlist"
+            />
+            <datalist id="condlist">
+              {PRESET_CONDITIONS.map(c => <option key={c} value={c} />)}
+            </datalist>
+            <div className="flex flex-wrap gap-2 mt-1">
+              {predis.map(c => (
+                <span key={c} className="text-xs border rounded-full px-2 py-0.5">
+                  {c} <button type="button" className="ml-1" onClick={() => setPredis(predis.filter(x => x !== c))}>×</button>
+                </span>
+              ))}
+            </div>
+          </label>
+
+          <label className="flex flex-col gap-1 md:col-span-1">
+            <span>Chronic conditions</span>
+            <input
+              className="rounded-md border px-3 py-2"
+              placeholder="Type to add (Enter)…"
+              onKeyDown={(e) => {
+                const v = (e.target as HTMLInputElement).value.trim();
+                if (e.key === "Enter" && v) {
+                  setChronic(Array.from(new Set([...chronic, v])));
+                  (e.target as HTMLInputElement).value = "";
+                }
+              }}
+              list="condlist"
+            />
+            <div className="flex flex-wrap gap-2 mt-1">
+              {chronic.map(c => (
+                <span key={c} className="text-xs border rounded-full px-2 py-0.5">
+                  {c} <button type="button" className="ml-1" onClick={() => setChronic(chronic.filter(x => x !== c))}>×</button>
+                </span>
+              ))}
+            </div>
+          </label>
+        </div>
+      </section>
+
       {/* Existing fixed sections (unchanged) */}
       <section className="rounded-xl border p-4">
         <h2 className="font-semibold mb-2">Vitals</h2>


### PR DESCRIPTION
## Summary
- add PUT support to `/api/profile` for updating patient info
- create `/api/admin/reset` endpoint to clear or zero observation data
- add Patient Info card with Save and Reset buttons to medical profile panel

## Testing
- `npm test`
- `npm run lint` *(failed: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b7bf0890832f81f84a4e6ee09057