### PR TITLE
feat: make sidebar links navigable

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,11 +16,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <ContextProvider>
             <TopicProvider>
               <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-                <div className="flex">
+                <div className="flex min-h-screen">
                   <Suspense fallback={null}>
                     <Sidebar />
                   </Suspense>
-                  <main className="flex-1 md:ml-64 min-h-dvh flex flex-col relative z-0">
+                  <main className="relative z-0 flex-1 md:ml-64 min-h-dvh flex flex-col">
                     {children}
                   </main>
                 </div>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,7 +6,7 @@ export default function Sidebar() {
   const handleNew = () => window.dispatchEvent(new Event('new-chat'));
   const handleSearch = (q: string) => window.dispatchEvent(new CustomEvent('search-chats', { detail: q }));
   return (
-    <nav className="sidebar-click-guard hidden md:flex md:flex-col !fixed inset-y-0 left-0 w-64 bg-white dark:bg-gray-900 border-r border-slate-200 dark:border-gray-800">
+    <nav className="sidebar-click-guard hidden md:flex md:flex-col !fixed inset-y-0 left-0 w-64 shrink-0 bg-white dark:bg-gray-900 border-r border-slate-200 dark:border-gray-800">
       <button type="button" onClick={handleNew} className="mx-3 my-3 h-10 rounded-xl bg-slate-100 hover:bg-slate-200 dark:bg-gray-800 dark:hover:bg-gray-700 flex items-center justify-center gap-2">
         <Plus size={16} /> New Chat
       </button>

--- a/components/nav/NavLink.tsx
+++ b/components/nav/NavLink.tsx
@@ -1,0 +1,31 @@
+"use client";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+
+export default function NavLink({
+  panel,
+  children,
+  className,
+}: {
+  panel: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const params = useSearchParams();
+  const threadId = params.get("threadId") ?? "";
+
+  const qs = new URLSearchParams();
+  qs.set("panel", panel);
+  if (threadId) qs.set("threadId", threadId);
+
+  return (
+    <Link
+      href={"?" + qs.toString()}
+      prefetch={false}
+      className={className ?? "block w-full text-left rounded-md px-3 py-2 hover:bg-muted"}
+      data-testid={`nav-${panel}`}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
-import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+import NavLink from "@/components/nav/NavLink";
 
 const tabs = [
   { key: "chat", label: "Chat" },
@@ -10,37 +10,24 @@ const tabs = [
   { key: "settings", label: "Settings" },
 ];
 
-function NavLink({ panel, children }: { panel: string; children: React.ReactNode }) {
-  const params = useSearchParams();
-  const threadId = params.get("threadId");
-  const qp = new URLSearchParams();
-  qp.set("panel", panel);
-  if (threadId) qp.set("threadId", threadId);
-  const active = (params.get("panel") ?? "chat") === panel;
-
-  return (
-    <Link
-      href={"?" + qp.toString()}
-      prefetch={false}
-      className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
-      data-testid={`nav-${panel}`}
-      onClick={() => {
-        if (panel === "chat") window.dispatchEvent(new Event("focus-chat-input"));
-      }}
-    >
-      {children}
-    </Link>
-  );
-}
-
 export default function Tabs() {
+  const params = useSearchParams();
+  const current = params.get("panel") ?? "chat";
   return (
     <ul className="mt-3 space-y-1">
-      {tabs.map((t) => (
-        <li key={t.key}>
-          <NavLink panel={t.key}>{t.label}</NavLink>
-        </li>
-      ))}
+      {tabs.map((t) => {
+        const active = current === t.key;
+        return (
+          <li key={t.key}>
+            <NavLink
+              panel={t.key}
+              className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
+            >
+              {t.label}
+            </NavLink>
+          </li>
+        );
+      })}
     </ul>
   );
 }


### PR DESCRIPTION
## Summary
- add NavLink helper using standard links for left panel
- wire sidebar tabs to NavLink for direct navigation
- ensure layout prevents overlaying sidebar

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c728139c832fa072955d812e551b