### PR TITLE
Enable client-side left panel routing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,18 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { Suspense, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
 import Timeline from "@/components/panels/Timeline";
 import AlertsPane from "@/components/panels/AlertsPane";
 import SettingsPane from "@/components/panels/SettingsPane";
 
-type Search = { panel?: string; threadId?: string };
-
-export default function Page({ searchParams }: { searchParams: Search }) {
-  const panel = (searchParams.panel ?? "chat").toLowerCase();
+function PageContent() {
+  const params = useSearchParams();
+  const panel = (params.get("panel") ?? "chat").toLowerCase();
+  const threadId = params.get("threadId") ?? undefined;
+  const allowed = new Set(["chat", "profile", "timeline", "alerts", "settings"]);
+  const activePanel = allowed.has(panel) ? panel : "chat";
   const chatInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -20,25 +23,33 @@ export default function Page({ searchParams }: { searchParams: Search }) {
 
   return (
     <>
-      <section className={panel === "chat" ? "block h-full" : "hidden"}>
+      <section className={activePanel === "chat" ? "block h-full" : "hidden"}>
         <ChatPane inputRef={chatInputRef} />
       </section>
 
-      <section className={panel === "profile" ? "block" : "hidden"}>
+      <section className={activePanel === "profile" ? "block" : "hidden"}>
         <MedicalProfile />
       </section>
 
-      <section className={panel === "timeline" ? "block" : "hidden"}>
-        <Timeline threadId={searchParams.threadId} />
+      <section className={activePanel === "timeline" ? "block" : "hidden"}>
+        <Timeline threadId={threadId} />
       </section>
 
-      <section className={panel === "alerts" ? "block" : "hidden"}>
+      <section className={activePanel === "alerts" ? "block" : "hidden"}>
         <AlertsPane />
       </section>
 
-      <section className={panel === "settings" ? "block" : "hidden"}>
+      <section className={activePanel === "settings" ? "block" : "hidden"}>
         <SettingsPane />
       </section>
     </>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <PageContent />
+    </Suspense>
   );
 }

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 
 const tabs = [
   { key: "chat", label: "Chat" },
@@ -12,15 +12,17 @@ const tabs = [
 
 function NavLink({ panel, children }: { panel: string; children: React.ReactNode }) {
   const params = useSearchParams();
-  const threadId = params.get("threadId");
-  const qp = new URLSearchParams();
-  qp.set("panel", panel);
-  if (threadId) qp.set("threadId", threadId);
+  const pathname = usePathname();
+  const query: Record<string, string> = {};
+  params.forEach((value, key) => {
+    query[key] = value;
+  });
+  query.panel = panel;
   const active = (params.get("panel") ?? "chat") === panel;
 
   return (
     <Link
-      href={"?" + qp.toString()}
+      href={{ pathname, query }}
       prefetch={false}
       className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
       data-testid={`nav-${panel}`}


### PR DESCRIPTION
## Summary
- use `useSearchParams` and a `Suspense` boundary in the main page so panel changes react instantly and unknown panels fall back to chat
- update sidebar tabs to push query-based links with `pathname` so navigation uses client-side routing and preserves other search params

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc8014d8832fbc51176d44e6d6b6