### PR TITLE
Enable client-side panel switching

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,15 +7,13 @@ import Timeline from "@/components/panels/Timeline";
 import AlertsPane from "@/components/panels/AlertsPane";
 import SettingsPane from "@/components/panels/SettingsPane";
 
-// Make the page dynamic so Vercel doesn’t try to SSG it
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
-
 function PageInner() {
   const params = useSearchParams();
+
   const panelRaw = (params.get("panel") ?? "chat").toLowerCase();
-  const allowed = new Set(["chat","profile","timeline","alerts","settings"]);
+  const allowed = new Set(["chat", "profile", "timeline", "alerts", "settings"]);
   const panel = allowed.has(panelRaw) ? panelRaw : "chat";
+
   const threadId = params.get("threadId") ?? undefined;
 
   const chatInputRef = useRef<HTMLInputElement>(null);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
@@ -7,13 +7,15 @@ import Timeline from "@/components/panels/Timeline";
 import AlertsPane from "@/components/panels/AlertsPane";
 import SettingsPane from "@/components/panels/SettingsPane";
 
-export default function Page() {
+// Make the page dynamic so Vercel doesn’t try to SSG it
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function PageInner() {
   const params = useSearchParams();
-
   const panelRaw = (params.get("panel") ?? "chat").toLowerCase();
-  const allowed = new Set(["chat", "profile", "timeline", "alerts", "settings"]);
+  const allowed = new Set(["chat","profile","timeline","alerts","settings"]);
   const panel = allowed.has(panelRaw) ? panelRaw : "chat";
-
   const threadId = params.get("threadId") ?? undefined;
 
   const chatInputRef = useRef<HTMLInputElement>(null);
@@ -45,6 +47,14 @@ export default function Page() {
         <SettingsPane />
       </section>
     </>
+  );
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <PageInner />
+    </Suspense>
   );
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,22 @@
 "use client";
 import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
 import Timeline from "@/components/panels/Timeline";
 import AlertsPane from "@/components/panels/AlertsPane";
 import SettingsPane from "@/components/panels/SettingsPane";
 
-type Search = { panel?: string; threadId?: string };
+export default function Page() {
+  const params = useSearchParams();
 
-export default function Page({ searchParams }: { searchParams: Search }) {
-  const panel = (searchParams.panel ?? "chat").toLowerCase();
+  const panelRaw = (params.get("panel") ?? "chat").toLowerCase();
+  const allowed = new Set(["chat", "profile", "timeline", "alerts", "settings"]);
+  const panel = allowed.has(panelRaw) ? panelRaw : "chat";
+
+  const threadId = params.get("threadId") ?? undefined;
+
   const chatInputRef = useRef<HTMLInputElement>(null);
-
   useEffect(() => {
     const handler = () => chatInputRef.current?.focus();
     window.addEventListener("focus-chat-input", handler);
@@ -29,7 +34,7 @@ export default function Page({ searchParams }: { searchParams: Search }) {
       </section>
 
       <section className={panel === "timeline" ? "block" : "hidden"}>
-        <Timeline threadId={searchParams.threadId} />
+        <Timeline threadId={threadId} />
       </section>
 
       <section className={panel === "alerts" ? "block" : "hidden"}>
@@ -42,3 +47,4 @@ export default function Page({ searchParams }: { searchParams: Search }) {
     </>
   );
 }
+

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 
 const tabs = [
   { key: "chat", label: "Chat" },
@@ -11,22 +11,29 @@ const tabs = [
 ];
 
 function NavLink({ panel, children }: { panel: string; children: React.ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
   const params = useSearchParams();
-  const threadId = params.get("threadId");
-  const qp = new URLSearchParams();
-  qp.set("panel", panel);
-  if (threadId) qp.set("threadId", threadId);
-  const active = (params.get("panel") ?? "chat") === panel;
+
+  const threadId = params.get("threadId") ?? undefined;
+  const href = { pathname, query: threadId ? { panel, threadId } : { panel } };
+
+  const active = ((params.get("panel") ?? "chat").toLowerCase()) === panel;
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();                         // ensure client-side nav fires
+    router.push(href as any, { scroll: false });
+    if (panel === "chat") window.dispatchEvent(new Event("focus-chat-input"));
+  };
 
   return (
     <Link
-      href={"?" + qp.toString()}
+      href={href}
       prefetch={false}
+      onClick={handleClick}
       className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
       data-testid={`nav-${panel}`}
-      onClick={() => {
-        if (panel === "chat") window.dispatchEvent(new Event("focus-chat-input"));
-      }}
+      aria-current={active ? "page" : undefined}
     >
       {children}
     </Link>
@@ -44,3 +51,4 @@ export default function Tabs() {
     </ul>
   );
 }
+


### PR DESCRIPTION
## Summary
- Implement client-side navigation for sidebar tabs so clicks update content and URL instantly without page reloads
- Read panel and thread ID from URL reactively to show the correct pane on load or deep links

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dcfb7ef8832f9521cac74ed6e1a5