### PR TITLE
Use query-preserving tabs and server page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-import { useEffect, useRef } from "react";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
 import Timeline from "@/components/panels/Timeline";
@@ -9,19 +7,15 @@ import SettingsPane from "@/components/panels/SettingsPane";
 type Search = { panel?: string; threadId?: string };
 
 export default function Page({ searchParams }: { searchParams: Search }) {
-  const panel = (searchParams.panel ?? "chat").toLowerCase();
-  const chatInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const handler = () => chatInputRef.current?.focus();
-    window.addEventListener("focus-chat-input", handler);
-    return () => window.removeEventListener("focus-chat-input", handler);
-  }, []);
+  const raw = (searchParams.panel ?? "chat").toLowerCase();
+  const allowed = new Set(["chat", "profile", "timeline", "alerts", "settings"]);
+  const panel = allowed.has(raw) ? raw : "chat";
+  const threadId = searchParams.threadId;
 
   return (
     <>
       <section className={panel === "chat" ? "block h-full" : "hidden"}>
-        <ChatPane inputRef={chatInputRef} />
+        <ChatPane />
       </section>
 
       <section className={panel === "profile" ? "block" : "hidden"}>
@@ -29,7 +23,7 @@ export default function Page({ searchParams }: { searchParams: Search }) {
       </section>
 
       <section className={panel === "timeline" ? "block" : "hidden"}>
-        <Timeline threadId={searchParams.threadId} />
+        <Timeline threadId={threadId} />
       </section>
 
       <section className={panel === "alerts" ? "block" : "hidden"}>

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -209,7 +209,16 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   const chatRef = useRef<HTMLDivElement>(null);
   const inputRef = externalInputRef ?? useRef<HTMLInputElement>(null);
 
-  useEffect(()=>{ chatRef.current?.scrollTo({ top: chatRef.current.scrollHeight }); },[messages]);
+  useEffect(() => {
+    chatRef.current?.scrollTo({ top: chatRef.current.scrollHeight });
+  }, [messages]);
+
+  useEffect(() => {
+    const handler = () => inputRef.current?.focus();
+    window.addEventListener('focus-chat-input', handler);
+    return () => window.removeEventListener('focus-chat-input', handler);
+  }, []);
+
   useEffect(() => {
     const init = () => {
       const msg = getRandomWelcome();

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, usePathname } from "next/navigation";
 
 const tabs = [
   { key: "chat", label: "Chat" },
@@ -12,18 +12,21 @@ const tabs = [
 
 function NavLink({ panel, children }: { panel: string; children: React.ReactNode }) {
   const params = useSearchParams();
-  const threadId = params.get("threadId");
-  const qp = new URLSearchParams();
-  qp.set("panel", panel);
-  if (threadId) qp.set("threadId", threadId);
-  const active = (params.get("panel") ?? "chat") === panel;
+  const pathname = usePathname();
+
+  const threadId = params.get("threadId") ?? undefined;
+  const query = threadId ? { panel, threadId } : { panel };
+  const active = ((params.get("panel") ?? "chat").toLowerCase()) === panel;
 
   return (
     <Link
-      href={"?" + qp.toString()}
+      href={{ pathname, query }}
       prefetch={false}
-      className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
+      className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${
+        active ? "bg-muted font-medium" : ""
+      }`}
       data-testid={`nav-${panel}`}
+      aria-current={active ? "page" : undefined}
       onClick={() => {
         if (panel === "chat") window.dispatchEvent(new Event("focus-chat-input"));
       }}


### PR DESCRIPTION
## Summary
- Use pathname-aware links in sidebar tabs to preserve existing query parameters
- Convert root page to server component with validated panels
- Focus chat input on tab switch within ChatPane

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e8006c20832f9d3716bf004632bd