### PR TITLE
feat: convert sidebar overlay to sticky

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,12 +11,6 @@
          dark:bg-gray-900 dark:text-slate-200 dark:border-gray-700 dark:hover:bg-gray-800;
 }
 
-/* Ensures sidebar sits above content and accepts clicks */
-.sidebar-click-guard {
-  position: relative;
-  z-index: 9999;
-  pointer-events: auto;
-}
 
 /* Compact typography for AI content */
 .prose-medx {
@@ -71,4 +65,18 @@
 .therapy-mode .btn-primary {
   background: #dbe9ff;
   color: #0b3d91;
+}
+
+/* Kill overlay behavior if any utility slips back in */
+.sidebar-click-guard {
+  position: static !important;
+  z-index: auto !important;
+  pointer-events: auto !important;
+}
+@media (min-width: 768px) {
+  .sidebar-click-guard {
+    position: sticky !important;
+    top: 0;
+    height: 100vh;
+  }
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,7 +6,18 @@ export default function Sidebar() {
   const handleNew = () => window.dispatchEvent(new Event('new-chat'));
   const handleSearch = (q: string) => window.dispatchEvent(new CustomEvent('search-chats', { detail: q }));
   return (
-    <nav className="sidebar-click-guard hidden md:flex md:flex-col !fixed inset-y-0 left-0 w-64 bg-white dark:bg-gray-900 border-r border-slate-200 dark:border-gray-800">
+    <nav
+      className="
+        sidebar-click-guard
+        hidden md:flex md:flex-col
+        w-64 shrink-0
+        md:sticky md:top-0 md:h-screen
+        bg-white dark:bg-gray-900
+        border-r border-slate-200 dark:border-gray-800
+        z-20
+      "
+      role="navigation"
+    >
       <button type="button" onClick={handleNew} className="mx-3 my-3 h-10 rounded-xl bg-slate-100 hover:bg-slate-200 dark:bg-gray-800 dark:hover:bg-gray-700 flex items-center justify-center gap-2">
         <Plus size={16} /> New Chat
       </button>


### PR DESCRIPTION
## Summary
- replace fixed overlay sidebar with bounded sticky column
- add CSS kill switch to keep sidebar static on mobile and sticky on desktop

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0fa12624832f96e72011f12a8e88