### PR TITLE
Fix Medical Profile input interactivity over overlays

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,13 +11,6 @@
          dark:bg-gray-900 dark:text-slate-200 dark:border-gray-700 dark:hover:bg-gray-800;
 }
 
-/* Ensures sidebar sits above content and accepts clicks */
-.sidebar-click-guard {
-  position: relative;
-  z-index: 9999;
-  pointer-events: auto;
-}
-
 /* Compact typography for AI content */
 .prose-medx {
   /* narrower line-height than Tailwind Typography defaults */
@@ -71,4 +64,15 @@
 .therapy-mode .btn-primary {
   background: #dbe9ff;
   color: #0b3d91;
+}
+
+/* The app's main work area is isolated and interactive */
+.main-pane {
+  isolation: isolate;         /* new stacking context */
+  pointer-events: auto;
+}
+
+/* sidebar should never sit on top of .main-pane */
+.sidebar-click-guard {
+  z-index: 10;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <Suspense fallback={null}>
                     <Sidebar />
                   </Suspense>
-                  <main className="flex-1 md:ml-64 min-h-dvh flex flex-col relative z-0">
+                  <main className="main-pane relative z-50 flex-1 md:ml-64 pointer-events-auto min-h-dvh flex flex-col">
                     {children}
                   </main>
                 </div>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,7 +6,10 @@ export default function Sidebar() {
   const handleNew = () => window.dispatchEvent(new Event('new-chat'));
   const handleSearch = (q: string) => window.dispatchEvent(new CustomEvent('search-chats', { detail: q }));
   return (
-    <nav className="sidebar-click-guard hidden md:flex md:flex-col !fixed inset-y-0 left-0 w-64 bg-white dark:bg-gray-900 border-r border-slate-200 dark:border-gray-800">
+    <nav
+      className="sidebar-click-guard hidden md:flex md:flex-col w-64 shrink-0 md:sticky md:top-0 md:h-screen bg-white dark:bg-gray-900 border-r border-slate-200 dark:border-gray-800 z-10"
+      role="navigation"
+    >
       <button type="button" onClick={handleNew} className="mx-3 my-3 h-10 rounded-xl bg-slate-100 hover:bg-slate-200 dark:bg-gray-800 dark:hover:bg-gray-700 flex items-center justify-center gap-2">
         <Plus size={16} /> New Chat
       </button>

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -60,6 +60,8 @@ export default function MedicalProfile() {
   const [predis, setPredis] = useState<string[]>([]);
   const [chronic, setChronic] = useState<string[]>([]);
 
+  const stopAll = (e: React.SyntheticEvent) => e.stopPropagation();
+
   async function loadProfile() {
     setErr(null);
     try {
@@ -190,6 +192,8 @@ export default function MedicalProfile() {
               value={fullName}
               onChange={e => setFullName(e.target.value)}
               placeholder="Full name"
+              onMouseDown={stopAll}
+              onFocus={stopAll}
             />
           </label>
 
@@ -200,6 +204,8 @@ export default function MedicalProfile() {
               className="rounded-md border px-3 py-2"
               value={dob || ""}
               onChange={e => setDob(e.target.value)}
+              onMouseDown={stopAll}
+              onFocus={stopAll}
             />
             <span className="text-xs text-muted-foreground">Age: {ageFromDob(dob)}</span>
           </label>
@@ -210,6 +216,8 @@ export default function MedicalProfile() {
               className="rounded-md border px-3 py-2"
               value={sex}
               onChange={e => setSex(e.target.value)}
+              onMouseDown={stopAll}
+              onFocus={stopAll}
             >
               <option value="">—</option>
               {SEXES.map(s => (
@@ -226,6 +234,8 @@ export default function MedicalProfile() {
               className="rounded-md border px-3 py-2"
               value={bloodGroup}
               onChange={e => setBloodGroup(e.target.value)}
+              onMouseDown={stopAll}
+              onFocus={stopAll}
             >
               <option value="">—</option>
               {BLOOD_GROUPS.map(bg => (


### PR DESCRIPTION
## Summary
- Elevate main content pane and isolate stacking to avoid hidden overlays capturing clicks
- Lower sidebar z-index and remove fixed overlay behavior
- Guard Medical Profile inputs against event hijacking

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ba12dd607c832f868db1502e3e243f