### PR TITLE
fix profile fetch cache

### DIFF
--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -64,9 +64,10 @@ export default function MedicalProfile() {
   async function loadProfile() {
     setErr(null);
     try {
-      const r = await fetch("/api/profile", { cache: "no-store" });
-      if (!r.ok) throw new Error(await r.text());
-      setData(await r.json());
+      const res = await fetch("/api/profile", { cache: "no-store" });
+      if (!res.ok) throw new Error(await res.text());
+      const json = await res.json();
+      setData(json);
     } catch (e: any) {
       setErr(e.message || "Failed to load profile");
     }


### PR DESCRIPTION
## Summary
- make profile API route dynamic and uncached
- fetch profile with no-store cache bypass

## Testing
- `npm test`
- `npm run lint` *(fails: asks for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68baaed0d134832f9c2d02a3a2ea592a