### PR TITLE
feat: add timeline API and client feed

### DIFF
--- a/app/api/timeline/route.ts
+++ b/app/api/timeline/route.ts
@@ -1,0 +1,75 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { getUserId } from "@/lib/getUserId";
+
+const noStore = { "Cache-Control": "no-store, max-age=0" };
+
+type TimelineItem = {
+  id: string;
+  kind: "prediction" | "observation";
+  name: string;
+  value?: string | number | null;
+  unit?: string | null;
+  probability?: number | null;
+  flags?: string[] | null;
+  observed_at: string; // ISO
+  source_upload_id?: string | null;
+  meta?: any;
+};
+
+export async function GET() {
+  const userId = await getUserId();
+  if (!userId) return NextResponse.json({ items: [] }, { headers: noStore });
+
+  const [predRes, obsRes] = await Promise.all([
+    supabaseAdmin()
+      .from("predictions")
+      .select("id, name, probability, observed_at, source_upload_id, details")
+      .eq("user_id", userId)
+      .order("observed_at", { ascending: false }),
+    supabaseAdmin()
+      .from("observations")
+      .select("id, name, value, unit, flags, observed_at, source_upload_id, meta")
+      .eq("user_id", userId)
+      .order("observed_at", { ascending: false }),
+  ]);
+
+  if (predRes.error) {
+    return NextResponse.json({ error: predRes.error.message }, { status: 500, headers: noStore });
+  }
+  if (obsRes.error) {
+    return NextResponse.json({ error: obsRes.error.message }, { status: 500, headers: noStore });
+  }
+
+  const preds: TimelineItem[] = (predRes.data ?? []).map((r: any) => ({
+    id: r.id,
+    kind: "prediction",
+    name: r.name ?? "Model prediction",
+    probability: r.probability ?? null,
+    observed_at: r.observed_at ?? new Date().toISOString(),
+    source_upload_id: r.source_upload_id ?? null,
+    meta: r.details ?? null,
+  }));
+
+  const obs: TimelineItem[] = (obsRes.data ?? []).map((r: any) => ({
+    id: r.id,
+    kind: "observation",
+    name: r.name ?? "Observation",
+    value: r.value ?? null,
+    unit: r.unit ?? null,
+    flags: r.flags ?? null,
+    observed_at: r.observed_at ?? new Date().toISOString(),
+    source_upload_id: r.source_upload_id ?? null,
+    meta: r.meta ?? null,
+  }));
+
+  const items = [...preds, ...obs].sort(
+    (a, b) => new Date(b.observed_at).getTime() - new Date(a.observed_at).getTime()
+  );
+
+  return NextResponse.json({ items }, { headers: noStore });
+}
+

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -1,113 +1,73 @@
 "use client";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
 
-type Prediction = { id: string; createdAt: string; riskScore: number; band: string };
+import { useEffect, useState } from "react";
 
-export default function Timeline(props: { threadId?: string }) {
-  const params = useSearchParams();
-  const urlThreadId = params.get("threadId") || undefined;
-  const threadId = props.threadId || urlThreadId || "";
+type TimelineItem = {
+  id: string;
+  kind: "prediction" | "observation";
+  name: string;
+  value?: string | number | null;
+  unit?: string | null;
+  probability?: number | null;
+  flags?: string[] | null;
+  observed_at: string;
+};
 
-  const router = useRouter();
-  const [preds, setPreds] = useState<Prediction[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [recomputing, setRecomputing] = useState(false);
+export default function Timeline(_props: { threadId?: string }) {
+  const [items, setItems] = useState<TimelineItem[]>([]);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchPredictions = useCallback(async () => {
-    if (!threadId) return;
-    setLoading(true);
-    setError(null);
+  const load = async () => {
     try {
-      const r = await fetch(`/api/predictions?threadId=${encodeURIComponent(threadId)}`, { cache: "no-store" });
-      if (!r.ok) throw new Error(await r.text());
-      const data = await r.json();
-      setPreds(data || []);
+      const res = await fetch("/api/timeline", { cache: "no-store" });
+      if (!res.ok) throw new Error(await res.text());
+      const data = await res.json();
+      setItems(data.items || []);
     } catch (e: any) {
-      setError(e.message || "Failed to load predictions");
+      setError(e.message || "Failed to load timeline");
     } finally {
       setLoading(false);
     }
-  }, [threadId]);
-
-  useEffect(() => {
-    if (threadId) fetchPredictions();
-  }, [threadId, fetchPredictions]);
-
-  const onRecompute = useCallback(async () => {
-    if (!threadId) return;
-    setRecomputing(true);
-    setError(null);
-    try {
-      const r = await fetch("/api/predictions/compute", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ threadId }),
-      });
-      if (!r.ok) throw new Error(await r.text());
-      await fetchPredictions();
-      if (typeof window !== "undefined") {
-        window.dispatchEvent(new Event("observations-updated"));
-      }
-    } catch (e: any) {
-      setError(e.message || "Recompute failed");
-    } finally {
-      setRecomputing(false);
-    }
-  }, [threadId, fetchPredictions]);
-
-  const scores = useMemo(() => preds.map((p) => p.riskScore), [preds]);
-  const max = Math.max(100, ...scores);
-  const points = useMemo(
-    () => preds.map((p, i) => `${(i / Math.max(preds.length - 1, 1)) * 100},${100 - (p.riskScore / max) * 100}`).join(" "),
-    [preds, max]
-  );
-
-  const goChat = (id: string) => {
-    const search = new URLSearchParams(window.location.search);
-    if (threadId) search.set("threadId", threadId);
-    search.set("panel", "chat");
-    router.push("?" + search.toString());
   };
 
+  useEffect(() => {
+    load();
+    const handler = () => load();
+    window.addEventListener("observations-updated", handler);
+    return () => window.removeEventListener("observations-updated", handler);
+  }, []);
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>;
+  if (error) return <p className="text-sm text-red-600">{error}</p>;
+  if (!items?.length) return <p className="text-sm text-muted-foreground">No timeline items yet</p>;
+
   return (
-    <div className="p-4 space-y-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Timeline</h2>
-        <button
-          onClick={onRecompute}
-          disabled={recomputing || !threadId}
-          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
-          aria-busy={recomputing}
-        >
-          {recomputing ? "Recomputing…" : "Recompute Risk"}
-        </button>
-      </div>
-
-      {error && <div className="text-sm text-red-600">{error}</div>}
-
-      {loading ? (
-        <div className="text-sm text-muted-foreground">Loading…</div>
-      ) : preds.length > 0 ? (
-        <>
-          <svg viewBox="0 0 100 100" className="w-full h-24" preserveAspectRatio="none">
-            <polyline points={points} fill="none" stroke="currentColor" strokeWidth="2" />
-          </svg>
-          <ul className="text-sm space-y-1">
-            {preds.map((p) => (
-              <li key={p.id} className="flex items-center gap-2">
-                <button onClick={() => goChat(p.id)} className="underline">
-                  {new Date(p.createdAt).toLocaleDateString()}
-                </button>
-                <span className="px-2 py-0.5 rounded-full text-xs border">{p.band}</span>
-              </li>
-            ))}
-          </ul>
-        </>
-      ) : (
-        <p className="text-sm text-muted-foreground">No predictions yet.</p>
-      )}
-    </div>
+    <ul className="space-y-2">
+      {items.map((it) => (
+        <li key={`${it.kind}:${it.id}`} className="rounded-md border p-3">
+          <div className="text-xs text-muted-foreground">
+            {new Date(it.observed_at).toLocaleString()}
+          </div>
+          <div className="font-medium">
+            {it.name}
+            {it.kind === "prediction" && typeof it.probability === "number" ? (
+              <> — {(it.probability * 100).toFixed(0)}%</>
+            ) : null}
+            {it.kind === "observation" && it.value != null ? (
+              <>
+                {" — "}
+                {String(it.value)}
+                {it.unit ? ` ${it.unit}` : ""}
+              </>
+            ) : null}
+          </div>
+          {it.flags?.length ? (
+            <div className="text-xs">{it.flags.join(", ")}</div>
+          ) : null}
+        </li>
+      ))}
+    </ul>
   );
 }
+


### PR DESCRIPTION
## Summary
- add `/api/timeline` endpoint combining predictions and observations
- render unified timeline list on client and disable caching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bab0346a18832fb409e11ed080e99e