### PR TITLE
refactor: simplify navigation and improve date parsing

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -327,16 +327,19 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
         setStickySystem(sys);
         setMessages(prev => {
           const without = prev.filter(
-            (m: any) => m.id !== 'medx-profile-sticky' && m.role !== 'system'
+            (m: any) =>
+              m.id !== 'medx-profile-sticky' &&
+              m.id !== 'medx-profile-intro' &&
+              m.role !== 'system'
           );
           return [
             sys,
             {
-              id: crypto.randomUUID(),
+              id: 'medx-profile-intro',
               role: 'assistant',
               kind: 'chat',
               content:
-                'I’ve loaded your patient packet and profile. Tell me what to correct or add (symptoms, meds, diagnoses), and I’ll update with reasons.',
+                'Loaded your packet. Tell me what to correct or add, and I’ll update with reasons.',
             },
             ...without,
           ];

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 
 type Tab = {
   key: string;
@@ -36,53 +36,22 @@ function NavLink({
   threadId?: string;
   context?: string;
 }) {
-  const router = useRouter();
-  const pathname = usePathname();
   const params = useSearchParams();
 
-  const currentThread = params.get("threadId") ?? undefined;
-  const threadId =
-    threadIdProp !== undefined
-      ? threadIdProp
-      : panel === "chat"
-      ? undefined
-      : currentThread;
-  const query: any = { panel };
-  if (threadId) query.threadId = threadId;
-  if (context) query.context = context;
-
-  const hrefObj = { pathname, query };
-  const hrefStr = `${pathname}?panel=${panel}${threadId ? `&threadId=${encodeURIComponent(threadId)}` : ""}${context ? `&context=${encodeURIComponent(context)}` : ""}`;
+  const threadId = threadIdProp;
+  const href = `/?panel=${panel}${threadId ? `&threadId=${encodeURIComponent(threadId)}` : ""}${
+    context ? `&context=${encodeURIComponent(context)}` : ""
+  }`;
 
   const active =
     ((params.get("panel") ?? "chat").toLowerCase()) === panel &&
-    ((threadIdProp ? params.get("threadId") === threadIdProp : !params.get("threadId")));
-
-  const softNav = () => {
-    try {
-      router.push(hrefObj as any, { scroll: false });
-      // verify panel changed soon; otherwise hard-fallback
-      requestAnimationFrame(() => {
-        const now = (new URLSearchParams(location.search).get("panel") ?? "chat").toLowerCase();
-        if (now !== panel.toLowerCase()) location.assign(hrefStr);
-      });
-    } catch {
-      location.assign(hrefStr);
-    }
-  };
-
-  const onClickCapture = (e: React.MouseEvent) => {
-    // primary click only; allow cmd/ctrl/shift/alt & middle/right clicks
-    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-    e.preventDefault();          // force client-side nav to preserve state
-    softNav();
-  };
+    (threadIdProp ? params.get("threadId") === threadIdProp : !params.get("threadId"));
 
   return (
     <Link
-      href={hrefObj}
+      href={href}
       prefetch={false}
-      onClickCapture={onClickCapture}
+      scroll={false}
       className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
       data-testid={`nav-${panel}`}
       aria-current={active ? "page" : undefined}

--- a/lib/reportDate.ts
+++ b/lib/reportDate.ts
@@ -1,7 +1,9 @@
 // Robust report-date extraction from OCR/PDF text or raw strings.
 const DATE_RX = [
   // Labeled patterns
-  /(report(ed)?|result|issued|dated|date|collected|sampled|drawn)\s*(on|:)?\s*(\d{1,2}[-/]\d{1,2}[-/]\d{2,4}|\d{4}[-\/.]\d{2}[-\/.]\d{2}|[A-Za-z]{3,9}\s+\d{1,2},?\s+\d{4}|(?:\d{1,2})\s*(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\s*,?\s*\d{4})/i,
+  /(report(ed)?|result|issued|dated|date|collected|sampled|drawn)\s*(on|:)?\s*(\d{1,2}[-/]\d{1,2}[-/]\d{2,4}(?:\s+\d{1,2}:\d{2}(?::\d{2})?\s*(?:AM|PM)?)?|\d{4}[-\/.]\d{2}[-\/.]\d{2}(?:\s+\d{1,2}:\d{2}(?::\d{2})?)?|[A-Za-z]{3,9}\s+\d{1,2},?\s+\d{4}|(?:\d{1,2})\s*(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\s*,?\s*\d{4})/i,
+  /\b(\d{1,2}[-/]\d{1,2}[-/]\d{2,4}\s+\d{1,2}:\d{2}(?::\d{2})?\s*(?:AM|PM)?)\b/i,
+  /\b(\d{4}[-\/.]\d{2}[-\/.]\d{2}\s+\d{1,2}:\d{2}(?::\d{2})?)\b/i,
   // First date fallback
   /\b(\d{1,2}[-/]\d{1,2}[-/]\d{2,4})\b/,
   /\b(\d{4}[-\/.]\d{2}[-\/.]\d{2})\b/,
@@ -23,6 +25,25 @@ export function extractReportDate(text: string): string | null {
 
 function normalizeDate(raw: string): string | null {
   const s = String(raw).replace(/\s+/g, " ").trim();
+  const isoNoTime = (y: string, m: string, d: string) =>
+    new Date(`${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T00:00:00Z`).toISOString();
+  const withTime = s.match(
+    /^(\d{1,2})[-/](\d{1,2})[-/](\d{2,4})\s+(\d{1,2}):(\d{2})(?::(\d{2}))?\s*(AM|PM)?$/i
+  );
+  if (withTime) {
+    let [, d, m, y, hh, mm, ss, ap] = withTime;
+    const yyyy = y.length === 2 ? "20" + y : y;
+    let hhNum = parseInt(hh, 10);
+    if (ap) {
+      const upper = ap.toUpperCase();
+      if (upper === "PM" && hhNum < 12) hhNum += 12;
+      if (upper === "AM" && hhNum === 12) hhNum = 0;
+    }
+    const iso = new Date(
+      `${yyyy}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T${String(hhNum).padStart(2, "0")}:${mm}:${ss || "00"}Z`
+    ).toISOString();
+    return iso;
+  }
   if (/^\d{4}[-\/.]\d{2}[-\/.]\d{2}$/.test(s)) {
     const t = s.replace(/\./g, "-");
     return new Date(t + "T00:00:00Z").toISOString();
@@ -31,7 +52,7 @@ function normalizeDate(raw: string): string | null {
   if (dmy) {
     const [, d, m, y] = dmy;
     const yyyy = y.length === 2 ? "20" + y : y;
-    return new Date(`${yyyy}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T00:00:00Z`).toISOString();
+    return isoNoTime(yyyy, m, d);
   }
   const ms = Date.parse(s);
   return isNaN(ms) ? null : new Date(ms).toISOString();


### PR DESCRIPTION
## Summary
- simplify sidebar tab navigation using plain links for Chat and AI Doc
- show one-time "Loaded your packet" message in profile chat
- expand report date extraction to handle more formats with times

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bafe3ac8d0832f9709eb219849c116