### PR TITLE
feat: enhance profile and AI doc interactions

### DIFF
--- a/app/api/ai-doc/note/route.ts
+++ b/app/api/ai-doc/note/route.ts
@@ -1,0 +1,29 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { getUserId } from "@/lib/getUserId";
+
+const noStore = { "Cache-Control": "no-store, max-age=0" };
+
+export async function POST(req: NextRequest) {
+  const userId = await getUserId();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+  const { text, meds } = await req.json().catch(() => ({ text: "" }));
+  if (!text) return NextResponse.json({ error: "text required" }, { status: 400, headers: noStore });
+  const meta: any = { kind: "note", source: "ai_doc", text, committed: true };
+  if (Array.isArray(meds)) meta.meds = meds;
+  const { error } = await supabaseAdmin()
+    .from("observations")
+    .insert({
+      user_id: userId,
+      observed_at: new Date().toISOString(),
+      name: "Note",
+      meta,
+    });
+  if (error)
+    return NextResponse.json({ error: error.message }, { status: 500, headers: noStore });
+  return NextResponse.json({ ok: true }, { headers: noStore });
+}

--- a/app/api/predictions/readiness/route.ts
+++ b/app/api/predictions/readiness/route.ts
@@ -1,0 +1,58 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { getUserId } from "@/lib/getUserId";
+
+const noStore = { "Cache-Control": "no-store, max-age=0" };
+const LAB_KEYS = {
+  hba1c: /hba1c/i,
+  fpg: /fasting_glucose|fpg|fbs/i,
+  egfr: /egfr/i,
+  lipids: /ldl|hdl|triglycerides|total_cholesterol/i,
+  tsh: /tsh/i,
+  vitd: /vitamin_d/i,
+};
+
+export function computeReadiness(profile: any, obs: any[]) {
+  let score = 0;
+  const missing: string[] = [];
+  const suggested: string[] = [];
+
+  const hasPred = Array.isArray(profile?.conditions_predisposition) && profile.conditions_predisposition.length > 0;
+  if (hasPred) score += 10; else missing.push('family_history');
+
+  const meds = obs.some(o => Array.isArray(o.meta?.meds) && o.meta.meds.length);
+  if (meds) score += 20; else missing.push('medications');
+
+  const labsSeen = new Set<string>();
+  for (const o of obs) {
+    const k = `${o.kind} ${o.name}`.toLowerCase();
+    for (const [key, rx] of Object.entries(LAB_KEYS)) if (rx.test(k)) labsSeen.add(key);
+  }
+  if (labsSeen.size >= 3) score += 20; else missing.push('labs');
+  const missingLabs = Object.keys(LAB_KEYS).filter(k => !labsSeen.has(k));
+  suggested.push(...missingLabs.map(k => k.toUpperCase()));
+
+  const weight = obs.filter(o => /weight|bmi/i.test(`${o.kind} ${o.name}`)).sort((a,b)=> +new Date(b.observed_at) - +new Date(a.observed_at))[0];
+  if (weight && (Date.now() - new Date(weight.observed_at).getTime())/86400000 < 30) score += 10; else missing.push('recent_weight');
+
+  const hasDoctor = obs.some(o => /summary/i.test(`${o.name} ${o.meta?.kind || ''}`));
+  if (hasDoctor) score += 10; else missing.push('doctor_summary');
+
+  return { score, missing, suggested_tests: suggested };
+}
+
+export async function GET() {
+  const userId = await getUserId();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+  const sb = supabaseAdmin();
+  const [p, o] = await Promise.all([
+    sb.from('profiles').select('conditions_predisposition').eq('id', userId).maybeSingle(),
+    sb.from('observations').select('kind,name,observed_at,meta').eq('user_id', userId),
+  ]);
+  const readiness = computeReadiness(p.data || {}, o.data || []);
+  return NextResponse.json(readiness, { headers: noStore });
+}

--- a/app/api/predictions/recompute/route.ts
+++ b/app/api/predictions/recompute/route.ts
@@ -1,0 +1,27 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { getUserId } from "@/lib/getUserId";
+import { computeReadiness } from "../readiness/route";
+
+const noStore = { "Cache-Control": "no-store, max-age=0" };
+
+export async function GET() {
+  const userId = await getUserId();
+  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
+  const sb = supabaseAdmin();
+  const [p, o] = await Promise.all([
+    sb.from('profiles').select('conditions_predisposition').eq('id', userId).maybeSingle(),
+    sb.from('observations').select('kind,name,observed_at,meta').eq('user_id', userId),
+  ]);
+  const readiness = computeReadiness(p.data || {}, o.data || []);
+  const out: any = { risk_focus: null, rationale: [], readiness };
+  if (readiness.missing.length) {
+    out.missing = readiness.missing;
+    out.suggested_tests = readiness.suggested_tests;
+  }
+  return NextResponse.json(out, { headers: noStore });
+}

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -180,7 +180,7 @@ export default function MedicalProfile() {
                 setSaving(true);
                 try {
                   const r = await fetch("/api/profile", {
-                    method: "PUT",
+                    method: "PATCH",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({
                       full_name: fullName || null,
@@ -264,7 +264,7 @@ export default function MedicalProfile() {
             <span>Predispositions</span>
             <input
               className="rounded-md border px-3 py-2"
-              placeholder="Type to add (Enter)…"
+              placeholder="Family history (who — condition). E.g., ‘Mother — breast cancer; Father — type-2 diabetes’."
               onKeyDown={e => {
                 const v = (e.target as HTMLInputElement).value.trim();
                 if (e.key === "Enter" && v) {

--- a/lib/gaps.ts
+++ b/lib/gaps.ts
@@ -1,0 +1,15 @@
+export function computeGaps({profile,timeline}:{profile:any;timeline:any[]}):Array<{key:string;prompt:string;saveAs:"profile"|"note"}>{
+  const gaps:any[]=[];
+  const hasPred = Array.isArray(profile?.conditions_predisposition)&&profile.conditions_predisposition.length>0;
+  const meds = new Set<string>();
+  for (const it of timeline||[]){
+    if (it.kind==="observation" && Array.isArray(it.meta?.meds)) it.meta.meds.forEach((m:string)=>meds.add(m));
+  }
+  const lastWeight = (timeline||[]).filter(it=>/weight|bmi/i.test(`${it.name} ${JSON.stringify(it.meta||{})}`)).sort((a,b)=>+new Date(b.observed_at)-+new Date(a.observed_at))[0];
+  const daysSinceWeight = lastWeight ? (Date.now()-new Date(lastWeight.observed_at).getTime())/86400000 : Infinity;
+
+  if (!hasPred) gaps.push({ key:"predispositions", prompt:"Any family history of chronic disease? (e.g., ‘Mother — breast cancer’)", saveAs:"profile" });
+  if (meds.size===0) gaps.push({ key:"meds", prompt:"Are you currently taking any medications? Please share name + dose (e.g., Metformin 500 mg).", saveAs:"profile" });
+  if (daysSinceWeight>30) gaps.push({ key:"weight", prompt:"When did you last check your weight? Please share current weight (kg).", saveAs:"profile" });
+  return gaps;
+}

--- a/lib/meds.ts
+++ b/lib/meds.ts
@@ -1,0 +1,15 @@
+const DIC = { metformin:["metformin","glycomet"], atorvastatin:["atorvastatin","lipitor"] } as Record<string,string[]>;
+const flat = Object.entries(DIC).flatMap(([g,arr])=>arr.map(a=>({alias:a,g})));
+export type ExtractedMed = { raw: string; norm?: string; doseMg?: number; confidence: number };
+export function extractMeds(t:string):ExtractedMed[]{
+  const out:ExtractedMed[]=[]; const rx=/([A-Za-z][A-Za-z\-]+)\s+(\d{1,4})\s?(mg|mcg|ml)\b/gi; let m;
+  while((m=rx.exec(t))){ const raw=`${m[1]} ${m[2]} ${m[3]}`; 
+    const alias=flat.find(x=>x.alias.toLowerCase()===m[1].toLowerCase());
+    out.push({ raw, norm: alias?.g || m[1], doseMg: m[3].toLowerCase()==="mg"?+m[2]:undefined, confidence: alias?0.9:0.6 });
+  }
+  if (!out.length){
+    const name=(t.match(/\b([A-Za-z][A-Za-z\-]{3,})\b/ )||[])[1];
+    if (name) out.push({ raw:name, confidence:0.3 });
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- allow patching profile arrays without overwriting and default to empty
- add meds extraction and gap checks with persistent AI Doc notes
- introduce readiness and recompute prediction endpoints

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3ad6a03c832f9807566287039947