### PR TITLE
feat: add doc ai state machine

### DIFF
--- a/app/api/aidoc/message/route.ts
+++ b/app/api/aidoc/message/route.ts
@@ -1,0 +1,87 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+import { NextRequest, NextResponse } from 'next/server';
+import { orchestrate, ClientState } from '@/lib/aidoc/orchestrator';
+import { hello, SAFETY } from '@/lib/aidoc/style';
+import { supabaseAdmin } from '@/lib/supabase/admin';
+import { getUserId } from '@/lib/getUserId';
+
+function noStore() {
+  return { 'Cache-Control': 'no-store, max-age=0' };
+}
+
+async function getName(): Promise<string | undefined> {
+  try {
+    const uid = await getUserId();
+    if (!uid) return undefined;
+    const { data } = await supabaseAdmin()
+      .from('profiles')
+      .select('full_name')
+      .eq('id', uid)
+      .maybeSingle();
+    const full = data?.full_name?.trim();
+    return full ? full.split(' ')[0] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({}));
+  const text = String(body.text || '').trim();
+  const client_state: ClientState = body.client_state || {};
+  const thread_id = body.thread_id || '';
+
+  const name = await getName();
+  const lower = text.toLowerCase();
+
+  // boot greeting
+  if (!text) {
+    const msg = hello(name);
+    return NextResponse.json({ messages: [{ role: 'assistant', content: msg }], new_state: { step: 'idle' } }, { headers: noStore() });
+  }
+
+  // research intent
+  if (/latest treatment|guidelines|trial/.test(lower)) {
+    return NextResponse.json(
+      {
+        messages: [{ role: 'assistant', content: `Sure — switching to research mode. ${SAFETY}` }],
+        handoff: { mode: 'research' },
+        new_state: client_state,
+      },
+      { headers: noStore() }
+    );
+  }
+
+  // danger ask
+  if (/do i have/.test(lower)) {
+    return NextResponse.json(
+      {
+        messages: [{ role: 'assistant', content: `I can't say for sure. A specialist visit would help. ${SAFETY}` }],
+        new_state: { step: 'resolved' },
+      },
+      { headers: noStore() }
+    );
+  }
+
+  // medication request
+  if (/what medicine|which medicine|medication should/i.test(lower)) {
+    return NextResponse.json(
+      {
+        messages: [
+          {
+            role: 'assistant',
+            content: `I can't prescribe. Over-the-counter options per label may help, but please speak to a clinician. ${SAFETY}`,
+          },
+        ],
+        new_state: { step: 'resolved' },
+      },
+      { headers: noStore() }
+    );
+  }
+
+  const result = orchestrate(text, client_state, name);
+  return NextResponse.json(result, { headers: noStore() });
+}

--- a/lib/aidoc/frames.json
+++ b/lib/aidoc/frames.json
@@ -1,0 +1,73 @@
+{
+  "covid": {
+    "synonyms": ["covid", "tested positive", "rt-pcr positive"],
+    "red_flags": [
+      "severe shortness of breath",
+      "chest pain",
+      "pressure",
+      "confusion",
+      "blue lips",
+      "blue face",
+      "fainting"
+    ],
+    "followups": [
+      { "key": "duration", "question": "Which day of illness is it?" },
+      { "key": "tempC", "question": "Highest temperature?" },
+      { "key": "spo2Pct", "question": "SpO₂ reading?" }
+    ],
+    "self_care": "Rest, stay hydrated, and use acetaminophen for fever if needed.",
+    "tests": ["Discuss COVID-19 testing and monitoring"],
+    "when_to_see": "Seek care if fever lasts over 3 days or breathing worsens."
+  },
+  "fever": {
+    "synonyms": ["fever", "high temperature"],
+    "red_flags": [
+      "above 39.4°C for more than 3 days",
+      "stiff neck",
+      "severe headache",
+      "rash",
+      "confusion",
+      "severe dehydration"
+    ],
+    "followups": [
+      { "key": "duration", "question": "How long has the fever been present?" },
+      { "key": "tempC", "question": "What's the highest temperature?" }
+    ],
+    "self_care": "Drink fluids and rest; consider acetaminophen to reduce fever.",
+    "tests": ["Discuss lab tests if fever persists"],
+    "when_to_see": "See a clinician if fever lasts more than 3 days or is very high."
+  },
+  "back_pain": {
+    "synonyms": ["back pain", "sore back"],
+    "red_flags": [
+      "severe leg weakness",
+      "loss of bladder or bowel control",
+      "numbness around the groin",
+      "fever with back pain",
+      "significant trauma"
+    ],
+    "followups": [
+      { "key": "duration", "question": "How long has the back pain been present?" },
+      { "key": "location", "question": "Where is the pain located?" },
+      { "key": "painScore", "question": "Pain level 0-10?" }
+    ],
+    "self_care": "Gentle stretching and over-the-counter pain relief may help.",
+    "tests": ["Discuss imaging or physical therapy if pain persists"],
+    "when_to_see": "See a clinician if pain lasts more than a few weeks or is severe."
+  },
+  "_generic_respiratory": {
+    "synonyms": ["cough", "cold", "sore throat", "runny nose", "throat pain"],
+    "red_flags": [
+      "blue lips",
+      "shortness of breath at rest",
+      "coughing blood",
+      "chest pain with breath"
+    ],
+    "followups": [
+      { "key": "duration", "question": "How long have these symptoms been around?" }
+    ],
+    "self_care": "Rest, hydrate, and try warm fluids.",
+    "tests": ["Discuss viral testing if symptoms persist or worsen"],
+    "when_to_see": "See a clinician if symptoms last over a week or worsen."
+  }
+}

--- a/lib/aidoc/frames.ts
+++ b/lib/aidoc/frames.ts
@@ -1,0 +1,35 @@
+import framesData from './frames.json' assert { type: 'json' };
+
+export type Followup = { key: string; question: string };
+export type Frame = {
+  synonyms: string[];
+  red_flags: string[];
+  followups: Followup[];
+  self_care: string;
+  tests: string[];
+  when_to_see: string;
+};
+
+const FRAMES: Record<string, Frame> = framesData as any;
+
+export function matchFrame(text: string): { key: string; frame: Frame } | null {
+  const q = text.toLowerCase();
+  for (const [key, frame] of Object.entries(FRAMES)) {
+    for (const syn of frame.synonyms) {
+      if (q.includes(syn.toLowerCase())) return { key, frame };
+    }
+  }
+  return null;
+}
+
+export function fallbackFrame(text: string): { key: string; frame: Frame } | null {
+  const generic = FRAMES['_generic_respiratory'];
+  if (!generic) return null;
+  const q = text.toLowerCase();
+  for (const syn of generic.synonyms) {
+    if (q.includes(syn.toLowerCase())) return { key: '_generic_respiratory', frame: generic };
+  }
+  return null;
+}
+
+export { FRAMES };

--- a/lib/aidoc/nlu.ts
+++ b/lib/aidoc/nlu.ts
@@ -1,0 +1,59 @@
+export function detectYesNo(text: string): 'yes' | 'no' | null {
+  const q = text.trim().toLowerCase();
+  if (/^(y|ya|yes|yeah|yep)\b/.test(q)) return 'yes';
+  if (/^(n|no|noo|nah|none|not really|no other symptoms)\b/.test(q)) return 'no';
+  return null;
+}
+
+export function parseDuration(text: string): { raw: string; bucket: 'Early' | 'Mid' | 'Late' } | null {
+  const q = text.toLowerCase();
+  let days: number | null = null;
+  let raw = '';
+  const m1 = q.match(/(\d+)(?:st|nd|rd|th)?\s*day/);
+  if (m1) { days = parseInt(m1[1], 10); raw = m1[0]; }
+  const m2 = q.match(/day\s*(\d+)/);
+  if (!days && m2) { days = parseInt(m2[1], 10); raw = m2[0]; }
+  const m3 = q.match(/d(\d+)/);
+  if (!days && m3) { days = parseInt(m3[1], 10); raw = m3[0]; }
+  const m4 = q.match(/(\d+)\s*days?/);
+  if (!days && m4) { days = parseInt(m4[1], 10); raw = m4[0]; }
+  const m5 = q.match(/(\d+)\s*hours?/);
+  if (!days && m5) { days = parseInt(m5[1], 10) / 24; raw = m5[0]; }
+  const m6 = q.match(/(\d+)\s*week/);
+  if (!days && m6) { days = parseInt(m6[1], 10) * 7; raw = m6[0]; }
+  if (!days && /since yesterday/.test(q)) { days = 1; raw = 'since yesterday'; }
+  if (days == null) return null;
+  const bucket = days <= 3 ? 'Early' : days <= 7 ? 'Mid' : 'Late';
+  return { raw: raw.trim(), bucket };
+}
+
+export function parseTemperature(text: string): { celsius: number; raw: string } | null {
+  const m = text.match(/(\d{2,3}(?:\.\d+)?)\s*(?:°\s*)?([cf])/i);
+  if (!m) return null;
+  const val = parseFloat(m[1]);
+  const scale = m[2].toLowerCase();
+  const celsius = scale === 'f' ? (val - 32) * 5/9 : val;
+  return { celsius: Math.round(celsius * 10) / 10, raw: m[0] };
+}
+
+export function parseSpO2(text: string): number | null {
+  const m = text.match(/(?:spo2|sats?|oxygen)[^\d]*(\d{2,3})/i);
+  if (m) return parseInt(m[1], 10);
+  const m2 = text.match(/(\d{2,3})\s*%/);
+  if (m2) return parseInt(m2[1], 10);
+  return null;
+}
+
+export function parsePainScore(text: string): number | null {
+  const m = text.match(/pain[^\d]*(\d{1,2})/i);
+  if (m) return parseInt(m[1], 10);
+  const m2 = text.match(/(\d{1,2})\s*\/\s*10/);
+  if (m2) return parseInt(m2[1], 10);
+  return null;
+}
+
+export function parseLocation(text: string): string | null {
+  const m = text.match(/(lower|upper|mid|middle|left|right)[\s-]*(back|spine)/i);
+  if (m) return m[0].toLowerCase();
+  return null;
+}

--- a/lib/aidoc/orchestrator.ts
+++ b/lib/aidoc/orchestrator.ts
@@ -1,0 +1,132 @@
+import { matchFrame, fallbackFrame, FRAMES, Frame } from './frames';
+import { detectYesNo, parseDuration, parseTemperature, parseSpO2, parsePainScore, parseLocation } from './nlu';
+import { askRedFlags, askFollowup, urgent, plan } from './style';
+
+export type ClientState = {
+  step?: 'idle' | 'awaiting_red_flags' | 'awaiting_followups' | 'resolved';
+  frame_key?: string;
+  symptom_text?: string;
+  flags_prompt_count?: number;
+  followup_stage?: number;
+  reask?: boolean;
+  collected?: {
+    duration?: string;
+    tempC?: number;
+    spo2Pct?: number;
+    painScore?: number;
+    location?: string;
+  };
+};
+
+export function orchestrate(text: string, state: ClientState = {}, name?: string) {
+  const lower = text.toLowerCase();
+  const messages: { role: 'assistant'; content: string }[] = [];
+  let newState: ClientState = { ...state };
+
+  if (!state.step || state.step === 'idle' || state.step === 'resolved') {
+    const match = matchFrame(lower) || fallbackFrame(lower);
+    if (!match) {
+      return { messages: [{ role: 'assistant', content: 'I\'m here to help with symptoms.' }], new_state: { step: 'idle' } };
+    }
+    const { key, frame } = match;
+    const spo2 = parseSpO2(text);
+    if (typeof spo2 === 'number' && spo2 <= 92) {
+      messages.push({ role: 'assistant', content: urgent() });
+      return { messages, new_state: { step: 'resolved' } };
+    }
+    const hit = frame.red_flags.some(r => lower.includes(r.toLowerCase()));
+    if (hit) {
+      messages.push({ role: 'assistant', content: urgent() });
+      return { messages, new_state: { step: 'resolved' } };
+    }
+    newState = {
+      step: 'awaiting_red_flags',
+      frame_key: key,
+      symptom_text: text,
+      flags_prompt_count: 1,
+      followup_stage: 0,
+      collected: {}
+    };
+    messages.push({ role: 'assistant', content: askRedFlags(name || null, text, frame.red_flags) });
+    return { messages, new_state: newState };
+  }
+
+  if (state.step === 'awaiting_red_flags' && state.frame_key) {
+    const frame = FRAMES[state.frame_key];
+    const yn = detectYesNo(text);
+    if (yn === 'yes') {
+      messages.push({ role: 'assistant', content: urgent() });
+      return { messages, new_state: { step: 'resolved' } };
+    }
+    if (yn === 'no') {
+      const fup = frame.followups[0];
+      newState = { ...state, step: 'awaiting_followups', followup_stage: 0, reask: false };
+      messages.push({ role: 'assistant', content: askFollowup(fup.question) });
+      return { messages, new_state: newState };
+    }
+    if ((state.flags_prompt_count || 0) < 2) {
+      newState = { ...state, flags_prompt_count: (state.flags_prompt_count || 0) + 1 };
+      messages.push({ role: 'assistant', content: askRedFlags(name || null, state.symptom_text || '', frame.red_flags) });
+      return { messages, new_state: newState };
+    }
+    // assume no
+    const fup = frame.followups[0];
+    newState = { ...state, step: 'awaiting_followups', followup_stage: 0, reask: false };
+    messages.push({ role: 'assistant', content: askFollowup(fup.question) });
+    return { messages, new_state: newState };
+  }
+
+  if (state.step === 'awaiting_followups' && state.frame_key) {
+    const frame = FRAMES[state.frame_key];
+    const idx = state.followup_stage || 0;
+    const follow = frame.followups[idx];
+    if (!follow || idx >= 2) {
+      messages.push({ role: 'assistant', content: plan(state.symptom_text || '', frame.self_care, frame.tests, frame.when_to_see) });
+      return { messages, new_state: { step: 'resolved' } };
+    }
+    let captured = false;
+    const collected = { ...(state.collected || {}) };
+    if (follow.key === 'duration') {
+      const d = parseDuration(text);
+      if (d) { collected.duration = d.raw; captured = true; }
+    } else if (follow.key === 'tempC') {
+      const t = parseTemperature(text);
+      if (t) { collected.tempC = t.celsius; captured = true; }
+    } else if (follow.key === 'spo2Pct') {
+      const s = parseSpO2(text);
+      if (typeof s === 'number') { collected.spo2Pct = s; captured = true; }
+    } else if (follow.key === 'painScore') {
+      const p = parsePainScore(text);
+      if (typeof p === 'number') { collected.painScore = p; captured = true; }
+    } else if (follow.key === 'location') {
+      const l = parseLocation(text);
+      if (l) { collected.location = l; captured = true; }
+    }
+
+    if (!captured && !state.reask) {
+      newState = { ...state, reask: true };
+      messages.push({ role: 'assistant', content: askFollowup(follow.question) });
+      return { messages, new_state: newState };
+    }
+
+    const nextIdx = idx + 1;
+    newState = { ...state, followup_stage: nextIdx, reask: false, collected };
+    if (nextIdx >= frame.followups.length || nextIdx >= 2) {
+      messages.push({ role: 'assistant', content: plan(state.symptom_text || '', frame.self_care, frame.tests, frame.when_to_see) });
+      return { messages, new_state: { step: 'resolved' } };
+    }
+    const nextFollow = frame.followups[nextIdx];
+    const echoes: string[] = [];
+    if (collected.duration && follow.key === 'duration') echoes.push(`day ~${collected.duration}`);
+    if (collected.tempC && follow.key === 'tempC') echoes.push(`~${collected.tempC}\xB0C`);
+    if (collected.spo2Pct && follow.key === 'spo2Pct') echoes.push(`SpO₂ ${collected.spo2Pct}%`);
+    if (collected.location && follow.key === 'location') echoes.push(collected.location);
+    if (collected.painScore && follow.key === 'painScore') echoes.push(`pain ${collected.painScore}/10`);
+    const ack = echoes.length ? `Got it — ${echoes.join('; ')}.` : 'Got it.';
+    messages.push({ role: 'assistant', content: `${ack} ${askFollowup(nextFollow.question)}`.trim() });
+    return { messages, new_state: newState };
+  }
+
+  messages.push({ role: 'assistant', content: plan(state.symptom_text || '', '', [], '') });
+  return { messages, new_state: { step: 'resolved' } };
+}

--- a/lib/aidoc/style.ts
+++ b/lib/aidoc/style.ts
@@ -1,0 +1,30 @@
+export const SAFETY = 'This is educational info, not a medical diagnosis. Please consult a clinician.';
+
+export function hello(name?: string, summary?: string) {
+  const n = name ? `Hi ${name}!` : 'Hi!';
+  const s = summary ? ` ${summary}` : '';
+  return `${n} I'm here to help with quick health questions.${s} ${SAFETY}`;
+}
+
+export function askRedFlags(name: string | null, symptom: string, flags: string[]) {
+  const intro = name ? `Got it ${name}.` : 'Got it.';
+  const list = flags.map(f => `- ${f}`).join('\n');
+  return `${intro} Any of these with your ${symptom}?\n${list}`;
+}
+
+export function askFollowup(q: string) {
+  return q;
+}
+
+export function urgent() {
+  return `That sounds serious. Please seek urgent medical care. ${SAFETY}`;
+}
+
+export function plan(symptom: string, selfCare: string, tests: string[], whenToSee: string) {
+  const testStr = tests.length ? `Discuss with a clinician: ${tests.join(', ')}.\n` : '';
+  return `For ${symptom}, ${selfCare}\n${testStr}${whenToSee}\n${SAFETY}`;
+}
+
+export function pickedOne(heard: string[], chosen: string) {
+  return `Heard ${heard.join(', ')} — focusing on ${chosen}.`;
+}


### PR DESCRIPTION
## Summary
- add Doc AI frames, NLU helpers, style phrases, and orchestrator
- expose `/api/aidoc/message` endpoint for deterministic Doc AI responses
- wire med-profile chat to Doc AI with boot greeting and state persistence

## Testing
- `npm test`
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0fc0067c832fb89ad2c0cfb54edd