### PR TITLE
feat: add research and trials APIs

### DIFF
--- a/app/api/books/ncbi/route.ts
+++ b/app/api/books/ncbi/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { searchNCBIBooks } from "@/lib/books_ncbi";
+
+export async function GET(req: NextRequest) {
+  if (!flags.enableBooksNCBI) return NextResponse.json({ disabled: true });
+  const q = new URL(req.url).searchParams.get("q") || "";
+  if (!q) return NextResponse.json({ error: "q required" }, { status: 400 });
+  const rows = await searchNCBIBooks(q, 10);
+  return NextResponse.json({ rows });
+}

--- a/app/api/medlineplus/route.ts
+++ b/app/api/medlineplus/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { medlinePlusByICD } from "@/lib/medlineplus";
+
+export async function GET(req: NextRequest) {
+  if (!flags.enableMedlinePlus) return NextResponse.json({ disabled: true });
+  const url = new URL(req.url);
+  const code = url.searchParams.get("code") || "";
+  const dn = url.searchParams.get("dn") || undefined;
+  if (!code) return NextResponse.json({ error: "code required" }, { status: 400 });
+  const xml = await medlinePlusByICD(code, dn);
+  return NextResponse.json({ xml });
+}

--- a/app/api/research/crossref/route.ts
+++ b/app/api/research/crossref/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { searchCrossref } from "@/lib/crossref";
+
+export async function GET(req: NextRequest) {
+  if (!flags.enableCrossref) return NextResponse.json({ disabled: true });
+  const q = new URL(req.url).searchParams.get("q") || "";
+  if (!q) return NextResponse.json({ error: "q required" }, { status: 400 });
+  const works = await searchCrossref(q, 10);
+  return NextResponse.json({ works });
+}

--- a/app/api/research/europepmc/route.ts
+++ b/app/api/research/europepmc/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { searchEuropePMC } from "@/lib/europepmc";
+
+export async function GET(req: NextRequest) {
+  if (!flags.enableEuropePMC) return NextResponse.json({ disabled: true });
+  const q = new URL(req.url).searchParams.get("q") || "";
+  if (!q) return NextResponse.json({ error: "q required" }, { status: 400 });
+  const works = await searchEuropePMC(q, 10);
+  return NextResponse.json({ works });
+}

--- a/app/api/research/openalex/route.ts
+++ b/app/api/research/openalex/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { searchOpenAlexWorks, getOpenAlexWorkById } from "@/lib/openalex";
+
+export async function GET(req: NextRequest) {
+  if (!flags.enableOpenAlex) return NextResponse.json({ disabled: true });
+  const url = new URL(req.url);
+  const id = url.searchParams.get("id");
+  if (id) {
+    const work = await getOpenAlexWorkById(id);
+    return NextResponse.json({ work });
+  }
+  const q = url.searchParams.get("q") || "";
+  if (!q) return NextResponse.json({ error: "q required" }, { status: 400 });
+  const perPage = parseInt(url.searchParams.get("perPage") || "10", 10);
+  const from = url.searchParams.get("from") || undefined;
+  const is_oa_param = url.searchParams.get("is_oa");
+  const is_oa = is_oa_param === null ? undefined : is_oa_param === "true";
+  const works = await searchOpenAlexWorks(q, perPage, from, is_oa);
+  return NextResponse.json({ works });
+}

--- a/app/api/research/semanticscholar/route.ts
+++ b/app/api/research/semanticscholar/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { searchSemanticScholar } from "@/lib/semanticscholar";
+
+export async function GET(req: NextRequest) {
+  if (!flags.enableSemanticScholar) return NextResponse.json({ disabled: true });
+  const q = new URL(req.url).searchParams.get("q") || "";
+  if (!q) return NextResponse.json({ error: "q required" }, { status: 400 });
+  const works = await searchSemanticScholar(q, 10);
+  return NextResponse.json({ works });
+}

--- a/app/api/research/unpaywall/route.ts
+++ b/app/api/research/unpaywall/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { resolveOAUrl } from "@/lib/unpaywall";
+
+export async function GET(req: NextRequest) {
+  if (!flags.enableUnpaywall) return NextResponse.json({ disabled: true });
+  const doi = new URL(req.url).searchParams.get("doi") || "";
+  if (!doi) return NextResponse.json({ error: "doi required" }, { status: 400 });
+  const url = await resolveOAUrl(doi);
+  return NextResponse.json({ doi, oa_url: url });
+}

--- a/app/api/trials/ctgov/route.ts
+++ b/app/api/trials/ctgov/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { searchCTGov } from "@/lib/trials_ctgov";
+
+export async function GET(req: NextRequest) {
+  if (!flags.enableTrialsCTG) return NextResponse.json({ disabled: true });
+  const url = new URL(req.url);
+  const condition = url.searchParams.get("condition") || "";
+  if (!condition) return NextResponse.json({ error: "condition required" }, { status: 400 });
+  const country = url.searchParams.get("country") || undefined;
+  const phase = url.searchParams.get("phase")?.split(",").map(s => s.trim()).filter(Boolean);
+  const status = url.searchParams.get("status")?.split(",").map(s => s.trim()).filter(Boolean);
+  const rows = await searchCTGov(condition, { country, phase, status, size: 10 });
+  return NextResponse.json({ rows });
+}

--- a/app/api/trials/euctr/route.ts
+++ b/app/api/trials/euctr/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { euctrFeedUrl } from "@/lib/trials_extras";
+
+export async function GET() {
+  if (!flags.enableTrialsEUCTR) return NextResponse.json({ disabled: true });
+  return NextResponse.json({ url: euctrFeedUrl() });
+}

--- a/app/api/trials/ictrp/route.ts
+++ b/app/api/trials/ictrp/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { ictrpInfoUrl } from "@/lib/trials_extras";
+
+export async function GET() {
+  if (!flags.enableTrialsICTRP) return NextResponse.json({ disabled: true });
+  return NextResponse.json({ url: ictrpInfoUrl() });
+}

--- a/app/api/trials/isrctn/route.ts
+++ b/app/api/trials/isrctn/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from "next/server";
+import { flags } from "@/lib/flags";
+import { searchISRCTN } from "@/lib/trials_extras";
+
+export async function GET(req: NextRequest) {
+  if (!flags.enableTrialsISRCTN) return NextResponse.json({ disabled: true });
+  const condition = new URL(req.url).searchParams.get("condition") || "";
+  if (!condition) return NextResponse.json({ error: "condition required" }, { status: 400 });
+  const rows = await searchISRCTN(condition);
+  return NextResponse.json({ rows });
+}

--- a/lib/books_ncbi.ts
+++ b/lib/books_ncbi.ts
@@ -1,0 +1,19 @@
+const BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils";
+export async function searchNCBIBooks(q: string, retmax = 10) {
+  const esearch = `${BASE}/esearch.fcgi?db=books&retmode=json&retmax=${retmax}&term=${encodeURIComponent(q)}`;
+  const r = await fetch(esearch, { cache: "no-store" });
+  if (!r.ok) return [];
+  const j = await r.json();
+  const ids: string[] = j?.esearchresult?.idlist || [];
+  const esummary = `${BASE}/esummary.fcgi?db=books&retmode=json&id=${ids.join(",")}`;
+  const r2 = await fetch(esummary, { cache: "no-store" });
+  if (!r2.ok) return [];
+  const j2 = await r2.json();
+  const res = j2?.result || {};
+  return ids.map(id => ({
+    id,
+    title: res[id]?.title,
+    url: res[id]?.bookurl,
+    source: "ncbi_books",
+  }));
+}

--- a/lib/crossref.ts
+++ b/lib/crossref.ts
@@ -1,0 +1,27 @@
+import type { Paper } from "@/types/research";
+const BASE = "https://api.crossref.org";
+
+export async function searchCrossref(q: string, rows = 10): Promise<Paper[]> {
+  const url = new URL(`${BASE}/works`);
+  url.searchParams.set("query", q);
+  url.searchParams.set("rows", String(Math.min(50, Math.max(1, rows))));
+  const r = await fetch(url, { cache: "no-store" });
+  if (!r.ok) return [];
+  const j = await r.json();
+  const items = j?.message?.items || [];
+  return items.map((p: any): Paper => ({
+    id: p.DOI ?? p.URL,
+    title: Array.isArray(p.title) ? p.title[0] : p.title,
+    abstract: p.abstract ? p.abstract.replace(/<[^>]+>/g, "") : null,
+    year: p.issued?.["date-parts"]?.[0]?.[0] ?? null,
+    type: p.type ?? null,
+    authors: (p.author || []).map((a: any) => ({ name: [a.given, a.family].filter(Boolean).join(" ") })),
+    venue: { name: p["container-title"]?.[0], issn: (p.ISSN || [])[0] },
+    cited_by_count: p["is-referenced-by-count"] ?? undefined,
+    is_oa: undefined,
+    oa_url: undefined,
+    url: p.URL ?? null,
+    doi: p.DOI ?? null,
+    source: "crossref",
+  }));
+}

--- a/lib/europepmc.ts
+++ b/lib/europepmc.ts
@@ -1,0 +1,29 @@
+import type { Paper } from "@/types/research";
+const BASE = "https://www.ebi.ac.uk/europepmc/webservices/rest";
+
+export async function searchEuropePMC(q: string, pageSize = 10): Promise<Paper[]> {
+  const url = new URL(`${BASE}/search`);
+  url.searchParams.set("query", q);
+  url.searchParams.set("resulttype", "core");
+  url.searchParams.set("format", "json");
+  url.searchParams.set("pageSize", String(Math.min(50, Math.max(1, pageSize))));
+  const r = await fetch(url, { cache: "no-store" });
+  if (!r.ok) return [];
+  const j = await r.json();
+  const res = j?.resultList?.result || [];
+  return res.map((p: any): Paper => ({
+    id: p.id,
+    title: p.title,
+    abstract: p.abstractText ?? null,
+    year: p.pubYear ? Number(p.pubYear) : null,
+    type: p.pubType ?? null,
+    authors: (p.authorList?.author || []).map((a: any) => ({ name: a.fullName })),
+    venue: { name: p.journalInfo?.journal?.title, issn: p.journalInfo?.journal?.issn },
+    cited_by_count: p.citedByCount ? Number(p.citedByCount) : undefined,
+    is_oa: p.isOpenAccess === "Y",
+    oa_url: p.fullTextUrlList?.fullTextUrl?.[0]?.url ?? null,
+    url: p.fullTextUrlList?.fullTextUrl?.[0]?.url ?? p.uri ?? null,
+    doi: p.doi ?? null,
+    source: "europepmc",
+  }));
+}

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -1,0 +1,13 @@
+export const flags = {
+  enableOpenAlex: true,
+  enableSemanticScholar: true,
+  enableEuropePMC: true,
+  enableCrossref: true,
+  enableUnpaywall: true,
+  enableTrialsCTG: true,
+  enableTrialsISRCTN: false,
+  enableTrialsEUCTR: false,
+  enableTrialsICTRP: false,
+  enableBooksNCBI: true,
+  enableMedlinePlus: true,
+};

--- a/lib/medlineplus.ts
+++ b/lib/medlineplus.ts
@@ -1,0 +1,12 @@
+// Example: ICD code "250.00" diabetes (ICD-9 sample); update mapping as needed.
+export async function medlinePlusByICD(code: string, displayName?: string) {
+  const url = new URL("https://connect.medlineplus.gov/service");
+  url.searchParams.set("mainSearchCriteria.v.cs", "2.16.840.1.113883.6.103"); // ICD-9
+  url.searchParams.set("mainSearchCriteria.v.c", code);
+  if (displayName) url.searchParams.set("mainSearchCriteria.v.dn", displayName);
+  url.searchParams.set("informationRecipient.languageCode.c", "en");
+  const r = await fetch(url.toString(), { cache: "no-store" });
+  if (!r.ok) return null;
+  const xml = await r.text(); // returns XML; parse client-side if needed
+  return xml;
+}

--- a/lib/openalex.ts
+++ b/lib/openalex.ts
@@ -1,0 +1,60 @@
+import type { Paper } from "@/types/research";
+const BASE = "https://api.openalex.org";
+
+function decodeAbstract(ii: Record<string, number[]> | undefined): string | null {
+  if (!ii) return null;
+  const entries = Object.entries(ii).flatMap(([word, idxs]) => idxs.map(i => ({ i, word })));
+  entries.sort((a, b) => a.i - b.i);
+  return entries.map(e => e.word).join(" ");
+}
+
+export async function searchOpenAlexWorks(q: string, perPage = 10, from?: string, is_oa?: boolean): Promise<Paper[]> {
+  const url = new URL(`${BASE}/works`);
+  if (q) url.searchParams.set("search", q);
+  url.searchParams.set("per-page", String(Math.min(50, Math.max(1, perPage))));
+  if (from) url.searchParams.set("from_publication_date", from);
+  if (typeof is_oa === "boolean") url.searchParams.set("is_oa", String(is_oa));
+  if (process.env.OPENALEX_MAILTO) url.searchParams.set("mailto", process.env.OPENALEX_MAILTO);
+  const r = await fetch(url, { cache: "no-store" });
+  if (!r.ok) return [];
+  const j = await r.json();
+  const results = j?.results || [];
+  return results.map((w: any): Paper => ({
+    id: w.id,
+    title: w.display_name,
+    abstract: decodeAbstract(w.abstract_inverted_index),
+    year: w.publication_year,
+    type: w.type,
+    authors: (w.authorships || []).map((a: any) => ({ name: a.author?.display_name, id: a.author?.id })),
+    venue: { name: w.primary_location?.source?.display_name, issn: (w.primary_location?.source?.issn || [])[0] },
+    cited_by_count: w.cited_by_count,
+    is_oa: w.open_access?.is_oa,
+    oa_url: w.open_access?.oa_url ?? null,
+    url: w.primary_location?.landing_page_url ?? null,
+    doi: w.doi ?? null,
+    source: "openalex",
+  }));
+}
+
+export async function getOpenAlexWorkById(id: string): Promise<Paper | null> {
+  const url = new URL(`${BASE}/works/${id}`);
+  if (process.env.OPENALEX_MAILTO) url.searchParams.set("mailto", process.env.OPENALEX_MAILTO);
+  const r = await fetch(url, { cache: "no-store" });
+  if (!r.ok) return null;
+  const w = await r.json();
+  return {
+    id: w.id,
+    title: w.display_name,
+    abstract: decodeAbstract(w.abstract_inverted_index),
+    year: w.publication_year,
+    type: w.type,
+    authors: (w.authorships || []).map((a: any) => ({ name: a.author?.display_name, id: a.author?.id })),
+    venue: { name: w.primary_location?.source?.display_name, issn: (w.primary_location?.source?.issn || [])[0] },
+    cited_by_count: w.cited_by_count,
+    is_oa: w.open_access?.is_oa,
+    oa_url: w.open_access?.oa_url ?? null,
+    url: w.primary_location?.landing_page_url ?? null,
+    doi: w.doi ?? null,
+    source: "openalex",
+  };
+}

--- a/lib/semanticscholar.ts
+++ b/lib/semanticscholar.ts
@@ -1,0 +1,27 @@
+import type { Paper } from "@/types/research";
+const BASE = "https://api.semanticscholar.org/graph/v1";
+
+export async function searchSemanticScholar(q: string, limit = 10): Promise<Paper[]> {
+  const url = new URL(`${BASE}/paper/search`);
+  url.searchParams.set("query", q);
+  url.searchParams.set("limit", String(Math.min(50, Math.max(1, limit))));
+  url.searchParams.set("fields", "title,abstract,url,year,citationCount,publicationTypes,authors,externalIds");
+  const r = await fetch(url, { cache: "no-store" });
+  if (!r.ok) return [];
+  const j = await r.json();
+  return (j?.data || []).map((p: any): Paper => ({
+    id: p.paperId,
+    title: p.title,
+    abstract: p.abstract ?? null,
+    year: p.year ?? null,
+    type: (p.publicationTypes || [])[0] ?? null,
+    authors: (p.authors || []).map((a: any) => ({ name: a.name, id: a.authorId })),
+    venue: { name: undefined, issn: undefined },
+    cited_by_count: p.citationCount ?? 0,
+    is_oa: undefined,
+    oa_url: undefined,
+    url: p.url ?? null,
+    doi: p.externalIds?.DOI ?? null,
+    source: "semanticscholar",
+  }));
+}

--- a/lib/trials_ctgov.ts
+++ b/lib/trials_ctgov.ts
@@ -1,0 +1,40 @@
+import type { Trial } from "@/types/research";
+
+export async function searchCTGov(condition: string, opts: { country?: string; phase?: string[]; status?: string[]; size?: number } = {}): Promise<Trial[]> {
+  const url = new URL("https://clinicaltrials.gov/api/v2/studies");
+  url.searchParams.set("query.term", condition);
+  url.searchParams.set("pageSize", String(Math.min(50, Math.max(1, opts.size ?? 10))));
+  if (opts.country) url.searchParams.set("filter.location.country", opts.country);
+  if (opts.phase && opts.phase.length) url.searchParams.set("filter.phase", opts.phase.join(","));
+  if (opts.status && opts.status.length) url.searchParams.set("filter.overallStatus", opts.status.join(","));
+  const r = await fetch(url, { cache: "no-store" });
+  if (!r.ok) return [];
+  const j = await r.json();
+  const studies = j?.studies || [];
+  return studies.map((s: any): Trial => {
+    const prot = s.protocolSection || {};
+    const idMod = prot.identificationModule || {};
+    const conds = prot.conditionsModule?.conditions || [];
+    const intervs = prot.armsInterventionsModule?.interventions?.map((i: any) => i.name) || [];
+    const contacts = prot.contactsLocationsModule?.locations?.[0] || {};
+    return {
+      id: idMod.nctId,
+      title: idMod.briefTitle,
+      conditions: conds,
+      interventions: intervs,
+      status: prot.statusModule?.overallStatus,
+      phase: (prot.designModule?.phases || []).join(", "),
+      start: prot.statusModule?.startDateStruct?.date,
+      complete: prot.statusModule?.completionDateStruct?.date,
+      type: prot.designModule?.studyType,
+      sponsor: prot.sponsorCollaboratorsModule?.leadSponsor?.name,
+      site: contacts.facility,
+      city: contacts.city,
+      country: contacts.country,
+      eligibility: prot.eligibilityModule?.eligibilityCriteria,
+      primaryOutcome: prot.outcomesModule?.primaryOutcomes?.[0]?.measure,
+      url: `https://clinicaltrials.gov/study/${idMod.nctId}`,
+      source: "ctgov",
+    };
+  });
+}

--- a/lib/trials_extras.ts
+++ b/lib/trials_extras.ts
@@ -1,0 +1,36 @@
+import type { Trial } from "@/types/research";
+
+// ISRCTN (simple JSON)
+export async function searchISRCTN(condition: string): Promise<Trial[]> {
+  const url = `https://www.isrctn.com/api/v1/search?condition=${encodeURIComponent(condition)}`;
+  const r = await fetch(url, { cache: "no-store" });
+  if (!r.ok) return [];
+  const j = await r.json();
+  const rows = j?.results || [];
+  return rows.map((t: any): Trial => ({
+    id: t.isrctn,
+    title: t.title,
+    conditions: (t.conditions || "").split(";").map((x: string) => x.trim()).filter(Boolean),
+    interventions: [],
+    status: t.status,
+    phase: t.phase,
+    city: t.cities?.[0],
+    country: t.countries?.[0],
+    url: `https://www.isrctn.com/${t.isrctn}`,
+    source: "isrctn",
+    eligibility: t.eligibility ?? undefined,
+    primaryOutcome: t.primaryOutcome ?? undefined,
+    sponsor: t.sponsorName ?? undefined,
+    type: t.studyDesign ?? undefined,
+  }));
+}
+
+// EU CTR: XML dump; here we expose the raw download URL for client or later ETL
+export function euctrFeedUrl() {
+  return "https://www.clinicaltrialsregister.eu/ctr-search/rest/download/full";
+}
+
+// WHO ICTRP: point to platform (no stable REST); leave for ETL later
+export function ictrpInfoUrl() {
+  return "https://www.who.int/clinical-trials-registry-platform";
+}

--- a/lib/unpaywall.ts
+++ b/lib/unpaywall.ts
@@ -1,0 +1,9 @@
+export async function resolveOAUrl(doi: string): Promise<string | null> {
+  const email = process.env.UNPAYWALL_EMAIL;
+  if (!email) return null;
+  const url = `https://api.unpaywall.org/v2/${encodeURIComponent(doi)}?email=${encodeURIComponent(email)}`;
+  const r = await fetch(url, { cache: "no-store" });
+  if (!r.ok) return null;
+  const j = await r.json();
+  return j?.best_oa_location?.url ?? null;
+}

--- a/types/research.ts
+++ b/types/research.ts
@@ -1,0 +1,35 @@
+export type Paper = {
+  id: string;
+  title: string;
+  abstract?: string | null;
+  year?: number | null;
+  type?: string | null;
+  authors?: { name: string; id?: string }[];
+  venue?: { name?: string | null; issn?: string | null };
+  cited_by_count?: number;
+  is_oa?: boolean;
+  oa_url?: string | null;
+  url?: string | null;
+  doi?: string | null;
+  source: "openalex" | "semanticscholar" | "europepmc" | "crossref";
+};
+
+export type Trial = {
+  id: string;
+  title: string;
+  conditions: string[];
+  interventions: string[];
+  status?: string;
+  phase?: string;
+  start?: string;
+  complete?: string;
+  type?: string;
+  sponsor?: string;
+  site?: string;
+  city?: string;
+  country?: string;
+  eligibility?: string;
+  primaryOutcome?: string;
+  url?: string;
+  source: "ctgov" | "isrctn" | "euctr" | "ictrp";
+};


### PR DESCRIPTION
## Summary
- add feature flags for research and trials providers
- implement paper search wrappers and routes for OpenAlex, Semantic Scholar, Europe PMC, Crossref, and Unpaywall OA resolver
- add trial search/feeds for ClinicalTrials.gov, ISRCTN, EUCTR, ICTRP
- expose book references and MedlinePlus Connect

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive setup)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bc1eb80ae8832fadc51ee7df4edeaa