### PR TITLE
feat: add context and intent management

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { COUNTRIES } from '@/data/countries';
+import { getContext, updateContext, resetContext } from '@/lib/contextManager';
+import { detectIntent } from '@/lib/intentClassifier';
+import { buildPrompt } from '@/lib/promptBuilder';
 
 export async function POST(req: NextRequest){
   const body = await req.json();
@@ -8,24 +11,59 @@ export async function POST(req: NextRequest){
   const key = process.env.LLM_API_KEY;
   if(!base || !key) return new NextResponse("LLM_BASE_URL or LLM_API_KEY not set", { status: 500 });
 
-  // Allow either a raw question/role pair or full chat messages
+  if (body.sessionId && body.userQuery) {
+    const { sessionId, userQuery, mode, reset } = body;
+
+    if (reset) {
+      resetContext(sessionId);
+      return NextResponse.json({ message: 'Context reset' });
+    }
+
+    let ctx = getContext(sessionId);
+    if (mode) ctx.mode = mode;
+
+    const intent = detectIntent(userQuery);
+
+    if (!ctx.mainTopic) {
+      updateContext(sessionId, userQuery);
+    } else {
+      updateContext(sessionId, undefined, userQuery);
+    }
+    ctx = getContext(sessionId);
+
+    const prompt = buildPrompt(ctx.mainTopic!, ctx.subtopics, ctx.mode, intent, userQuery);
+
+    const res = await fetch(`${base.replace(/\/+$/,'')}/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },
+      body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }], temperature: 0.2 })
+    });
+    if (!res.ok) {
+      const t = await res.text();
+      return new NextResponse(`LLM error: ${t}`, { status: 500 });
+    }
+    const json = await res.json();
+    const text = json.choices?.[0]?.message?.content || "";
+    return NextResponse.json({ response: text });
+  }
+
+  // Fallback to existing behavior
   let messages = body.messages;
   if(!messages){
     const { question, role, country: code } = body;
     const country = COUNTRIES.find(c => c.code3 === code) || COUNTRIES.find(c => c.code3 === 'USA')!;
-    const base = role==='clinician'
+    const baseMsg = role==='clinician'
       ? 'You are a clinical assistant. Be precise, cite sources if mentioned. Avoid medical advice; provide evidence and guideline pointers.'
       : role==='admin'
         ? 'You help administrative staff with medical documents. Summarize logistics and coding info. Avoid medical advice.'
         : 'You explain in simple, friendly language for patients. Avoid medical advice; encourage consulting a doctor.';
-    const sys = `You are MedX. User country: ${country.code3}.\nPrefer local guidelines, availability, dosing units, and OTC product examples used in ${country.name}.\nIf country-specific examples are uncertain, give generic names and note availability varies by region.\n` + base;
+    const sys = `You are MedX. User country: ${country.code3}.\nPrefer local guidelines, availability, dosing units, and OTC product examples used in ${country.name}.\nIf country-specific examples are uncertain, give generic names and note availability varies by region.\n` + baseMsg;
     messages = [
       { role: 'system', content: sys },
       { role: 'user', content: question }
     ];
   }
 
-  // OpenAI-compatible completion (v1/chat/completions)
   const res = await fetch(`${base.replace(/\/+$/,'')}/chat/completions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${key}` },

--- a/lib/contextManager.ts
+++ b/lib/contextManager.ts
@@ -1,0 +1,26 @@
+export type Mode = "patient" | "doctor" | "research";
+export type Intent = "overview" | "research" | "generate" | "resources";
+
+export interface ContextState {
+  mainTopic: string | null;
+  subtopics: string[];
+  mode: Mode;
+}
+
+let sessionContext: Record<string, ContextState> = {};
+
+export function getContext(sessionId: string): ContextState {
+  return sessionContext[sessionId] ?? { mainTopic: null, subtopics: [], mode: "patient" };
+}
+
+export function updateContext(sessionId: string, topic?: string, subtopic?: string, mode?: Mode) {
+  const ctx = getContext(sessionId);
+  if (topic) ctx.mainTopic = topic;
+  if (subtopic) ctx.subtopics.push(subtopic);
+  if (mode) ctx.mode = mode;
+  sessionContext[sessionId] = ctx;
+}
+
+export function resetContext(sessionId: string) {
+  sessionContext[sessionId] = { mainTopic: null, subtopics: [], mode: "patient" };
+}

--- a/lib/intentClassifier.ts
+++ b/lib/intentClassifier.ts
@@ -1,0 +1,11 @@
+import { Intent } from "./contextManager";
+
+export function detectIntent(query: string): Intent {
+  const q = query.toLowerCase();
+  if (q.includes("latest") || q.includes("research") || q.includes("studies") || q.includes("clinical"))
+    return "research";
+  if (q.includes("book") || q.includes("resource")) return "resources";
+  if (q.includes("paper") || q.includes("long form") || q.includes("5000"))
+    return "generate";
+  return "overview";
+}

--- a/lib/promptBuilder.ts
+++ b/lib/promptBuilder.ts
@@ -1,0 +1,29 @@
+import { Intent, Mode } from "./contextManager";
+
+export function buildPrompt(mainTopic: string, subtopics: string[], mode: Mode, intent: Intent, userQuery: string) {
+  const modeTemplates: Record<Mode, string> = {
+    patient: "Explain simply and clearly for a non-medical audience.",
+    doctor: "Provide detailed, clinically accurate information with medical terminology.",
+    research: "Summarize latest studies, clinical trials, and include citations if available."
+  };
+
+  const intentTemplates: Record<Intent, string> = {
+    overview: "Give a concise, accurate overview.",
+    research: "Summarize key studies, include dates, sources, citations.",
+    generate: "Create a structured, long-form response with sections and references.",
+    resources: "List books, websites, or organizations related to the topic."
+  };
+
+  return `
+Main Topic: ${mainTopic}
+Subtopics: ${subtopics.join(", ")}
+Mode: ${mode}
+Intent: ${intent}
+
+Guidelines:
+${modeTemplates[mode]}
+${intentTemplates[intent]}
+
+User Query: ${userQuery}
+  `;
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint || true",
-    "test": "tsx test/medx.test.ts"
+    "test": "tsx test/*.test.ts"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.78",

--- a/test/intentPrompt.test.ts
+++ b/test/intentPrompt.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectIntent } from '@/lib/intentClassifier';
+import { buildPrompt } from '@/lib/promptBuilder';
+
+
+describe('intent classifier', () => {
+  it('detects research intent', () => {
+    const intent = detectIntent('latest clinical trials for diabetes');
+    assert.equal(intent, 'research');
+  });
+
+  it('detects generate intent', () => {
+    const intent = detectIntent('write a 5000 word paper on cancer');
+    assert.equal(intent, 'generate');
+  });
+});
+
+describe('prompt builder', () => {
+  it('builds patient overview prompt', () => {
+    const prompt = buildPrompt('diabetes', ['symptoms'], 'patient', 'overview', 'What are the symptoms?');
+    assert(prompt.includes('Main Topic: diabetes'));
+    assert(prompt.includes('Subtopics: symptoms'));
+    assert(prompt.includes('Mode: patient'));
+    assert(prompt.includes('Intent: overview'));
+    assert(prompt.includes('Explain simply and clearly for a non-medical audience.'));
+    assert(prompt.includes('Give a concise, accurate overview.'));
+  });
+});


### PR DESCRIPTION
## Summary
- implement session-based context manager with mode memory
- detect user intent to tailor responses and prompts
- add dynamic prompt builder and unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc44473d00832f9838d64bdfed2426