### PR TITLE
Fetch real trial data and refine chat prompts

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest){
       : role==='admin'
         ? 'You help administrative staff with medical documents. Summarize logistics and coding info. Avoid medical advice.'
         : 'You explain in simple, friendly language for patients. Avoid medical advice; encourage consulting a doctor.';
-    const sys = `You are MedX. User country: ${country.code3}.\nPrefer local guidelines, availability, dosing units, and OTC product examples used in ${country.name}.\nIf country-specific examples are uncertain, give generic names and note availability varies by region.\n` + base;
+    const sys = `You are MedX. User country: ${country.code3}.\nPrefer local guidelines, availability, dosing units, and OTC product examples used in ${country.name}.\nIf country-specific examples are uncertain, give generic names and note availability varies by region.\nAlways keep answers scoped to the user’s current topic unless they change it.\nIf the question is ambiguous, ask ONE brief clarifying question, then answer briefly.\nEnd every answer with one short follow-up question (<=10 words) on the same topic.` + base;
     messages = [
       { role: 'system', content: sys },
       { role: 'user', content: question }


### PR DESCRIPTION
## Summary
- fetch live clinical trials and build structured summaries for patient or clinician views
- add medical typo checks before sending to LLM
- extend default system prompts with follow-up question guidance

## Testing
- `npm test`
- `npm run lint` *(fails: interactive eslint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bc615a393c832f9529800809276631