### PR TITLE
feat: show follow-up chips

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -14,10 +14,8 @@ import { splitFollowUps } from '@/lib/splitFollowUps';
 import { getTrials } from "@/lib/hooks/useTrials";
 import { patientTrialsPrompt, clinicianTrialsPrompt } from "@/lib/prompts/trials";
 import FeedbackBar from "@/components/FeedbackBar";
-import type {
-  ChatMessage as BaseChatMessage,
-  AnalysisCategory,
-} from '@/lib/context';
+import type { ChatMessage as BaseChatMessage } from "@/types/chat";
+import type { AnalysisCategory } from '@/lib/context';
 import { ensureThread, loadMessages, saveMessages, generateTitle, updateThreadTitle } from '@/lib/chatThreads';
 
 type ChatUiState = {
@@ -28,12 +26,32 @@ type ChatUiState = {
 const UI_DEFAULTS: ChatUiState = { topic: null, contextFrom: null };
 const uiKey = (threadId: string) => `chat:${threadId}:ui`;
 
-type ChatMessage = BaseChatMessage & {
-  tempId?: string;
-  parentId?: string;
-  pending?: boolean;
-  error?: string | null;
-};
+type ChatMessage =
+  | (BaseChatMessage & {
+      role: "user";
+      kind: "chat";
+      tempId?: string;
+      parentId?: string;
+      pending?: boolean;
+      error?: string | null;
+    })
+  | (BaseChatMessage & {
+      role: "assistant";
+      kind: "chat";
+      tempId?: string;
+      parentId?: string;
+      pending?: boolean;
+      error?: string | null;
+    })
+  | (BaseChatMessage & {
+      role: "assistant";
+      kind: "analysis";
+      category?: AnalysisCategory;
+      tempId?: string;
+      parentId?: string;
+      pending?: boolean;
+      error?: string | null;
+    });
 
 const uid = () => Math.random().toString(36).slice(2);
 

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -10,6 +10,7 @@ import { useActiveContext } from '@/lib/context';
 import { isFollowUp } from '@/lib/followup';
 import { detectFollowupIntent } from '@/lib/intents';
 import { safeJson } from '@/lib/safeJson';
+import { splitFollowUps } from '@/lib/splitFollowUps';
 import { getTrials } from "@/lib/hooks/useTrials";
 import { patientTrialsPrompt, clinicianTrialsPrompt } from "@/lib/prompts/trials";
 import FeedbackBar from "@/components/FeedbackBar";
@@ -201,22 +202,35 @@ function AnalysisCard({ m, researchOn, onQuickAction, busy }: { m: Extract<ChatM
   );
 }
 
-function ChatCard({ m }: { m: Extract<ChatMessage, { kind: "chat" }> }) {
+function ChatCard({ m, therapyMode, onFollowUpClick }: { m: Extract<ChatMessage, { kind: "chat" }>; therapyMode: boolean; onFollowUpClick: (text: string) => void }) {
   if (m.pending) return <PendingChatCard label="Thinking…" />;
   return (
     <article className="mr-auto max-w-[90%] rounded-2xl p-4 md:p-6 shadow-sm space-y-2 bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800">
       <div className="prose prose-slate dark:prose-invert max-w-none prose-medx text-sm md:text-base">
         <Markdown text={m.content} />
       </div>
+      {!therapyMode && m.followUps?.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {m.followUps.map((f, i) => (
+            <button
+              key={i}
+              onClick={() => onFollowUpClick(f)}
+              className="rounded-full border px-3 py-1 text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+            >
+              {f}
+            </button>
+          ))}
+        </div>
+      )}
     </article>
   );
 }
 
-function AssistantMessage({ m, researchOn, onQuickAction, busy }: { m: ChatMessage; researchOn: boolean; onQuickAction: (k: "simpler" | "doctor" | "next") => void; busy: boolean }) {
+function AssistantMessage({ m, researchOn, onQuickAction, busy, therapyMode, onFollowUpClick }: { m: ChatMessage; researchOn: boolean; onQuickAction: (k: "simpler" | "doctor" | "next") => void; busy: boolean; therapyMode: boolean; onFollowUpClick: (text: string) => void }) {
   return m.kind === "analysis" ? (
     <AnalysisCard m={m} researchOn={researchOn} onQuickAction={onQuickAction} busy={busy} />
   ) : (
-    <ChatCard m={m} />
+    <ChatCard m={m} therapyMode={therapyMode} onFollowUpClick={onFollowUpClick} />
   );
 }
 
@@ -468,7 +482,12 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
             } catch {}
           }
         }
-        setMessages(prev => prev.map(m => (m.id === pendingId ? { ...m, pending: false } : m)));
+        const { main, followUps } = splitFollowUps(acc);
+        setMessages(prev =>
+          prev.map(m =>
+            m.id === pendingId ? { ...m, content: main, followUps, pending: false } : m
+          )
+        );
         return;
       }
       if (therapyMode) {
@@ -644,9 +663,14 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
           } catch {}
         }
       }
-      setMessages(prev => prev.map(m => (m.id === pendingId ? { ...m, pending: false } : m)));
-      if (acc.length > 400) {
-        setFromChat({ id: pendingId, content: acc });
+      const { main, followUps } = splitFollowUps(acc);
+      setMessages(prev =>
+        prev.map(m =>
+          m.id === pendingId ? { ...m, content: main, followUps, pending: false } : m
+        )
+      );
+      if (main.length > 400) {
+        setFromChat({ id: pendingId, content: main });
         setUi(prev => ({ ...prev, contextFrom: 'Conversation summary' }));
       }
     } catch (e: any) {
@@ -881,6 +905,10 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
     }
   }
 
+  function handleFollowUpClick(text: string) {
+    send(text, researchMode);
+  }
+
   return (
     <div className="relative flex h-full flex-col">
       <Header
@@ -928,6 +956,8 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
                   researchOn={researchMode}
                   onQuickAction={onQuickAction}
                   busy={loadingAction !== null}
+                  therapyMode={therapyMode}
+                  onFollowUpClick={handleFollowUpClick}
                 />
                 <FeedbackBar
                   conversationId={conversationId}

--- a/lib/context.tsx
+++ b/lib/context.tsx
@@ -18,14 +18,21 @@ export type AnalysisCategory =
   | "other_medical_doc";
 
 export type ChatMessage =
-  | { id: string; role: "user"; kind: "chat"; content: string }
-  | { id: string; role: "assistant"; kind: "chat"; content: string }
+  | { id: string; role: "user"; kind: "chat"; content: string; followUps?: string[] }
+  | {
+      id: string;
+      role: "assistant";
+      kind: "chat";
+      content: string;
+      followUps?: string[];
+    }
   | {
       id: string;
       role: "assistant";
       kind: "analysis";
       category?: AnalysisCategory;
       content: string;
+      followUps?: string[];
     };
 
 type Ctx = {

--- a/lib/context.tsx
+++ b/lib/context.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { createContext, useContext, useRef, useState } from "react";
+import type { ChatMessage as BaseChatMessage } from "@/types/chat";
 
 export type ActiveContext = {
   id: string;
@@ -18,22 +19,9 @@ export type AnalysisCategory =
   | "other_medical_doc";
 
 export type ChatMessage =
-  | { id: string; role: "user"; kind: "chat"; content: string; followUps?: string[] }
-  | {
-      id: string;
-      role: "assistant";
-      kind: "chat";
-      content: string;
-      followUps?: string[];
-    }
-  | {
-      id: string;
-      role: "assistant";
-      kind: "analysis";
-      category?: AnalysisCategory;
-      content: string;
-      followUps?: string[];
-    };
+  | (BaseChatMessage & { role: "user"; kind: "chat" })
+  | (BaseChatMessage & { role: "assistant"; kind: "chat" })
+  | (BaseChatMessage & { role: "assistant"; kind: "analysis"; category?: AnalysisCategory });
 
 type Ctx = {
   active: ActiveContext | null;

--- a/lib/medx.ts
+++ b/lib/medx.ts
@@ -1,6 +1,9 @@
 import { MedxResponseSchema, type MedxResponse } from "@/schemas/medx";
 import { normalizeTopic } from "@/lib/topic/normalize";
 import { searchTrials } from "@/lib/trials/search";
+import { splitFollowUps } from "./splitFollowUps";
+
+export { splitFollowUps };
 
 const BASE = process.env.LLM_BASE_URL!;
 const MODEL = process.env.LLM_MODEL_ID || "llama-3.1-8b-instant";

--- a/lib/splitFollowUps.ts
+++ b/lib/splitFollowUps.ts
@@ -6,8 +6,8 @@ export function splitFollowUps(answer: string): { main: string; followUps: strin
   const followUps: string[] = [];
   const mainLines: string[] = [];
   for (const line of lines) {
-    if (/^follow[- ]?up[:]/i.test(line)) {
-      followUps.push(line.replace(/^follow[- ]?up[:]\s*/i, ""));
+    if (/^(next|follow[- ]?up)[:]?/i.test(line) || /\?\s*$/.test(line)) {
+      followUps.push(line.replace(/^(next|follow[- ]?up)[:]?/i, "").trim());
     } else {
       mainLines.push(line);
     }

--- a/lib/splitFollowUps.ts
+++ b/lib/splitFollowUps.ts
@@ -1,0 +1,16 @@
+export function splitFollowUps(answer: string): { main: string; followUps: string[] } {
+  const lines = (answer || "")
+    .split("\n")
+    .map(l => l.trim())
+    .filter(Boolean);
+  const followUps: string[] = [];
+  const mainLines: string[] = [];
+  for (const line of lines) {
+    if (/^follow[- ]?up[:]/i.test(line)) {
+      followUps.push(line.replace(/^follow[- ]?up[:]\s*/i, ""));
+    } else {
+      mainLines.push(line);
+    }
+  }
+  return { main: mainLines.join("\n"), followUps };
+}

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,0 +1,6 @@
+export type ChatMessage = {
+  id: string;
+  role: "user" | "assistant" | "system";
+  content: string;
+  followUps?: string[];
+};


### PR DESCRIPTION
## Summary
- add utility to split follow-up prompts from answers
- extend ChatMessage with optional followUps field
- render assistant follow-ups as chips and handle click to resend message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc86348764832f9990ce3f9cf0e866