### PR TITLE
feat: add research orchestrator and citation chips

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -227,9 +227,9 @@ function ChatCard({ m, therapyMode, onFollowUpClick }: { m: Extract<ChatMessage,
       <div className="prose prose-slate dark:prose-invert max-w-none prose-medx text-sm md:text-base">
         <Markdown text={m.content} />
       </div>
-      {m.citations?.length > 0 && (
+      {m.role === "assistant" && m.citations?.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-2">
-          {m.citations.slice(0, 6).map((c: any, i: number) => (
+          {m.citations.slice(0, 6).map((c, i) => (
             <a
               key={i}
               href={c.url}
@@ -237,7 +237,7 @@ function ChatCard({ m, therapyMode, onFollowUpClick }: { m: Extract<ChatMessage,
               rel="noreferrer"
               className="rounded-full border px-3 py-1 text-xs hover:bg-gray-100"
             >
-              {c.source?.toUpperCase()}
+              {c.source.toUpperCase()}
             </a>
           ))}
         </div>

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -227,6 +227,21 @@ function ChatCard({ m, therapyMode, onFollowUpClick }: { m: Extract<ChatMessage,
       <div className="prose prose-slate dark:prose-invert max-w-none prose-medx text-sm md:text-base">
         <Markdown text={m.content} />
       </div>
+      {m.citations?.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {m.citations.slice(0, 6).map((c: any, i: number) => (
+            <a
+              key={i}
+              href={c.url}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded-full border px-3 py-1 text-xs hover:bg-gray-100"
+            >
+              {c.source?.toUpperCase()}
+            </a>
+          ))}
+        </div>
+      )}
       {!therapyMode && m.followUps?.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-2">
           {m.followUps.map((f, i) => (

--- a/lib/medx.ts
+++ b/lib/medx.ts
@@ -52,7 +52,7 @@ export async function v2Generate(body: any): Promise<MedxResponse> {
   let researchPacket: any = null;
   const shouldResearch = body.mode === "research" || process.env.RESEARCH_ALWAYS_ON === "true";
   if (shouldResearch) {
-    researchPacket = await orchestrateResearch(query, { country: body.country, phase: body.phase });
+    researchPacket = await orchestrateResearch(query);
   }
 
   const citations = researchPacket?.citations?.slice(0, 8).map((c: any) => `- ${c.title} (${c.url})`).join("\n");

--- a/lib/research/dedupe.ts
+++ b/lib/research/dedupe.ts
@@ -1,0 +1,9 @@
+export function dedupeResults(items: any[]) {
+  const seen = new Set<string>();
+  const out: any[] = [];
+  for (const it of items) {
+    const key = (it.id || it.url || it.title).toLowerCase();
+    if (!seen.has(key)) { seen.add(key); out.push(it); }
+  }
+  return out;
+}

--- a/lib/research/net.ts
+++ b/lib/research/net.ts
@@ -1,0 +1,11 @@
+export async function fetchJson(url: string, timeoutMs = 12000) {
+  const ctrl = new AbortController();
+  const to = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const r = await fetch(url, { signal: ctrl.signal });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return await r.json();
+  } finally {
+    clearTimeout(to);
+  }
+}

--- a/lib/research/orchestrator.ts
+++ b/lib/research/orchestrator.ts
@@ -1,0 +1,48 @@
+import { fetchJson } from "@/lib/research/net";
+import { rankResults } from "@/lib/research/ranking";
+import { dedupeResults } from "@/lib/research/dedupe";
+
+export type Citation = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  date?: string;
+  extra?: any;
+};
+
+export type ResearchPacket = {
+  topic: string;
+  citations: Citation[];
+  meta: { widened?: boolean; tookMs: number; sourcesHit: string[] };
+};
+
+export async function orchestrateResearch(query: string, opts?: { country?: string; phase?: string }) {
+  const t0 = Date.now();
+  const sourcesHit: string[] = [];
+
+  const [ctgov, ctri, pubmed] = await Promise.allSettled([
+    searchCtgov(query),
+    searchCtri(query, opts?.country ?? "IN"),
+    searchPubMed(query),
+  ]);
+
+  const results = collectOk([ctgov, ctri, pubmed]);
+  let citations = dedupeResults(results);
+  citations = rankResults(citations, { topic: query });
+
+  return {
+    topic: query,
+    citations,
+    meta: { widened: results.length === 0, tookMs: Date.now() - t0, sourcesHit },
+  };
+}
+
+function collectOk(arr: PromiseSettledResult<any>[]) {
+  return arr.filter(a => a.status === "fulfilled").flatMap((a: any) => a.value ?? []);
+}
+
+// Stub searchers (fill in later)
+async function searchCtgov(q: string) { return []; }
+async function searchCtri(q: string, country: string) { return []; }
+async function searchPubMed(q: string) { return []; }

--- a/lib/research/orchestrator.ts
+++ b/lib/research/orchestrator.ts
@@ -1,6 +1,7 @@
 import { rankResults } from "@/lib/research/ranking";
 import { dedupeResults } from "@/lib/research/dedupe";
 import { searchCtgov } from "@/lib/research/sources/ctgov";
+import { searchCtri } from "@/lib/research/sources/ctri";
 import { searchPubMed } from "@/lib/research/sources/pubmed";
 
 export type Citation = {
@@ -21,21 +22,31 @@ export type ResearchPacket = {
 export async function orchestrateResearch(query: string): Promise<ResearchPacket> {
   const t0 = Date.now();
 
-  const [ctRes, pmRes] = await Promise.allSettled([
+  const [ctRes, pmRes, ctriRes] = await Promise.allSettled([
     searchCtgov(query, { recruitingOnly: true }),
     searchPubMed(query),
+    searchCtri(query),
   ]);
 
   let trials = ctRes.status === "fulfilled" ? ctRes.value : [];
   if (!trials.length) {
-    const ctAll = await searchCtgov(query, { recruitingOnly: false }).catch(() => []);
+    const ctAll = await safe(() => searchCtgov(query, { recruitingOnly: false }));
     trials = ctAll || [];
   }
 
+  const ctri = ctriRes.status === "fulfilled" ? ctriRes.value : [];
   const papers = pmRes.status === "fulfilled" ? pmRes.value : [];
 
-  let citations = dedupeResults([...trials, ...papers]);
+  let citations = dedupeResults([...trials, ...ctri, ...papers]);
   citations = rankResults(citations, { topic: query });
 
   return { topic: query, citations, meta: { widened: !trials.length, tookMs: Date.now() - t0 } };
+}
+
+async function safe<T>(fn: () => Promise<T>): Promise<T | null> {
+  try {
+    return await fn();
+  } catch {
+    return null;
+  }
 }

--- a/lib/research/ranking.ts
+++ b/lib/research/ranking.ts
@@ -1,0 +1,15 @@
+export function rankResults(items: any[], { topic }: { topic: string }) {
+  return items
+    .map(x => ({ x, score: score(x, topic) }))
+    .sort((a, b) => b.score - a.score)
+    .map(a => a.x);
+}
+
+function score(item: any, topic: string) {
+  let s = 0;
+  if (item.source?.includes("ct")) s += 3;  // clinical > papers
+  if ((item.title || "").toLowerCase().includes(topic.toLowerCase())) s += 3;
+  if (item.extra?.recruiting) s += 2;
+  if (item.date && Date.now() - Date.parse(item.date) < 365*24*3600*1000) s += 2;
+  return s;
+}

--- a/lib/research/sources/ctgov.ts
+++ b/lib/research/sources/ctgov.ts
@@ -1,0 +1,40 @@
+import { fetchJson } from "@/lib/research/net";
+
+export type Citation = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  date?: string;
+  extra?: any;
+};
+
+/**
+ * Search ClinicalTrials.gov for trials by query.
+ * Recruiting only by default; falls back to all if none found.
+ */
+export async function searchCtgov(query: string, opts?: { recruitingOnly?: boolean }): Promise<Citation[]> {
+  const fields = ["NCTId","BriefTitle","OverallStatus","StudyFirstPostDate","LastUpdatePostDate"];
+  const url = `https://clinicaltrials.gov/api/query/study_fields?expr=${encodeURIComponent(query)}&fields=${fields.join(",")}&min_rnk=1&max_rnk=75&fmt=json`;
+
+  const data = await fetchJson(url).catch(() => null);
+  if (!data?.StudyFieldsResponse?.StudyFields) return [];
+
+  const rows = data.StudyFieldsResponse.StudyFields as any[];
+  return rows.map(r => {
+    const id = r.NCTId?.[0] || "";
+    const title = r.BriefTitle?.[0] || "";
+    const status = r.OverallStatus?.[0] || "";
+    const date = r.LastUpdatePostDate?.[0] || r.StudyFirstPostDate?.[0] || "";
+
+    return {
+      id,
+      title,
+      url: id ? `https://clinicaltrials.gov/study/${id}` : "",
+      source: "ctgov",
+      date,
+      extra: { status, recruiting: /recruiting/i.test(status) }
+    };
+  }).filter(c => opts?.recruitingOnly ? c.extra?.recruiting : true);
+}
+

--- a/lib/research/sources/ctri.ts
+++ b/lib/research/sources/ctri.ts
@@ -1,0 +1,86 @@
+import { fetch as _fetch } from "undici";
+
+export type Citation = {
+  id: string;
+  title: string;
+  url: string;
+  source: "ctri";
+  date?: string;
+  extra?: { status?: string; recruiting?: boolean };
+};
+
+const ORIGIN = "https://ctri.nic.in";
+const SEARCH = ORIGIN + "/Clinicaltrials/advsearch.php";
+
+// lightweight fetch with timeout + UA; keep separate from fetchJson(JSON-only)
+async function fetchHtml(url: string, timeoutMs = 12000): Promise<string> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const r = await _fetch(url, {
+      signal: ctrl.signal,
+      headers: { "user-agent": "MedX/1.0 (+research; contact: support@medx.example)" },
+    });
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return await r.text();
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+// very small HTML helper
+function text(v?: string) {
+  return (v || "").replace(/\s+/g, " ").trim();
+}
+
+export async function searchCtri(query: string, opts?: { max?: number }): Promise<Citation[]> {
+  // CTRI’s advanced search params vary; this query hits title/condition broadly.
+  const url = `${SEARCH}?term=${encodeURIComponent(query)}`;
+  let html: string;
+  try {
+    html = await fetchHtml(url);
+  } catch {
+    return [];
+  }
+
+  // Parse rows. CTRI typically renders results with anchors to view.php?trialid=...
+  // We’ll capture blocks containing trial link + visible title/status.
+  const out: Citation[] = [];
+  const reRow = /<a[^>]*href="([^\"]*view\.php\?trialid=\d+[^\"]*)"[^>]*>(.*?)<\/a>[\s\S]*?<td[^>]*>\s*Status\s*:<\/td>\s*<td[^>]*>(.*?)<\/td>|<a[^>]*href="([^\"]*view\.php\?trialid=\d+[^\"]*)"[^>]*>(.*?)<\/a>/gi;
+
+  let m: RegExpExecArray | null;
+  while ((m = reRow.exec(html)) && out.length < (opts?.max ?? 30)) {
+    // Two patterns: with inline status capture or without.
+    const href = text(m[1] || m[4] || "");
+    const title = text(stripTags(m[2] || m[5] || ""));
+    const status = text(stripTags(m[3] || ""));
+
+    if (!href || !title) continue;
+
+    // Extract CTRI id if present in detail page (we’ll leave as title-derived if absent)
+    const detailUrl = href.startsWith("http") ? href : ORIGIN + "/Clinicaltrials/" + href.replace(/^\/+/, "");
+    const idMatch =
+      title.match(/\bCTRI\/[0-9]{4}\/[0-9]{2}\/[0-9]{6}\b/i) ||
+      detailUrl.match(/\bCTRI\/[0-9]{4}\/[0-9]{2}\/[0-9]{6}\b/i);
+
+    out.push({
+      id: idMatch ? idMatch[0] : detailUrl,
+      title,
+      url: detailUrl,
+      source: "ctri",
+      // CTRI pages sometimes show “Date of Registration: dd-mm-yyyy”
+      // We won’t over-parse dates here; orchestrator will still work without.
+      extra: {
+        status: status || undefined,
+        recruiting: /recruiting/i.test(status),
+      },
+    });
+  }
+
+  return out;
+}
+
+function stripTags(s: string) {
+  return s.replace(/<[^>]*>/g, "");
+}
+

--- a/lib/research/sources/pubmed.ts
+++ b/lib/research/sources/pubmed.ts
@@ -1,0 +1,39 @@
+import { fetchJson } from "@/lib/research/net";
+
+export type Citation = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  date?: string;
+  extra?: any;
+};
+
+/**
+ * Search PubMed for relevant articles.
+ * Returns first 50 results with titles and links.
+ */
+export async function searchPubMed(query: string): Promise<Citation[]> {
+  const esearch = `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&retmax=50&retmode=json&term=${encodeURIComponent(query)}`
+    + (process.env.NCBI_API_KEY ? `&api_key=${process.env.NCBI_API_KEY}` : "");
+  const ids = await fetchJson(esearch).then(j => j?.esearchresult?.idlist || []).catch(() => []);
+  if (!ids.length) return [];
+
+  const esummary = `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&retmode=json&id=${ids.join(",")}`
+    + (process.env.NCBI_API_KEY ? `&api_key=${process.env.NCBI_API_KEY}` : "");
+  const sum = await fetchJson(esummary).catch(() => null);
+  const recs = sum?.result || {};
+
+  return ids.map((id: string) => {
+    const r = recs[id];
+    return r ? {
+      id,
+      title: (r.title || "").trim(),
+      url: `https://pubmed.ncbi.nlm.nih.gov/${id}/`,
+      source: "pubmed",
+      date: (r.pubdate || r.epubdate || "").slice(0, 10),
+      extra: { journal: r.fulljournalname }
+    } : null;
+  }).filter(Boolean) as Citation[];
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tesseract.js": "^5.0.5",
+        "undici": "^5.29.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -722,6 +723,15 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -7913,6 +7923,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tesseract.js": "^5.0.5",
+    "undici": "^5.29.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -3,4 +3,5 @@ export type ChatMessage = {
   role: "user" | "assistant" | "system";
   content: string;
   followUps?: string[];
+  citations?: any[];
 };

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -1,7 +1,9 @@
+import type { Citation } from "@/lib/research/orchestrator";
+
 export type ChatMessage = {
   id: string;
   role: "user" | "assistant" | "system";
   content: string;
   followUps?: string[];
-  citations?: any[];
+  citations?: Citation[];
 };


### PR DESCRIPTION
## Summary
- add research orchestrator with dedupe and ranking helpers
- integrate orchestrated citations into generation flow
- show citation chips on assistant messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc942dedb4832f9315a89818953f08