### PR TITLE
feat: expand orchestrator sources and add caching

### DIFF
--- a/lib/research/orchestrator.ts
+++ b/lib/research/orchestrator.ts
@@ -3,6 +3,11 @@ import { dedupeResults } from "@/lib/research/dedupe";
 import { searchCtgov } from "@/lib/research/sources/ctgov";
 import { searchCtri } from "@/lib/research/sources/ctri";
 import { searchPubMed } from "@/lib/research/sources/pubmed";
+import { searchEuropePmc } from "@/lib/research/sources/eupmc";
+import { searchCrossref } from "@/lib/research/sources/crossref";
+import { searchOpenAlex } from "@/lib/research/sources/openalex";
+import { searchIctrp } from "@/lib/research/sources/ictrp";
+import { searchDrugSafety } from "@/lib/research/sources/drugSafety";
 
 export type Citation = {
   id: string;
@@ -19,13 +24,27 @@ export type ResearchPacket = {
   meta: { widened?: boolean; tookMs: number };
 };
 
-export async function orchestrateResearch(query: string): Promise<ResearchPacket> {
-  const t0 = Date.now();
+const cache = new Map<string, { ts: number; data: ResearchPacket }>();
+const CACHE_MS = 5 * 60 * 1000;
 
-  const [ctRes, pmRes, ctriRes] = await Promise.allSettled([
+export async function orchestrateResearch(query: string): Promise<ResearchPacket> {
+  const now = Date.now();
+  const cached = cache.get(query);
+  if (cached && now - cached.ts < CACHE_MS) {
+    return cached.data;
+  }
+
+  const t0 = now;
+
+  const [ctRes, pmRes, ctriRes, epmcRes, crossRes, oaRes, ictrpRes, drugRes] = await Promise.allSettled([
     searchCtgov(query, { recruitingOnly: true }),
     searchPubMed(query),
     searchCtri(query),
+    searchEuropePmc(query),
+    searchCrossref(query),
+    searchOpenAlex(query),
+    searchIctrp(query),
+    searchDrugSafety(query),
   ]);
 
   let trials = ctRes.status === "fulfilled" ? ctRes.value : [];
@@ -35,12 +54,21 @@ export async function orchestrateResearch(query: string): Promise<ResearchPacket
   }
 
   const ctri = ctriRes.status === "fulfilled" ? ctriRes.value : [];
-  const papers = pmRes.status === "fulfilled" ? pmRes.value : [];
+  const ictrp = ictrpRes.status === "fulfilled" ? ictrpRes.value : [];
+  const papers = [
+    ...(pmRes.status === "fulfilled" ? pmRes.value : []),
+    ...(epmcRes.status === "fulfilled" ? epmcRes.value : []),
+    ...(crossRes.status === "fulfilled" ? crossRes.value : []),
+    ...(oaRes.status === "fulfilled" ? oaRes.value : []),
+  ];
+  const safety = drugRes.status === "fulfilled" ? drugRes.value : [];
 
-  let citations = dedupeResults([...trials, ...ctri, ...papers]);
+  let citations = dedupeResults([...trials, ...ctri, ...ictrp, ...papers, ...safety]);
   citations = rankResults(citations, { topic: query });
 
-  return { topic: query, citations, meta: { widened: !trials.length, tookMs: Date.now() - t0 } };
+  const packet = { topic: query, citations, meta: { widened: !trials.length, tookMs: Date.now() - t0 } };
+  cache.set(query, { ts: now, data: packet });
+  return packet;
 }
 
 async function safe<T>(fn: () => Promise<T>): Promise<T | null> {
@@ -50,3 +78,4 @@ async function safe<T>(fn: () => Promise<T>): Promise<T | null> {
     return null;
   }
 }
+

--- a/lib/research/sources/crossref.ts
+++ b/lib/research/sources/crossref.ts
@@ -1,0 +1,25 @@
+import { fetchJson } from "@/lib/research/net";
+
+export type Citation = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  date?: string;
+  extra?: any;
+};
+
+export async function searchCrossref(query: string): Promise<Citation[]> {
+  const url = `https://api.crossref.org/works?query=${encodeURIComponent(query)}&rows=25`;
+  const data = await fetchJson(url).catch(() => null);
+  const items = data?.message?.items || [];
+  return items.map((p: any) => ({
+    id: p.DOI || p.URL || "",
+    title: Array.isArray(p.title) ? p.title[0] : p.title || "",
+    url: p.URL || (p.DOI ? `https://doi.org/${p.DOI}` : ""),
+    source: "crossref",
+    date: p.issued?.["date-parts"]?.[0]?.join("-") || "",
+    extra: { journal: (p["container-title"] || [])[0] }
+  }));
+}
+

--- a/lib/research/sources/dailymed.ts
+++ b/lib/research/sources/dailymed.ts
@@ -1,0 +1,25 @@
+import { fetchJson } from "@/lib/research/net";
+
+export type Citation = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  date?: string;
+  extra?: any;
+};
+
+export async function searchDailyMed(rxCui: string): Promise<Citation[]> {
+  const url = `https://dailymed.nlm.nih.gov/dailymed/services/v2/spls.json?rx=${encodeURIComponent(rxCui)}&pagesize=5`;
+  const data = await fetchJson(url).catch(() => null);
+  const list = data?.data?.spls || data?.spls || [];
+  return list.map((d: any) => ({
+    id: d.setid || d.id || "",
+    title: d.title || d.name || "",
+    url: d.setid ? `https://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=${d.setid}` : "",
+    source: "dailymed",
+    date: d.modified || d.date || "",
+    extra: { rxCui }
+  }));
+}
+

--- a/lib/research/sources/drugSafety.ts
+++ b/lib/research/sources/drugSafety.ts
@@ -1,0 +1,17 @@
+import type { Citation } from "./dailymed";
+import { fetchRxCui } from "./rxnorm";
+import { searchDailyMed } from "./dailymed";
+import { searchOpenFda } from "./openfda";
+
+export async function searchDrugSafety(drug: string): Promise<Citation[]> {
+  const rx = await fetchRxCui(drug);
+  if (!rx) return [];
+  const [dmRes, fdaRes] = await Promise.allSettled([
+    searchDailyMed(rx),
+    searchOpenFda(drug)
+  ]);
+  const dm = dmRes.status === "fulfilled" ? dmRes.value : [];
+  const fda = fdaRes.status === "fulfilled" ? fdaRes.value : [];
+  return [...dm, ...fda];
+}
+

--- a/lib/research/sources/eupmc.ts
+++ b/lib/research/sources/eupmc.ts
@@ -1,0 +1,25 @@
+import { fetchJson } from "@/lib/research/net";
+
+export type Citation = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  date?: string;
+  extra?: any;
+};
+
+export async function searchEuropePmc(query: string): Promise<Citation[]> {
+  const url = `https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=${encodeURIComponent(query)}&resulttype=lite&format=json&pageSize=25`;
+  const data = await fetchJson(url).catch(() => null);
+  const results = data?.resultList?.result || [];
+  return results.map((r: any) => ({
+    id: r.id || r.pmid || r.pmcid || "",
+    title: r.title || "",
+    url: r.doi ? `https://doi.org/${r.doi}` : `https://europepmc.org/article/${r.source}/${r.id}`,
+    source: "eupmc",
+    date: r.firstPublicationDate || r.pubYear || "",
+    extra: { journal: r.journalTitle }
+  }));
+}
+

--- a/lib/research/sources/ictrp.ts
+++ b/lib/research/sources/ictrp.ts
@@ -1,0 +1,25 @@
+import { fetchJson } from "@/lib/research/net";
+
+export type Citation = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  date?: string;
+  extra?: any;
+};
+
+export async function searchIctrp(query: string): Promise<Citation[]> {
+  const url = `https://trialsearch.who.int/api/TrialSearch?query=${encodeURIComponent(query)}`;
+  const data = await fetchJson(url).catch(() => null);
+  const trials = (data?.results || data || []) as any[];
+  return trials.map(t => ({
+    id: t.TrialID || t.trialid || t.ID || "",
+    title: t.ScientificTitle || t.PublicTitle || t.title || "",
+    url: t.TrialID ? `https://trialsearch.who.int/Trial2.aspx?TrialID=${encodeURIComponent(t.TrialID)}` : "",
+    source: "ictrp",
+    date: t.DateRegistration || t.date || "",
+    extra: { status: t.RecruitmentStatus || t.status }
+  }));
+}
+

--- a/lib/research/sources/openalex.ts
+++ b/lib/research/sources/openalex.ts
@@ -1,0 +1,28 @@
+import { fetchJson } from "@/lib/research/net";
+
+export type Citation = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  date?: string;
+  extra?: any;
+};
+
+export async function searchOpenAlex(query: string): Promise<Citation[]> {
+  const url = new URL(`https://api.openalex.org/works`);
+  if (query) url.searchParams.set("search", query);
+  url.searchParams.set("per-page", "25");
+  if (process.env.OPENALEX_MAILTO) url.searchParams.set("mailto", process.env.OPENALEX_MAILTO);
+  const data = await fetchJson(url.toString()).catch(() => null);
+  const results = data?.results || [];
+  return results.map((w: any) => ({
+    id: w.id,
+    title: w.display_name || "",
+    url: w.primary_location?.landing_page_url || w.id,
+    source: "openalex",
+    date: w.publication_date || (w.publication_year ? String(w.publication_year) : ""),
+    extra: { authors: (w.authorships || []).map((a: any) => a.author?.display_name).filter(Boolean) }
+  }));
+}
+

--- a/lib/research/sources/openfda.ts
+++ b/lib/research/sources/openfda.ts
@@ -1,0 +1,26 @@
+import { fetchJson } from "@/lib/research/net";
+
+export type Citation = {
+  id: string;
+  title: string;
+  url: string;
+  source: string;
+  date?: string;
+  extra?: any;
+};
+
+export async function searchOpenFda(drug: string): Promise<Citation[]> {
+  const apiKey = process.env.OPENFDA_API_KEY;
+  const url = `https://api.fda.gov/drug/event.json?search=patient.drug.medicinalproduct:${encodeURIComponent(drug)}&limit=5${apiKey ? `&api_key=${apiKey}` : ""}`;
+  const data = await fetchJson(url).catch(() => null);
+  const results = data?.results || [];
+  return results.map((r: any) => ({
+    id: r.safetyreportid || "",
+    title: `Adverse event report for ${drug}`,
+    url: "",
+    source: "openfda",
+    date: r.receivedate || "",
+    extra: { reaction: r.patient?.reaction?.[0]?.reactionmeddrapt }
+  }));
+}
+

--- a/lib/research/sources/rxnorm.ts
+++ b/lib/research/sources/rxnorm.ts
@@ -1,0 +1,9 @@
+import { fetchJson } from "@/lib/research/net";
+
+export async function fetchRxCui(drug: string): Promise<string | null> {
+  const url = `https://rxnav.nlm.nih.gov/REST/rxcui.json?name=${encodeURIComponent(drug)}`;
+  const data = await fetchJson(url).catch(() => null);
+  const id = data?.idGroup?.rxnormId?.[0];
+  return id || null;
+}
+


### PR DESCRIPTION
## Summary
- add Europe PMC, Crossref, OpenAlex, WHO ICTRP, and drug safety pipeline sources
- extend research orchestrator with fail-soft fetches and 5‑min cache
- collect drug safety info via RxNorm -> DailyMed/OpenFDA

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bca017db6c832fa47cbac540d87466