### PR TITLE
feat: structured trial query parsing and targeted CTGov search

### DIFF
--- a/lib/research/answerComposer.ts
+++ b/lib/research/answerComposer.ts
@@ -1,0 +1,31 @@
+import type { Citation } from "./orchestrator";
+
+export function composeTrialsAnswer(q: string, trials: Citation[], papers: Citation[]) {
+  const head = "| Trial (NCT) | Phase | Status | Last Update |\n|---|---|---|---|";
+  const rows = trials.slice(0, 8).map(t => {
+    const nct = t.id || "—";
+    const title = sanitize(t.title);
+    const phase = (t.extra?.phase || "").replace(/phase\s*/i, "Phase ").trim() || "—";
+    const status = t.extra?.status || "—";
+    const date = t.date || "—";
+    return `| [${title}](${t.url}) (${nct}) | ${phase} | ${status} | ${date} |`;
+  });
+
+  const trialsBlock = rows.length ? [head, ...rows].join("\n") : "_No matching trials found._";
+
+  const papersBlock = (papers || [])
+    .slice(0, 3)
+    .map(p => `- ${sanitize(p.title)} (${p.date || "—"}) — ${p.url}`)
+    .join("\n");
+
+  return [
+    `Here are the most relevant clinical trials for **${q}**:`,
+    "",
+    trialsBlock,
+    papersBlock ? "\nKey related publications:\n" + papersBlock : "",
+  ].join("\n");
+}
+
+function sanitize(s?: string) {
+  return (s || "").replace(/\|/g, "\\|").trim();
+}

--- a/lib/research/answerComposer.ts
+++ b/lib/research/answerComposer.ts
@@ -1,31 +1,31 @@
 import type { Citation } from "./orchestrator";
 
-export function composeTrialsAnswer(q: string, trials: Citation[], papers: Citation[]) {
-  const head = "| Trial (NCT) | Phase | Status | Last Update |\n|---|---|---|---|";
+export function composeTrialsAnswer(userQuery: string, trials: Citation[], papers: Citation[]) {
+  const header = `Here are the most relevant **clinical trials** for: **${userQuery}**`;
+  const tableHead = "| Trial (Registry) | Phase | Status | Last Update |\n|---|---|---|---|";
   const rows = trials.slice(0, 8).map(t => {
-    const nct = t.id || "—";
     const title = sanitize(t.title);
+    const id = t.id || "—";
     const phase = (t.extra?.phase || "").replace(/phase\s*/i, "Phase ").trim() || "—";
     const status = t.extra?.status || "—";
     const date = t.date || "—";
-    return `| [${title}](${t.url}) (${nct}) | ${phase} | ${status} | ${date} |`;
+    return `| [${title}](${t.url}) (${id}) | ${phase} | ${status} | ${date} |`;
   });
 
-  const trialsBlock = rows.length ? [head, ...rows].join("\n") : "_No matching trials found._";
+  const trialsBlock = rows.length ? [tableHead, ...rows].join("\n") : "";
 
-  const papersBlock = (papers || [])
+  const pubBlock = (papers || [])
     .slice(0, 3)
     .map(p => `- ${sanitize(p.title)} (${p.date || "—"}) — ${p.url}`)
     .join("\n");
 
-  return [
-    `Here are the most relevant clinical trials for **${q}**:`,
-    "",
-    trialsBlock,
-    papersBlock ? "\nKey related publications:\n" + papersBlock : "",
-  ].join("\n");
+  const parts = [header];
+  if (trialsBlock) parts.push("", trialsBlock);
+  if (pubBlock) parts.push("\n**Related publications:**\n" + pubBlock);
+
+  return parts.join("\n");
 }
 
-function sanitize(s?: string) {
+function sanitize(s?: string){
   return (s || "").replace(/\|/g, "\\|").trim();
 }

--- a/lib/research/ctgovQuery.ts
+++ b/lib/research/ctgovQuery.ts
@@ -1,0 +1,36 @@
+export function buildCtgovExpr(q: {
+  condition?: string;
+  keywords?: string[];
+  phase?: "1" | "2" | "3" | "4";
+  recruiting?: boolean;
+  country?: string;
+}) {
+  const parts: string[] = [];
+
+  if (q.condition) {
+    parts.push(`AREA[ConditionSearch] ${quote(q.condition)}`);
+  }
+  if (q.keywords?.length) {
+    for (const kw of q.keywords) parts.push(`AREA[FullTextSearch] ${quote(kw)}`);
+  }
+  if (q.phase) {
+    parts.push(`AREA[Phase] "${romanPhase(q.phase)}"`);
+  }
+  if (q.recruiting === true) {
+    parts.push(`AREA[OverallStatus] "Recruiting"`);
+  }
+  if (q.country) {
+    parts.push(`AREA[LocationCountry] ${quote(q.country)}`);
+  }
+
+  const expr = parts.length ? parts.join(" AND ") : `AREA[FullTextSearch] ${quote("cancer")}`;
+  return expr;
+}
+
+export function quote(s: string) {
+  return `"${s.replace(/"/g, '\\"')}"`;
+}
+
+export function romanPhase(n: "1" | "2" | "3" | "4") {
+  return ["I", "II", "III", "IV"][parseInt(n) - 1];
+}

--- a/lib/research/orchestrator.ts
+++ b/lib/research/orchestrator.ts
@@ -1,6 +1,9 @@
 import { rankResults } from "@/lib/research/ranking";
 import { dedupeResults } from "@/lib/research/dedupe";
-import { searchCtgov } from "@/lib/research/sources/ctgov";
+import { interpretTrialQuery } from "@/lib/research/queryInterpreter";
+import { buildCtgovExpr, romanPhase } from "@/lib/research/ctgovQuery";
+import { composeTrialsAnswer } from "@/lib/research/answerComposer";
+import { searchCtgovByExpr } from "@/lib/research/sources/ctgov";
 import { searchCtri } from "@/lib/research/sources/ctri";
 import { searchPubMed } from "@/lib/research/sources/pubmed";
 import { searchEuropePmc } from "@/lib/research/sources/eupmc";
@@ -19,8 +22,9 @@ export type Citation = {
 };
 
 export type ResearchPacket = {
-  topic: string;
+  content: string;
   citations: Citation[];
+  followUps: string[];
   meta: { widened?: boolean; tookMs: number };
 };
 
@@ -36,8 +40,17 @@ export async function orchestrateResearch(query: string): Promise<ResearchPacket
 
   const t0 = now;
 
+  const tq = interpretTrialQuery(query);
+  const expr = buildCtgovExpr({
+    condition: tq.condition || tq.cancerType,
+    keywords: tq.keywords,
+    phase: tq.phase,
+    recruiting: tq.recruiting ?? true,
+    country: tq.country,
+  });
+
   const [ctRes, pmRes, ctriRes, epmcRes, crossRes, oaRes, ictrpRes, drugRes] = await Promise.allSettled([
-    searchCtgov(query, { recruitingOnly: true }),
+    searchCtgovByExpr(expr, { max: 75 }),
     searchPubMed(query),
     searchCtri(query),
     searchEuropePmc(query),
@@ -47,14 +60,21 @@ export async function orchestrateResearch(query: string): Promise<ResearchPacket
     searchDrugSafety(query),
   ]);
 
-  let trials = ctRes.status === "fulfilled" ? ctRes.value : [];
-  if (!trials.length) {
-    const ctAll = await safe(() => searchCtgov(query, { recruitingOnly: false }));
-    trials = ctAll || [];
-  }
+  const ctgovTargeted = ctRes.status === "fulfilled" ? ctRes.value : [];
+  const ctgovFiltered = ctgovTargeted.filter(t => {
+    if (!tq.phase) return true;
+    const p = (t.extra?.phase || "").toUpperCase();
+    return p.includes(romanPhase(tq.phase!));
+  });
 
   const ctri = ctriRes.status === "fulfilled" ? ctriRes.value : [];
   const ictrp = ictrpRes.status === "fulfilled" ? ictrpRes.value : [];
+
+  const ctriFiltered = ctri.filter(t => !tq.phase || (t.extra?.phase || "").toUpperCase().includes(romanPhase(tq.phase!)));
+  const ictrpFiltered = ictrp.filter(t => !tq.phase || (t.extra?.phase || "").toUpperCase().includes(romanPhase(tq.phase!)));
+
+  const trials = [...ctgovFiltered, ...ctriFiltered, ...ictrpFiltered];
+
   const papers = [
     ...(pmRes.status === "fulfilled" ? pmRes.value : []),
     ...(epmcRes.status === "fulfilled" ? epmcRes.value : []),
@@ -63,10 +83,27 @@ export async function orchestrateResearch(query: string): Promise<ResearchPacket
   ];
   const safety = drugRes.status === "fulfilled" ? drugRes.value : [];
 
-  let citations = dedupeResults([...trials, ...ctri, ...ictrp, ...papers, ...safety]);
+  let citations = dedupeResults([...trials, ...papers, ...safety]);
   citations = rankResults(citations, { topic: query });
 
-  const packet = { topic: query, citations, meta: { widened: !trials.length, tookMs: Date.now() - t0 } };
+  let followUps: string[] = [];
+  let content: string;
+  if (!trials.length) {
+    const phaseStr = tq.phase ? `Phase ${tq.phase} ` : "";
+    const condStr = tq.condition || tq.cancerType || "";
+    const statusStr = tq.recruiting === false ? "" : "active ";
+    content = `I didn't find ${statusStr}${phaseStr}${condStr} trials matching your filters.`.trim();
+    followUps = ["Include completed trials", "Any phase", "Add countries: US, EU"];
+  } else {
+    content = composeTrialsAnswer(query, trials, papers);
+  }
+
+  const packet: ResearchPacket = {
+    content,
+    citations,
+    followUps,
+    meta: { widened: false, tookMs: Date.now() - t0 },
+  };
   cache.set(query, { ts: now, data: packet });
   return packet;
 }

--- a/lib/research/queryInterpreter.ts
+++ b/lib/research/queryInterpreter.ts
@@ -1,0 +1,94 @@
+export type TrialQuery = {
+  condition?: string;
+  cancerType?: string;
+  phase?: "1" | "2" | "3" | "4";
+  recruiting?: boolean;
+  country?: string;
+  keywords?: string[];
+};
+
+const PHASE_RE = /\bphase\s*(I{1,3}|iv|1|2|3|4)\b/i;
+const RECRUITING_RE = /\b(recruiting|active|enrolling)\b/i;
+const COUNTRY_MAP: Record<string, string> = {
+  india: "India",
+  us: "United States",
+  usa: "United States",
+  uk: "United Kingdom",
+  europe: "Europe",
+};
+
+const ALIAS_MAP: Record<string, string> = {
+  "nonmall": "non-small",
+  "non\\s*small": "non-small",
+  "luekimia": "leukemia",
+  "bevacizab": "bevacizumab",
+  "avin": "bevacizumab",
+  "atolizumab": "atezolizumab",
+  "nivolum": "nivolumab",
+};
+
+function normalizeAliases(q: string): string {
+  let out = q;
+  for (const [k, v] of Object.entries(ALIAS_MAP)) {
+    const re = new RegExp(k, "gi");
+    out = out.replace(re, v);
+  }
+  return out;
+}
+
+export function interpretTrialQuery(q: string): TrialQuery {
+  const s = normalizeAliases((q || "").toLowerCase());
+
+  const phaseMatch = s.match(PHASE_RE);
+  const phase = phaseMatch
+    ? (["i", "ii", "iii", "iv"].includes(phaseMatch[1].toLowerCase())
+        ? ((["i", "ii", "iii", "iv"].indexOf(phaseMatch[1].toLowerCase()) + 1).toString() as any)
+        : (phaseMatch[1] as any))
+    : undefined;
+
+  const recruiting = RECRUITING_RE.test(s) ? true : undefined;
+
+  const countryKey = Object.keys(COUNTRY_MAP).find((k) => s.includes(k));
+  const country = countryKey ? COUNTRY_MAP[countryKey] : undefined;
+
+  const condition = extractCondition(s);
+  const cancerType = extractCancerType(s);
+
+  const keywords = extractKeywords(s, { condition, phase, country });
+
+  return { condition, cancerType, phase, recruiting, country, keywords };
+}
+
+function extractCondition(s: string) {
+  if (s.includes("nsclc")) return "non-small cell lung cancer";
+  if (s.includes("leukemia")) return "leukemia";
+  if (s.includes("lymphoma")) return "lymphoma";
+  if (s.includes("breast cancer")) return "breast cancer";
+  if (s.includes("lung cancer")) return "lung cancer";
+  return undefined;
+}
+function extractCancerType(s: string) {
+  if (s.includes("blood cancer")) return "hematologic malignancy";
+  if (s.includes("leukemia")) return "leukemia";
+  if (s.includes("lymphoma")) return "lymphoma";
+  return undefined;
+}
+function extractKeywords(s: string, known: { condition?: string; phase?: string; country?: string }) {
+  const stop = new Set<string>([
+    ...(known.condition ? known.condition.split(/\s+/) : []),
+    known.phase || "",
+    known.country?.toLowerCase() || "",
+    "phase",
+    "trial",
+    "trials",
+    "clinical",
+    "cancer",
+    "worldwide",
+    "latest",
+    "recruiting",
+  ]);
+  return s
+    .split(/[^a-z0-9+]/i)
+    .filter((w) => w && !stop.has(w))
+    .slice(0, 5);
+}

--- a/lib/research/queryInterpreter.ts
+++ b/lib/research/queryInterpreter.ts
@@ -17,27 +17,24 @@ const COUNTRY_MAP: Record<string, string> = {
   europe: "Europe",
 };
 
-const ALIAS_MAP: Record<string, string> = {
+const ALIAS: Record<string, string> = {
   "nonmall": "non-small",
-  "non\\s*small": "non-small",
+  "non small": "non-small",
   "luekimia": "leukemia",
   "bevacizab": "bevacizumab",
-  "avin": "bevacizumab",
   "atolizumab": "atezolizumab",
+  "avin": "avastin",
   "nivolum": "nivolumab",
 };
 
-function normalizeAliases(q: string): string {
-  let out = q;
-  for (const [k, v] of Object.entries(ALIAS_MAP)) {
-    const re = new RegExp(k, "gi");
-    out = out.replace(re, v);
-  }
-  return out;
+export function normalizeInput(q: string) {
+  let s = " " + (q || "").toLowerCase() + " ";
+  for (const [k, v] of Object.entries(ALIAS)) s = s.replaceAll(` ${k} `, ` ${v} `);
+  return s.trim();
 }
 
 export function interpretTrialQuery(q: string): TrialQuery {
-  const s = normalizeAliases((q || "").toLowerCase());
+  const s = normalizeInput(q);
 
   const phaseMatch = s.match(PHASE_RE);
   const phase = phaseMatch

--- a/lib/research/sources/ctri.ts
+++ b/lib/research/sources/ctri.ts
@@ -1,4 +1,3 @@
-import { fetch as _fetch } from "undici";
 import { normalizePhase } from "./utils";
 
 export type Citation = {
@@ -7,7 +6,14 @@ export type Citation = {
   url: string;
   source: "ctri";
   date?: string;
-  extra?: { status?: string; recruiting?: boolean; evidenceLevel?: string };
+  extra?: {
+    status?: string;
+    recruiting?: boolean;
+    /** Raw phase string as reported by CTRI (e.g., "Phase 3") */
+    phase?: string;
+    /** Normalized evidence level derived from the phase */
+    evidenceLevel?: string;
+  };
 };
 
 const ORIGIN = "https://ctri.nic.in";
@@ -18,7 +24,7 @@ async function fetchHtml(url: string, timeoutMs = 12000): Promise<string> {
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
-    const r = await _fetch(url, {
+    const r = await fetch(url, {
       signal: ctrl.signal,
       headers: { "user-agent": "MedX/1.0 (+research; contact: support@medx.example)" },
     });
@@ -82,6 +88,7 @@ export async function searchCtri(query: string, opts?: { max?: number }): Promis
       extra: {
         status: status || undefined,
         recruiting: /recruiting/i.test(status),
+        phase: phase || undefined,
         evidenceLevel,
       },
     });

--- a/lib/research/sources/ictrp.ts
+++ b/lib/research/sources/ictrp.ts
@@ -7,7 +7,14 @@ export type Citation = {
   url: string;
   source: string;
   date?: string;
-  extra?: any;
+  extra?: {
+    status?: string;
+    recruiting?: boolean;
+    /** Raw phase string as reported by the registry */
+    phase?: string;
+    /** Normalized evidence level derived from the phase */
+    evidenceLevel?: string;
+  };
 };
 
 export async function searchIctrp(query: string): Promise<Citation[]> {
@@ -24,7 +31,12 @@ export async function searchIctrp(query: string): Promise<Citation[]> {
       url: t.TrialID ? `https://trialsearch.who.int/Trial2.aspx?TrialID=${encodeURIComponent(t.TrialID)}` : "",
       source: "ictrp",
       date: t.DateRegistration || t.date || "",
-      extra: { status, recruiting: /recruiting/i.test(status), evidenceLevel },
+      extra: {
+        status,
+        recruiting: /recruiting/i.test(status),
+        phase: phaseRaw || undefined,
+        evidenceLevel,
+      },
     };
   });
 }

--- a/lib/research/validators.ts
+++ b/lib/research/validators.ts
@@ -1,0 +1,27 @@
+export function isTrial(c: any): boolean {
+  const src = String(c.source || "").toLowerCase();
+  return src === "ctgov" || src === "ctri" || src === "ictrp";
+}
+
+export function hasRegistryId(c: any): boolean {
+  const id = String(c.id || "");
+  return /\bNCT\d{8}\b/.test(id) || /\bCTRI\/\d{4}\/\d{2}\/\d{6}\b/i.test(id) || /^[A-Z0-9-]{6,}$/.test(id);
+}
+
+export function matchesPhase(c: any, phase?: "1"|"2"|"3"|"4"): boolean {
+  if (!phase) return true;
+  const p = String(c.extra?.phase || "").toUpperCase();
+  const roman = ["I","II","III","IV"][parseInt(phase)-1];
+  return p.includes(roman);
+}
+
+export function matchesRecruiting(c: any, recruiting?: boolean): boolean {
+  if (recruiting !== true) return true;
+  return !!c.extra?.recruiting;
+}
+
+export function matchesCountry(c: any, country?: string): boolean {
+  if (!country) return true;
+  const inItem = String(c.extra?.country || c.extra?.location || "").toLowerCase();
+  return inItem.includes(country.toLowerCase());
+}


### PR DESCRIPTION
## Summary
- interpret free-text trial questions into structured filters with alias normalization
- build CTGov expressions from parsed filters and query trials safely
- compose trial summaries in table format with guardrails and follow-up suggestions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcaa9f0614832f9c94a6b943115682