### PR TITLE
chore: add placeholder guard

### DIFF
--- a/app/api/medx/route.ts
+++ b/app/api/medx/route.ts
@@ -11,7 +11,7 @@ async function classifyIntent(query: string, mode: 'patient'|'doctor') {
 - CLINICAL_TRIALS_QUERY (fetch trials)
 - GENERAL_HEALTH (explain simply)
 
-Return JSON: {"intent":"...","keywords":["..."]}`;
+Return JSON: {"intent":"","keywords":[""]}`;
   const r = await fetch(`${BASE.replace(/\/$/,'')}/chat/completions`,{
     method:'POST',
     headers:{'Content-Type':'application/json',Authorization:`Bearer ${KEY}`},

--- a/components/SafeLink.tsx
+++ b/components/SafeLink.tsx
@@ -15,7 +15,7 @@ export function normalizeExternalHref(input?: string): string | null {
   if (!input) return null;
   let href = input.trim();
 
-  // If model returned "[Learn more](www.nhs.uk/...)" (no protocol), add https
+  // If model returned "[Learn more](www.nhs.uk/)" (no protocol), add https
   if (/^www\./i.test(href)) href = "https://" + href;
 
   // If relative or missing protocol → invalid

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -229,9 +229,9 @@ function ChatCard({ m, therapyMode, onFollowUpClick, simple }: { m: Extract<Chat
       <div className="prose prose-slate dark:prose-invert max-w-none prose-medx text-sm md:text-base">
         <Markdown text={m.content} />
       </div>
-      {m.role === "assistant" && m.citations?.length > 0 && (
+      {m.role === "assistant" && (m.citations?.length || 0) > 0 && (
         <div className="mt-2 flex flex-wrap gap-2">
-          {m.citations.slice(0, simple ? 3 : 6).map((c, i) => (
+          {(m.citations || []).slice(0, simple ? 3 : 6).map((c, i) => (
             <a
               key={i}
               href={c.url}
@@ -245,9 +245,9 @@ function ChatCard({ m, therapyMode, onFollowUpClick, simple }: { m: Extract<Chat
           ))}
         </div>
       )}
-      {!therapyMode && m.followUps?.length > 0 && (
+      {!therapyMode && (m.followUps?.length || 0) > 0 && (
         <div className="mt-2 flex flex-wrap gap-2">
-          {m.followUps.map((f, i) => (
+          {(m.followUps || []).map((f, i) => (
             <button
               key={i}
               onClick={() => onFollowUpClick(f)}
@@ -878,7 +878,7 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
       } catch {}
     }
 
-    // Regular chat flow (file or note) ...
+    // Regular chat flow (file or note)
     if (!pendingFile && !note.trim()) return;
     if (pendingFile) {
       await analyzeFile(pendingFile, note);
@@ -1106,8 +1106,8 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
               className="flex-1 bg-transparent outline-none text-sm md:text-base leading-6 placeholder:text-slate-400 dark:placeholder:text-slate-500 px-2"
               placeholder={
                 pendingFile
-                  ? 'Add a note or question for this document (optional)...'
-                  : 'Send a message...'
+                  ? 'Add a note or question for this document (optional)'
+                  : 'Send a message'
               }
               value={note}
               onChange={e => setNote(e.target.value)}

--- a/lib/research/sources/ctri.ts
+++ b/lib/research/sources/ctri.ts
@@ -50,7 +50,7 @@ export async function searchCtri(query: string, opts?: { max?: number }): Promis
     return [];
   }
 
-  // Parse rows. CTRI typically renders results with anchors to view.php?trialid=...
+  // Parse rows. CTRI typically renders results with anchors to view.php?trialid=
   // We’ll capture blocks containing trial link + visible title/status.
   const out: Citation[] = [];
   const reRow = /<a[^>]*href="([^\"]*view\.php\?trialid=\d+[^\"]*)"[^>]*>(.*?)<\/a>[\s\S]*?<td[^>]*>\s*Status\s*:<\/td>\s*<td[^>]*>(.*?)<\/td>|<a[^>]*href="([^\"]*view\.php\?trialid=\d+[^\"]*)"[^>]*>(.*?)<\/a>/gi;

--- a/lib/topic/normalize.ts
+++ b/lib/topic/normalize.ts
@@ -20,6 +20,6 @@ export function normalizeTopic(raw: string): Topic {
       excludes: [/hip|arthroplasty|femoral|shoulder|retina|hepatic|liver|prostate/i],
     };
   }
-  // add more conditions here...
+  // add more conditions here
   return { canonical: raw.trim(), synonyms: [raw.trim()], excludes: [] };
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "private": true,
   "scripts": {
+    "prebuild": "node tools/check-placeholders.cjs",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/tools/check-placeholders.cjs
+++ b/tools/check-placeholders.cjs
@@ -1,0 +1,32 @@
+// tools/check-placeholders.cjs
+// Fails the build if any file contains the literal '...' placeholder.
+const { readFileSync, readdirSync, statSync } = require('fs');
+const { join } = require('path');
+
+function walk(dir, files = []) {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'tools' || name === '.next') continue;
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, files);
+    else files.push(p);
+  }
+  return files;
+}
+
+const exts = /\.(ts|tsx|js|jsx|json|md|yml|yaml|mjs|cjs)$/;
+const bad = [];
+
+for (const f of walk(process.cwd())) {
+  if (!exts.test(f)) continue;
+  const s = readFileSync(f, 'utf8');
+  if (/\.\.\.(?![A-Za-z0-9_$\(\[])/.test(s)) bad.push(f);
+}
+
+if (bad.length) {
+  console.error('ERROR: Placeholder "..." found in files:');
+  for (const f of bad) console.error(' -', f);
+  process.exit(1);
+} else {
+  console.log('✅ No "..." placeholders detected.');
+}

--- a/tools/remove-ellipses.cjs
+++ b/tools/remove-ellipses.cjs
@@ -1,0 +1,35 @@
+// tools/remove-ellipses.cjs
+// One-time surgical cleanup: removes literal '...' tokens from source files.
+// Run: node tools/remove-ellipses.cjs
+const { readFileSync, writeFileSync, readdirSync, statSync } = require('fs');
+const { join } = require('path');
+
+function walk(dir, files = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, files);
+    else files.push(p);
+  }
+  return files;
+}
+
+const exts = /\.(ts|tsx|js|jsx|json|md|yml|yaml|mjs|cjs)$/;
+let touched = 0;
+let totalRemoved = 0;
+
+for (const f of walk(process.cwd())) {
+  if (!exts.test(f)) continue;
+  const s = readFileSync(f, 'utf8');
+  if (!s.includes('...')) continue;
+
+  const removed = (s.match(/\.{3}/g) || []).length;
+  const out = s.replace(/\.{3}/g, '');
+  writeFileSync(f, out, 'utf8');
+  touched++;
+  totalRemoved += removed;
+  console.log(`• Cleaned ${removed} ellipses in ${f}`);
+}
+
+console.log(`\n✅ Done. Files touched: ${touched}. Tokens removed: ${totalRemoved}.`);
+console.log('Tip: commit these changes, then rely on prebuild guard going forward.');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,28 +1,31 @@
 {
   "compilerOptions": {
     "target": "ES2020",
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2021"
+    ],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
     "jsx": "preserve",
     "strict": false,
-    "esModuleInterop": true,
-    "allowJs": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
     "baseUrl": ".",
     "paths": {
       "@/*": [
-        "*"
+        "./*"
       ]
     },
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
+    "types": [
+      "node"
     ],
+    "allowJs": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "resolveJsonModule": true,
     "isolatedModules": true,
     "plugins": [
       {
@@ -31,9 +34,10 @@
     ]
   },
   "include": [
-    "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
+    "**/*.d.ts",
+    "next-env.d.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": [

--- a/types/trials.ts
+++ b/types/trials.ts
@@ -3,7 +3,7 @@ export type TrialRow = {
   title: string;
   conditions: string[];
   interventions: string[];
-  status: string;                  // Recruiting, Active, Completed...
+  status: string;                  // Recruiting, Active, Completed
   phase: string;                   // Phase 1/2/3/4, NA
   start?: string;
   complete?: string;
@@ -14,5 +14,5 @@ export type TrialRow = {
   country?: string;
   eligibility?: string;            // raw text
   primaryOutcome?: string;         // first primary outcome if present
-  url: string;                     // https://clinicaltrials.gov/study/NCT...
+  url: string;                     // https://clinicaltrials.gov/study/NCT
 };


### PR DESCRIPTION
## Summary
- add scripts to remove and guard against literal `...` placeholders
- wire placeholder guard via prebuild and update tsconfig paths
- clean up placeholder ellipses in comments and strengthen chat pane rendering

## Testing
- `node tools/check-placeholders.cjs`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bd6dd3fe40832f9f1f5c31b7fe7e8f