### PR TITLE
Improve profile memory and conversation persistence

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -55,6 +55,9 @@ export async function POST(req: Request) {
   // 5) Call LLM
   const assistant = await callLLM(system, recent as any, text);
 
+  // Add natural pacing (2–4 sec)
+  await new Promise(r => setTimeout(r, 2000 + Math.random() * 2000));
+
   // 6) Save assistant message
   await appendMessage({ threadId: activeThreadId, role: "assistant", content: assistant });
 

--- a/lib/memory/contextBuilder.ts
+++ b/lib/memory/contextBuilder.ts
@@ -34,10 +34,16 @@ export async function buildPromptContext(opts: {
   const system = [
     persona,
     researchLine,
-    "Never re-ask details already present in profile unless user says they changed.",
-    "If user asks to ‘remember’ something long-term, store it under profile memory.",
-    `Compact context summary:\n${thread.runningSummary || "(none)"}`,
-    profile ? `Known profile:\n${profile}` : "Known profile: (empty)",
+    "Profile memory (never re-ask unless updated by user):",
+    profile ? profile : "(none)",
+    "Compact summary of conversation so far:",
+    thread.runningSummary || "(none)",
+    "Rules:",
+    "- Do not ask for height/weight/age if already in profile.",
+    "- If user provides a new value, update profile memory immediately.",
+    "- Treat diet type (veg/non-veg) and goal (fat loss, muscle gain) as persistent until user changes them.",
+    "- Be conversational: reflect back understanding before answering.",
+    "- Take 3–4 seconds to respond, giving impression of thoughtful analysis."
   ].join("\n\n");
 
   return { system, recent };

--- a/lib/memory/outOfContext.ts
+++ b/lib/memory/outOfContext.ts
@@ -2,39 +2,37 @@ import { prisma } from "@/lib/prisma";
 import { embed, cosine } from "./embeddings";
 import type { OutOfContextDecision } from "@/types/memory";
 
-const SIM_THRESHOLD = 0.35; // tune: 0.3..0.5
+const HEALTH_KEYWORDS = [
+  "bmi", "weight", "height", "diet", "protein",
+  "calorie", "exercise", "workout", "meal", "food", "nutrition"
+];
 
 export async function decideOutOfContext(threadId: string, userText: string): Promise<OutOfContextDecision> {
+  const lower = userText.toLowerCase();
+
+  // Health-related? Always stick in same thread
+  if (HEALTH_KEYWORDS.some(k => lower.includes(k))) {
+    return { isOutOfContext: false, reason: "Health keyword detected" };
+  }
+
+  // Else → fall back to embeddings
   const thread = await prisma.chatThread.findUnique({
     where: { id: threadId },
-    include: {
-      messages: { orderBy: { createdAt: "desc" }, take: 8 }, // last 8
-    },
+    include: { messages: { orderBy: { createdAt: "desc" }, take: 8 } },
   });
   if (!thread) return { isOutOfContext: false };
 
-  const topicEmbedding = thread.topicEmbedding?.buffer ? new Float32Array(thread.topicEmbedding.buffer) : null;
-
-  // Compare to running topic if exists; else to last assistant/user combo
-  const recent = thread.messages
-    .filter(m => m.role !== "system")
-    .slice(0, 4) // most recent 4 for signal
-    .reverse();
-
   const userVec = await embed(userText);
-
   let sims: number[] = [];
-  if (topicEmbedding) {
-    sims.push(cosine(Array.from(userVec), Array.from(topicEmbedding)));
-  }
-  for (const m of recent) {
+
+  for (const m of thread.messages) {
     if (!m.embedding) continue;
     const msgVec = Array.from(new Float32Array(m.embedding.buffer));
     sims.push(cosine(userVec, msgVec));
   }
 
-  const best = sims.length ? Math.max(...sims) : 1; // if no data, do not split
-  return { isOutOfContext: best < SIM_THRESHOLD, similarity: best };
+  const best = sims.length ? Math.max(...sims) : 1;
+  return { isOutOfContext: best < 0.35, similarity: best };
 }
 
 export async function seedTopicEmbedding(threadId: string, text: string) {

--- a/lib/memory/store.ts
+++ b/lib/memory/store.ts
@@ -39,15 +39,23 @@ export async function getThread(threadId: string) {
 }
 
 export async function upsertProfileMemory(threadId: string, key: string, value: string) {
-  const v = await embed(`${key}: ${value}`);
+  // Normalize keys (avoid duplicates like "Weight" vs "weight")
+  const normalizedKey = key.trim().toLowerCase();
+  const normalizedValue = value.trim();
+
+  const v = await embed(`${normalizedKey}: ${normalizedValue}`);
+
   return prisma.memory.upsert({
-    where: { threadId_scope_key: { threadId, scope: "profile", key } },
+    where: { threadId_scope_key: { threadId, scope: "profile", key: normalizedKey } },
     create: {
-      threadId, scope: "profile", key, value,
+      threadId,
+      scope: "profile",
+      key: normalizedKey,
+      value: normalizedValue,
       embedding: Buffer.from(new Float32Array(v).buffer),
     },
     update: {
-      value,
+      value: normalizedValue,
       embedding: Buffer.from(new Float32Array(v).buffer),
     },
   });

--- a/lib/memory/summary.ts
+++ b/lib/memory/summary.ts
@@ -2,25 +2,25 @@ import { setRunningSummary } from "./store";
 
 /**
  * Extremely small, deterministic summarizer:
- * - Keep bullet points of key user facts and current task/topic.
- * - Trim over 1500 chars.
- * Replace with LLM summarizer later if desired.
+ * - Maintain bullet lines for conversation context.
+ * - Trim over maxChars, keeping the most recent content.
  */
 export function updateSummary(prev: string, lastUser: string, lastAssistant?: string, maxChars = 1500) {
-  const lines = [
-    prev?.trim() ? prev.trim() : "• Context: (initial)\n",
-    `• User said: ${lastUser}`,
-    lastAssistant ? `• We replied: ${lastAssistant}` : undefined,
+  const newLines = [
+    prev?.trim() || "• Context started",
+    `• User: ${lastUser}`,
+    lastAssistant ? `• Assistant: ${lastAssistant}` : undefined,
   ].filter(Boolean) as string[];
 
-  let out = lines.join("\n");
+  let out = newLines.join("\n");
+
+  // Trim oldest if too long
   if (out.length > maxChars) {
-    // trim oldest part
     out = out.slice(out.length - maxChars);
-    // ensure starts cleanly
     const idx = out.indexOf("•");
     if (idx > 0) out = out.slice(idx);
   }
+
   return out;
 }
 


### PR DESCRIPTION
## Summary
- Normalize profile memory keys and update embeddings to avoid duplicates
- Detect health-related context before falling back to embeddings for thread branching
- Enrich prompt context with profile memory, conversation summary, and behavioral rules
- Maintain compact rolling summaries and add natural pacing to responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd73078128832f91e70d744b746b46