### PR TITLE
feat: add research filters and trials table

### DIFF
--- a/components/ResearchFilters.tsx
+++ b/components/ResearchFilters.tsx
@@ -1,98 +1,95 @@
-'use client';
-import { useState } from 'react';
-import { useResearchFilters, defaultFilters } from '@/store/researchFilters';
+"use client";
 
-const phaseOptions = ['1','2','3','4'] as const;
-const statusOptions = [
-  { value: 'recruiting', label: 'Recruiting' },
-  { value: 'active', label: 'Active (not recruiting)' },
-  { value: 'completed', label: 'Completed' },
-  { value: 'any', label: 'Any' },
-];
-const countryOptions = [
-  'United States',
-  'India',
-  'European Union',
-  'United Kingdom',
-  'Japan',
-  'Worldwide'
-];
-const geneSuggestions = ['EGFR','ALK','ROS1','BRAF','PD-L1','KRAS','HER2'];
+import { useResearchFilters } from "@/store/researchFilters";
+import type { Phase, Status } from "@/types/research-core";
 
-function summaryCount(filters: any) {
-  let n = 0;
-  if (filters.phase) n++;
-  if (filters.status && filters.status !== 'recruiting') n++;
-  if (filters.countries?.length) n++;
-  if (filters.genes?.length) n++;
-  return n;
-}
+const phaseOptions: Readonly<Phase[]> = ["1", "2", "3", "4"] as const;
+const statusOptions: Readonly<Status[]> = ["Recruiting", "Completed"] as const;
+const countryOptions = ["USA", "India", "EU", "Global"] as const;
+const geneOptions = ["EGFR", "ALK", "KRAS", "Other"] as const;
 
-export default function ResearchFilters({ mode }: { mode: 'patient'|'doctor'|'research'|'therapy' }) {
+export default function ResearchFilters() {
   const { filters, setFilters, reset } = useResearchFilters();
-  const [draft, setDraft] = useState(filters);
-  const [open, setOpen] = useState(mode !== 'patient');
-  const count = summaryCount(filters);
-
-  function apply() {
-    setFilters(draft);
-    if (mode === 'patient') setOpen(false);
-  }
-  function doReset() {
-    setDraft(defaultFilters);
-    reset();
-  }
-  function toggleCountry(c: string) {
-    const list = new Set(draft.countries || []);
-    if (list.has(c)) list.delete(c); else list.add(c);
-    setDraft({ ...draft, countries: Array.from(list) });
-  }
-  const geneInput = (draft.genes || []).join(', ');
 
   return (
-    <div className="border-b border-slate-200 dark:border-gray-800 px-4 py-2">
-      {mode === 'patient' && (
-        <button type="button" className="btn-secondary mb-2" onClick={() => setOpen(o=>!o)}>
-          {open ? 'Hide filters' : `Refine results${count?` (${count})`:''}`}
-        </button>
-      )}
-      {open && (
-        <div className="flex flex-wrap gap-2 items-end text-sm">
-          <div className="flex items-center gap-1">
-            <span className="font-medium">Phase:</span>
-            <div className="flex border rounded overflow-hidden">
-              <button className={`px-2 py-1 ${!draft.phase?'bg-indigo-600 text-white':'bg-transparent'}`} onClick={()=>setDraft({...draft, phase: undefined})}>Any</button>
-              {phaseOptions.map(p=> (
-                <button key={p} className={`px-2 py-1 ${draft.phase===p?'bg-indigo-600 text-white':'bg-transparent'}`} onClick={()=>setDraft({...draft, phase:p})}> {p} </button>
-              ))}
-            </div>
-          </div>
-          <label className="flex items-center gap-1">
-            <span className="font-medium">Status:</span>
-            <select className="border rounded px-2 py-1" value={draft.status || 'recruiting'} onChange={e=>setDraft({...draft, status: e.target.value as any})}>
-              {statusOptions.map(o=> <option key={o.value} value={o.value}>{o.label}</option>)}
-            </select>
-          </label>
-          <div className="flex items-center gap-1">
-            <span className="font-medium">Country:</span>
-            <div className="flex flex-wrap gap-1">
-              {countryOptions.map(c=> (
-                <button key={c} type="button" className={`px-2 py-1 border rounded ${draft.countries?.includes(c)?'bg-indigo-600 text-white':'bg-transparent'}`} onClick={()=>toggleCountry(c)}>
-                  {c}
-                </button>
-              ))}
-            </div>
-          </div>
-          <label className="flex items-center gap-1 flex-wrap">
-            <span className="font-medium">Genes:</span>
-            <input className="border rounded px-2 py-1" value={geneInput} placeholder="EGFR, ALK" onChange={e=>setDraft({...draft, genes: e.target.value.split(/\s*,\s*/).filter(Boolean)})} />
-          </label>
-          <div className="ml-auto flex items-center gap-2">
-            <button className="btn-secondary" onClick={doReset}>Reset</button>
-            <button className="btn-primary" onClick={apply}>Apply {count ? <span className="ml-1 rounded-full bg-indigo-600 text-white px-2">{count}</span> : null}</button>
-          </div>
-        </div>
-      )}
+    <div className="flex flex-wrap gap-3 mb-4 p-2 border-b border-gray-200">
+      {/* Phase */}
+      <select
+        value={filters.phase ?? ""}
+        onChange={(e) =>
+          setFilters({
+            ...filters,
+            phase: (e.target.value || undefined) as Phase | undefined,
+          })
+        }
+        className="border rounded px-2 py-1"
+      >
+        <option value="">All Phases</option>
+        {phaseOptions.map((p) => (
+          <option key={p} value={p}>
+            Phase {p}
+          </option>
+        ))}
+      </select>
+
+      {/* Status */}
+      <select
+        value={filters.status ?? ""}
+        onChange={(e) =>
+          setFilters({
+            ...filters,
+            status: (e.target.value || undefined) as Status | undefined,
+          })
+        }
+        className="border rounded px-2 py-1"
+      >
+        <option value="">Any Status</option>
+        {statusOptions.map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+
+      {/* Country */}
+      <select
+        value={filters.country ?? ""}
+        onChange={(e) =>
+          setFilters({ ...filters, country: e.target.value || undefined })
+        }
+        className="border rounded px-2 py-1"
+      >
+        <option value="">Any Country</option>
+        {countryOptions.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+
+      {/* Gene */}
+      <select
+        value={filters.gene ?? ""}
+        onChange={(e) =>
+          setFilters({ ...filters, gene: e.target.value || undefined })
+        }
+        className="border rounded px-2 py-1"
+      >
+        <option value="">Any Gene</option>
+        {geneOptions.map((g) => (
+          <option key={g} value={g}>
+            {g}
+          </option>
+        ))}
+      </select>
+
+      <button
+        onClick={reset}
+        className="px-3 py-1 border rounded bg-gray-100"
+      >
+        Reset
+      </button>
     </div>
   );
 }
+

--- a/components/TrialsTable.tsx
+++ b/components/TrialsTable.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useResearchFilters } from "@/store/researchFilters";
+import type { Phase, Status } from "@/types/research-core";
+
+type Trial = {
+  id: string;
+  title: string;
+  phase?: Phase;
+  status?: Status;
+  country?: string;
+  gene?: string;
+  url: string;
+};
+
+export default function TrialsTable({ trials }: { trials: Trial[] }) {
+  const { filters } = useResearchFilters();
+  if (!trials || trials.length === 0) return null;
+
+  const filtered = trials.filter((t) => {
+    if (filters.phase && t.phase !== filters.phase) return false;
+    if (filters.status && t.status !== filters.status) return false;
+    if (filters.country && t.country !== filters.country) return false;
+    if (filters.gene && t.gene !== filters.gene) return false;
+    return true;
+  });
+
+  if (!filtered.length) return <p>No matching trials found.</p>;
+
+  return (
+    <table className="w-full border-collapse border border-gray-300 text-sm">
+      <thead>
+        <tr className="bg-gray-100">
+          <th className="border px-2 py-1">ID</th>
+          <th className="border px-2 py-1">Title</th>
+          <th className="border px-2 py-1">Phase</th>
+          <th className="border px-2 py-1">Status</th>
+          <th className="border px-2 py-1">Country</th>
+          <th className="border px-2 py-1">Gene</th>
+        </tr>
+      </thead>
+      <tbody>
+        {filtered.map((t) => (
+          <tr key={t.id}>
+            <td className="border px-2 py-1">{t.id}</td>
+            <td className="border px-2 py-1">
+              <a
+                href={t.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 underline"
+              >
+                {t.title}
+              </a>
+            </td>
+            <td className="border px-2 py-1">{t.phase}</td>
+            <td className="border px-2 py-1">{t.status}</td>
+            <td className="border px-2 py-1">{t.country}</td>
+            <td className="border px-2 py-1">{t.gene}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -4,7 +4,10 @@ import { useSearchParams } from 'next/navigation';
 import Header from '../Header';
 import Markdown from '../Markdown';
 import ResearchFilters from '@/components/ResearchFilters';
+import TrialsTable from '@/components/TrialsTable';
 import { useResearchFilters } from '@/store/researchFilters';
+import { useAppMode } from '@/store/appMode';
+import { useResearchToggle } from '@/store/researchToggle';
 import { Send } from 'lucide-react';
 import { useCountry } from '@/lib/country';
 import { getRandomWelcome } from '@/lib/welcomeMessages';
@@ -286,6 +289,8 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   const chatRef = useRef<HTMLDivElement>(null);
   const inputRef = externalInputRef ?? useRef<HTMLInputElement>(null);
   const { filters } = useResearchFilters();
+  const { mode: appMode } = useAppMode();
+  const { researchOn } = useResearchToggle();
 
   const params = useSearchParams();
   const threadId = params.get('threadId');
@@ -952,10 +957,9 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
         mode={mode}
         onModeChange={setMode}
         researchOn={researchMode}
-        onResearchChange={setResearchMode}
-        onTherapyChange={setTherapyMode}
-      />
-      <ResearchFilters mode={currentMode} />
+      onResearchChange={setResearchMode}
+      onTherapyChange={setTherapyMode}
+    />
       <div
         ref={chatRef}
         className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 pt-4 md:pt-6 pb-28"
@@ -998,6 +1002,12 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
                   onFollowUpClick={handleFollowUpClick}
                   simple={currentMode === 'patient'}
                 />
+                {appMode === 'doctor' && researchOn && (m as any).trials?.length > 0 && (
+                  <>
+                    <ResearchFilters />
+                    <TrialsTable trials={(m as any).trials} />
+                  </>
+                )}
                 <FeedbackBar
                   conversationId={conversationId}
                   messageId={m.id}

--- a/lib/research/answerComposer.ts
+++ b/lib/research/answerComposer.ts
@@ -1,21 +1,14 @@
 import type { Citation } from "./orchestrator";
 import { isSelfDisclosure } from "@/lib/research/queryInterpreter";
-import type { ResearchFilters } from "@/store/researchFilters";
+import type { ResearchFilters } from "@/types/research-core";
 
 function summarize(filters?: ResearchFilters) {
   if (!filters) return "";
   const parts: string[] = [];
   if (filters.phase) parts.push(`Phase ${filters.phase}`);
-  if (filters.status && filters.status !== "any") {
-    const map: any = {
-      recruiting: "Recruiting",
-      active: "Active, not recruiting",
-      completed: "Completed",
-    };
-    parts.push(map[filters.status] || filters.status);
-  }
-  if (filters.countries?.length) parts.push(filters.countries.join("/") );
-  if (filters.genes?.length) parts.push(filters.genes.join(", "));
+  if (filters.status) parts.push(filters.status);
+  if (filters.country) parts.push(filters.country);
+  if (filters.gene) parts.push(filters.gene);
   return parts.length ? `Filters: ${parts.join(" · ")}` : "";
 }
 

--- a/lib/research/queryInterpreter.ts
+++ b/lib/research/queryInterpreter.ts
@@ -4,6 +4,7 @@ export type TrialQuery = {
   phase?: "1" | "2" | "3" | "4";
   recruiting?: boolean;
   country?: string;
+  gene?: string;
   keywords?: string[];
 };
 

--- a/store/appMode.tsx
+++ b/store/appMode.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { createContext, useContext, useState } from 'react';
+
+const Ctx = createContext<{ mode: 'patient'|'doctor'; setMode: (m:'patient'|'doctor')=>void }>({ mode: 'patient', setMode: () => {} });
+
+export function AppModeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setMode] = useState<'patient'|'doctor'>('patient');
+  return <Ctx.Provider value={{ mode, setMode }}>{children}</Ctx.Provider>;
+}
+
+export function useAppMode() {
+  return useContext(Ctx);
+}
+

--- a/store/researchFilters.tsx
+++ b/store/researchFilters.tsx
@@ -1,31 +1,29 @@
 'use client';
-import React, { createContext, useContext, useState } from 'react';
 
-export type ResearchFilters = {
-  phase?: '1'|'2'|'3'|'4';
-  status?: 'recruiting'|'active'|'completed'|'any';
-  countries?: string[];
-  genes?: string[];
-};
+import { createContext, useContext, useState } from 'react';
+import type { ResearchFilters } from '@/types/research-core';
 
-export const defaultFilters: ResearchFilters = { status: 'recruiting' };
+export const defaultFilters: ResearchFilters = {};
 
-type CtxType = {
+const Ctx = createContext<{
   filters: ResearchFilters;
   setFilters: (f: ResearchFilters) => void;
   reset: () => void;
-};
-
-const Ctx = createContext<CtxType | null>(null);
+} | null>(null);
 
 export function ResearchFiltersProvider({ children }: { children: React.ReactNode }) {
   const [filters, setFilters] = useState<ResearchFilters>(defaultFilters);
   const reset = () => setFilters(defaultFilters);
-  return <Ctx.Provider value={{ filters, setFilters, reset }}>{children}</Ctx.Provider>;
+  return (
+    <Ctx.Provider value={{ filters, setFilters, reset }}>
+      {children}
+    </Ctx.Provider>
+  );
 }
 
 export function useResearchFilters() {
   const ctx = useContext(Ctx);
-  if (!ctx) throw new Error('useResearchFilters must be used within ResearchFiltersProvider');
+  if (!ctx) throw new Error('useResearchFilters must be used inside ResearchFiltersProvider');
   return ctx;
 }
+

--- a/store/researchToggle.tsx
+++ b/store/researchToggle.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { createContext, useContext, useState } from 'react';
+
+const Ctx = createContext<{ researchOn: boolean; setResearchOn: (v:boolean)=>void }>({ researchOn: false, setResearchOn: () => {} });
+
+export function ResearchToggleProvider({ children, defaultOn=false }: { children: React.ReactNode; defaultOn?: boolean }) {
+  const [researchOn, setResearchOn] = useState(defaultOn);
+  return <Ctx.Provider value={{ researchOn, setResearchOn }}>{children}</Ctx.Provider>;
+}
+
+export function useResearchToggle() {
+  return useContext(Ctx);
+}
+

--- a/types/research-core.ts
+++ b/types/research-core.ts
@@ -1,0 +1,23 @@
+export type Phase = "1" | "2" | "3" | "4";
+export type Status = "Recruiting" | "Completed";
+
+export type ResearchFilters = {
+  phase?: Phase;
+  status?: Status;
+  country?: string;
+  gene?: string;
+};
+
+export function normalizePhase(raw?: string): Phase | undefined {
+  if (!raw) return;
+  const v = raw.replace(/[^0-9]/g, "");
+  if (["1", "2", "3", "4"].includes(v)) return v as Phase;
+}
+
+export function normalizeStatus(raw?: string): Status | undefined {
+  if (!raw) return;
+  const v = raw.trim().toLowerCase();
+  if (v === "recruiting") return "Recruiting";
+  if (v === "completed") return "Completed";
+}
+


### PR DESCRIPTION
## Summary
- add shared research-core types for phase, status, and filters
- refactor research filters store and component to use shared types
- introduce trials table and gate rendering in doctor research mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd744199cc832f950e27bbb504c8b2