### PR TITLE
feat: smarter context routing and understanding

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -5,53 +5,57 @@ import { decideContext } from "@/lib/memory/contextRouter";
 import { seedTopicEmbedding } from "@/lib/memory/outOfContext";
 import { updateSummary, persistUpdatedSummary } from "@/lib/memory/summary";
 import { buildPromptContext } from "@/lib/memory/contextBuilder";
+import { parseIntentAndEntities } from "@/lib/nlu/intent";
+import { detectAndApplyUpdates } from "@/lib/memory/updates";
 
-// Replace with real LLM
-async function callLLM(system: string, recent: { role: string; content: string }[], userText: string) {
-  return `Demo: I understood "${userText}" in context.`;
+// TODO: replace with your real LLM
+async function callLLM(system: string, recent: {role:string;content:string}[], userText: string) {
+  return `Demo: understood intent and context for "${userText}".`;
 }
 
 export async function POST(req: Request) {
   const { userId, activeThreadId, text, mode, researchOn } = await req.json();
 
-  // Context routing
+  // 1) Route context
   const decision = await decideContext(userId, activeThreadId, text);
   let threadId = activeThreadId;
 
   if (decision.action === "continue") {
     threadId = decision.threadId;
   } else if (decision.action === "newThread") {
-    const newT = await prisma.chatThread.create({
-      data: { userId, title: "New topic" },
-    });
-    threadId = newT.id;
-    await seedTopicEmbedding(newT.id, text);
+    const t = await prisma.chatThread.create({ data: { userId, title: "New topic" } });
+    threadId = t.id;
+    await seedTopicEmbedding(threadId, text);
   } else if (decision.action === "clarify") {
-    return NextResponse.json({
-      ok: true,
-      clarify: true,
-      options: decision.candidates,
-    });
+    return NextResponse.json({ ok: true, clarify: true, options: decision.candidates });
   }
 
-  // Save user message
+  // 2) Save user message
   await appendMessage({ threadId, role: "user", content: text });
 
-  // Build context
+  // 3) Detect profile updates (weight, height, diet, etc.)
+  await detectAndApplyUpdates(threadId, text);
+
+  // 4) NLU for downstream routing (optional hinting)
+  const nlu = parseIntentAndEntities(text);
+
+  // 5) Build context (system + recent + profile memory & summary inside)
   const { system, recent } = await buildPromptContext({
     threadId,
     options: { mode, researchOn },
   });
 
-  // Call LLM
+  // 6) Call LLM
   const assistant = await callLLM(system, recent as any, text);
 
-  // Save assistant
+  // 7) Save assistant & update summary
   await appendMessage({ threadId, role: "assistant", content: assistant });
-
-  // Update running summary
   const updated = updateSummary("", text, assistant);
   await persistUpdatedSummary(threadId, updated);
 
-  return NextResponse.json({ ok: true, threadId, text: assistant });
+  // 8) Natural pacing (2–4s)
+  await new Promise(r => setTimeout(r, 2000 + Math.random() * 2000));
+
+  return NextResponse.json({ ok: true, threadId, text: assistant, intent: nlu.intent, entities: nlu.entities });
 }
+

--- a/components/ClarifyPrompt.tsx
+++ b/components/ClarifyPrompt.tsx
@@ -3,25 +3,38 @@
 export default function ClarifyPrompt({
   options,
   onSelect,
+  onStartNew,
 }: {
   options: { threadId: string; title: string; similarity: number }[];
   onSelect: (threadId: string) => void;
+  onStartNew: () => void;
 }) {
   return (
-    <div className="p-3 border rounded bg-yellow-50 text-sm">
-      <p>Did you mean to continue with one of these topics?</p>
-      <ul className="mt-2 space-y-1">
+    <div className="p-3 border rounded bg-yellow-50 text-sm space-y-2">
+      <p className="font-medium">I’m not fully sure which topic you meant—pick one:</p>
+      <ul className="space-y-1">
         {options.map((o) => (
           <li key={o.threadId}>
             <button
-              className="px-2 py-1 rounded bg-white border"
+              className="px-2 py-1 rounded bg-white border hover:bg-gray-50"
               onClick={() => onSelect(o.threadId)}
+              title={`Match confidence: ${Math.round(o.similarity * 100)}%`}
             >
-              {o.title} ({Math.round(o.similarity * 100)}%)
+              {o.title} — {Math.round(o.similarity * 100)}%
             </button>
           </li>
         ))}
       </ul>
+      <div className="pt-1">
+        <button
+          className="px-2 py-1 rounded border"
+          onClick={onStartNew}
+          title="Start a fresh topic"
+        >
+          Start new topic
+        </button>
+      </div>
     </div>
   );
 }
+

--- a/lib/memory/contextRouter.ts
+++ b/lib/memory/contextRouter.ts
@@ -1,58 +1,77 @@
 import { prisma } from "@/lib/prisma";
 import { embed, cosine } from "./embeddings";
 
+// Tune these if needed
+const HARD_CONTINUE = 0.70;  // very confident continue
+const CLARIFY_MIN   = 0.45;  // candidate for clarify
+const NEW_THREAD_MAX= 0.30;  // clearly new topic
+const RECENCY_HALFLIFE_HRS = 72; // recency de-weights older threads
+const KEYWORD_BOOST = 0.08;  // boost if query/thread topic shares domain keywords
+
+const DOMAIN_KEYWORDS: Record<string,string[]> = {
+  health: ["bmi","diet","protein","calorie","workout","exercise","weight","height","food","meal","nutrition","fat loss","muscle"],
+  oncology: ["nsclc","trial","oncology","chemo","immunotherapy","gene","egfr","alk","kras","phase","recruiting","completed"],
+  general: []
+};
+
+function recencyWeight(updatedAt: Date) {
+  const ageHrs = (Date.now() - updatedAt.getTime()) / 36e5;
+  const w = Math.pow(0.5, ageHrs / RECENCY_HALFLIFE_HRS);
+  return Math.max(0.3, Math.min(1, w)); // clamp to [0.3, 1]
+}
+
+function keywordBoost(q: string, title: string) {
+  const L = (s: string) => s.toLowerCase();
+  const text = `${L(q)} ${L(title)}`;
+  let boost = 0;
+  for (const group of Object.values(DOMAIN_KEYWORDS)) {
+    if (group.some(k => text.includes(k))) { boost += KEYWORD_BOOST; break; }
+  }
+  return boost;
+}
+
 export type ContextDecision =
   | { action: "continue"; threadId: string; similarity: number }
   | { action: "clarify"; candidates: { threadId: string; title: string; similarity: number }[] }
   | { action: "newThread" };
 
-const SIM_THRESHOLD = 0.35;  // below → new thread
-const CLARIFY_RANGE = 0.45;  // medium → ask user
-
-export async function decideContext(
-  userId: string,
-  activeThreadId: string,
-  query: string
-): Promise<ContextDecision> {
+export async function decideContext(userId: string, activeThreadId: string, query: string): Promise<ContextDecision> {
   const threads = await prisma.chatThread.findMany({
     where: { userId },
-    select: { id: true, title: true, topicEmbedding: true },
-    orderBy: { updatedAt: "desc" },
+    select: { id: true, title: true, topicEmbedding: true, updatedAt: true },
+    orderBy: { updatedAt: "desc" }
   });
-
   if (!threads.length) return { action: "newThread" };
 
   const qVec = await embed(query);
-  const sims = threads
-    .filter((t) => t.topicEmbedding)
-    .map((t) => {
+  const scored = threads
+    .filter(t => t.topicEmbedding)
+    .map(t => {
       const vec = Array.from(new Float32Array(t.topicEmbedding!.buffer));
-      return {
-        threadId: t.id,
-        title: t.title ?? "Untitled",
-        similarity: cosine(qVec, vec),
-      };
+      let sim = cosine(qVec, vec);
+      sim = sim * recencyWeight(t.updatedAt) + keywordBoost(query, t.title ?? "");
+      return { threadId: t.id, title: t.title ?? "Untitled", similarity: sim };
     })
-    .sort((a, b) => b.similarity - a.similarity);
+    .sort((a,b)=> b.similarity - a.similarity);
 
-  if (!sims.length) return { action: "newThread" };
+  if (!scored.length) return { action: "newThread" };
 
-  // Best match
-  const best = sims[0];
-  if (best.similarity >= 0.65) {
+  const best = scored[0];
+
+  if (best.similarity >= HARD_CONTINUE) {
     return { action: "continue", threadId: best.threadId, similarity: best.similarity };
   }
 
-  if (best.similarity < SIM_THRESHOLD) {
+  const clarify = scored.filter(s => s.similarity >= CLARIFY_MIN).slice(0, 3);
+  if (clarify.length > 1) {
+    return { action: "clarify", candidates: clarify };
+  }
+
+  if (best.similarity <= NEW_THREAD_MAX) {
     return { action: "newThread" };
   }
 
-  // Multiple close matches → clarify
-  const candidates = sims.filter((s) => s.similarity >= CLARIFY_RANGE).slice(0, 3);
-  if (candidates.length > 1) {
-    return { action: "clarify", candidates };
-  }
-
-  // Otherwise → new thread
-  return { action: "newThread" };
+  // fallback: continue with the best (slightly unsure but better than cold-start)
+  return { action: "continue", threadId: best.threadId, similarity: best.similarity };
 }
+

--- a/lib/memory/updates.ts
+++ b/lib/memory/updates.ts
@@ -1,0 +1,19 @@
+import { upsertProfileMemory } from "./store";
+
+export async function detectAndApplyUpdates(threadId: string, text: string) {
+  const t = text.toLowerCase();
+  // weight updates e.g., "weight 80", "i'm 82 kg now"
+  const kg = t.match(/(?:weight|weigh|wt)\s*[:=]?\s*(\d{2,3})\s?kg/) || t.match(/(\d{2,3})\s?kg\s?(?:now|today)?/);
+  if (kg) {
+    await upsertProfileMemory(threadId, "weight", `${parseInt(kg[1],10)} kg`);
+  }
+  // height examples (simple)
+  const cm = t.match(/(\d{3})\s?cm/);
+  if (cm) {
+    await upsertProfileMemory(threadId, "height", `${parseInt(cm[1],10)} cm`);
+  }
+  // diet type updates
+  if (/\bnon[-\s]?veg\b|chicken|fish|egg/.test(t)) await upsertProfileMemory(threadId, "diet", "non-veg");
+  else if (/\bveg\b/.test(t)) await upsertProfileMemory(threadId, "diet", "veg");
+}
+

--- a/lib/nlu/intent.ts
+++ b/lib/nlu/intent.ts
@@ -1,0 +1,38 @@
+export type Intent =
+  | "diet_plan" | "workout_plan" | "bmi_calc" | "trials_query" | "general_help";
+
+export type Entities = {
+  weightKg?: number;
+  heightCm?: number;
+  dietType?: "veg" | "non-veg" | "mixed";
+  goal?: "fat_loss" | "muscle_gain" | "recomp";
+};
+
+export function parseIntentAndEntities(text: string): { intent: Intent; entities: Entities } {
+  const t = text.toLowerCase();
+
+  const intent: Intent =
+    /bmi|body mass/.test(t) ? "bmi_calc" :
+    /trial|nsclc|phase|recruiting/.test(t) ? "trials_query" :
+    /workout|exercise|gym|training/.test(t) ? "workout_plan" :
+    /diet|meal|protein|calorie|food/.test(t) ? "diet_plan" :
+    "general_help";
+
+  const entities: Entities = {};
+  const kg = t.match(/(\d+)\s?kg/);
+  if (kg) entities.weightKg = parseInt(kg[1], 10);
+
+  const cm = t.match(/(\d+)\s?cm/);
+  if (cm) entities.heightCm = parseInt(cm[1], 10);
+
+  if (/\bveg\b/.test(t)) entities.dietType = "veg";
+  if (/\bnon[-\s]?veg\b|chicken|fish|egg/.test(t)) entities.dietType = "non-veg";
+  if (/mixed/.test(t)) entities.dietType = "mixed";
+
+  if (/muscle|bulk|gain/.test(t)) entities.goal = "muscle_gain";
+  if (/fat|weight.*loss|cut/.test(t)) entities.goal = "fat_loss";
+  if (/recomp|both/.test(t)) entities.goal = "recomp";
+
+  return { intent, entities };
+}
+

--- a/scripts/backfill-thread-embeddings.ts
+++ b/scripts/backfill-thread-embeddings.ts
@@ -1,7 +1,3 @@
-/**
- * Backfill embeddings for old threads without topicEmbedding.
- * Run once: npx tsx scripts/backfill-thread-embeddings.ts
- */
 import { prisma } from "@/lib/prisma";
 import { embed } from "@/lib/memory/embeddings";
 
@@ -14,28 +10,16 @@ async function main() {
   console.log(`Found ${threads.length} threads missing embeddings`);
 
   for (const t of threads) {
-    const seedText =
-      t.messages.map((m) => `${m.role}: ${m.content}`).join("\n") ||
-      t.title ||
-      "Untitled";
-
+    const seedText = t.messages.map(m => `${m.role}: ${m.content}`).join("\n") || t.title || "Untitled";
     const v = await embed(seedText);
     await prisma.chatThread.update({
       where: { id: t.id },
       data: { topicEmbedding: Buffer.from(new Float32Array(v).buffer) },
     });
-
     console.log(`✅ Backfilled ${t.id} (${t.title || "Untitled"})`);
   }
 
   console.log("🎉 Done backfilling thread embeddings.");
 }
+main().catch(e=>{console.error(e);process.exit(1)}).finally(async()=>{await prisma.$disconnect()});
 
-main()
-  .catch((e) => {
-    console.error(e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });


### PR DESCRIPTION
## Summary
- add recency-weighted, keyword-boosted context routing
- integrate intent/entity parsing and profile update detector in chat API
- add confidence-aware clarify prompt and backfill embedding script

## Testing
- `npm test`
- `npx tsx scripts/backfill-thread-embeddings.ts` *(fails: @prisma/client did not initialize yet)*
- `npm run lint` *(blocked: Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7a659284832f960782799247e843