### PR TITLE
feat: refresh medx UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+/* color palette */
+:root {
+  --p: #0564F5;
+  --ps: #639AE9;
+  --a: #EA4758;
+  --g50: #EFEFEF;
+  --g300: #C5C4C5;
+  --g400: #9C9D9E;
+}
+
 /* smooth theme transitions */
 * { transition: background-color .15s ease, color .15s ease, border-color .15s ease; }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata = { title: "MedX", description: "Global medical AI" };
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="min-h-screen bg-white dark:bg-slate-950 text-slate-900 dark:text-gray-100">
+      <body className="min-h-screen bg-white dark:bg-[#0B1020] text-slate-900 dark:text-[#F9FAFB]">
         <CountryProvider>
           <ContextProvider>
             <TopicProvider>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,7 +19,7 @@ export default function Header({
   onTherapyChange: (v: boolean) => void;
 }) {
   return (
-    <header className="sticky top-0 z-40 h-14 md:h-16 bg-white/80 dark:bg-gray-900/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:supports-[backdrop-filter]:bg-gray-900/60 border-b border-slate-200 dark:border-gray-800">
+    <header className="sticky top-0 z-40 h-14 md:h-16 bg-gradient-to-b from-[#f8fbff] to-white dark:from-[rgba(5,100,245,0.3)] dark:to-[rgba(5,100,245,0.1)] border-b border-[var(--g300)] dark:border-white/25">
       <div className="max-w-6xl mx-auto h-full px-4 sm:px-6 flex items-center justify-between">
         <div className="flex items-center gap-2 text-base md:text-lg font-semibold">
           <div>MedX</div>
@@ -29,7 +29,7 @@ export default function Header({
           <TherapyToggle onChange={onTherapyChange} />
           <button
             onClick={() => onModeChange(mode === 'patient' ? 'doctor' : 'patient')}
-            className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm bg-slate-100 text-slate-800 border-slate-200 hover:bg-slate-200 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700 dark:hover:bg-gray-700"
+            className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm border border-transparent transition shadow-sm bg-[var(--p)] text-white shadow"
           >
             {mode === 'patient' ? (
               <>

--- a/components/ResearchToggle.tsx
+++ b/components/ResearchToggle.tsx
@@ -9,13 +9,18 @@ export function ResearchToggle({ defaultOn=false, onChange }:{defaultOn?:boolean
 
   const toggle = () => { const v = !on; setOn(v); onChange?.(v); };
   return (
-    <button type="button" aria-pressed={on} onClick={toggle}
-      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition
-        ${on
-        ? "bg-emerald-100 text-emerald-900 border-emerald-200/60 dark:bg-emerald-900/30 dark:text-emerald-200 dark:border-emerald-800"
-        : "bg-slate-100 text-slate-800 border-slate-200 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700"}`}>
-      <span className={`inline-block h-2.5 w-2.5 rounded-full ${on?"bg-emerald-500":"bg-slate-400"}`} />
-      {on ? "Research On" : "Research Off"}
+    <button
+      type="button"
+      aria-pressed={on}
+      onClick={toggle}
+      className={`inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm border transition shadow-sm ${
+        on
+          ? 'bg-[var(--p)] text-white border-transparent shadow'
+          : 'bg-[var(--g50)] text-inherit border-[var(--g300)] opacity-85 hover:shadow dark:bg-[#0F172A] dark:text-[#CBD5E1] dark:border-[var(--g300)]'
+      }`}
+    >
+      <span className={`inline-block h-2.5 w-2.5 rounded-full ${on ? 'bg-white' : 'bg-[var(--g400)]'}`} />
+      {on ? 'Research On' : 'Research Off'}
     </button>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -31,14 +31,18 @@ export default function Sidebar() {
   };
   const filtered = threads.filter(t => t.title.toLowerCase().includes(q.toLowerCase()));
   return (
-    <nav className="sidebar-click-guard hidden md:flex md:flex-col !fixed inset-y-0 left-0 w-64 bg-white dark:bg-gray-900 border-r border-slate-200 dark:border-gray-800">
-      <button type="button" onClick={handleNew} className="mx-3 my-3 h-10 rounded-xl bg-slate-100 hover:bg-slate-200 dark:bg-gray-800 dark:hover:bg-gray-700 flex items-center justify-center gap-2">
+    <nav className="sidebar-click-guard hidden md:flex md:flex-col !fixed inset-y-0 left-0 w-64 rounded-r-2xl border-r border-[var(--g300)] bg-[var(--g50)] shadow-sm dark:bg-[#111827] dark:text-[#F9FAFB] dark:border-white/25 p-3">
+      <button
+        type="button"
+        onClick={handleNew}
+        className="w-full flex items-center gap-2 rounded-xl px-3 py-2.5 text-sm border border-dashed border-[var(--g300)] dark:border-white/25"
+      >
         <Plus size={16} /> New Chat
       </button>
 
       <div className="px-3">
         <div className="relative">
-          <input className="w-full h-10 rounded-lg pl-3 pr-8 bg-slate-100 dark:bg-gray-800 placeholder:text-slate-500 dark:placeholder:text-slate-500 text-sm" placeholder="Search chats" onChange={e => handleSearch(e.target.value)} />
+          <input className="w-full h-10 rounded-lg pl-3 pr-8 bg-white text-inherit placeholder:text-slate-500 border border-[var(--g300)] dark:bg-[#1F2937] dark:text-[#F9FAFB] dark:border-white/25 dark:placeholder:text-[#E5E7EB] text-sm" placeholder="Search chats" onChange={e => handleSearch(e.target.value)} />
           <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500" />
         </div>
         <Tabs />
@@ -49,7 +53,7 @@ export default function Sidebar() {
           <button
             key={t.id}
             onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
-            className="w-full text-left rounded-md px-2 py-1 text-sm hover:bg-muted"
+            className="w-full text-left rounded-md px-2 py-1 text-sm hover:bg-[var(--g50)] dark:hover:bg-white/10"
           >
             {t.title}
           </button>

--- a/components/TherapyToggle.tsx
+++ b/components/TherapyToggle.tsx
@@ -30,9 +30,9 @@ export default function TherapyToggle({
     onChange(next);
   }
 
-  const baseChip = 'rounded-full px-3 h-9 inline-flex items-center gap-2 border text-sm font-medium';
-  const onChip = 'bg-blue-100 text-blue-900 border-blue-300';
-  const offChip = 'bg-white text-neutral-900 border-neutral-300';
+  const baseChip = 'inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm border transition shadow-sm';
+  const onChip = 'bg-[var(--p)] text-white border-transparent shadow';
+  const offChip = 'bg-[var(--g50)] text-inherit border-[var(--g300)] opacity-85 hover:shadow dark:bg-[#0F172A] dark:text-[#CBD5E1] dark:border-[var(--g300)]';
 
   if (variant === 'floating') {
     return (

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -5,7 +5,7 @@ import Header from '../Header';
 import Markdown from '../Markdown';
 import ResearchFilters from '@/components/ResearchFilters';
 import { useResearchFilters } from '@/store/researchFilters';
-import { Send } from 'lucide-react';
+import { Send, Upload } from 'lucide-react';
 import { useCountry } from '@/lib/country';
 import { getRandomWelcome } from '@/lib/welcomeMessages';
 import { useActiveContext } from '@/lib/context';
@@ -152,16 +152,16 @@ No fabricated IDs. Provide themes, not specific trial numbers unless confident.`
 
 function PendingAnalysisCard({ label }: { label: string }) {
   return (
-    <article className="mr-auto max-w-[90%] rounded-2xl p-4 md:p-6 shadow-sm bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800">
-      <div className="text-sm text-slate-600 dark:text-slate-300">{label}</div>
+    <article className="mr-auto max-w-[75%] rounded-2xl px-4 py-3.5 text-sm leading-6 shadow-sm bg-[var(--g50)] border border-[var(--g300)] dark:bg-[#1F2937] dark:text-[#E5E7EB] dark:border-white/10">
+      <div className="text-sm text-slate-600 dark:text-[#E5E7EB]">{label}</div>
     </article>
   );
 }
 
 function PendingChatCard({ label }: { label: string }) {
   return (
-    <article className="mr-auto max-w-[90%] rounded-2xl p-4 md:p-6 shadow-sm bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800">
-      <div className="text-sm text-slate-600 dark:text-slate-300">{label}</div>
+    <article className="mr-auto max-w-[75%] rounded-2xl px-4 py-3.5 text-sm leading-6 shadow-sm bg-[var(--g50)] border border-[var(--g300)] dark:bg-[#1F2937] dark:text-[#E5E7EB] dark:border-white/10">
+      <div className="text-sm text-slate-600 dark:text-[#E5E7EB]">{label}</div>
     </article>
   );
 }
@@ -170,7 +170,7 @@ function AnalysisCard({ m, researchOn, onQuickAction, busy }: { m: Extract<ChatM
   const header = titleForCategory(m.category);
   if (m.pending) return <PendingAnalysisCard label="Analyzing file…" />;
   return (
-    <article className="mr-auto max-w-[90%] rounded-2xl p-4 md:p-6 shadow-sm space-y-2 bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800">
+    <article className="mr-auto max-w-[75%] rounded-2xl px-4 py-3.5 text-sm leading-6 shadow-sm space-y-2 bg-[var(--g50)] border border-[var(--g300)] dark:bg-[#1F2937] dark:text-[#E5E7EB] dark:border-white/10">
       <header className="flex items-center gap-2">
         <h2 className="text-lg md:text-xl font-semibold">{header}</h2>
         {researchOn && (
@@ -225,7 +225,7 @@ function AnalysisCard({ m, researchOn, onQuickAction, busy }: { m: Extract<ChatM
 function ChatCard({ m, therapyMode, onFollowUpClick, simple }: { m: Extract<ChatMessage, { kind: "chat" }>; therapyMode: boolean; onFollowUpClick: (text: string) => void; simple: boolean }) {
   if (m.pending) return <PendingChatCard label="Thinking…" />;
   return (
-    <article className="mr-auto max-w-[90%] rounded-2xl p-4 md:p-6 shadow-sm space-y-2 bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800">
+    <article className="mr-auto max-w-[75%] rounded-2xl px-4 py-3.5 text-sm leading-6 shadow-sm space-y-2 bg-[var(--g50)] border border-[var(--g300)] dark:bg-[#1F2937] dark:text-[#E5E7EB] dark:border-white/10">
       <div className="prose prose-slate dark:prose-invert max-w-none prose-medx text-sm md:text-base">
         <Markdown text={m.content} />
       </div>
@@ -983,7 +983,7 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
             m.role === 'user' ? (
               <div
                 key={m.id}
-                className="ml-auto max-w-[85%] rounded-2xl px-4 py-3 shadow-sm bg-slate-200 text-slate-900 dark:bg-gray-700 dark:text-gray-100"
+                className="ml-auto max-w-[75%] rounded-2xl px-4 py-3.5 text-sm leading-6 shadow-sm bg-[var(--p)] text-white"
               >
                 <Markdown text={m.content} />
               </div>
@@ -1073,10 +1073,14 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
               e.preventDefault();
               onSubmit();
             }}
-            className="w-full flex items-center gap-3 rounded-full border border-slate-200 dark:border-gray-800 bg-slate-100 dark:bg-gray-900 px-3 py-2"
+            className="w-full flex items-center gap-3 rounded-full border border-[var(--g300)] bg-white dark:border-white/10 dark:bg-[#1F2937] px-3 py-2"
           >
-            <label className="cursor-pointer px-3 py-1.5 text-sm rounded-full bg-slate-200 text-slate-800 hover:bg-slate-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">
-              📄
+            <label
+              className="cursor-pointer inline-flex items-center justify-center h-9 w-9 rounded-lg bg-white text-slate-600 border border-slate-300 hover:bg-slate-100 transition dark:bg-gray-700 dark:text-gray-100 dark:border-gray-700 dark:hover:bg-white/10"
+              title="Upload"
+              aria-label="Upload"
+            >
+              <Upload size={18} />
               <input
                 type="file"
                 accept="application/pdf,image/*"
@@ -1089,7 +1093,7 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
               />
             </label>
             {pendingFile && (
-              <div className="flex items-center gap-2 rounded-full bg-white/70 dark:bg-gray-800/70 px-3 py-1 text-xs">
+              <div className="flex items-center gap-2 rounded-full bg-white/70 dark:bg-[#1F2937]/70 px-3 py-1 text-xs">
                 <span className="truncate max-w-[8rem]">{pendingFile.name}</span>
                 <button
                   type="button"
@@ -1103,7 +1107,7 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
             )}
             <input
               ref={inputRef}
-              className="flex-1 bg-transparent outline-none text-sm md:text-base leading-6 placeholder:text-slate-400 dark:placeholder:text-slate-500 px-2"
+              className="flex-1 bg-transparent outline-none text-sm md:text-base leading-6 placeholder:text-slate-400 dark:placeholder:text-[#E5E7EB] px-2"
               placeholder={
                 pendingFile
                   ? 'Add a note or question for this document (optional)'


### PR DESCRIPTION
## Summary
- add palette variables and blue upload icon
- improve chat bubble contrast and sidebar visuals
- unify mode toggles and top bar styling

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bd904c5974832faed567650104a20f