### PR TITLE
Implement trials search API and frontend wiring

### DIFF
--- a/app/api/trials/search/route.ts
+++ b/app/api/trials/search/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { searchTrials } from "@/lib/trials/search";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+
+    const q = typeof body.query === "string" ? body.query.trim() : undefined;
+    const phase = body.phase as "1" | "2" | "3" | "4" | undefined;
+    const status = body.status as "Recruiting" | "Completed" | undefined;
+    const country = typeof body.country === "string" ? body.country : undefined;
+    const genes = Array.isArray(body.genes) ? body.genes : undefined;
+
+    const trials = await searchTrials({ query: q, phase, status, country, genes });
+
+    return NextResponse.json({ trials });
+  } catch (err: any) {
+    console.error("[API] /api/trials/search error:", err);
+    return NextResponse.json(
+      { error: err?.message || "Failed to fetch trials" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/components/TrialsDock.tsx
+++ b/components/TrialsDock.tsx
@@ -3,95 +3,28 @@
 import { useState } from "react";
 import TrialsSearchBar from "@/components/TrialsSearchBar";
 import TrialsTable from "@/components/TrialsTable";
-import { useResearchFilters } from "@/store/researchFilters";
 import type { TrialRow } from "@/types/trials";
 
-type FetchState =
-  | { kind: "idle" }
-  | { kind: "loading" }
-  | { kind: "error"; message: string }
-  | { kind: "done" };
-
 export default function TrialsDock() {
-  const [status, setStatus] = useState<FetchState>({ kind: "idle" });
   const [rows, setRows] = useState<TrialRow[]>([]);
-  const { filters } = useResearchFilters();
+  const [searched, setSearched] = useState(false);
 
-  // Map UI filters -> API strings
-  function mapPhase(p?: string): string | undefined {
-    if (!p) return undefined;
-    if (p === "1" || p === "2" || p === "3" || p === "4") return `Phase ${p}`;
-    return undefined;
-  }
-  function mapStatus(s?: string): string | undefined {
-    if (!s || s === "any") return undefined;
-    if (s.toLowerCase() === "recruiting") return "Recruiting";
-    if (s.toLowerCase() === "active") return "Active, not recruiting";
-    if (s.toLowerCase() === "completed") return "Completed";
-    return undefined;
-  }
-
-  async function doSearch(keyword: string) {
-    setStatus({ kind: "loading" });
-
-    try {
-      const phase = mapPhase((filters as any).phase);
-      const status = mapStatus((filters as any).status);
-      const countries: string[] = Array.isArray((filters as any).countries)
-        ? (filters as any).countries
-        : [];
-      const country = countries.includes("Worldwide") ? undefined : countries[0];
-      const genes =
-        Array.isArray((filters as any).genes) && (filters as any).genes.length
-          ? (filters as any).genes
-          : undefined;
-
-      const payload = {
-        query: keyword || undefined,
-        phase,
-        status,
-        country,
-        genes,
-      };
-
-      const res = await fetch("/api/trials", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      if (!res.ok) {
-        const msg = await res.text().catch(() => "");
-        throw new Error(`Trials API ${res.status}: ${msg || "Request failed"}`);
-      }
-
-      const data = await res.json().catch(() => ({}));
-      const all: TrialRow[] = Array.isArray(data?.trials) ? data.trials : [];
-
-      setRows(all);
-      setStatus({ kind: "done" });
-    } catch (err: any) {
-      setRows([]);
-      setStatus({ kind: "error", message: err?.message || "Failed to fetch trials" });
-    }
+  function handleTrials(trials: TrialRow[]) {
+    setRows(trials);
+    setSearched(true);
   }
 
   return (
     <div className="my-3">
-      <TrialsSearchBar onSearch={doSearch} busy={status.kind === "loading"} />
+      <TrialsSearchBar onTrials={handleTrials} />
 
-      {status.kind === "error" && (
-        <div className="text-red-600 text-sm my-2">
-          {status.message}
-        </div>
-      )}
-
-      {status.kind === "done" && rows.length === 0 && (
+      {searched && rows.length === 0 && (
         <div className="text-gray-600 text-sm my-2">
           No trials found. Try removing a filter, switching country, or using broader keywords.
         </div>
       )}
 
-      <TrialsTable rows={rows} />
+      {rows.length > 0 && <TrialsTable rows={rows} />}
     </div>
   );
 }

--- a/components/TrialsSearchBar.tsx
+++ b/components/TrialsSearchBar.tsx
@@ -1,32 +1,112 @@
 "use client";
 
 import { useState } from "react";
+import type { TrialRow } from "@/types/trials";
 
-export default function TrialsSearchBar({
-  onSearch,
-  busy,
-}: {
-  onSearch: (query: string) => void;
-  busy?: boolean;
-}) {
-  const [keyword, setKeyword] = useState("");
+type Props = {
+  onTrials?: (rows: TrialRow[]) => void;
+};
+
+export default function TrialsSearchBar({ onTrials }: Props) {
+  const [keywords, setKeywords] = useState("");
+  const [condition, setCondition] = useState("");
+  const [phase, setPhase] = useState("");
+  const [status, setStatus] = useState("");
+  const [country, setCountry] = useState("");
+  const [genesInput, setGenesInput] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    const payload = {
+      query: (keywords || condition || "").trim() || undefined,
+      phase: phase && phase !== "Any" ? phase : undefined,
+      status: status && status !== "Any" ? status : undefined,
+      country: country && country !== "Any" ? country : undefined,
+      genes: (genesInput || "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    } as any;
+
+    if (!payload.genes?.length) delete payload.genes;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/trials/search", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+
+      if (!res.ok || data.error) {
+        throw new Error(data.error || "Search failed");
+      }
+
+      onTrials?.(data.trials || []);
+    } catch (err: any) {
+      console.error("[Trials] search error", err);
+      setError(err.message || "Failed to fetch trials");
+      onTrials?.([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }
 
   return (
-    <div className="flex flex-wrap gap-2 items-center mb-3">
-      <input
-        className="border rounded px-2 py-1 min-w-[240px]"
-        placeholder="Keyword (e.g., leukemia)"
-        value={keyword}
-        onChange={(e) => setKeyword(e.target.value)}
-      />
-      <button
-        className="px-3 py-1 rounded bg-blue-600 text-white disabled:opacity-50"
-        disabled={!keyword || busy}
-        onClick={() => onSearch(keyword)}
-      >
-        {busy ? "Searching…" : "Search Trials"}
-      </button>
-    </div>
+    <form onSubmit={onSubmit} className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          className="border rounded px-2 py-1"
+          placeholder="Keywords"
+          value={keywords}
+          onChange={(e) => setKeywords(e.target.value)}
+        />
+        <input
+          className="border rounded px-2 py-1"
+          placeholder="Condition"
+          value={condition}
+          onChange={(e) => setCondition(e.target.value)}
+        />
+        <input
+          className="border rounded px-2 py-1"
+          placeholder="Phase"
+          value={phase}
+          onChange={(e) => setPhase(e.target.value)}
+        />
+        <input
+          className="border rounded px-2 py-1"
+          placeholder="Status"
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+        />
+        <input
+          className="border rounded px-2 py-1"
+          placeholder="Country"
+          value={country}
+          onChange={(e) => setCountry(e.target.value)}
+        />
+        <input
+          className="border rounded px-2 py-1"
+          placeholder="Genes (comma separated)"
+          value={genesInput}
+          onChange={(e) => setGenesInput(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="px-3 py-1 rounded bg-blue-600 text-white disabled:opacity-50"
+          disabled={isLoading}
+        >
+          {isLoading ? "Searching…" : "Search"}
+        </button>
+      </div>
+      {error && <div className="text-red-600 text-sm">{error}</div>}
+    </form>
   );
 }
 

--- a/components/panels/TrialsPane.tsx
+++ b/components/panels/TrialsPane.tsx
@@ -63,32 +63,47 @@ export default function TrialsPane() {
 
       <div className="text-sm text-gray-500">Informational only; not medical advice. Confirm eligibility with the sponsor.</div>
 
-      <div className="overflow-auto border rounded">
-        <table className="w-full text-sm">
-          <thead className="bg-gray-50">
-            <tr><th className="p-2 text-left">Title</th><th className="p-2">Phase</th><th className="p-2">Status</th><th className="p-2">Location</th><th className="p-2">NCT</th></tr>
-          </thead>
-          <tbody>
-            {rows.map(r=> (
-              <tr key={r.id} className="border-t">
-                <td className="p-2">
-                  {r.title}
-                  {r.hints && r.hints.length > 0 && (
-                    <span className="ml-1" title={r.hints.join('; ')}>⚑</span>
-                  )}
-                </td>
-                <td className="p-2 text-center">{r.phase||"—"}</td>
-                <td className="p-2 text-center">{r.status||"—"}</td>
-                <td className="p-2 text-center">{[r.city, r.country].filter(Boolean).join(", ")||"—"}</td>
-                <td className="p-2 text-center">
-                  {r.id ? <a className="underline" href={r.url} target="_blank" rel="noreferrer">{r.id}</a> : "—"}
-                </td>
+      {rows.length > 0 && (
+        <div className="overflow-auto border rounded">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="p-2 text-left">Title</th>
+                <th className="p-2">Phase</th>
+                <th className="p-2">Status</th>
+                <th className="p-2">Location</th>
+                <th className="p-2">NCT</th>
               </tr>
-            ))}
-            {!rows.length && <tr><td className="p-4 text-gray-400" colSpan={5}>No results yet</td></tr>}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr key={r.id} className="border-t">
+                  <td className="p-2">
+                    {r.title}
+                    {r.hints && r.hints.length > 0 && (
+                      <span className="ml-1" title={r.hints.join('; ')}>⚑</span>
+                    )}
+                  </td>
+                  <td className="p-2 text-center">{r.phase || "—"}</td>
+                  <td className="p-2 text-center">{r.status || "—"}</td>
+                  <td className="p-2 text-center">
+                    {[r.city, r.country].filter(Boolean).join(", ") || "—"}
+                  </td>
+                  <td className="p-2 text-center">
+                    {r.id ? (
+                      <a className="underline" href={r.url} target="_blank" rel="noreferrer">
+                        {r.id}
+                      </a>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/trials/search.ts
+++ b/lib/trials/search.ts
@@ -1,8 +1,52 @@
-import { fetchTrials } from "@/lib/trials";
-import type { TrialRow } from "@/types/trials";
-import { Topic } from "../topic/normalize";
+type Input = {
+  query?: string;
+  phase?: "1" | "2" | "3" | "4";
+  status?: "Recruiting" | "Completed";
+  country?: string;
+  genes?: string[];
+};
 
-export type Trial = { title: string; condition?: string };
+import { Topic } from "@/lib/topic/normalize";
+
+export type Trial = {
+  id: string;
+  title: string;
+  url: string;
+  phase?: "1" | "2" | "3" | "4";
+  status?: "Recruiting" | "Completed";
+  country?: string;
+  gene?: string;
+};
+
+function normalizePhase(p: any): "1" | "2" | "3" | "4" | undefined {
+  const phase = String(p || "").toLowerCase();
+  if (phase.includes("1")) return "1";
+  if (phase.includes("2")) return "2";
+  if (phase.includes("3")) return "3";
+  if (phase.includes("4")) return "4";
+  return undefined;
+}
+
+function normalizeStatus(s: any): "Recruiting" | "Completed" | undefined {
+  const status = String(s || "").toLowerCase();
+  if (status.includes("recruit")) return "Recruiting";
+  if (status.includes("complete")) return "Completed";
+  return undefined;
+}
+
+export async function searchTrials(input: Input): Promise<Trial[]> {
+  const results = await clinicalTrialsGovSearch(input);
+
+  return results.map((r: any) => ({
+    id: r.nctId || r.id,
+    title: r.title,
+    url: r.url,
+    phase: normalizePhase(r.phase),
+    status: normalizeStatus(r.status),
+    country: r.country,
+    gene: r.gene,
+  }));
+}
 
 export function scoreTrialRelevance(t: Trial, topic: Topic): number {
   const title = (t.title || "").toLowerCase();
@@ -18,22 +62,36 @@ export function filterTrials(trials: Trial[], topic: Topic): Trial[] {
   return trials.filter((t) => scoreTrialRelevance(t, topic) >= 2);
 }
 
-function geneMatch(r: TrialRow, genes: string[]): boolean {
-  const hay = `${r.title} ${r.interventions?.join(" ") ?? ""}`.toLowerCase();
-  return genes.every((g) => hay.includes(g.toLowerCase()));
-}
+async function clinicalTrialsGovSearch(input: Input): Promise<any[]> {
+  const terms: string[] = [];
+  if (input.query) terms.push(input.query);
+  if (input.genes?.length) terms.push(input.genes.join(" "));
+  if (input.country) terms.push(`location:${input.country}`);
+  if (input.phase) terms.push(`phase:${input.phase}`);
+  if (input.status) terms.push(`status:${input.status}`);
 
-export async function searchTrials(body: {
-  query: string;
-  phase?: string;
-  status?: string;
-  country?: string;
-  genes?: string[];
-}): Promise<TrialRow[]> {
-  console.log("Searching trials with:", body);
-  const { query, phase, status, country, genes } = body;
-  if (!query) return [];
-  const rows = await fetchTrials({ condition: query, phase, status, country, min: 1, max: 25 });
-  return genes && genes.length ? rows.filter((t) => geneMatch(t, genes)) : rows;
+  const q = encodeURIComponent(terms.join(" "));
+
+  const url = `https://clinicaltrials.gov/api/v2/studies?format=json&query.term=${q}&pageSize=25`;
+  const res = await fetch(url, { next: { revalidate: 3600 } });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`ClinicalTrials.gov error ${res.status}: ${text}`);
+  }
+
+  const data = await res.json();
+
+  const items = (data?.studies || []).map((s: any) => ({
+    id: s.protocolSection?.identificationModule?.nctId,
+    title: s.protocolSection?.identificationModule?.briefTitle,
+    url: `https://clinicaltrials.gov/study/${s.protocolSection?.identificationModule?.nctId}`,
+    phase: s.protocolSection?.designModule?.phases?.[0],
+    status: s.protocolSection?.statusModule?.overallStatus,
+    country: s.protocolSection?.contactsLocationsModule?.locations?.[0]?.country,
+    gene: undefined,
+  }));
+
+  return items;
 }
 


### PR DESCRIPTION
## Summary
- add `/api/trials/search` endpoint that calls new provider wrapper
- front-end search bar submits cleaned filters and handles errors
- render trials table only when results exist

## Testing
- `node tools/check-placeholders.cjs`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bda44b5c14832f9ea0cf8a0528a501