### PR TITLE
refactor trials search filters

### DIFF
--- a/lib/trials/api.ts
+++ b/lib/trials/api.ts
@@ -1,0 +1,22 @@
+import type { TrialRow } from "@/types/trials";
+
+export async function searchTrials(filters: {
+  condition?: string;
+  phase?: number | "any";
+  status?: string | "any";
+  country?: string[];
+  genes?: string[];
+}): Promise<TrialRow[]> {
+  const params = new URLSearchParams();
+
+  if (filters.condition) params.append("condition", filters.condition);
+  if (filters.phase && filters.phase !== "any") params.append("phase", String(filters.phase));
+  if (filters.status && filters.status !== "any") params.append("status", filters.status);
+  if (filters.country?.length) params.append("country", filters.country.join(","));
+  if (filters.genes?.length) params.append("genes", filters.genes.join(","));
+
+  const res = await fetch(`/api/trials/search?${params.toString()}`);
+  if (!res.ok) throw new Error("Failed to fetch trials");
+  const data = await res.json();
+  return data.trials || [];
+}


### PR DESCRIPTION
## Summary
- remove plain filter inputs and unify trials search bar state
- add client helper to serialize filters to query params
- update server route to parse query params and query ClinicalTrials.gov

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaa5d1468832f834670dcb1f872fd