### PR TITLE
feat: add conversational ack handling

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -1,9 +1,35 @@
 import { NextRequest } from 'next/server';
 import { profileChatSystem } from '@/lib/profileChatSystem';
+import { classifyAct } from '@/lib/nlu/markers';
+import { politeAck, suggestNextByContext } from '@/lib/text/polish';
 export const runtime = 'edge';
 
 export async function POST(req: NextRequest) {
-  const { messages = [], threadId, context } = await req.json();
+  const body = await req.json();
+  const { messages = [], threadId, context } = body;
+  const history = messages;
+  const lastUser = [...history].reverse().find((m: any) => m.role === 'user');
+  const userText: string = lastUser?.content ?? '';
+  const lastAssistant = [...history].reverse().find((m: any) => m.role === 'assistant');
+  const lastTopic =
+    lastAssistant?.meta?.topic ||
+    // Fallback: try to extract a topic-ish hint from last assistant title/heading
+    lastAssistant?.title ||
+    lastAssistant?.topic ||
+    undefined;
+
+  const act = classifyAct(userText, lastTopic);
+
+  // If it's an acknowledgment, short-circuit with a warm, context-tied reply.
+  if (act === 'ack') {
+    const nextActions = suggestNextByContext(lastTopic);
+    const text = politeAck({ topic: lastTopic, nextActions }, 'warm');
+    return new Response(
+      JSON.stringify({ reply: text, meta: { act, topic: lastTopic, handledBy: 'ack-shortcircuit' } }),
+      { headers: { 'content-type': 'application/json' } }
+    );
+  }
+
   const base  = process.env.LLM_BASE_URL!;
   const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
   const key   = process.env.LLM_API_KEY!;

--- a/lib/nlu/markers.test.ts
+++ b/lib/nlu/markers.test.ts
@@ -1,0 +1,10 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { classifyAct } from './markers';
+
+test('classifies niceties as ack', () => {
+  assert.equal(classifyAct('nice'), 'ack');
+  assert.equal(classifyAct('Exactly.'), 'ack');
+  assert.equal(classifyAct('thanks!!'), 'ack');
+  assert.equal(classifyAct('great 👍'), 'ack');
+});

--- a/lib/nlu/markers.ts
+++ b/lib/nlu/markers.ts
@@ -1,0 +1,37 @@
+import type { ConversationalAct } from "@/types/conversation";
+
+const ACK_PATTERNS = [
+  "nice", "great", "exactly", "perfect", "awesome", "cool",
+  "thanks", "thank you", "good job", "well done", "works", "love it",
+  "sweet", "sounds good", "looks good", "nailed it", "amazing"
+];
+
+function normalize(s: string) {
+  return s
+    .toLowerCase()
+    .replace(/\p{Extended_Pictographic}+/gu, "") // strip emojis
+    .replace(/[^a-z0-9\s]/g, " ")               // strip punctuation
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function classifyAct(userText: string, lastTopic?: string): ConversationalAct {
+  const n = normalize(userText);
+
+  // Exact ack?
+  if (ACK_PATTERNS.some(p => n === p || n.startsWith(p))) return "ack";
+
+  // Short consent/confirmation
+  if (/\b(ok|okay|cool|yep|yup|sure|done|great|perfect)\b/.test(n)) return "ack";
+
+  // Heuristics: if very short and no verbs → likely ack
+  if (n.split(" ").length <= 3 && !/\b(what|how|why|when|where|who|can|should|make|do)\b/.test(n)) {
+    return "ack";
+  }
+
+  // If message references previous topic terms, treat as followup
+  if (lastTopic && n.includes(normalize(lastTopic))) return "followup";
+
+  // Default: new topic or clarify
+  return /(\?$|^why|^how|^what|^can|^should)/.test(n) ? "clarify" : "new_topic";
+}

--- a/lib/nlu/topicHint.ts
+++ b/lib/nlu/topicHint.ts
@@ -1,0 +1,7 @@
+export function inferTopicFromAssistant(text: string): string | undefined {
+  if (/butter chicken/i.test(text)) return "Butter chicken recipe";
+  if (/clinical trial/i.test(text)) return "Clinical trials";
+  if (/diet|meal plan/i.test(text)) return "Diet plan";
+  if (/workout|strength|abs/i.test(text)) return "Workout plan";
+  return undefined;
+}

--- a/lib/text/polish.ts
+++ b/lib/text/polish.ts
@@ -29,3 +29,36 @@ export function polishText(input: string): string {
 
   return s;
 }
+
+type AckTone = "warm" | "neutral";
+
+export type TopicHint = {
+  topic?: string;          // e.g., "butter chicken recipe", "leukemia trials"
+  nextActions?: string[];  // brief CTA suggestions
+};
+
+export function politeAck(hint: TopicHint, tone: AckTone = "warm") {
+  const topic = hint.topic ? ` on **${hint.topic}**` : "";
+  const actions = hint.nextActions?.length
+    ? ` Want me to ${hint.nextActions.map((a, i) => (i === 0 ? a : a)).join(" or ")}?`
+    : "";
+
+  const base =
+    tone === "warm"
+      ? "Glad that helps! "
+      : "Noted. ";
+
+  return `${base}Appreciate the feedback${topic}.${actions}`;
+}
+
+/**
+ * Short helper to generate crisp suggestions by context.
+ */
+export function suggestNextByContext(topic?: string) {
+  if (!topic) return ["continue", "save this"];
+  const n = topic.toLowerCase();
+  if (n.includes("recipe")) return ["lock this recipe", "add variations", "generate a shopping list"];
+  if (n.includes("trial") || n.includes("trials")) return ["refine filters", "save these results", "set an alert"];
+  if (n.includes("diet") || n.includes("workout")) return ["save this plan", "tune macros", "make a grocery list"];
+  return ["continue", "save this"];
+}

--- a/types/conversation.ts
+++ b/types/conversation.ts
@@ -1,0 +1,5 @@
+export type ConversationalAct =
+  | "ack"          // nice / exactly / thanks
+  | "clarify"      // user asks clarification
+  | "followup"     // user extends same topic
+  | "new_topic";   // clearly different topic


### PR DESCRIPTION
## Summary
- add `ConversationalAct` type and lightweight marker classifier
- generate warm, topic-aware acknowledgements with suggested next steps
- short-circuit chat stream route when user sends acknowledgement

## Testing
- `npm test`
- `npx tsx --test lib/nlu/markers.test.ts`
- `npm run lint` *(fails: interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaf521b7c832fac24a8e936b65c48