### PR TITLE
Preserve chat thread when switching tabs

### DIFF
--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -62,11 +62,18 @@ function NavLink({
 }
 
 export default function Tabs() {
+  // preserve current threadId when navigating back to Chat
+  const params = useSearchParams();
+  const currentThreadId = params.get("threadId") || undefined;
   return (
     <ul className="mt-3 space-y-1">
       {tabs.map((t) => (
         <li key={t.key}>
-          <NavLink panel={t.panel} threadId={t.threadId} context={t.context}>
+          <NavLink
+            panel={t.panel}
+            threadId={t.key === "chat" ? (t.threadId ?? currentThreadId) : t.threadId}
+            context={t.context}
+          >
             {t.label}
           </NavLink>
         </li>


### PR DESCRIPTION
## Summary
- keep current threadId when leaving and returning to Chat so chat state persists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb652e7bc832fab100ff46a85207f