### PR TITLE
feat: improve dark mode contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
 .btn-secondary{
   @apply inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm transition
          bg-white text-slate-700 border-slate-200 hover:bg-slate-50
-         dark:bg-gray-900 dark:text-slate-200 dark:border-gray-700 dark:hover:bg-gray-800;
+         dark:bg-gray-800 dark:text-slate-100 dark:border-gray-600 dark:hover:bg-gray-700;
 }
 
 /* Ensures sidebar sits above content and accepts clicks */
@@ -55,10 +55,11 @@
   margin-bottom: 0.4rem;
 }
 
-/* Make bullets a touch lighter in dark mode */
-.dark .prose-medx :where(li)::marker {
-  color: rgb(148 163 184); /* slate-400 */
-}
+/* Ensure body/content contrast in dark */
+.dark body { color: rgb(229 231 235); }           /* text-gray-200 */
+.dark .card,.dark .panel { background: #0f172a; } /* slate-900 */
+.dark .border { border-color: rgb(71 85 105); }   /* slate-600 */
+.dark .prose-medx :where(li)::marker { color: rgb(148 163 184); }
 
 :root.therapy-mode, .therapy-mode body {
   /* keep it gentle and readable */


### PR DESCRIPTION
## Summary
- enhance dark theme styling for secondary buttons
- add global dark mode tokens for body, panels, borders, and list markers

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb6760eb4832f83a0485c875784ca