### PR TITLE
emit profile update event and guard overlays

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -82,3 +82,8 @@
   @apply border border-gray-300 px-2 py-1;
 }
 
+.content-layer {
+  position: relative;
+  z-index: 1;
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ export default function Page({ searchParams }: { searchParams: Search }) {
   }, []);
 
   return (
-    <>
+    <main className="flex-1 overflow-y-auto content-layer">
       <section className={panel === "chat" ? "block h-full" : "hidden"}>
         <ResearchFiltersProvider>
           <ChatPane inputRef={chatInputRef} />
@@ -42,6 +42,6 @@ export default function Page({ searchParams }: { searchParams: Search }) {
       <section className={panel === "settings" ? "block" : "hidden"}>
         <SettingsPane />
       </section>
-    </>
+    </main>
   );
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -319,6 +319,16 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     addAssistant(content, { id });
   }
 
+  useEffect(() => {
+    const onProfileUpdated = () => {
+      // if profile thread is open, nudge a silent refresh of readiness/prompts
+      // (kept light: we don’t spam messages, just clear cached “askedRecently”.)
+      sessionStorage.removeItem('asked:proactive');
+    };
+    window.addEventListener('profile-updated', onProfileUpdated);
+    return () => window.removeEventListener('profile-updated', onProfileUpdated);
+  }, []);
+
   // Load per-thread UI whenever threadId changes
   useEffect(() => {
     if (!threadId) { setUi(UI_DEFAULTS); return; }
@@ -477,7 +487,12 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
       return; // wait for user Yes/No
     }
     setNote('');
-    if (!isProfileThread && threadId && messages.filter(m => m.role === 'user').length === 0) {
+    if (
+      !isProfileThread &&
+      threadId &&
+      text.trim() &&
+      messages.filter(m => m.role === 'user').length === 0
+    ) {
       updateThreadTitle(threadId, generateTitle(text));
     }
 

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -129,7 +129,7 @@ export default function MedicalProfile() {
   };
 
   return (
-    <div className="p-4 space-y-4">
+    <div className="p-4 space-y-4 relative z-0">
       <section className="rounded-xl border p-4">
         <div className="flex items-center justify-between">
           <h2 className="font-semibold">Patient Info</h2>
@@ -194,6 +194,9 @@ export default function MedicalProfile() {
                   if (!r.ok) throw new Error(await r.text());
                   await loadProfile();
                   await loadSummary(); // ensure visible summary reflects just-saved arrays
+                  if (typeof window !== "undefined") {
+                    window.dispatchEvent(new Event("profile-updated"));
+                  }
                 } catch (e: any) {
                   alert(e.message || "Save failed");
                 } finally {


### PR DESCRIPTION
## Summary
- dispatch `profile-updated` after saving medical profile so other panels refresh
- refresh chat context on profile updates and avoid empty auto-titles
- ensure profile/main content is above overlays via `content-layer`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdba2a0244832f830570e6a7bd5b24