### PR TITLE
feat: unify trials search filters

### DIFF
--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { fetchTrials } from "@/lib/research/searchTrials";
+import { useTrialsSearchStore } from "@/lib/research/useTrialsSearchStore";
+import TopBar from "@/components/research/TopBar";
+import FiltersBar from "@/components/research/FiltersBar";
+
+export default function ResearchPage() {
+  const { set } = useTrialsSearchStore();
+  const onSearch = async () => {
+    await fetchTrials();
+  };
+
+  return (
+    <>
+      <TopBar />
+      <div className="px-4">
+        <FiltersBar onSearch={onSearch} />
+        {/* trials table */}
+      </div>
+    </>
+  );
+}

--- a/components/research/FiltersBar.tsx
+++ b/components/research/FiltersBar.tsx
@@ -1,0 +1,108 @@
+"use client";
+import { useTrialsSearchStore } from "@/lib/research/useTrialsSearchStore";
+
+const countryMap = {
+  "United States": "US",
+  India: "IN",
+  "United Kingdom": "GB",
+  Japan: "JP",
+  "European Union": "EU",
+  Worldwide: "WW",
+} as const;
+
+export default function FiltersBar({ onSearch }: { onSearch: () => void }) {
+  const { phases, status, countries, genes, set, q } = useTrialsSearchStore();
+
+  const togglePhase = (p: 1 | 2 | 3 | 4) =>
+    set({ phases: phases.includes(p) ? phases.filter((x) => x !== p) : [...phases, p] });
+
+  const toggleCountry = (label: keyof typeof countryMap) => {
+    const iso = countryMap[label];
+    set({ countries: countries.includes(iso) ? countries.filter((c) => c !== iso) : [...countries, iso] });
+  };
+
+  return (
+    <div className="px-4 pt-3 pb-2">
+      {/* phase chips */}
+      <div className="flex flex-wrap gap-2">
+        {[1, 2, 3, 4].map((p) => (
+          <button
+            key={p}
+            onClick={() => togglePhase(p as 1 | 2 | 3 | 4)}
+            className={`px-2 py-1 rounded border text-xs ${
+              phases.includes(p as 1 | 2 | 3 | 4)
+                ? "bg-blue-600 text-white border-blue-600"
+                : "bg-white dark:bg-slate-800 dark:border-slate-700"
+            }`}
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+
+      {/* status select */}
+      <div className="mt-2">
+        <select
+          value={status}
+          onChange={(e) => set({ status: e.target.value as any })}
+          className="rounded border px-2 py-1 text-sm dark:bg-slate-800 dark:border-slate-700"
+        >
+          <option>Any</option>
+          <option>Recruiting</option>
+          <option>Active, not recruiting</option>
+          <option>Completed</option>
+          <option>Enrolling by invitation</option>
+        </select>
+      </div>
+
+      {/* countries */}
+      <div className="mt-2 flex flex-wrap gap-2">
+        {(
+          [
+            "United States",
+            "India",
+            "European Union",
+            "United Kingdom",
+            "Japan",
+            "Worldwide",
+          ] as const
+        ).map((lbl) => (
+          <button
+            key={lbl}
+            onClick={() => toggleCountry(lbl)}
+            className={`px-2 py-1 rounded border text-xs ${
+              countries.includes(countryMap[lbl])
+                ? "bg-blue-600 text-white border-blue-600"
+                : "bg-white dark:bg-slate-800 dark:border-slate-700"
+            }`}
+          >
+            {lbl}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 flex items-center gap-2">
+        <input
+          placeholder="Genes (comma separated)"
+          defaultValue={genes.join(",")}
+          onBlur={(e) =>
+            set({ genes: e.target.value.split(",").map((s) => s.trim()).filter(Boolean) })
+          }
+          className="flex-1 rounded border px-2 py-1 text-sm dark:bg-slate-800 dark:border-slate-700"
+        />
+        <button
+          onClick={onSearch}
+          className="px-3 py-1.5 rounded-lg text-sm border bg-blue-600 text-white dark:border-blue-600"
+        >
+          Apply
+        </button>
+        <button
+          onClick={() => set({ phases: [], status: "Any", countries: [], genes: [] })}
+          className="px-3 py-1.5 rounded-lg text-sm border"
+        >
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/research/TopBar.tsx
+++ b/components/research/TopBar.tsx
@@ -11,8 +11,8 @@ export default function TopBar() {
         onKeyDown={(e) =>
           e.key === "Enter" &&
           document
-            .getElementById("trials-search-btn")?
-            .dispatchEvent(new Event("click", { bubbles: true }))
+            .getElementById("trials-search-btn")
+            ?.dispatchEvent(new Event("click", { bubbles: true }))
         }
         placeholder="Search trials (e.g., cancer, EGFR, melanoma)…"
         className="w-full rounded-lg border px-3 py-2 text-sm dark:bg-slate-800 dark:border-slate-700"

--- a/components/research/TopBar.tsx
+++ b/components/research/TopBar.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { useTrialsSearchStore } from "@/lib/research/useTrialsSearchStore";
+
+export default function TopBar() {
+  const { q, set } = useTrialsSearchStore();
+  return (
+    <div className="flex items-center gap-2 px-4 py-3 border-b bg-white dark:bg-slate-900 sticky top-0 z-10">
+      <input
+        value={q}
+        onChange={(e) => set({ q: e.target.value })}
+        onKeyDown={(e) =>
+          e.key === "Enter" &&
+          document
+            .getElementById("trials-search-btn")?
+            .dispatchEvent(new Event("click", { bubbles: true }))
+        }
+        placeholder="Search trials (e.g., cancer, EGFR, melanoma)…"
+        className="w-full rounded-lg border px-3 py-2 text-sm dark:bg-slate-800 dark:border-slate-700"
+      />
+      <button
+        id="trials-search-btn"
+        className="px-3 py-2 rounded-lg text-sm border bg-blue-600 text-white dark:border-blue-600"
+      >
+        Search
+      </button>
+    </div>
+  );
+}

--- a/lib/research/searchTrials.ts
+++ b/lib/research/searchTrials.ts
@@ -1,0 +1,29 @@
+import { useTrialsSearchStore } from "./useTrialsSearchStore";
+
+const iso2ToApi = (iso: string) => {
+  if (iso === "WW") return "Worldwide";
+  if (iso === "EU") return "European Union";
+  return iso; // "US","IN","GB","JP"
+};
+
+export async function fetchTrials() {
+  const { q, phases, status, countries, genes } = useTrialsSearchStore.getState();
+
+  const params = new URLSearchParams();
+  if (q) params.set("q", q);
+
+  // API expects phases as CSV of integers: "1,2"
+  if (phases.length) params.set("phase", phases.join(","));
+
+  // API expects status as exact text; omit "Any"
+  if (status && status !== "Any") params.set("status", status);
+
+  // Countries: send as CSV of labels the backend understands
+  if (countries.length) params.set("country", countries.map(iso2ToApi).join(","));
+
+  if (genes.length) params.set("genes", genes.join(","));
+
+  const res = await fetch(`/api/trials?${params.toString()}`, { cache: "no-store" });
+  if (!res.ok) throw new Error("Failed to fetch trials");
+  return res.json();
+}

--- a/lib/research/useTrialsSearchStore.ts
+++ b/lib/research/useTrialsSearchStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+
+type Phase = 1 | 2 | 3 | 4;
+type Status = "Recruiting" | "Completed" | "Active, not recruiting" | "Enrolling by invitation";
+type CountryISO2 = "US" | "IN" | "GB" | "JP" | "EU" | "WW";
+
+type State = {
+  q: string;
+  phases: Phase[];
+  status: Status | "Any";
+  countries: CountryISO2[];
+  genes: string[];
+  set: (p: Partial<State>) => void;
+};
+
+export const useTrialsSearchStore = create<State>((set) => ({
+  q: "",
+  phases: [],
+  status: "Any",
+  countries: [],
+  genes: [],
+  set: (p) => set(p),
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "remark-gfm": "^4.0.1",
         "tesseract.js": "^5.0.5",
         "undici": "^5.29.0",
-        "zod": "^3.25.76"
+        "zod": "^3.25.76",
+        "zustand": "^4.5.2"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.16",
@@ -9547,6 +9548,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9991,6 +10001,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "remark-gfm": "^4.0.1",
     "tesseract.js": "^5.0.5",
     "undici": "^5.29.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",


### PR DESCRIPTION
## Summary
- add Zustand store for trial search filters
- implement top and bottom filter bars using shared state
- serialize search params before calling trials API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdba852ea0832fb4234cc58f2cafdc