### PR TITLE
feat: polish conversations and improve chat rendering

### DIFF
--- a/components/chat/Renderer.tsx
+++ b/components/chat/Renderer.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from "react";
+
+export const Renderer = {
+  h1: ({ children }: { children: ReactNode }) => (
+    <h1 className="text-lg font-semibold">{children}</h1>
+  ),
+  ul: ({ children }: { children: ReactNode }) => (
+    <ul className="list-disc ml-4 space-y-1">{children}</ul>
+  ),
+};

--- a/lib/conversation/acknowledgment.ts
+++ b/lib/conversation/acknowledgment.ts
@@ -1,0 +1,13 @@
+export function acknowledgmentLayer(msg: string): string | null {
+  const lower = msg.toLowerCase();
+  if (["thanks", "thank you"].includes(lower)) {
+    return "Appreciate that 🙏 Want me to expand on it?";
+  }
+  if (["nice", "great", "exactly"].includes(lower)) {
+    return "Glad it landed well! Should I refine this further?";
+  }
+  if (["ok", "okay", "sure"].includes(lower)) {
+    return "Got it 👍 Want me to continue?";
+  }
+  return null;
+}

--- a/lib/conversation/disambiguation.ts
+++ b/lib/conversation/disambiguation.ts
@@ -1,0 +1,9 @@
+export function disambiguate(userMsg: string, context: string): string | null {
+  if (/spicy/i.test(userMsg)) {
+    return "Got it — do you mean more chili in the marinade, or extra heat in the sauce?";
+  }
+  if (/expand|more/i.test(userMsg) && context.includes("recipe")) {
+    return "Do you want me to add more steps, or give alternative ingredients?";
+  }
+  return null;
+}

--- a/lib/conversation/middleware.ts
+++ b/lib/conversation/middleware.ts
@@ -1,0 +1,10 @@
+export function withContextRetention(baseHandler: (ctx: any) => any) {
+  return async (ctx: any) => {
+    const msg = ctx.lastUserMessage?.trim().toLowerCase();
+    if (["ok", "okay", "yes", "sure", "nice", "thanks", "thank you"].includes(msg)) {
+      ctx.meta = ctx.meta || {};
+      ctx.meta.addAcknowledgment = true;
+    }
+    return baseHandler(ctx);
+  };
+}

--- a/lib/conversation/polish.ts
+++ b/lib/conversation/polish.ts
@@ -1,0 +1,13 @@
+export function polishResponse(text: string): string {
+  let polished = text
+    .replace(/\s{2,}/g, " ")
+    .replace(/\.\.\.$/, "…");
+
+  // Capitalize first letter
+  polished = polished.charAt(0).toUpperCase() + polished.slice(1);
+
+  // Remove lazy "etc."
+  polished = polished.replace(/\betc\.*$/i, "");
+
+  return polished.trim();
+}


### PR DESCRIPTION
## Summary
- add context-retention middleware for smoother conversational flow
- introduce acknowledgment, polish, and disambiguation layers
- standardize chat renderer headings and lists

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc1469fb8832fa91043401baaeccf