### PR TITLE
feat: add user memory system

### DIFF
--- a/app/api/memory/route.ts
+++ b/app/api/memory/route.ts
@@ -1,8 +1,61 @@
 import { NextResponse } from "next/server";
-import { upsertProfileMemory } from "@/lib/memory/store";
+import { createClient } from "@/lib/supabase/server";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const scope = searchParams.get("scope");
+  const thread_id = searchParams.get("thread_id");
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  let q = supabase.from("medx_memory").select("*").eq("user_id", user.id);
+  if (scope) q = q.eq("scope", scope);
+  if (thread_id) q = q.eq("thread_id", thread_id);
+
+  const { data, error } = await q.order("updated_at", { ascending: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ items: data });
+}
 
 export async function POST(req: Request) {
-  const { threadId, key, value } = await req.json();
-  const mem = await upsertProfileMemory(threadId, key, value);
-  return NextResponse.json({ ok: true, memory: { key: mem.key, value: mem.value } });
+  const body = await req.json();
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  const payload = Array.isArray(body) ? body : [body];
+  const rows = payload.map((m: any) => ({
+    user_id: user.id,
+    scope: m.scope ?? "global",
+    thread_id: m.thread_id ?? null,
+    key: m.key,
+    value: m.value,
+    source: m.source ?? "manual",
+    confidence: m.confidence ?? 0.8,
+  }));
+
+  const { data, error } = await supabase.from("medx_memory")
+    .upsert(rows, { onConflict: "user_id,scope,thread_id,key" })
+    .select("*");
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ items: data });
+}
+
+export async function DELETE(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+
+  if (!id) return NextResponse.json({ error: "missing id" }, { status: 400 });
+  const { error } = await supabase.from("medx_memory")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
 }

--- a/app/api/memory/suggest/route.ts
+++ b/app/api/memory/suggest/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+const RX = {
+  allergy: /\ballergic to\s+([a-z0-9\s\-]+)/i,
+  med: /\bon\s+([A-Za-z][A-Za-z0-9\-\s]+)\s*(\d+\s*(mg|mcg|iu))?/i,
+  diet: /\b(vegetarian|vegan|keto|gluten[-\s]*free|low\s*carb)\b/i,
+};
+
+export async function POST(req: Request) {
+  const { text, thread_id } = await req.json();
+  const out: any[] = [];
+
+  const allergy = RX.allergy.exec(text);
+  if (allergy) out.push({ key: "allergy", value: { item: allergy[1].trim() }, scope: "global" });
+
+  const med = RX.med.exec(text);
+  if (med) out.push({ key: "medication", value: { name: med[1], dose: med[2] }, scope: "thread", thread_id });
+
+  const diet = RX.diet.exec(text);
+  if (diet) out.push({ key: "diet_preference", value: { label: diet[1].toLowerCase() }, scope: "global" });
+
+  return NextResponse.json({ suggestions: out });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { CountryProvider } from "@/lib/country";
 import { ContextProvider } from "@/lib/context";
 import { TopicProvider } from "@/lib/topic";
 import { Suspense } from "react";
+import MemorySnackbar from "@/components/memory/Snackbar";
 
 export const metadata = { title: "MedX", description: "Global medical AI" };
 
@@ -22,6 +23,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   </Suspense>
                   <main className="flex-1 md:ml-64 min-h-dvh flex flex-col relative z-0">
                     {children}
+                    <MemorySnackbar />
                   </main>
                 </div>
               </ThemeProvider>

--- a/components/memory/Snackbar.tsx
+++ b/components/memory/Snackbar.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { useMemoryStore } from "@/lib/memory/useMemoryStore";
+
+export default function MemorySnackbar() {
+  const { suggestions, clearSuggestion } = useMemoryStore();
+
+  if (!suggestions.length) return null;
+  const current = suggestions[0];
+
+  const onSave = async () => {
+    await fetch("/api/memory", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(current),
+    });
+    clearSuggestion(current.key);
+  };
+
+  const onDismiss = () => clearSuggestion(current.key);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 max-w-sm rounded-xl border bg-white dark:bg-slate-800 shadow-lg p-3">
+      <div className="text-sm mb-2">Save memory: {current.key}?</div>
+      <div className="flex gap-2 justify-end">
+        <button onClick={onDismiss} className="px-3 py-1 border text-sm">No</button>
+        <button onClick={onSave} className="px-3 py-1 bg-blue-600 text-white text-sm">Save</button>
+      </div>
+    </div>
+  );
+}

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -21,6 +21,7 @@ import FeedbackBar from "@/components/FeedbackBar";
 import type { ChatMessage as BaseChatMessage } from "@/types/chat";
 import type { AnalysisCategory } from '@/lib/context';
 import { ensureThread, loadMessages, saveMessages, generateTitle, updateThreadTitle } from '@/lib/chatThreads';
+import { useMemoryStore } from "@/lib/memory/useMemoryStore";
 
 type ChatUiState = {
   topic: string | null;
@@ -287,6 +288,7 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
 
   const [trialRows, setTrialRows] = useState<TrialRow[]>([]);
   const [searched, setSearched] = useState(false);
+  const pushSuggestion = useMemoryStore(s => s.pushSuggestion);
 
   function handleTrials(rows: TrialRow[]) {
     setTrialRows(rows);
@@ -905,6 +907,15 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
       await analyzeFile(pendingFile, note);
     } else {
       await send(note, researchMode);
+      try {
+        const res = await fetch('/api/memory/suggest', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text: note, thread_id: threadId }),
+        });
+        const j = await res.json().catch(() => null);
+        j?.suggestions?.forEach((m: any) => pushSuggestion(m));
+      } catch {}
     }
   }
 

--- a/lib/memory/useMemoryStore.ts
+++ b/lib/memory/useMemoryStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+
+export type MemoryItem = {
+  id?: string;
+  key: string;
+  value: any;
+  scope: "global" | "thread";
+  thread_id?: string;
+};
+
+type State = {
+  enabled: boolean;
+  rememberThisThread: boolean;
+  suggestions: MemoryItem[];
+  setEnabled: (v: boolean) => void;
+  setRememberThisThread: (v: boolean) => void;
+  pushSuggestion: (m: MemoryItem) => void;
+  clearSuggestion: (key: string) => void;
+};
+
+export const useMemoryStore = create<State>((set) => ({
+  enabled: true,
+  rememberThisThread: false,
+  suggestions: [],
+  setEnabled: (v) => set({ enabled: v }),
+  setRememberThisThread: (v) => set({ rememberThisThread: v }),
+  pushSuggestion: (m) => set(s => ({ suggestions: [...s.suggestions, m] })),
+  clearSuggestion: (key) => set(s => ({ suggestions: s.suggestions.filter(x => x.key !== key) })),
+}));

--- a/lib/prompt/contextBuilder.ts
+++ b/lib/prompt/contextBuilder.ts
@@ -1,0 +1,21 @@
+import { createClient } from "@/lib/supabase/server";
+
+export async function buildContextBundle(thread_id?: string) {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return {};
+
+  const { data: globalMem } = await supabase
+    .from("medx_memory").select("key,value")
+    .eq("user_id", user.id).eq("scope","global").limit(8);
+
+  let threadMem: any[] = [];
+  if (thread_id) {
+    const { data } = await supabase
+      .from("medx_memory").select("key,value")
+      .eq("user_id", user.id).eq("scope","thread").eq("thread_id", thread_id).limit(8);
+    threadMem = data ?? [];
+  }
+
+  return { memories: [...(globalMem ?? []), ...threadMem] };
+}

--- a/lib/prompt/systemPrompt.ts
+++ b/lib/prompt/systemPrompt.ts
@@ -1,0 +1,14 @@
+import { buildContextBundle } from "./contextBuilder";
+
+export async function systemPrompt(thread_id?: string) {
+  const bundle = await buildContextBundle(thread_id);
+  const memoryLines = (bundle.memories ?? [])
+    .map(m => `- ${m.key}: ${JSON.stringify(m.value)}`).join("\n");
+
+  return `
+You are MedX. Use the user’s memory if helpful, but never invent facts.
+
+Memory context:
+${memoryLines || "- none"}
+`;
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,23 @@
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export function createClient() {
+  const cookieStore = cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value;
+        },
+        set(name: string, value: string, options: any) {
+          cookieStore.set({ name, value, ...options });
+        },
+        remove(name: string, options: any) {
+          cookieStore.set({ name, value: "", ...options });
+        },
+      },
+    }
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "remark-gfm": "^4.0.1",
         "tesseract.js": "^5.0.5",
         "undici": "^5.29.0",
-        "zod": "^3.25.76"
+        "zod": "^3.25.76",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.16",
@@ -9991,6 +9992,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "remark-gfm": "^4.0.1",
     "tesseract.js": "^5.0.5",
     "undici": "^5.29.0",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/supabase/migrations/20241003120000_memory.sql
+++ b/supabase/migrations/20241003120000_memory.sql
@@ -1,0 +1,33 @@
+-- Enum
+create type memory_scope as enum ('global','thread');
+
+-- Table
+create table if not exists medx_memory (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  scope memory_scope not null default 'global',
+  thread_id text,
+  key text not null,
+  value jsonb not null,
+  source text not null default 'manual',
+  confidence real not null default 0.8,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  expires_at timestamptz
+);
+
+-- Uniqueness (separate for global vs thread)
+create unique index if not exists idx_memory_unique_global
+  on medx_memory (user_id, scope, key)
+  where thread_id is null;
+
+create unique index if not exists idx_memory_unique_thread
+  on medx_memory (user_id, scope, thread_id, key)
+  where thread_id is not null;
+
+-- Helpful indexes
+create index if not exists idx_memory_user_scope
+  on medx_memory (user_id, scope);
+
+create index if not exists idx_memory_user_thread
+  on medx_memory (user_id, thread_id);


### PR DESCRIPTION
## Summary
- add Supabase schema and API routes for storing user and thread memories
- detect memory cues from chat messages and surface save prompts via snackbar
- expose memory context in LLM system prompt for personalization

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcd511688832f99a264a4af940835