### PR TITLE
feat: add trials summarizer

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -22,6 +22,7 @@ import type { ChatMessage as BaseChatMessage } from "@/types/chat";
 import type { AnalysisCategory } from '@/lib/context';
 import { ensureThread, loadMessages, saveMessages, generateTitle, updateThreadTitle } from '@/lib/chatThreads';
 import { useMemoryStore } from "@/lib/memory/useMemoryStore";
+import { summarizeTrials } from "@/lib/research/summarizeTrials";
 
 type ChatUiState = {
   topic: string | null;
@@ -288,11 +289,16 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
 
   const [trialRows, setTrialRows] = useState<TrialRow[]>([]);
   const [searched, setSearched] = useState(false);
+  const [summary, setSummary] = useState<string | null>(null);
   const pushSuggestion = useMemoryStore(s => s.pushSuggestion);
 
   function handleTrials(rows: TrialRow[]) {
     setTrialRows(rows);
     setSearched(true);
+
+    // summarize trials for quick overview
+    const s = summarizeTrials(rows as any, mode === "doctor" ? "doctor" : "patient");
+    setSummary(s);
   }
 
   const params = useSearchParams();
@@ -994,6 +1000,11 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
             {searched && trialRows.length === 0 && (
               <div className="text-gray-600 text-sm my-2">
                 No trials found. Try removing a filter, switching country, or using broader keywords.
+              </div>
+            )}
+            {summary && (
+              <div className="my-2 text-sm p-3 rounded bg-slate-50 dark:bg-slate-800 border dark:border-slate-700">
+                {summary}
               </div>
             )}
             {trialRows.length > 0 && <TrialsTable rows={trialRows} />}

--- a/lib/research/summarizeTrials.ts
+++ b/lib/research/summarizeTrials.ts
@@ -1,0 +1,35 @@
+import type { Trial } from "@/lib/trials/search";
+
+export function summarizeTrials(trials: Trial[], mode: "patient" | "doctor"): string {
+  if (!trials.length) return "No trials found for the selected filters.";
+
+  const countsByPhase: Record<string, number> = {};
+  const countsByStatus: Record<string, number> = {};
+  const countsByCountry: Record<string, number> = {};
+
+  for (const t of trials) {
+    if (t.phase) countsByPhase[t.phase] = (countsByPhase[t.phase] || 0) + 1;
+    if (t.status) countsByStatus[t.status] = (countsByStatus[t.status] || 0) + 1;
+    if (t.country) countsByCountry[t.country] = (countsByCountry[t.country] || 0) + 1;
+  }
+
+  const total = trials.length;
+
+  if (mode === "patient") {
+    // patient-friendly summary
+    const mainPhase = Object.entries(countsByPhase).sort((a,b)=>b[1]-a[1])[0]?.[0];
+    const mainStatus = Object.entries(countsByStatus).sort((a,b)=>b[1]-a[1])[0]?.[0];
+    const mainCountry = Object.entries(countsByCountry).sort((a,b)=>b[1]-a[1])[0]?.[0];
+
+    return `We found ${total} trials. Most are in ${mainPhase ? `Phase ${mainPhase}` : "different phases"} and ${mainStatus || "varied status"}. ${mainCountry ? `Many are based in ${mainCountry}.` : ""}`;
+  }
+
+  // doctor mode summary
+  const phases = Object.entries(countsByPhase).map(([p,c]) => `${c}× Phase ${p}`).join(", ");
+  const statuses = Object.entries(countsByStatus).map(([s,c]) => `${c}× ${s}`).join(", ");
+  const topCountries = Object.entries(countsByCountry).sort((a,b)=>b[1]-a[1]).slice(0,3)
+    .map(([c,cnt]) => `${c} (${cnt})`).join(", ");
+
+  return `${total} trials retrieved. Phases: ${phases || "N/A"}. Statuses: ${statuses || "N/A"}. Top countries: ${topCountries || "N/A"}.`;
+}
+


### PR DESCRIPTION
## Summary
- add utility to summarize clinical trial results by phase, status, and country
- show brief summary above trial table in ChatPane for patient and doctor modes

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd4aee1dc832f91c8890a0952ef4d