### PR TITLE
feat: add AI Doc core backend

### DIFF
--- a/app/api/ai-doc/route.ts
+++ b/app/api/ai-doc/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserId } from "@/lib/getUserId";
+import { prisma } from "@/lib/prisma";
+import { getAiDocMem, upsertMem } from "@/lib/aidoc/memory";
+import { buildAiDocSystem } from "@/lib/aidoc/prompt";
+import { AIDOC_JSON_INSTRUCTION } from "@/lib/aidoc/schema";
+import { callOpenAIJson } from "@/lib/aidoc/vendor";
+
+export async function POST(req: NextRequest) {
+  const userId = await getUserId(req);
+  if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  const { threadId, message } = await req.json();
+
+  const profile = await prisma.patientProfile.upsert({ where:{userId}, update:{}, create:{userId} });
+  const [labs, meds, conditions, mem] = await Promise.all([
+    prisma.labResult.findMany({ where:{ profileId: profile.id }}),
+    prisma.medication.findMany({ where:{ profileId: profile.id }}),
+    prisma.condition.findMany({ where:{ profileId: profile.id }}),
+    getAiDocMem(threadId),
+  ]);
+
+  const system = buildAiDocSystem({ profile, labs, meds, conditions, mem });
+  const out = await callOpenAIJson({ system, user: message, instruction: AIDOC_JSON_INSTRUCTION });
+
+  // Persist SAVES
+  for (const m of out.save?.medications ?? []) {
+    const row = await prisma.medication.create({ data: { profileId: profile.id, name:m.name, dose:m.dose||null, route:m.route||null, freq:m.freq||null, startedAt:m.startedAt?new Date(m.startedAt):null }});
+    await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:m.startedAt?"med_start":"note", refId: row.id, summary:`Started ${m.name} ${m.dose||""}`.trim() }});
+  }
+  for (const c of out.save?.conditions ?? []) {
+    const row = await prisma.condition.create({ data: { profileId: profile.id, code:c.code||c.label, label:c.label, status:c.status||"active", since:c.since?new Date(c.since):null }});
+    await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:"diagnosis", refId: row.id, summary:c.label }});
+  }
+  for (const l of out.save?.labs ?? []) {
+    const row = await prisma.labResult.create({ data: { profileId: profile.id, panel:l.panel||"Manual", name:l.name, value:l.value??null, unit:l.unit||null, refLow:l.refLow??null, refHigh:l.refHigh??null, abnormal:l.abnormal??null, takenAt:l.takenAt?new Date(l.takenAt):new Date() }});
+    await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:"lab", refId: row.id, summary:`${l.name}: ${l.value??""}${l.unit??""}`.trim() }});
+  }
+  for (const n of out.save?.notes ?? []) {
+    await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:"note", summary:`${n.type}: ${n.key} – ${n.value}` }});
+  }
+  for (const p of out.save?.prefs ?? []) {
+    await upsertMem(threadId, "aidoc.pref", p.key, p.value);
+  }
+
+  // Recompute alerts so Alerts panel isn’t empty when it shouldn’t be
+  await fetch(new URL("/api/alerts/recompute", req.url), { method:"POST", headers:{ cookie: req.headers.get("cookie") || "" } }).catch(()=>{});
+
+  return NextResponse.json({
+    reply: out.reply,
+    observations: out.observations
+  });
+}
+

--- a/lib/aidoc/memory.ts
+++ b/lib/aidoc/memory.ts
@@ -1,0 +1,22 @@
+import { prisma } from "@/lib/prisma";
+
+type Scope = "aidoc.pref" | "aidoc.fact" | "aidoc.redflag" | "aidoc.embedding";
+
+export async function getAiDocMem(threadId: string) {
+  const rows = await prisma.memory.findMany({ where: { threadId } });
+  const byScope = (s: Scope) => rows.filter(r => r.scope === s);
+  return {
+    prefs: byScope("aidoc.pref").map(r => ({ key: r.key, value: r.value })),
+    facts: byScope("aidoc.fact").map(r => ({ key: r.key, value: r.value })),
+    redflags: byScope("aidoc.redflag").map(r => ({ key: r.key, value: r.value })),
+  };
+}
+
+export async function upsertMem(threadId: string, scope: Scope, key: string, value: string) {
+  await prisma.memory.upsert({
+    where: { threadId_scope_key: { threadId, scope, key } },
+    update: { value },
+    create: { threadId, scope, key, value },
+  });
+}
+

--- a/lib/aidoc/prompt.ts
+++ b/lib/aidoc/prompt.ts
@@ -1,0 +1,21 @@
+export function buildAiDocSystem({ profile, labs, meds, conditions, mem }: { profile: any; labs: any[]; meds: any[]; conditions: any[]; mem: any }) {
+  const now = Date.now();
+  const recentLabs = labs.filter(l => now - new Date(l.takenAt).getTime() <= 90 * 24 * 60 * 60 * 1000);
+  const active = (conditions || []).filter((c: any) => c.status === "active").map((c: any) => c.label);
+
+  return [
+    "You are AI Doc: precise, kind, clinically responsible.",
+    "RULES:",
+    "- Don’t quote any lab value older than 90 days. If needed, suggest repeating instead of quoting.",
+    "- Do not repeat family/predisposition every time; only mention if it changes current advice.",
+    "- Always consider ACTIVE conditions.",
+    "- Confirm missing med details (dose/route/frequency) before saving.",
+    "- Prefer numbered, actionable next steps.",
+    "",
+    `Active conditions: ${active.join(", ") || "none"}`,
+    `Meds: ${(meds || []).map((m: any) => m.name + (m.dose ? ` ${m.dose}` : "")).join(", ") || "none"}`,
+    `Recent labs (≤90d): ${recentLabs.map(l => `${l.name} ${l.value ?? ""}${l.unit ?? ""} (${new Date(l.takenAt).toISOString().slice(0, 10)})`).join("; ") || "none"}`,
+    `Known preferences: ${mem.prefs?.map((p: any) => `${p.key}=${p.value}`).join(", ") || "none"}`,
+  ].join("\n");
+}
+

--- a/lib/aidoc/schema.ts
+++ b/lib/aidoc/schema.ts
@@ -1,0 +1,18 @@
+export const AIDOC_JSON_INSTRUCTION = `
+Return ONLY valid JSON with this shape:
+{
+  "reply": "assistant message",
+  "save": {
+    "medications": [{"name": "...", "dose": "500 mg", "route": "oral", "freq": "bid", "startedAt":"YYYY-MM-DD"}],
+    "conditions": [{"label":"Type 2 Diabetes", "code":"E11", "status":"active","since":"YYYY-MM-DD"}],
+    "labs": [{"panel":"LFT","name":"ALT","value":42,"unit":"U/L","refLow":0,"refHigh":40,"takenAt":"YYYY-MM-DD"}],
+    "notes": [{"type":"symptom","key":"fever","value":"2 days"}],
+    "prefs": [{"key":"pill_form","value":"prefers liquid syrups"}]
+  },
+  "observations": {
+    "short": "2-3 lines; no family hx repetition; action-oriented",
+    "long": "full nuance; list ACTIVE conditions; list stale panels to repeat"
+  }
+}
+`;
+

--- a/lib/aidoc/vendor.ts
+++ b/lib/aidoc/vendor.ts
@@ -1,0 +1,21 @@
+const OAI_URL = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
+const OAI_KEY = process.env.OPENAI_API_KEY!;
+const OAI_MODEL = process.env.OPENAI_TEXT_MODEL || 'gpt-4o-mini';
+
+export async function callOpenAIJson({ system, user, instruction }:{ system: string; user: string; instruction: string; }) {
+  if (!OAI_KEY) throw new Error('OPENAI_API_KEY missing');
+  const messages = [
+    { role: 'system', content: `${system}\n${instruction}` },
+    { role: 'user', content: user }
+  ];
+  const r = await fetch(`${OAI_URL}/chat/completions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${OAI_KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: OAI_MODEL, messages, temperature: 0, response_format: { type: 'json_object' } })
+  });
+  const j = await r.json();
+  if (!r.ok) throw new Error(`OpenAI: ${j?.error?.message || r.statusText}`);
+  const content = j.choices?.[0]?.message?.content || '{}';
+  return JSON.parse(content);
+}
+


### PR DESCRIPTION
## Summary
- add scoped memory utilities for AI Doc
- build system prompt with clinical guardrails and preferences
- wire new AI Doc chat route that saves meds, conditions, labs, notes, and prefs

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd464b3a8832faa26805a8a8b8fce