### PR TITLE
Fix memory persistence and expose smart memory toggle

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -109,16 +109,16 @@ export async function POST(req: Request) {
   const recap = buildConstraintRecap(state.constraints);
   if (recap) assistant += recap;
 
-  assistant = sanitizeLLM(assistant);
-  assistant = finalReplyGuard(text, assistant);
+  const sanitized = sanitizeLLM(assistant);
+  const final = finalReplyGuard(text, sanitized);
 
   // 7) Save assistant + summary
-  await appendMessage({ threadId, role: "assistant", content: assistant });
-  const updated = updateSummary("", text, assistant);
+  await appendMessage({ threadId, role: "assistant", content: final });
+  const updated = updateSummary("", text, final);
   await persistUpdatedSummary(threadId, updated);
 
   // 8) Optional natural pacing (2–4s)
   await new Promise(r => setTimeout(r, 1800 + Math.random() * 1200));
 
-  return NextResponse.json({ ok: true, threadId, text: assistant });
+  return NextResponse.json({ ok: true, threadId, text: final });
 }

--- a/app/api/memory/route.ts
+++ b/app/api/memory/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: Request) {
   }));
 
   const { data, error } = await supabase.from("medx_memory")
-    .upsert(rows, { onConflict: "user_id,scope,thread_id,key" })
+    .insert(rows)
     .select("*");
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/components/memory/Snackbar.tsx
+++ b/components/memory/Snackbar.tsx
@@ -11,6 +11,7 @@ export default function MemorySnackbar() {
     await fetch("/api/memory", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      credentials: "include", // ensure Supabase auth session is passed
       body: JSON.stringify(current),
     });
     clearSuggestion(current.key);
@@ -18,9 +19,16 @@ export default function MemorySnackbar() {
 
   const onDismiss = () => clearSuggestion(current.key);
 
+  const label = (() => {
+    if (current.key === "allergy") return `Save allergy: ${current.value.item}?`;
+    if (current.key === "diet_preference") return `Save diet: ${current.value.label}?`;
+    if (current.key === "medication") return `Save medication: ${current.value.name}${current.value.dose ? ` ${current.value.dose}` : ""}?`;
+    return `Save memory: ${current.key}?`;
+  })();
+
   return (
     <div className="fixed bottom-4 right-4 z-50 max-w-sm rounded-xl border bg-white dark:bg-slate-800 shadow-lg p-3">
-      <div className="text-sm mb-2">Save memory: {current.key}?</div>
+      <div className="text-sm mb-2">{label}</div>
       <div className="flex gap-2 justify-end">
         <button onClick={onDismiss} className="px-3 py-1 border text-sm">No</button>
         <button onClick={onSave} className="px-3 py-1 bg-blue-600 text-white text-sm">Save</button>

--- a/components/settings/MemorySettings.tsx
+++ b/components/settings/MemorySettings.tsx
@@ -1,0 +1,17 @@
+"use client";
+import { useMemoryStore } from "@/lib/memory/useMemoryStore";
+
+export function MemorySettings() {
+  const { enabled, setEnabled } = useMemoryStore();
+  return (
+    <label className="flex items-center gap-2">
+      <input
+        type="checkbox"
+        checked={enabled}
+        onChange={e => setEnabled(e.target.checked)}
+      />
+      <span className="text-sm">Smart Memory</span>
+    </label>
+  );
+}
+

--- a/components/settings/Preferences.tsx
+++ b/components/settings/Preferences.tsx
@@ -1,0 +1,3 @@
+"use client";
+export { default } from "../panels/SettingsPane";
+

--- a/components/settings/SettingsPanel.tsx
+++ b/components/settings/SettingsPanel.tsx
@@ -1,0 +1,12 @@
+import Preferences from "./Preferences";
+import { MemorySettings } from "@/components/settings/MemorySettings";
+
+export default function SettingsPanel() {
+  return (
+    <div className="space-y-4">
+      <Preferences />
+      <MemorySettings /> {/* show Smart Memory toggle */}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Ensure Supabase memory persistence by inserting new rows
- Preserve auth cookies when saving memories and show context-aware snackbar labels
- Expose Smart Memory toggle in settings and sanitize/guard chat replies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd47bfd20832fa6f2c87d9bd2f0c4