### PR TITLE
feat: summarize clinical trials with copyable overview

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -7,7 +7,7 @@ import ResearchFilters from '@/components/ResearchFilters';
 import TrialsTable from "@/components/TrialsTable";
 import type { TrialRow } from "@/types/trials";
 import { useResearchFilters } from '@/store/researchFilters';
-import { Send, Paperclip } from 'lucide-react';
+import { Send, Paperclip, Clipboard, Stethoscope, Users } from 'lucide-react';
 import { useCountry } from '@/lib/country';
 import { getRandomWelcome } from '@/lib/welcomeMessages';
 import { useActiveContext } from '@/lib/context';
@@ -996,19 +996,32 @@ Do not invent IDs. If info missing, omit that field. Keep to 5–10 items. End w
       {mode === "doctor" && researchMode && (
         <>
           <ResearchFilters mode="research" onResults={handleTrials} />
-          <div className="my-3 px-4">
-            {searched && trialRows.length === 0 && (
-              <div className="text-gray-600 text-sm my-2">
-                No trials found. Try removing a filter, switching country, or using broader keywords.
+          {searched && trialRows.length === 0 && (
+            <div className="text-gray-600 text-sm my-2 mx-4 md:mx-4">
+              No trials found. Try removing a filter, switching country, or using broader keywords.
+            </div>
+          )}
+          {summary && (
+            <div className="my-2 mx-4 md:mx-4 text-sm p-3 rounded border bg-slate-50 dark:bg-slate-800 dark:border-slate-700 flex items-start gap-2">
+              <div className="mt-0.5">
+                {mode === "doctor" ? <Stethoscope size={16}/> : <Users size={16}/>}
               </div>
-            )}
-            {summary && (
-              <div className="my-2 text-sm p-3 rounded bg-slate-50 dark:bg-slate-800 border dark:border-slate-700">
-                {summary}
-              </div>
-            )}
-            {trialRows.length > 0 && <TrialsTable rows={trialRows} />}
-          </div>
+              <div className="flex-1 whitespace-pre-wrap">{summary}</div>
+              <button
+                type="button"
+                onClick={() => navigator.clipboard.writeText(summary)}
+                className="btn-secondary flex items-center gap-1 px-2 py-1 text-xs"
+                title="Copy summary"
+              >
+                <Clipboard size={14}/> Copy
+              </button>
+            </div>
+          )}
+          {trialRows.length > 0 && (
+            <div className="mx-4 md:mx-4">
+              <TrialsTable rows={trialRows} />
+            </div>
+          )}
         </>
       )}
       <div

--- a/lib/research/summarizeTrials.ts
+++ b/lib/research/summarizeTrials.ts
@@ -1,35 +1,82 @@
 import type { Trial } from "@/lib/trials/search";
 
+// Lightweight vocab (extend anytime)
+const BIOMARKERS = [
+  "EGFR","ALK","KRAS","NRAS","BRAF","HER2","ERBB2","PIK3CA","ROS1","RET",
+  "NTRK","MET","PD-L1","PD1","BRCA1","BRCA2","CD19","CD20","CD22","CD33",
+  "FLT3","IDH1","IDH2","PTEN","TP53","JAK2","KIT","CDK4","CDK6","VEGF","VEGFA"
+];
+
+const CONDITIONS = [
+  "melanoma","lung cancer","nsclc","sclc","breast cancer","colon cancer",
+  "colorectal","glioma","glioblastoma","leukemia","aml","cll","myeloma",
+  "lymphoma","prostate cancer","ovarian cancer","pancreatic cancer",
+  "gastric cancer","hepatic","liver cancer","renal cell carcinoma","rcc",
+  "myelodysplastic","mcl","mm","sarcoma","thyroid cancer","endometrial",
+];
+
+type CountMap = Record<string, number>;
+const topN = (m: CountMap, n = 3) =>
+  Object.entries(m).sort((a,b)=>b[1]-a[1]).slice(0,n);
+
+function scan(trials: Trial[]) {
+  const byPhase: CountMap = {};
+  const byStatus: CountMap = {};
+  const byCountry: CountMap = {};
+  const genes: CountMap = {};
+  const conditions: CountMap = {};
+
+  for (const t of trials) {
+    if (t.phase) byPhase[t.phase] = (byPhase[t.phase] || 0) + 1;
+    if (t.status) byStatus[t.status] = (byStatus[t.status] || 0) + 1;
+    if (t.country) byCountry[t.country] = (byCountry[t.country] || 0) + 1;
+
+    const title = (t.title || "").toLowerCase();
+
+    for (const g of BIOMARKERS) {
+      if (title.includes(g.toLowerCase())) genes[g] = (genes[g] || 0) + 1;
+    }
+    for (const c of CONDITIONS) {
+      if (title.includes(c)) conditions[c] = (conditions[c] || 0) + 1;
+    }
+  }
+  return { byPhase, byStatus, byCountry, genes, conditions };
+}
+
 export function summarizeTrials(trials: Trial[], mode: "patient" | "doctor"): string {
   if (!trials.length) return "No trials found for the selected filters.";
 
-  const countsByPhase: Record<string, number> = {};
-  const countsByStatus: Record<string, number> = {};
-  const countsByCountry: Record<string, number> = {};
-
-  for (const t of trials) {
-    if (t.phase) countsByPhase[t.phase] = (countsByPhase[t.phase] || 0) + 1;
-    if (t.status) countsByStatus[t.status] = (countsByStatus[t.status] || 0) + 1;
-    if (t.country) countsByCountry[t.country] = (countsByCountry[t.country] || 0) + 1;
-  }
-
+  const { byPhase, byStatus, byCountry, genes, conditions } = scan(trials);
   const total = trials.length;
 
-  if (mode === "patient") {
-    // patient-friendly summary
-    const mainPhase = Object.entries(countsByPhase).sort((a,b)=>b[1]-a[1])[0]?.[0];
-    const mainStatus = Object.entries(countsByStatus).sort((a,b)=>b[1]-a[1])[0]?.[0];
-    const mainCountry = Object.entries(countsByCountry).sort((a,b)=>b[1]-a[1])[0]?.[0];
+  const phaseStr = topN(byPhase).map(([p,c]) => `${c}× Phase ${p}`).join(", ") || "N/A";
+  const statusStr = topN(byStatus).map(([s,c]) => `${c}× ${s}`).join(", ") || "N/A";
+  const countryStr = topN(byCountry).map(([c,cnt]) => `${c} (${cnt})`).join(", ") || "N/A";
+  const geneStr = topN(genes).map(([g,c]) => `${g} (${c})`).join(", ");
+  const condStr = topN(conditions).map(([k,c]) => `${k} (${c})`).join(", ");
 
-    return `We found ${total} trials. Most are in ${mainPhase ? `Phase ${mainPhase}` : "different phases"} and ${mainStatus || "varied status"}. ${mainCountry ? `Many are based in ${mainCountry}.` : ""}`;
+  if (mode === "patient") {
+    const mainPhase = topN(byPhase)[0]?.[0];
+    const mainStatus = topN(byStatus)[0]?.[0];
+    const mainCountry = topN(byCountry)[0]?.[0];
+
+    const bits: string[] = [];
+    bits.push(`We found ${total} trials.`);
+    if (mainPhase) bits.push(`Most are in Phase ${mainPhase}.`);
+    if (mainStatus) bits.push(`${mainStatus} is the most common status.`);
+    if (mainCountry) bits.push(`Many are in ${mainCountry}.`);
+    if (condStr) bits.push(`Common focus: ${condStr.split(", ")[0].replace(/\s\(\d+\)$/,"")}.`);
+    return bits.join(" ");
   }
 
-  // doctor mode summary
-  const phases = Object.entries(countsByPhase).map(([p,c]) => `${c}× Phase ${p}`).join(", ");
-  const statuses = Object.entries(countsByStatus).map(([s,c]) => `${c}× ${s}`).join(", ");
-  const topCountries = Object.entries(countsByCountry).sort((a,b)=>b[1]-a[1]).slice(0,3)
-    .map(([c,cnt]) => `${c} (${cnt})`).join(", ");
-
-  return `${total} trials retrieved. Phases: ${phases || "N/A"}. Statuses: ${statuses || "N/A"}. Top countries: ${topCountries || "N/A"}.`;
+  // doctor
+  const lines = [
+    `${total} trials retrieved.`,
+    `Phases: ${phaseStr}.`,
+    `Statuses: ${statusStr}.`,
+    `Top countries: ${countryStr}.`,
+  ];
+  if (geneStr) lines.push(`Frequent molecular targets: ${geneStr}.`);
+  if (condStr) lines.push(`Conditions represented: ${condStr}.`);
+  return lines.join(" ");
 }
-


### PR DESCRIPTION
## Summary
- add intelligent summarizer scanning phases, statuses, countries, biomarkers and conditions for patient and doctor modes
- display trial summary with role icon and copy button in chat pane

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd97a67d4832fa1d15d0b86154ecf