### PR TITLE
feat: add smart memory toggle and cookie auth

### DIFF
--- a/components/memory/Snackbar.tsx
+++ b/components/memory/Snackbar.tsx
@@ -8,19 +8,33 @@ export default function MemorySnackbar() {
   const current = suggestions[0];
 
   const onSave = async () => {
-    await fetch("/api/memory", {
+    const res = await fetch("/api/memory", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
+      credentials: "include", // ✅ pass session cookies
       body: JSON.stringify(current),
     });
+    if (!res.ok) {
+      console.error("Memory save failed", await res.text());
+      return;
+    }
     clearSuggestion(current.key);
   };
 
   const onDismiss = () => clearSuggestion(current.key);
 
+  const label = (() => {
+    if (current.key === "allergy" && current.value?.item) return `Save allergy: ${current.value.item}?`;
+    if (current.key === "diet_preference" && current.value?.label) return `Save diet: ${current.value.label}?`;
+    if (current.key === "medication" && current.value?.name) {
+      return `Save medication: ${current.value.name}${current.value?.dose ? ` ${current.value.dose}` : ""}?`;
+    }
+    return `Save memory: ${current.key}?`;
+  })();
+
   return (
     <div className="fixed bottom-4 right-4 z-50 max-w-sm rounded-xl border bg-white dark:bg-slate-800 shadow-lg p-3">
-      <div className="text-sm mb-2">Save memory: {current.key}?</div>
+      <div className="text-sm mb-2">{label}</div>
       <div className="flex gap-2 justify-end">
         <button onClick={onDismiss} className="px-3 py-1 border text-sm">No</button>
         <button onClick={onSave} className="px-3 py-1 bg-blue-600 text-white text-sm">Save</button>

--- a/components/panels/SettingsPane.tsx
+++ b/components/panels/SettingsPane.tsx
@@ -1,34 +1,12 @@
 'use client';
-import { useEffect, useState } from 'react';
-import { safeJson } from '@/lib/safeJson';
+import Preferences from "../settings/Preferences";
+import { MemorySettings } from "../settings/MemorySettings";
 
 export default function SettingsPane() {
-  const [consent, setConsent] = useState(false);
-
-  useEffect(() => {
-    safeJson(fetch('/api/auth/session'))
-      .then(s => setConsent(Boolean(s?.user?.consentFlags?.process)))
-      .catch(() => setConsent(false));
-  }, []);
-
-  const toggle = async () => {
-    const next = !consent;
-    setConsent(next);
-    try {
-      await fetch('/api/user', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ consentFlags: { process: next } }),
-      });
-    } catch {}
-  };
-
   return (
-    <div className="p-4">
-      <label className="flex items-center gap-2">
-        <input type="checkbox" checked={consent} onChange={toggle} />
-        <span className="text-sm">Process my health data</span>
-      </label>
+    <div className="p-4 space-y-4">
+      <Preferences />
+      <MemorySettings />
     </div>
   );
 }

--- a/components/settings/MemorySettings.tsx
+++ b/components/settings/MemorySettings.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useMemoryStore } from "@/lib/memory/useMemoryStore";
+
+export function MemorySettings() {
+  const { enabled, setEnabled } = useMemoryStore();
+  return (
+    <div className="rounded-xl border p-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="font-medium">Smart Memory</div>
+          <div className="text-sm text-slate-500">
+            Remember preferences and key facts with your consent. You can turn this off anytime.
+          </div>
+        </div>
+        <label className="inline-flex items-center gap-2 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />
+          <span className="text-sm">Enabled</span>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/components/settings/Preferences.tsx
+++ b/components/settings/Preferences.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { useEffect, useState } from "react";
+import { safeJson } from "@/lib/safeJson";
+
+export default function Preferences() {
+  const [consent, setConsent] = useState(false);
+
+  useEffect(() => {
+    safeJson(fetch("/api/auth/session"))
+      .then((s) => setConsent(Boolean(s?.user?.consentFlags?.process)))
+      .catch(() => setConsent(false));
+  }, []);
+
+  const toggle = async () => {
+    const next = !consent;
+    setConsent(next);
+    try {
+      await fetch("/api/user", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ consentFlags: { process: next } }),
+      });
+    } catch {}
+  };
+
+  return (
+    <div className="rounded-xl border p-4">
+      <label className="flex items-center gap-2">
+        <input type="checkbox" checked={consent} onChange={toggle} />
+        <span className="text-sm">Process my health data</span>
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Smart Memory toggle with persistable enabled state
- mount Smart Memory controls in Settings panel alongside preferences
- secure memory API using Supabase route handler client and improve snackbar save flow

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bddc321154832fa81f224bc01b97bd