### PR TITLE
feat: add adaptive clarifier

### DIFF
--- a/lib/conversation/disambiguation.ts
+++ b/lib/conversation/disambiguation.ts
@@ -1,9 +1,34 @@
+import { MemoryItem } from "@/lib/memory/useMemoryStore";
+
 export function disambiguate(userMsg: string, context: string): string | null {
-  if (/spicy/i.test(userMsg)) {
-    return "Got it — do you mean more chili in the marinade, or extra heat in the sauce?";
+  const msg = userMsg.toLowerCase();
+
+  if (/spicy|hot/i.test(msg)) {
+    return "Got it — do you mean more chili, or just extra seasoning?";
   }
-  if (/expand|more/i.test(userMsg) && context.includes("recipe")) {
-    return "Do you want me to add more steps, or give alternative ingredients?";
+  if (/expand|more/i.test(msg) && context.includes("recipe")) {
+    return "Do you want me to add more steps, or suggest ingredient swaps?";
+  }
+  if (/pain/i.test(msg) && !/where|location|severity/.test(msg)) {
+    return "Can you tell me where the pain is and how strong it feels?";
+  }
+  if (/allergy/i.test(msg) && context.includes("diet")) {
+    return "Thanks for sharing — do you want me to suggest allergy-safe alternatives?";
+  }
+  return null;
+}
+
+export function disambiguateWithMemory(
+  userMsg: string,
+  memories: MemoryItem[]
+): string | null {
+  const msg = userMsg.toLowerCase();
+
+  if (/recipe|diet/i.test(msg)) {
+    const allergy = memories.find((m) => m.key === "allergy");
+    if (allergy) {
+      return `Noted your allergy to ${allergy.value.item}. Want me to suggest safe alternatives?`;
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- expand disambiguation to cover pain, allergies and extra-heat queries
- insert clarifier step in chat route before LLM call
- add memory-aware disambiguation helper

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68be112f41c8832f821574f833ec1f85