### PR TITLE
feat: add clarification checks

### DIFF
--- a/lib/conversation/disambiguation.ts
+++ b/lib/conversation/disambiguation.ts
@@ -1,5 +1,6 @@
 import { MemoryItem } from "@/lib/memory/useMemoryStore";
 
+// Clarifier without memory
 export function disambiguate(userMsg: string, context: string): string | null {
   const msg = userMsg.toLowerCase();
 
@@ -12,22 +13,22 @@ export function disambiguate(userMsg: string, context: string): string | null {
   if (/pain/i.test(msg) && !/where|location|severity/.test(msg)) {
     return "Can you tell me where the pain is and how strong it feels?";
   }
-  if (/allergy/i.test(msg) && context.includes("diet")) {
-    return "Thanks for sharing — do you want me to suggest allergy-safe alternatives?";
+  if (/reset|start over|fresh chat/.test(msg)) {
+    return "Do you want me to clear context and begin a fresh chat?";
   }
   return null;
 }
 
+// Clarifier with memory
 export function disambiguateWithMemory(
   userMsg: string,
   memories: MemoryItem[]
 ): string | null {
   const msg = userMsg.toLowerCase();
-
-  if (/recipe|diet/i.test(msg)) {
+  if (/cookie|recipe/.test(msg)) {
     const allergy = memories.find((m) => m.key === "allergy");
     if (allergy) {
-      return `Noted your allergy to ${allergy.value.item}. Want me to suggest safe alternatives?`;
+      return `Noted your allergy to ${allergy.value.item}. Want me to suggest a safe, nut-free version instead?`;
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- add stateless and memory-based clarifiers for user messages
- integrate memory bundle lookup and apply clarifier checks in chat route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be1d7d8f68832f97bea85d404ee1eb