### PR TITLE
feat: support blob uploads via JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project includes:
 ## Endpoints
 - `GET /api/banner` — aggregated headlines
 - `POST /api/chat` — body: `{question, role: "patient"|"clinician"}`
-- `POST /api/analyze` — multipart form-data with `file` and optional `doctorMode`
+- `POST /api/analyze` — JSON `{ files: [{ url, name, type }], note? }` or multipart form-data with `file` and optional `doctorMode`
 - Plus wrappers: `/api/clinicaltrials`, `/api/pubmed`, `/api/who`, `/api/openfda`, `/api/dailymed`, `/api/rxnorm`, `/api/icd11`
 
 ## Notes


### PR DESCRIPTION
## Summary
- allow /api/analyze to accept JSON payloads with blob URLs
- fall back to existing single-file FormData handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be1fabc534832fb6be18d5dca36b9e