### PR TITLE
feat: add thread kebab menu with rename and delete

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import Tabs from './sidebar/Tabs';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { createNewThreadId, listThreads, Thread } from '@/lib/chatThreads';
+import ThreadKebab from '@/components/chat/ThreadKebab';
 
 export default function Sidebar() {
   const router = useRouter();
@@ -46,13 +47,30 @@ export default function Sidebar() {
 
       <div className="mt-3 space-y-1 px-2 flex-1 overflow-y-auto">
         {filtered.map(t => (
-          <button
+          <div
             key={t.id}
-            onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
-            className="w-full text-left rounded-md px-2 py-1 text-sm hover:bg-muted"
+            className="flex items-center gap-2 rounded-md px-2 py-1 hover:bg-muted"
           >
-            {t.title}
-          </button>
+            <button
+              onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
+              className="flex-1 text-left truncate text-sm"
+              title={t.title}
+            >
+              {t.title}
+            </button>
+            <ThreadKebab
+              id={t.id}
+              title={t.title}
+              onRenamed={nt => {
+                setThreads(prev =>
+                  prev.map(x => (x.id === t.id ? { ...x, title: nt, updatedAt: Date.now() } : x))
+                );
+              }}
+              onDeleted={() => {
+                setThreads(prev => prev.filter(x => x.id !== t.id));
+              }}
+            />
+          </div>
         ))}
       </div>
 

--- a/components/chat/ThreadKebab.tsx
+++ b/components/chat/ThreadKebab.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { useState, useRef, useEffect } from "react";
+import { renameThread, deleteThread } from "@/lib/chatThreads";
+import { useRouter } from "next/navigation";
+
+export default function ThreadKebab({ id, title, onRenamed, onDeleted }: {
+  id: string; title: string;
+  onRenamed?: (newTitle: string)=>void;
+  onDeleted?: ()=>void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [askRename, setAskRename] = useState(false);
+  const [name, setName] = useState(title);
+  const ref = useRef<HTMLDivElement>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, []);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        className="px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800"
+        onClick={() => setOpen(s => !s)}
+        aria-label="Thread options"
+        title="Options"
+      >
+        ⋯
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-1 w-44 rounded-md border bg-white dark:bg-slate-900 dark:border-slate-700 shadow-lg z-20">
+          <button
+            className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
+            onClick={() => { setAskRename(true); setOpen(false); }}
+          >
+            Rename
+          </button>
+          <button
+            className="w-full text-left px-3 py-2 text-sm text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-900/20"
+            onClick={() => {
+              setOpen(false);
+              if (confirm("Delete this chat? This cannot be undone.")) {
+                deleteThread(id);
+                onDeleted?.();
+                // if currently on this thread route, send to home
+                try {
+                  const url = new URL(window.location.href);
+                  if (url.searchParams.get("threadId") === id) {
+                    url.searchParams.delete("threadId");
+                    router.push(url.pathname + (url.search ? url.search : ""));
+                  }
+                } catch {}
+              }
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      )}
+
+      {/* Rename dialog (lightweight inline) */}
+      {askRename && (
+        <div className="fixed inset-0 z-30 flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/40" onClick={()=>setAskRename(false)} />
+          <div className="relative w-full max-w-sm rounded-lg border bg-white dark:bg-slate-900 dark:border-slate-700 p-4">
+            <div className="text-sm font-medium mb-2">Rename chat</div>
+            <input
+              autoFocus
+              value={name}
+              onChange={e=>setName(e.target.value)}
+              className="w-full rounded border px-2 py-1 text-sm dark:bg-slate-800 dark:border-slate-700"
+            />
+            <div className="mt-3 flex justify-end gap-2">
+              <button className="px-3 py-1.5 text-sm rounded border"
+                onClick={()=>setAskRename(false)}>Cancel</button>
+              <button
+                className="px-3 py-1.5 text-sm rounded border bg-blue-600 text-white dark:border-blue-600 disabled:opacity-50"
+                onClick={()=>{
+                  const nn = name.trim() || "Untitled";
+                  renameThread(id, nn);
+                  onRenamed?.(nn);
+                  setAskRename(false);
+                }}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -20,7 +20,7 @@ import { patientTrialsPrompt, clinicianTrialsPrompt } from "@/lib/prompts/trials
 import FeedbackBar from "@/components/FeedbackBar";
 import type { ChatMessage as BaseChatMessage } from "@/types/chat";
 import type { AnalysisCategory } from '@/lib/context';
-import { ensureThread, loadMessages, saveMessages, generateTitle, updateThreadTitle } from '@/lib/chatThreads';
+import { ensureThread, loadMessages, saveMessages, generateTitle, updateThreadTitle, upsertThreadIndex } from '@/lib/chatThreads';
 import { useMemoryStore } from "@/lib/memory/useMemoryStore";
 import { summarizeTrials } from "@/lib/research/summarizeTrials";
 import { computeTrialStats, type TrialStats } from "@/lib/research/trialStats";
@@ -515,7 +515,9 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
       text.trim() &&
       messages.filter(m => m.role === 'user').length === 0
     ) {
-      updateThreadTitle(threadId, generateTitle(text));
+      const nt = generateTitle(text);
+      updateThreadTitle(threadId, nt);
+      upsertThreadIndex(threadId, nt);
     }
 
     try {


### PR DESCRIPTION
## Summary
- add thread index helpers and thread delete/rename utilities
- introduce ThreadKebab menu for per-thread actions
- wire up thread menu in sidebar and keep index in sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be2b2efda0832fa08b2439877590d3