### PR TITLE
feat: improve AI Doc resilience and JSON parsing

### DIFF
--- a/app/api/ai-doc/route.ts
+++ b/app/api/ai-doc/route.ts
@@ -1,6 +1,7 @@
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
+export const maxDuration = 60;
 
 import { NextRequest, NextResponse } from "next/server";
 import { getUserId } from "@/lib/getUserId";
@@ -13,93 +14,66 @@ import { extractPrefsFromUser } from "@/lib/aidoc/extractors/prefs";
 import { buildAiDocPrompt } from "@/lib/ai/prompts/aidoc";
 
 export async function POST(req: NextRequest) {
-  const userId = await getUserId(req);
-  if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  try{
+    const userId = await getUserId(req);
+    if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    const { threadId, message } = await req.json();
+    if (!message) return NextResponse.json({ error: "no message" }, { status: 400 });
 
-  const { threadId, message } = await req.json();
-  if (!message) return NextResponse.json({ error: "no message" }, { status: 400 });
+    const profile = await prisma.patientProfile.upsert({ where: { userId }, update: {}, create: { userId } });
+    const [labs, meds, conditions] = await Promise.all([
+      prisma.labResult.findMany({ where: { profileId: profile.id } }),
+      prisma.medication.findMany({ where: { profileId: profile.id } }),
+      prisma.condition.findMany({ where: { profileId: profile.id } }),
+    ]);
 
-  // Ensure profile & load clinical state + memory
-  const profile = await prisma.patientProfile.upsert({ where: { userId }, update: {}, create: { userId } });
-  const [labs, meds, conditions, mem] = await Promise.all([
-    prisma.labResult.findMany({ where: { profileId: profile.id } }),
-    prisma.medication.findMany({ where: { profileId: profile.id } }),
-    prisma.condition.findMany({ where: { profileId: profile.id } }),
-    getMemByThread(threadId || ""),
-  ]);
+    const ackParts:string[] = [];
+    for (const p of extractPrefsFromUser(message)) {
+      await upsertMem(threadId, "aidoc.pref", p.key, p.value);
+      await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:"preference", summary:`Saved preference: ${p.key} = ${p.value}` } });
+      ackParts.push(`${p.key.replace(/^pref_/,'').replace(/_/g,' ')}: ${p.value}`);
+    }
 
-  // Opportunistically capture preferences from user's message
-  for (const p of extractPrefsFromUser(message)) {
-    await upsertMem(threadId, "aidoc.pref", p.key, p.value);
-    await prisma.timelineEvent.create({
-      data: { profileId: profile.id, at:new Date(), type:"preference", summary:`Saved preference: ${p.key} = ${p.value}` }
-    });
+    const system = buildAiDocPrompt({ profile, labs, meds, conditions });
+    const out = await callOpenAIJson({ system, user: message, instruction: "Return JSON with {reply, save:{medications,conditions,labs,notes,prefs}, observations:{short,long}}" });
+
+    for (const p of out?.save?.prefs ?? []) {
+      await upsertMem(threadId, "aidoc.pref", p.key, String(p.value));
+      await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:"preference", summary:`Saved preference: ${p.key} = ${p.value}` } });
+    }
+    for (const m of out?.save?.medications ?? []) {
+      const row = await prisma.medication.create({ data:{ profileId: profile.id, name:m.name, dose:m.dose||null, route:m.route||null, freq:m.freq||null, startedAt:m.startedAt?new Date(m.startedAt):null } });
+      await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:"med_start", refId: row.id, summary:`Started ${m.name} ${m.dose||""}`.trim() } });
+    }
+    for (const c of out?.save?.conditions ?? []) {
+      const row = await prisma.condition.create({ data:{ profileId: profile.id, code:c.code||c.label, label:c.label, status:c.status||"active", since:c.since?new Date(c.since):null } });
+      await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:"diagnosis", refId: row.id, summary:c.label } });
+    }
+    for (const l of out?.save?.labs ?? []) {
+      const row = await prisma.labResult.create({ data:{ profileId: profile.id, panel:l.panel||"Manual", name:l.name, value:l.value??null, unit:l.unit||null, refLow:l.refLow??null, refHigh:l.refHigh??null, abnormal:l.abnormal??null, takenAt:l.takenAt?new Date(l.takenAt):new Date() } });
+      await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:"lab", refId: row.id, summary:`${l.name}: ${l.value??""}${l.unit??""}`.trim() } });
+    }
+    for (const n of out?.save?.notes ?? []) {
+      await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:"note", summary:`${n.type}: ${n.key} – ${n.value}` } });
+    }
+
+    const memAfter = await getMemByThread(threadId || "");
+    const ruled = runRules({ labs, meds, conditions, mem: memAfter });
+    const plan = buildPersonalPlan(ruled, memAfter);
+
+    fetch(new URL("/api/alerts/recompute", req.url), { method:"POST", headers:{ cookie: req.headers.get("cookie") || "" } }).catch(()=>{});
+
+    await prisma.timelineEvent.create({ data:{ profileId: profile.id, at:new Date(), type:"ai_reason", summary:`Rules: ${plan.rulesFired.join(", ")}`, details: JSON.stringify({ rules: plan.rulesFired }) } });
+
+    const ack = ackParts.length ? `Noted — ${ackParts.join(", ")}. ` : "";
+    const reply = `${ack}${out?.reply ?? ""}`.trim();
+    return NextResponse.json({ reply, observations: out.observations, plan, alertsCreated: 0 });
+  }catch(e:any){
+    return NextResponse.json({
+      reply:"I captured your note. There was a temporary issue, but you can continue.",
+      observations:{short:"Temporary server issue — safe fallback used.", long:""},
+      plan:{ title:"Personalized next steps", steps:[], nudges:[], rulesFired:[] },
+      alertsCreated:0, _error:String(e?.message||e)
+    },{ status:200 });
   }
-
-  // System prompt with guardrails
-  const system = buildAiDocPrompt({ profile, labs, meds, conditions });
-
-  // Call LLM (JSON-only)
-  const out = await callOpenAIJson({
-    system,
-    user: message,
-    instruction: "Return JSON with {reply, save:{medications,conditions,labs,notes,prefs}, observations:{short,long}}"
-  });
-
-  // Persist structured saves + timeline
-  for (const p of out?.save?.prefs ?? []) {
-    await upsertMem(threadId, "aidoc.pref", p.key, String(p.value));
-    await prisma.timelineEvent.create({
-      data: { profileId: profile.id, at:new Date(), type:"preference", summary:`Saved preference: ${p.key} = ${p.value}` }
-    });
-  }
-  for (const m of out?.save?.medications ?? []) {
-    const row = await prisma.medication.create({
-      data: { profileId: profile.id, name:m.name, dose:m.dose||null, route:m.route||null, freq:m.freq||null, startedAt:m.startedAt?new Date(m.startedAt):null }
-    });
-    await prisma.timelineEvent.create({
-      data: { profileId: profile.id, at:new Date(), type:"med_start", refId: row.id, summary:`Started ${m.name} ${m.dose||""}`.trim() }
-    });
-  }
-  for (const c of out?.save?.conditions ?? []) {
-    const row = await prisma.condition.create({
-      data: { profileId: profile.id, code:c.code||c.label, label:c.label, status:c.status||"active", since:c.since?new Date(c.since):null }
-    });
-    await prisma.timelineEvent.create({
-      data: { profileId: profile.id, at:new Date(), type:"diagnosis", refId: row.id, summary:c.label }
-    });
-  }
-  for (const l of out?.save?.labs ?? []) {
-    const row = await prisma.labResult.create({
-      data: { profileId: profile.id, panel:l.panel||"Manual", name:l.name, value:l.value??null, unit:l.unit||null, refLow:l.refLow??null, refHigh:l.refHigh??null, abnormal:l.abnormal??null, takenAt:l.takenAt?new Date(l.takenAt):new Date() }
-    });
-    await prisma.timelineEvent.create({
-      data: { profileId: profile.id, at:new Date(), type:"lab", refId: row.id, summary:`${l.name}: ${l.value??""}${l.unit??""}`.trim() }
-    });
-  }
-  for (const n of out?.save?.notes ?? []) {
-    await prisma.timelineEvent.create({
-      data: { profileId: profile.id, at:new Date(), type:"note", summary:`${n.type}: ${n.key} – ${n.value}` }
-    });
-  }
-
-  // Personalization via rule engine
-  const memAfter = await getMemByThread(threadId || "");
-  const ruled = runRules({ labs, meds, conditions, mem: memAfter });
-  const plan = buildPersonalPlan(ruled, memAfter);
-
-  // Keep core alerts fresh (stale/abnormal)
-  await fetch(new URL("/api/alerts/recompute", req.url), { method:"POST", headers:{ cookie: req.headers.get("cookie") || "" } }).catch(()=>{});
-
-  // Log which rules fired
-  await prisma.timelineEvent.create({
-    data: { profileId: profile.id, at:new Date(), type:"ai_reason", summary:`Rules: ${plan.rulesFired.join(", ")}`, details: JSON.stringify({ rules: plan.rulesFired }) }
-  });
-
-  return NextResponse.json({
-    reply: out.reply,
-    observations: out.observations,
-    plan,
-    alertsCreated: 0
-  });
 }

--- a/components/ai/NextStepsCard.tsx
+++ b/components/ai/NextStepsCard.tsx
@@ -1,0 +1,8 @@
+export function NextStepsCard({plan}:{plan?:{title:string;steps:string[];nudges:string[]}}){
+  if(!plan) return null; const {title,steps=[],nudges=[]}=plan;
+  return (<div className="rounded-2xl border p-4 shadow-sm">
+    <div className="font-semibold mb-2">{title}</div>
+    {steps.length>0 && <ol className="list-decimal ml-5 space-y-1">{steps.map((s,i)=><li key={i}>{s}</li>)}</ol>}
+    {nudges.length>0 && <div className="mt-3 text-sm opacity-80"><div className="font-medium mb-1">Nudges</div><ul className="list-disc ml-5 space-y-1">{nudges.map((n,i)=><li key={i}>{n}</li>)}</ul></div>}
+  </div>);
+}

--- a/components/ai/Observations.tsx
+++ b/components/ai/Observations.tsx
@@ -1,0 +1,4 @@
+export function Observations({shortText,longText}:{shortText?:string;longText?:string}) {
+  if(!shortText && !longText) return null;
+  return (<div className="rounded-xl border p-3">{shortText&&<div className="text-sm font-medium">{shortText}</div>}{longText&&<pre className="whitespace-pre-wrap text-sm mt-2">{longText}</pre>}</div>);
+}

--- a/lib/aidoc/vendor.ts
+++ b/lib/aidoc/vendor.ts
@@ -1,35 +1,32 @@
+import { safeParseJson, withDefaults } from "@/lib/utils/safeJson";
 import OpenAI from "openai";
 
-/**
- * Call OpenAI for AI Doc ensuring JSON-only replies.
- */
-type CallIn = { system: string; user: string; instruction: string };
+const oai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY!, timeout: Number(process.env.AIDOC_MODEL_TIMEOUT_MS||25000), maxRetries: 0 });
 
+type CallIn = { system:string; user:string; instruction:string };
 export async function callOpenAIJson({ system, user, instruction }: CallIn): Promise<any> {
-  const oai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
   const model = process.env.AIDOC_MODEL || "gpt-5";
-  try {
-    const resp = await oai.chat.completions.create({
-      model,
-      temperature: 0.2,
-      response_format: { type: "json_object" },
-      messages: [
-        { role: "system", content: system },
-        { role: "user", content: `${instruction}\n\nUSER:\n${user}` },
-      ],
-    });
-    const content = resp.choices?.[0]?.message?.content ?? "{}";
-    return JSON.parse(content);
-  } catch (e) {
-    console.error("callOpenAIJson error", e);
-    // Fallback stub for dev or failure
-    return {
-      reply: "Thanks — I’ll personalize advice using your history. What symptoms are you having today?",
-      save: { medications: [], conditions: [], labs: [], notes: [], prefs: [] },
-      observations: {
-        short: "Let’s gather a bit more info and plan next steps. No stale labs will be quoted.",
-        long: "I’ll consider your active conditions. If we need a lab that’s stale, I’ll suggest a repeat.",
-      },
-    };
+  const SOFT = Number(process.env.AIDOC_SOFT_TIMEOUT_MS||18000);
+  const RETRIES = Number(process.env.AIDOC_SOFT_RETRIES||2);
+  const backoff = (n:number)=>400*Math.pow(2,n);
+  const tryOnce = async (n:number):Promise<any>=>{
+    const ctl = new AbortController(); const timer = setTimeout(()=>ctl.abort("soft-timeout"), SOFT);
+    try{
+      const r = await oai.chat.completions.create({
+        model, temperature:0.2, response_format:{type:"json_object"},
+        messages:[{role:"system",content:system},{role:"user",content:`${instruction}\n\nUSER:\n${user}`}],
+      },{signal:ctl.signal});
+      const content=(r.choices?.[0]?.message?.content??"").trim();
+      const parsed = safeParseJson(content);
+      if(parsed.ok) return withDefaults(parsed.data,{ reply:"", save:{medications:[],conditions:[],labs:[],notes:[],prefs:[]}, observations:{short:"",long:""} });
+      return { reply: content || "I captured your note.", save:{medications:[],conditions:[],labs:[],notes:[],prefs:[]}, observations:{short:"Model returned non-JSON. Using safe fallback.", long:""}, _warn:"non-json" };
+    }catch(e:any){
+      if((e?.name==="AbortError"||String(e).includes("soft-timeout")) && n<RETRIES){ await new Promise(r=>setTimeout(r,backoff(n))); return tryOnce(n+1); }
+      throw e;
+    }finally{ clearTimeout(timer); }
+  };
+  try{ return await tryOnce(0); }catch(err:any){
+    return { reply:"I noted your message. The model is temporarily unavailable.", save:{medications:[],conditions:[],labs:[],notes:[],prefs:[]},
+      observations:{short:"Temporary AI issue — safe fallback used.", long:""}, _error:String(err?.message||err) };
   }
 }

--- a/lib/hooks/useAiDoc.ts
+++ b/lib/hooks/useAiDoc.ts
@@ -1,0 +1,9 @@
+import { useState } from "react";
+export type AiDocOut={reply:string;observations?:{short?:string;long?:string};plan?:{title:string;steps:string[];nudges:string[];rulesFired:string[]}};
+export function useAiDoc(threadId:string){
+  const [loading,setLoading]=useState(false); const [last,setLast]=useState<AiDocOut|null>(null);
+  const send=async(message:string)=>{ setLoading(true); try{
+    const r=await fetch("/api/ai-doc",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({threadId,message})});
+    const data:AiDocOut=await r.json(); setLast(data); return data;
+  }finally{ setLoading(false); } }; return {loading,last,send};
+}

--- a/lib/utils/safeJson.ts
+++ b/lib/utils/safeJson.ts
@@ -1,0 +1,19 @@
+export function stripFences(s: string) {
+  if (!s) return s;
+  const m = s.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  return m ? m[1] : s;
+}
+export function safeParseJson<T=any>(raw:any):{ok:true;data:T}|{ok:false;error:string}{
+  try{
+    if(typeof raw!=="string")return{ok:true,data:raw as T};
+    const s0=raw.trim(); if(!s0) return{ok:false,error:"empty"};
+    try{return{ok:true,data:JSON.parse(s0) as T}}catch{}
+    const s1=stripFences(s0).trim();
+    try{return{ok:true,data:JSON.parse(s1) as T}}catch{}
+    for(let i=s1.length-1;i>=0;i--){ if(s1[i]==="}"){ const c=s1.slice(0,i+1); try{return{ok:true,data:JSON.parse(c) as T}}catch{} }}
+    return{ok:false,error:"parse-failed"};
+  }catch(e:any){ return{ok:false,error:String(e?.message||e)} }
+}
+export function withDefaults<T extends object>(obj:any, defaults:T):T {
+  return { ...(defaults as any), ...(obj||{}) } as T;
+}

--- a/tests/aidoc.prompt.test.ts
+++ b/tests/aidoc.prompt.test.ts
@@ -1,0 +1,9 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildAiDocPrompt } from "@/lib/ai/prompts/aidoc";
+
+test("prompt bans quoting labs >90d", () => {
+  const t=new Date(Date.now()-91*24*60*60*1000).toISOString();
+  const p=buildAiDocPrompt({profile:{},labs:[{name:"HbA1c",value:7.4,takenAt:t}],meds:[],conditions:[]});
+  assert.match(p, /Recent Labs \(≤90d\): none/i);
+});

--- a/tests/aidoc.rules.test.ts
+++ b/tests/aidoc.rules.test.ts
@@ -1,0 +1,9 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { runRules } from "@/lib/aidoc/rules";
+
+test("A1c stale -> repeat", () => {
+  const t=new Date(Date.now()-91*24*60*60*1000).toISOString();
+  const out=runRules({ labs:[{name:"HbA1c",value:7.4,takenAt:t}], meds:[], conditions:[], mem:{prefs:[{key:"pref_test_time",value:"morning"}]} } as any);
+  assert.match(out.steps.join(" "), /Repeat HbA1c/i);
+});


### PR DESCRIPTION
## Summary
- add safe JSON parsing utilities and apply to OpenAI vendor with soft timeout retries
- harden AI Doc API route with preference acks, non-blocking alerts, and graceful fallbacks
- expose client hook and UI components for observations and next steps

## Testing
- `npm test`
- `npx tsx --test tests/aidoc.rules.test.ts tests/aidoc.prompt.test.ts`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68be338bb0b8832f85e28bc70f4da8aa