### PR TITLE
Implement deterministic doctor mode with JSON-only rendering

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -25,10 +25,11 @@ import { sanitizeLLM } from "@/lib/conversation/sanitize";
 import { finalReplyGuard } from "@/lib/conversation/finalReplyGuard";
 import { disambiguate, disambiguateWithMemory } from "@/lib/conversation/disambiguation";
 import { detectTopic, wantsNewTopic, inferTopicFromHistory, seemsOffTopic, rewriteToTopic } from "@/lib/conversation/topic";
-import { renderDoctorSummary } from "@/lib/renderer/templates/doctor";
-import { enforceDoctorMode } from "@/lib/conversation/doctorGuard";
-import { doctorSafetyNotes } from "@/lib/rules/doctorSafety";
 import { polishResponse } from "@/lib/conversation/polish";
+import { normalizeMode } from "@/lib/conversation/mode";
+import { DOCTOR_JSON_SYSTEM, coerceDoctorJson } from "@/lib/conversation/doctorJson";
+import { renderDeterministicDoctorReport } from "@/lib/renderer/templates/doctor";
+import { buildPatientSnapshot } from "@/lib/patient/snapshot";
 
 function contextStringFrom(messages: ChatCompletionMessageParam[]): string {
   return messages
@@ -36,62 +37,34 @@ function contextStringFrom(messages: ChatCompletionMessageParam[]): string {
     .join(" ");
 }
 
-async function buildPatientSnapshot(threadId: string) {
-  // Placeholder patient snapshot; replace with memory aggregation
-  return {
-    name: "Rohan",
-    age: 45,
-    sex: "M",
-    encounterDate: new Date().toISOString().slice(0, 10),
-    diagnoses: ["acute myeloid leukemia"],
-    comorbidities: ["asthma"],
-    meds: ["cytarabine"],
-    labs: [
-      { name: "creatinine", value: 2.1, unit: "mg/dL" },
-      { name: "alt", value: 60, unit: "U/L" },
-    ],
-  };
-}
-
 export async function POST(req: Request) {
-  const { userId, activeThreadId, text, mode, researchOn, clarifySelectId } = await req.json();
+  const body = await req.json();
+  const { messages, mode: rawMode, thread_id } = body;
+  const mode = normalizeMode(rawMode);
+  const userMessage = messages?.[messages.length - 1]?.content || "";
+
+  // DEBUG LOG (remove later): verify we're actually in doctor path
+  console.log("[DoctorMode] mode=", mode, "thread_id=", thread_id);
 
   if (mode === "doctor") {
-    const patient = await buildPatientSnapshot(activeThreadId);
-    const skeleton = renderDoctorSummary(patient);
-
-    const systemWithTemplate = `
-You are MedX Doctor Mode.
-- Provide a structured, clinically reasoned report.
-- Use the following sections exactly as given.
-- Do NOT mention clinical trials, PubMed, NCI, or research.
-- No references or external links.
-- No lifestyle/general wellness advice.
-
-TEMPLATE:
-${skeleton}
-`;
-
-    const messages: ChatCompletionMessageParam[] = [
-      { role: "system", content: systemWithTemplate },
-      { role: "user", content: text },
+    const patient = await buildPatientSnapshot(thread_id);
+    const systemPrompt = DOCTOR_JSON_SYSTEM;
+    const msg: ChatCompletionMessageParam[] = [
+      { role: "system", content: systemPrompt },
+      ...(messages || []),
     ];
-    const raw = await callGroq(messages, { temperature: 0.25, max_tokens: 1200 });
-
-    // Apply Doctor Mode guard
-    let guarded = enforceDoctorMode(raw, skeleton);
-
-    // Standard pipeline
-    let out = polishResponse(guarded);
+    const jsonStr = await callGroq(msg, { temperature: 0 });
+    const sections = coerceDoctorJson(jsonStr);
+    let out = renderDeterministicDoctorReport(patient, sections);
+    out = out.replace(/https?:\/\/\S+/g, "");
+    out = out.replace(/.*\b(trial|study|research|pubmed|clinicaltrials\.gov|NCI|ICTRP|registry)\b.*\n?/gi, "");
+    out = polishResponse(out);
     out = sanitizeLLM(out);
-    const safety = doctorSafetyNotes(patient);
-    if (safety.length) {
-      out += `\n\n**Safety Notes**\n${safety.map(s => `- ${s}`).join("\n")}`;
-    }
-    const final = finalReplyGuard(text, out);
-
-    return NextResponse.json({ ok: true, threadId: activeThreadId, text: final });
+    const final = finalReplyGuard(userMessage, out);
+    return NextResponse.json({ text: final });
   }
+
+  const { userId, activeThreadId, text, researchOn, clarifySelectId } = body;
 
   if (shouldReset(text)) {
     // start new thread logic here

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -39,9 +39,9 @@ function contextStringFrom(messages: ChatCompletionMessageParam[]): string {
 
 export async function POST(req: Request) {
   const body = await req.json();
-  const { messages, mode: rawMode, thread_id } = body;
+  const { messages: incomingMessages, mode: rawMode, thread_id } = body;
   const mode = normalizeMode(rawMode);
-  const userMessage = messages?.[messages.length - 1]?.content || "";
+  const userMessage = incomingMessages?.[incomingMessages.length - 1]?.content || "";
 
   // DEBUG LOG (remove later): verify we're actually in doctor path
   console.log("[DoctorMode] mode=", mode, "thread_id=", thread_id);
@@ -51,7 +51,7 @@ export async function POST(req: Request) {
     const systemPrompt = DOCTOR_JSON_SYSTEM;
     const msg: ChatCompletionMessageParam[] = [
       { role: "system", content: systemPrompt },
-      ...(messages || []),
+      ...(incomingMessages || []),
     ];
     const jsonStr = await callGroq(msg, { temperature: 0 });
     const sections = coerceDoctorJson(jsonStr);

--- a/lib/conversation/doctorJson.ts
+++ b/lib/conversation/doctorJson.ts
@@ -1,0 +1,43 @@
+export const DOCTOR_JSON_SYSTEM = `
+You are MedX Doctor Mode.
+Return ONLY valid JSON matching this TypeScript type:
+{
+  "clinical_implications": string[],
+  "management_options": string[],
+  "supportive_palliative": string[],
+  "red_flags": string[]
+}
+Rules:
+- No trials, research, PubMed, registries, links, or references.
+- No lifestyle/wellness tips.
+- No headings, no markdown, no prose. JSON ONLY.
+- Each array item must be a concise clinical bullet.
+`;
+
+const RESEARCH_RX = /\b(trial|trials|study|studies|research|pubmed|clinicaltrials\.gov|registry|NCI|ICTRP|WHO)\b/i;
+const URL_RX = /https?:\/\/\S+/gi;
+
+export function stripResearchFromBullets(arr: string[]): string[] {
+  return (arr || [])
+    .map(x => x.replace(URL_RX, "").trim())
+    .filter(x => x && !RESEARCH_RX.test(x));
+}
+
+export function coerceDoctorJson(s: string) {
+  try {
+    const j = JSON.parse(s || "{}");
+    return {
+      clinical_implications: stripResearchFromBullets(j.clinical_implications || []),
+      management_options: stripResearchFromBullets(j.management_options || []),
+      supportive_palliative: stripResearchFromBullets(j.supportive_palliative || []),
+      red_flags: stripResearchFromBullets(j.red_flags || []),
+    };
+  } catch {
+    return {
+      clinical_implications: [],
+      management_options: [],
+      supportive_palliative: [],
+      red_flags: [],
+    };
+  }
+}

--- a/lib/conversation/mode.ts
+++ b/lib/conversation/mode.ts
@@ -1,0 +1,10 @@
+export type MedxMode = "doctor" | "patient" | "research" | "therapy" | "doc_ai";
+
+export function normalizeMode(input?: string): MedxMode {
+  const m = (input || "").toLowerCase().trim();
+  if (m.includes("doctor")) return "doctor";
+  if (m.includes("research")) return "research";
+  if (m.includes("therapy")) return "therapy";
+  if (m.includes("doc")) return "doc_ai";
+  return "patient";
+}

--- a/lib/patient/snapshot.ts
+++ b/lib/patient/snapshot.ts
@@ -1,0 +1,20 @@
+export async function buildPatientSnapshot(thread_id: string) {
+  // TODO: Merge memory + recent messages + uploaded docs.
+  // Temporary stub for your Rohan demo:
+  return {
+    name: "Rohan",
+    age: 45,
+    sex: "Male",
+    encounterDate: new Date().toISOString().slice(0,10),
+    diagnoses: ["acute myeloid leukemia (stage 4)"],
+    comorbidities: ["asthma", "hepatomegaly", "renal dysfunction"],
+    meds: ["cytarabine", "beclometasone inhaled"],
+    labs: [
+      { name: "creatinine", value: 2.1, unit: "mg/dL" },
+      { name: "alt", value: 80, unit: "U/L" },
+      { name: "bilirubin total", value: 2.0, unit: "mg/dL" },
+      { name: "hemoglobin", value: 8, unit: "g/dL" },
+    ],
+    allergies: ["penicillin"],
+  };
+}


### PR DESCRIPTION
## Summary
- Normalize conversation modes for doctor and other flows
- Add doctor JSON prompt, research stripping, and deterministic report renderer
- Integrate Doctor Mode path in chat route using patient snapshot stub

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be3adb2a7c832fb3c17a90abd4bba6