### PR TITLE
Ensure auto-opened chat thread appears in sidebar

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -398,6 +398,12 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   }, [threadId, isProfileThread]);
 
   useEffect(() => {
+    if (!threadId) return;
+    // Ensure first auto-opened chat also shows in sidebar
+    upsertThreadIndex(threadId, "Untitled");
+  }, [threadId]);
+
+  useEffect(() => {
     if (!isProfileThread || !threadId) return;
     if (bootedRef.current[threadId]) return;     // run once per thread
     bootedRef.current[threadId] = true;


### PR DESCRIPTION
## Summary
- upsert first thread ID into sidebar index when ChatPane initializes

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68be3c42b4fc832fbe5e5bdf9252d92e