### PR TITLE
feat: add doctor mode chat path and stream guard

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -3,7 +3,10 @@ import { profileChatSystem } from '@/lib/profileChatSystem';
 export const runtime = 'edge';
 
 export async function POST(req: NextRequest) {
-  const { messages = [], threadId, context } = await req.json();
+  const { messages = [], threadId, context, mode } = await req.json();
+  if (String(mode || '').toLowerCase().includes('doctor')) {
+    return new Response('Doctor Mode is not available on the stream endpoint. Use /api/chat.', { status: 400 });
+  }
   const base  = process.env.LLM_BASE_URL!;
   const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
   const key   = process.env.LLM_API_KEY!;


### PR DESCRIPTION
## Summary
- route doctor-mode chats through non-stream `/api/chat`
- prevent doctor mode calls to streaming endpoint

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68be8fec32fc832fa60deead93fc30c8