### PR TITLE
Store full conversation history per thread

### DIFF
--- a/lib/memory/shortTerm.ts
+++ b/lib/memory/shortTerm.ts
@@ -1,0 +1,44 @@
+export type ShortRole = "user" | "assistant";
+export type ShortMsg = { role: ShortRole; text: string; ts: number };
+
+const key = (threadId: string) => `chat:${threadId}:fullmem`;
+
+function sanitize(text: string) {
+  return String(text || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 4000); // cap per-message length, not count
+}
+
+export function getFullMem(threadId: string): ShortMsg[] {
+  try {
+    const raw = localStorage.getItem(key(threadId));
+    const arr = raw ? (JSON.parse(raw) as ShortMsg[]) : [];
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+export function pushFullMem(threadId: string, role: ShortRole, text: string) {
+  try {
+    const arr = getFullMem(threadId);
+    arr.push({ role, text: sanitize(text), ts: Date.now() });
+    localStorage.setItem(key(threadId), JSON.stringify(arr));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Build context from the *entire* conversation */
+export function buildFullContext(threadId: string): string {
+  const mem = getFullMem(threadId);
+  if (!mem.length) return "";
+
+  // Join everything as role-tagged turns
+  const turns = mem
+    .map(m => `${m.role === "user" ? "User" : "Assistant"}: ${m.text}`)
+    .join("\n");
+
+  return turns.slice(0, 20000); // safety cap so prompt doesn’t blow up
+}


### PR DESCRIPTION
## Summary
- Track complete chat history in localStorage with new thread memory utilities.
- Persist user and assistant messages in ChatPane and build follow-up prompts from entire conversation.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be9d091130832f8fb7a824430a065e