### PR TITLE
feat: add structured memory and local recipe edits

### DIFF
--- a/lib/editors/recipeEdit.ts
+++ b/lib/editors/recipeEdit.ts
@@ -1,0 +1,42 @@
+// lib/editors/recipeEdit.ts
+// Minimal, markdown-safe text edits. No parsing library—keep robust & simple.
+
+export function replaceEverywhere(md: string, from: string, to: string) {
+  if (!from || from.toLowerCase() === to.toLowerCase()) return md;
+  const esc = from.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(esc, "gi");
+  return md.replace(re, to);
+}
+
+export function addLineToSection(md: string, section: "Ingredients" | "Instructions", line: string) {
+  if (!line.trim()) return md;
+  const re = new RegExp(`(^|\\n)\\s*#*\\s*${section}\\s*:?\\s*\\n`, "i");
+  const m = md.match(re);
+  if (!m) {
+    // fallback: append new section at end
+    return md + `\n\n## ${section}\n- ${line.trim()}\n`;
+  }
+  const idx = m.index! + m[0].length;
+  return md.slice(0, idx) + `- ${line.trim()}\n` + md.slice(idx);
+}
+
+export function removeEverywhere(md: string, what: string) {
+  if (!what.trim()) return md;
+  const esc = what.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const lineRE = new RegExp(`^.*${esc}.*$\\n?`, "gmi");
+  let out = md.replace(lineRE, (ln) => {
+    // try not to nuke headings
+    return /^#/.test(ln) ? ln : "";
+  });
+  // also general text occurrences
+  const wordRE = new RegExp(esc, "gi");
+  out = out.replace(wordRE, "");
+  return out;
+}
+
+export function addBurrataIfMissing(md: string) {
+  if (/burrata/i.test(md)) return md;
+  let out = addLineToSection(md, "Ingredients", "1 ball burrata (about 8 oz)");
+  out = addLineToSection(out, "Instructions", "Tear burrata into pieces and fold through the warm sauce just before serving.");
+  return out;
+}

--- a/lib/intents/editIntents.ts
+++ b/lib/intents/editIntents.ts
@@ -1,0 +1,43 @@
+export type EditIntent =
+  | { type: "recall"; target?: "recipe" | "plan" }
+  | { type: "finalize"; target?: "recipe" | "plan" }
+  | { type: "replace"; from: string; to: string }
+  | { type: "add"; what: string }
+  | { type: "remove"; what: string }
+  | { type: "transform"; to: "pasta" | "soup" | "sandwich" | "salad" | "generic"; extra?: string }
+  | null;
+
+const clean = (s: string) => s.trim().replace(/^["'`]|["'`]$/g, "");
+
+export function detectEditIntent(text: string): EditIntent {
+  const s = text.toLowerCase().trim();
+
+  // recall / show again
+  if (/\b(pull up|show|repeat|again|previous|last)\b/.test(s) &&
+      /\b(recipe|plan)?\b/.test(s)) {
+    return { type: "recall" };
+  }
+  if (/\bfinal( recipe| plan)?\b/.test(s) || /\bfinalize\b/.test(s)) {
+    return { type: "finalize" };
+  }
+
+  // replace X with Y
+  const rep = s.match(/\breplace\b\s+(.+?)\s+\bwith\b\s+(.+)/i);
+  if (rep) return { type: "replace", from: clean(rep[1]), to: clean(rep[2]) };
+
+  // add X
+  const add = s.match(/\badd\b\s+(.+)/i);
+  if (add) return { type: "add", what: clean(add[1]) };
+
+  // remove X / without X
+  const rem = s.match(/\b(remove|without|no)\b\s+(.+)/i);
+  if (rem) return { type: "remove", what: clean(rem[2]) };
+
+  // simple transforms
+  if (/\b(make|turn)\b.*\binto\b.*\bpasta\b/.test(s)) return { type: "transform", to: "pasta" };
+  if (/\b(make|turn)\b.*\binto\b.*\bsoup\b/.test(s))  return { type: "transform", to: "soup" };
+  if (/\b(make|turn)\b.*\binto\b.*\bsandwich\b/.test(s)) return { type: "transform", to: "sandwich" };
+  if (/\b(make|turn)\b.*\binto\b.*\bsalad\b/.test(s)) return { type: "transform", to: "salad" };
+
+  return null;
+}

--- a/lib/memory/structured.ts
+++ b/lib/memory/structured.ts
@@ -1,0 +1,46 @@
+export type StructuredKind = "recipe" | "plan" | "list" | "other";
+
+export type StructuredBlob = {
+  kind: StructuredKind;
+  title?: string;
+  content: string;       // full markdown text we displayed
+  ts: number;
+};
+
+const key = (threadId: string) => `chat:${threadId}:lastStructured`;
+
+export function getLastStructured(threadId: string): StructuredBlob | null {
+  try {
+    const raw = localStorage.getItem(key(threadId));
+    return raw ? (JSON.parse(raw) as StructuredBlob) : null;
+  } catch { return null; }
+}
+
+export function setLastStructured(threadId: string, blob: StructuredBlob) {
+  try { localStorage.setItem(key(threadId), JSON.stringify(blob)); } catch {}
+}
+
+/** Heuristic: detect if an assistant message looks like a recipe/plan/list */
+export function maybeIndexStructured(threadId: string, assistantMarkdown: string) {
+  const text = String(assistantMarkdown || "");
+  const lower = text.toLowerCase();
+
+  // Simple signals for "recipe-like"
+  const isRecipe =
+    /(^|\n)#+\s*ingredients\b/.test(lower) ||
+    /(^|\n)ingredients\s*:/i.test(text) ||
+    /(^|\n)#+\s*instructions\b/.test(lower) ||
+    /(^|\n)method\s*:/i.test(text);
+
+  const isPlanOrList =
+    /(^|\n)#+\s*(plan|steps|todo|checklist)\b/.test(lower) ||
+    /(^|\n)(-|\*|\d+\.)\s+/.test(text);
+
+  const kind: StructuredKind =
+    isRecipe ? "recipe" : isPlanOrList ? "plan" : "other";
+
+  if (kind === "other") return; // keep it minimal
+
+  const title = (text.match(/^#\s*(.+)$/m) || [, undefined])[1];
+  setLastStructured(threadId, { kind, title, content: text, ts: Date.now() });
+}


### PR DESCRIPTION
## Summary
- add structured memory helpers and simple recipe editor utilities
- detect edit intents for quick recipe and plan tweaks
- wire ChatPane to index structured replies and handle fast-path edits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bea29df1d4832f9165e3760462e673