### PR TITLE
feat: add answer recall registry and context

### DIFF
--- a/lib/intents/recall.ts
+++ b/lib/intents/recall.ts
@@ -1,0 +1,29 @@
+export type RecallIntent =
+  | { type: "repeatLast" }
+  | { type: "recallTag"; tag: "diet"|"recipe"|"plan"|"workout"|"dosage"|"meds"|"symptoms"|"labs"|"guidelines"|"trials" }
+  | null;
+
+export function detectRecallIntent(text: string): RecallIntent {
+  const s = text.toLowerCase().trim();
+
+  // “repeat”, “pull up again”, “show previous”, “show that again”
+  if (/\b(repeat|again|pull up|show (it|that|previous|last))\b/.test(s)) {
+    return { type: "repeatLast" };
+  }
+
+  // “show the diet again”, “pull up the recipe”, “recall trials”
+  const tagMap: Record<string, RecallIntent["tag"]> = {
+    diet: "diet", recipe: "recipe", plan: "plan", workout: "workout", exercise: "workout",
+    dosage: "dosage", dose: "dosage", meds: "meds", medication: "meds",
+    symptoms: "symptoms", labs: "labs", guidelines: "guidelines", trials: "trials"
+  };
+
+  for (const k of Object.keys(tagMap)) {
+    if (new RegExp(`\\b(${k})\\b`).test(s) && /\b(show|pull up|repeat|again|bring back|recall)\b/.test(s)) {
+      return { type: "recallTag", tag: tagMap[k] };
+    }
+  }
+
+  return null;
+}
+

--- a/lib/memory/answerRegistry.ts
+++ b/lib/memory/answerRegistry.ts
@@ -1,0 +1,68 @@
+export type AnswerTag =
+  | "diet" | "recipe" | "plan" | "workout" | "dosage" | "meds"
+  | "symptoms" | "labs" | "guidelines" | "trials" | "general";
+
+export type AnswerSnap = {
+  id: string;
+  ts: number;
+  title?: string;
+  tags: AnswerTag[];
+  content: string;   // markdown we showed
+};
+
+const key = (threadId: string) => `chat:${threadId}:answers`;
+
+export function getAnswers(threadId: string): AnswerSnap[] {
+  try {
+    const raw = localStorage.getItem(key(threadId));
+    const arr = raw ? (JSON.parse(raw) as AnswerSnap[]) : [];
+    return Array.isArray(arr) ? arr : [];
+  } catch { return []; }
+}
+
+export function setAnswers(threadId: string, snaps: AnswerSnap[]) {
+  try { localStorage.setItem(key(threadId), JSON.stringify(snaps)); } catch {}
+}
+
+export function indexAnswer(threadId: string, markdown: string) {
+  const content = String(markdown || "").trim();
+  if (!content) return;
+
+  const lower = content.toLowerCase();
+  const tags: AnswerTag[] = [];
+  const has = (re: RegExp) => re.test(lower);
+
+  // very small, safe heuristics
+  if (has(/\bdiet\b|\bnutrition\b/)) tags.push("diet");
+  if (has(/\brecipe\b|ingredients|instructions|method/)) tags.push("recipe");
+  if (has(/\bplan\b|steps|checklist/)) tags.push("plan");
+  if (has(/\bworkout\b|exercise|yoga|walk|cardio|strength/)) tags.push("workout");
+  if (has(/\bdose|dosage|mg\b/)) tags.push("dosage");
+  if (has(/\bmedication|medicine|drug\b/)) tags.push("meds");
+  if (has(/\bsymptom\b/)) tags.push("symptoms");
+  if (has(/\blab\b|hba1c|ldl|hdl|tsh|crp|platelets|wbc/)) tags.push("labs");
+  if (has(/\bguideline|recommendation/i)) tags.push("guidelines");
+  if (has(/\bclinical trial|nct|phase\b/)) tags.push("trials");
+  if (!tags.length) tags.push("general");
+
+  const title = (content.match(/^#\s*(.+)$/m) || [, undefined])[1];
+
+  const snaps = getAnswers(threadId);
+  snaps.push({ id: crypto.randomUUID(), ts: Date.now(), title, tags, content });
+  // optional soft cap (keep newest 200)
+  setAnswers(threadId, snaps.slice(-200));
+}
+
+export function findLatestByTag(threadId: string, tag: AnswerTag): AnswerSnap | null {
+  const snaps = getAnswers(threadId);
+  for (let i = snaps.length - 1; i >= 0; i--) {
+    if (snaps[i].tags.includes(tag)) return snaps[i];
+  }
+  return null;
+}
+
+export function getLastAnswer(threadId: string): AnswerSnap | null {
+  const snaps = getAnswers(threadId);
+  return snaps.length ? snaps[snaps.length - 1] : null;
+}
+

--- a/lib/memory/context.ts
+++ b/lib/memory/context.ts
@@ -1,0 +1,27 @@
+import { findLatestByTag, getLastAnswer } from "./answerRegistry";
+import { buildFullContext } from "./shortTerm"; // already in your repo
+
+export function buildChatContextForPrompt(threadId: string, hintTag?: string) {
+  const full = buildFullContext(threadId); // entire dialog (capped in that util)
+  let featured = "";
+
+  if (hintTag) {
+    const snap = findLatestByTag(threadId, hintTag as any);
+    if (snap) featured =
+`----- Featured prior answer (${hintTag}) -----
+${snap.content}
+----- /featured -----
+`;
+  } else {
+    // default: last answer as anchor
+    const last = getLastAnswer(threadId);
+    if (last) featured =
+`----- Featured prior answer -----
+${last.content}
+----- /featured -----
+`;
+  }
+
+  return `${featured}\n${full}`.trim();
+}
+


### PR DESCRIPTION
## Summary
- track assistant answers in localStorage for tagged recall
- detect recall intents and surface previous answers without LLM
- compose prior answers into prompt context and index new responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bea66737d4832fb8b820a1d4b1f39c