### PR TITLE
feat: add domain routing and tagging

### DIFF
--- a/lib/intents/domains.ts
+++ b/lib/intents/domains.ts
@@ -1,0 +1,13 @@
+export type DomainKind =
+  | "allied" | "wellness" | "technical" | "behavioral" | "supportive" | "compliance" | null;
+
+export function detectDomain(text: string): DomainKind {
+  const s = text.toLowerCase();
+  if (/\bnurse|nursing|paramedic|physio|occupational therapy|speech therapy|respiratory therapy|rehab\b/.test(s)) return "allied";
+  if (/\bnutrition|diet|meal plan|fitness|workout|sports medicine|sleep|insomnia|apnea|lifestyle|ayurveda|tcm|naturopathy\b/.test(s)) return "wellness";
+  if (/\bchemistry|biochemistry|pharmacology|toxicology|genomics|microbiology|virology|molar mass|stoichiometry|experiment|assay\b/.test(s)) return "technical";
+  if (/\bpsychology|psychiatry|cbt|addiction|substance use|sexual health|mindfulness|public health\b/.test(s)) return "behavioral";
+  if (/\bdental|dermatology|occupational health|travel medicine|forensic|economics|qaly|hta\b/.test(s)) return "supportive";
+  if (/\behr|fhir|dicom|interoperability|hipaa|gdpr|compliance|telemedicine|virtual care|hl7\b/.test(s)) return "compliance";
+  return null;
+}

--- a/lib/intents/recall.ts
+++ b/lib/intents/recall.ts
@@ -1,0 +1,10 @@
+export function recallDomainTags(text: string): string[] | null {
+  const s = text.toLowerCase();
+  if (/pull up the rehab plan|rehab plan|rehab protocol/.test(s)) {
+    return ["physiotherapy", "wellness"];
+  }
+  if (/show the sleep protocol|sleep protocol|sleep plan/.test(s)) {
+    return ["sleep", "wellness"];
+  }
+  return null;
+}

--- a/lib/memory/answerRegistry.ts
+++ b/lib/memory/answerRegistry.ts
@@ -1,0 +1,62 @@
+export type AnswerTag =
+  | "allied" | "paramedic" | "nursing" | "physiotherapy" | "ot" | "speech"
+  | "respiratory" | "wellness" | "nutrition" | "fitness" | "sportsmed" | "sleep"
+  | "mentalhealth" | "lifestyle" | "altmed"
+  | "chem" | "biochem" | "pharmacology" | "toxicology" | "genomics" | "microbiology" | "virology"
+  | "envhealth" | "biomed" | "biostats" | "epi" | "ai-data"
+  | "psychiatry" | "addiction" | "sexual" | "mindfulness" | "publichealth"
+  | "dental" | "derm" | "occupational" | "travel" | "forensic" | "healthecon"
+  | "healthit" | "regulatory" | "edresearch" | "telemedicine"
+  | string;
+
+export function indexAnswer(content: string): AnswerTag[] {
+  const lower = content.toLowerCase();
+  const tags: AnswerTag[] = [];
+
+  if (/\bnurse|nursing|np\b/.test(lower)) tags.push("nursing", "allied");
+  if (/\bparamedic|first responder|trauma|emt\b/.test(lower)) tags.push("paramedic", "allied");
+  if (/\bphysio|physiotherapy|rehab\b/.test(lower)) tags.push("physiotherapy", "allied");
+  if (/\boccupational therapy|ergonomic|adl\b/.test(lower)) tags.push("ot", "allied");
+  if (/\bspeech therapy|aphasia|dysphagia|slp\b/.test(lower)) tags.push("speech", "allied");
+  if (/\brespiratory therapy|ventilator|copd\b/.test(lower)) tags.push("respiratory", "allied");
+
+  if (/\bnutrition|dietitian|meal plan|macro\b/.test(lower)) tags.push("nutrition", "wellness");
+  if (/\bfitness|exercise|strength|mobility\b/.test(lower)) tags.push("fitness", "wellness");
+  if (/\bsports medicine|acl|rotator cuff|return to play\b/.test(lower)) tags.push("sportsmed", "wellness");
+  if (/\bsleep|insomnia|apnea|sleep hygiene\b/.test(lower)) tags.push("sleep", "wellness");
+  if (/\bcbt|counselor|psychologist|anxiety|depression\b/.test(lower)) tags.push("mentalhealth", "wellness");
+  if (/\blifestyle medicine|habit|behavior change\b/.test(lower)) tags.push("lifestyle", "wellness");
+  if (/\bayurveda|tcm|naturopathy|acupuncture\b/.test(lower)) tags.push("altmed", "wellness");
+
+  if (/\bpharmacology|dose|interaction|side effect\b/.test(lower)) tags.push("pharmacology");
+  if (/\btoxicology|overdose|poison\b/.test(lower)) tags.push("toxicology");
+  if (/\bchemistry|biochemistry|metabolite\b/.test(lower)) tags.push("chem", "biochem");
+  if (/\bgenomic|crisper|mutation|variant\b/.test(lower)) tags.push("genomics");
+  if (/\bmicrobiolog|bacteria|antibiotic\b/.test(lower)) tags.push("microbiology");
+  if (/\bvirology|virus|viral load\b/.test(lower)) tags.push("virology");
+  if (/\benvironmental health|pollution|occupational hazard\b/.test(lower)) tags.push("envhealth");
+  if (/\bbiomedical engineer|device|prosthetic|wearable\b/.test(lower)) tags.push("biomed");
+  if (/\bbiostat|survival|cox|p value\b/.test(lower)) tags.push("biostats");
+  if (/\bepidemiolog|incidence|prevalence|rr|or\b/.test(lower)) tags.push("epi");
+  if (/\bmachine learning|ai|model|auc|roc|cnn\b/.test(lower)) tags.push("ai-data");
+
+  if (/\bpsychiatry|mood|psychosis|antipsychotic\b/.test(lower)) tags.push("psychiatry");
+  if (/\baddiction|substance use|rehab center\b/.test(lower)) tags.push("addiction");
+  if (/\bsexual health|sti|contraception\b/.test(lower)) tags.push("sexual");
+  if (/\bmindful|meditation|breathing\b/.test(lower)) tags.push("mindfulness");
+  if (/\bpublic health|vaccination|screening program\b/.test(lower)) tags.push("publichealth");
+
+  if (/\bdentist|oral surgery|periodontal\b/.test(lower)) tags.push("dental");
+  if (/\bdermatology|acne|aesthetic|cosmetic\b/.test(lower)) tags.push("derm");
+  if (/\boccupational health|fit test|ergonomics\b/.test(lower)) tags.push("occupational");
+  if (/\btravel medicine|vaccine certificate|malaria prophylaxis\b/.test(lower)) tags.push("travel");
+  if (/\bforensic|medicolegal|toxicology report\b/.test(lower)) tags.push("forensic");
+  if (/\bhealth economics|cost-effectiveness|qaly|hta\b/.test(lower)) tags.push("healthecon");
+
+  if (/\behr|hl7|fhir|dicom|interop\b/.test(lower)) tags.push("healthit");
+  if (/\bhipaa|gdpr|compliance|regulatory\b/.test(lower)) tags.push("regulatory");
+  if (/\bmedical education|curriculum|residency\b/.test(lower)) tags.push("edresearch");
+  if (/\btelemedicine|remote care|virtual visit\b/.test(lower)) tags.push("telemedicine");
+
+  return Array.from(new Set(tags));
+}

--- a/lib/memory/answerRegistry.ts
+++ b/lib/memory/answerRegistry.ts
@@ -1,4 +1,5 @@
 export type AnswerTag =
+  | "pediatrics" | "nephrology" | "cardiology"
   | "allied" | "paramedic" | "nursing" | "physiotherapy" | "ot" | "speech"
   | "respiratory" | "wellness" | "nutrition" | "fitness" | "sportsmed" | "sleep"
   | "mentalhealth" | "lifestyle" | "altmed"
@@ -12,6 +13,10 @@ export type AnswerTag =
 export function indexAnswer(content: string): AnswerTag[] {
   const lower = content.toLowerCase();
   const tags: AnswerTag[] = [];
+
+  if (/\bpediatric|child\b/.test(lower)) tags.push("pediatrics");
+  if (/\bnephro|kidney\b/.test(lower)) tags.push("nephrology");
+  if (/\bcardio|heart\b/.test(lower)) tags.push("cardiology");
 
   if (/\bnurse|nursing|np\b/.test(lower)) tags.push("nursing", "allied");
   if (/\bparamedic|first responder|trauma|emt\b/.test(lower)) tags.push("paramedic", "allied");

--- a/lib/prompts/domains.ts
+++ b/lib/prompts/domains.ts
@@ -1,0 +1,21 @@
+export const ALLIED_STYLE = `
+Allied Health expert tone. Provide stepwise, practical workflows, safety checks, and escalation criteria.
+Output: (1) brief context, (2) step-by-step protocol, (3) red flags, (4) patient & caregiver instructions, (5) references.`.trim();
+
+export const WELLNESS_STYLE = `
+Wellness & preventive tone. Evidence-based recommendations with ranges (macros, sets/reps, sleep hygiene).
+Output: (1) baseline, (2) plan with specifics, (3) adherence tips, (4) cautions/contraindications, (5) references.`.trim();
+
+export const TECHNICAL_SCI_STYLE = `
+Scientific/technical tone. Use correct units, equations, and methods. Cite authoritative sources (NIST, IUPAC, PubMed).
+Output: (1) framework/formulas, (2) calculation/logic, (3) result with units, (4) validation, (5) references.`.trim();
+
+export const BEHAVIORAL_STYLE = `
+Behavioral health tone. Supportive, non-judgmental, evidence-based (CBT/MI). Safety first with crisis resources.
+Output: (1) concern summary, (2) brief formulation, (3) stepwise plan, (4) red flags + crisis links, (5) references.`.trim();
+
+export const SUPPORTIVE_STYLE = `
+Supportive/adjacent specialties (dental/derm/occupational/travel/forensic/econ). Provide clear triage, when-to-refer, and concise patient advice with references.`.trim();
+
+export const COMPLIANCE_STYLE = `
+Tech + compliance tone. Be precise about standards (HIPAA, GDPR, HL7/FHIR/DICOM). Provide implementation steps and checklists. Avoid legal advice; provide references.`.trim();


### PR DESCRIPTION
## Summary
- expand answer tagging with allied health, wellness, technical, and other domain tags and heuristics
- add domain-specific prompt styles and intent detection
- route chat prompts through domain styles based on detected user intent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bec0056670832f957427f864e3141c