### PR TITLE
feat: add advanced domain routing and styles

### DIFF
--- a/lib/intents/advanced.ts
+++ b/lib/intents/advanced.ts
@@ -1,0 +1,33 @@
+export type AdvancedDomain =
+  | "behav-med"
+  | "env-occ"
+  | "data-tech"
+  | "genomics"
+  | "preventive"
+  | "systems-policy"
+  | null;
+
+export function detectAdvancedDomain(text: string): AdvancedDomain {
+  const s = text.toLowerCase();
+
+  if (/\bclinical psychology|behavioral medicine|cognitive neuroscience|neurocognitive|health coaching|adherence\b/.test(s))
+    return "behav-med";
+
+  if (/\benvironmental health|pollution|toxicology|occupational|ergonomic|aerospace|hyperbaric|diving\b/.test(s))
+    return "env-occ";
+
+  if (/\bbiomedical engineering|implant|sensor|informatics|ehr|telemedicine|digital therapeutics|bioinformatics|proteomics|biostatistics|epidemiolog.*model|ai ethics|explainability|fairness\b/.test(s))
+    return "data-tech";
+
+  if (/\bgenetic|epigenetic|pharmacogenomic|molecular diagnostic|liquid biopsy|crispr\b/.test(s))
+    return "genomics";
+
+  if (/\bsleep|chronobiology|circadian|lifestyle medicine|diet|exercise|integrative|complementary|ayurveda|acupuncture|mindfulness\b/.test(s))
+    return "preventive";
+
+  if (/\bglobal health|pandemic|health economics|policy|qaly|hta|medical education|adaptive learning|clinical decision support\b/.test(s))
+    return "systems-policy";
+
+  return null;
+}
+

--- a/lib/memory/answerRegistry.ts
+++ b/lib/memory/answerRegistry.ts
@@ -1,10 +1,73 @@
-export type AnswerTag = "general" | "math" | "history";
+export type AnswerTag =
+  | "general"
+  | "math"
+  | "history"
+  | "behavmed"
+  | "clinpsych"
+  | "cogneuro"
+  | "healthcoaching"
+  | "envhealth"
+  | "occupational"
+  | "aerospace"
+  | "hyperbaric"
+  | "biomed"
+  | "healthit"
+  | "bioinformatics"
+  | "compbio"
+  | "biostats"
+  | "epi-modeling"
+  | "ai-ethics"
+  | "genetics"
+  | "epigenetics"
+  | "pharmacogenomics"
+  | "mol-diagnostics"
+  | "sleep"
+  | "chronobiology"
+  | "lifestyle"
+  | "integrative"
+  | "complementary"
+  | "globalhealth"
+  | "healthecon"
+  | "policy"
+  | "meded";
 
 export function indexAnswer(text: string) {
   const tags: AnswerTag[] = [];
   const lower = text.toLowerCase();
   if (/\=|∫|∂|√|\btheorem|lemma|proof\b/i.test(lower)) tags.push("math");
   if (/\bempire|dynasty|treaty|revolution|war|reign|century\b/i.test(lower)) tags.push("history");
+  // lower = answer text lowercased
+  if (/\bclinical psychology|cbt|dbt|mi\b/.test(lower)) tags.push("clinpsych", "behavmed");
+  if (/\bbehavioral medicine|addiction|relapse prevention\b/.test(lower)) tags.push("behavmed");
+  if (/\bcognitive neuroscience|executive function|working memory|neurorehab\b/.test(lower)) tags.push("cogneuro");
+  if (/\bhealth coaching|motivational interviewing|adherence\b/.test(lower)) tags.push("healthcoaching");
+
+  if (/\benvironmental health|air quality|pollution|toxicology\b/.test(lower)) tags.push("envhealth");
+  if (/\boccupational medicine|ergonomics|repetitive strain\b/.test(lower)) tags.push("occupational");
+  if (/\baerospace medicine|high altitude|g force|flight surgeon\b/.test(lower)) tags.push("aerospace");
+  if (/\bhyperbaric|decompression sickness|diving medicine\b/.test(lower)) tags.push("hyperbaric");
+
+  if (/\bbiomedical engineering|implant|sensor|prosthetic|device integration\b/.test(lower)) tags.push("biomed");
+  if (/\behr|telemedicine|digital therapeutics|informatics\b/.test(lower)) tags.push("healthit");
+  if (/\bbioinformatics|proteomics|sequence alignment|systems biology\b/.test(lower)) tags.push("bioinformatics", "compbio");
+  if (/\bbiostatistics|survival analysis|cox|kaplan\-meier\b/.test(lower)) tags.push("biostats");
+  if (/\bepidemiolog(y|ic(al)?) modeling|seir|r0|r_t\b/.test(lower)) tags.push("epi-modeling");
+  if (/\bai ethics|fairness|explainability|bias detection\b/.test(lower)) tags.push("ai-ethics");
+
+  if (/\bgenetics|genome|variant|snv|cnv\b/.test(lower)) tags.push("genetics");
+  if (/\bepigenetic|methylation|chromatin\b/.test(lower)) tags.push("epigenetics");
+  if (/\bpharmacogenomic|cyp2d6|cyp2c19|hlar\b/.test(lower)) tags.push("pharmacogenomics");
+  if (/\bmolecular diagnostics|liquid biopsy|crispr test\b/.test(lower)) tags.push("mol-diagnostics");
+
+  if (/\bsleep medicine|insomnia|apnea|chronotype\b/.test(lower)) tags.push("sleep");
+  if (/\bchronobiology|circadian|zeitgeber\b/.test(lower)) tags.push("chronobiology");
+  if (/\blifestyle medicine|diet|exercise|stress management\b/.test(lower)) tags.push("lifestyle");
+  if (/\bintegrative medicine|complementary|acupuncture|ayurveda|mindfulness\b/.test(lower)) tags.push("integrative", "complementary");
+
+  if (/\bglobal health|pandemic|cross\-border|travel advisory\b/.test(lower)) tags.push("globalhealth");
+  if (/\bhealth economics|cost\-effectiveness|qaly|hta|payer\b/.test(lower)) tags.push("healthecon", "policy");
+  if (/\bpolicy|regulatory impact|reimbursement\b/.test(lower)) tags.push("policy");
+  if (/\bmedical education|curriculum|adaptive learning|cds\b/.test(lower)) tags.push("meded");
   if (!tags.length) tags.push("general");
   return tags;
 }

--- a/lib/prompts/advancedDomains.ts
+++ b/lib/prompts/advancedDomains.ts
@@ -1,0 +1,36 @@
+export const BEHAV_MED_STYLE = `
+Behavioral & Mental Health tone:
+- Use evidence-based models (CBT, DBT, MI), clear steps, crisis resources.
+- Output: (1) concern summary, (2) brief formulation, (3) plan, (4) red flags, (5) references.
+`.trim();
+
+export const ENV_OCC_STYLE = `
+Environmental & Occupational Health tone:
+- Risk pathways, exposure limits, control hierarchy, ergonomic adjustments.
+- Output: (1) hazard summary, (2) assessment, (3) mitigation steps, (4) escalation, (5) references.
+`.trim();
+
+export const DATA_TECH_STYLE = `
+Data & Technology Sciences tone:
+- Be precise on devices, standards (HL7/FHIR/DICOM), pipelines, analytics, and XAI.
+- Output: (1) architecture, (2) method/metrics, (3) risks/bias, (4) implementation steps, (5) references.
+`.trim();
+
+export const GENOMICS_STYLE = `
+Genomics & Precision Medicine tone:
+- Variant interpretation (ACMG), gene-drug, panels, privacy.
+- Output: (1) context, (2) assay/variant details, (3) clinical relevance, (4) actionability, (5) references.
+`.trim();
+
+export const PREVENTIVE_STYLE = `
+Preventive & Lifestyle Sciences tone:
+- Sleep/chrono, diet, exercise; give ranges and progression, contraindications.
+- Output: (1) baseline, (2) plan with specifics, (3) adherence tips, (4) cautions, (5) references.
+`.trim();
+
+export const SYSTEMS_POLICY_STYLE = `
+Health Systems & Policy tone:
+- Systems view, resources, equity, cost-effectiveness; avoid legal advice.
+- Output: (1) policy context, (2) options with trade-offs, (3) implementation, (4) measurement, (5) references.
+`.trim();
+


### PR DESCRIPTION
## Summary
- expand answer tagging to cover behavioral medicine, environmental health, data tech, genomics, preventive, and policy domains
- add advanced domain intent detection and style prompts
- integrate domain-specific styles into chat send flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bec73ef8b8832fa21f86f870ad3a79