### PR TITLE
feat: add clinical trial detail lookup

### DIFF
--- a/lib/medx.ts
+++ b/lib/medx.ts
@@ -93,6 +93,13 @@ function buildSystemPrompt({ mode, citations, topic }: { mode: string; citations
   if (citations) {
     sys += `\nCitations:\n${citations}`;
   }
+  sys += `
+
+TOOLING NOTE:
+- If the user mentions an NCT ID and asks for details, do NOT summarize blindly.
+- Reply with: "Fetching details for NCT########…" THEN rely on the UI fast-path to show structured details.
+- If details are missing, say so briefly and suggest the ct.gov page.
+`.trim();
   return sys;
 }
 

--- a/lib/trials/details.ts
+++ b/lib/trials/details.ts
@@ -1,0 +1,38 @@
+export type TrialDetail = {
+  id: string; title: string; status: string;
+  phase: string | null;
+  conditions: string[];
+  outcomes: { measure: string; description: string }[];
+  locations: { facility?: string; city?: string; country?: string }[];
+  url: string | null;
+};
+
+export async function fetchTrialDetail(nctid: string): Promise<TrialDetail> {
+  const r = await fetch(`/api/trials/${encodeURIComponent(nctid)}`);
+  if (!r.ok) throw new Error(`Failed to fetch trial ${nctid}`);
+  const j = await r.json();
+  return j.trial as TrialDetail;
+}
+
+export function formatTrialDetail(t: TrialDetail): string {
+  const lines: string[] = [];
+  lines.push(`**${t.title || t.id}**`);
+  lines.push(`- **NCT ID:** ${t.id}`);
+  if (t.phase)   lines.push(`- **Phase:** ${t.phase}`);
+  if (t.status)  lines.push(`- **Status:** ${t.status}`);
+  if (t.conditions?.length) lines.push(`- **Conditions:** ${t.conditions.join(", ")}`);
+  if (t.outcomes?.length) {
+    lines.push(`- **Primary outcomes:**`);
+    for (const o of t.outcomes.slice(0, 3)) {
+      lines.push(`  - ${o.measure}${o.description ? ` — ${o.description}` : ""}`);
+    }
+  }
+  if (t.locations?.length) {
+    const locs = t.locations.slice(0, 5)
+      .map(l => [l.facility, l.city, l.country].filter(Boolean).join(", "))
+      .filter(Boolean);
+    if (locs.length) lines.push(`- **Locations (sample):** ${locs.join(" · ")}`);
+  }
+  if (t.url) lines.push(`- **Link:** ${t.url}`);
+  return lines.join("\n");
+}

--- a/pages/api/trials/[nctid].ts
+++ b/pages/api/trials/[nctid].ts
@@ -1,0 +1,48 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+// Small helper to keep JSON shape stable for UI
+function normalizeCtGov(study: any) {
+  const p = study?.protocolSection ?? {};
+  const id = p?.identificationModule?.nctId ?? "";
+  const title = p?.identificationModule?.briefTitle ?? "";
+  const status = p?.statusModule?.overallStatus ?? "";
+  const phases = p?.designModule?.phases ?? [];
+  const conditions = p?.conditionsModule?.conditions ?? [];
+  const outcomes = (p?.outcomesModule?.primaryOutcomes ?? []).map((o: any) => ({
+    measure: o?.measure ?? "",
+    description: o?.description ?? ""
+  }));
+  const locations =
+    p?.contactsLocationsModule?.locations?.map((l: any) => ({
+      facility: l?.facility,
+      city: l?.city,
+      country: l?.country
+    })) ?? [];
+  return {
+    id, title, status,
+    phase: phases?.[0] ?? null,
+    conditions, outcomes, locations,
+    url: id ? `https://clinicaltrials.gov/study/${id}` : null
+  };
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const { nctid } = req.query;
+    if (!nctid || typeof nctid !== "string" || !/^NCT\d{8}$/i.test(nctid))
+      return res.status(400).json({ error: "Missing or invalid NCT ID" });
+
+    const url = `https://clinicaltrials.gov/api/v2/studies/${encodeURIComponent(nctid.toUpperCase())}`;
+    const r = await fetch(url, { next: { revalidate: 3600 } }); // passive cache OK on Vercel
+    if (!r.ok) return res.status(r.status).json({ error: `ct.gov ${r.status}` });
+
+    const data = await r.json();
+    const study = Array.isArray(data?.studies) ? data.studies[0] : data;
+    if (!study) return res.status(404).json({ error: "Not found" });
+
+    return res.status(200).json({ trial: normalizeCtGov(study), raw: undefined }); // no raw by default
+  } catch (e: any) {
+    console.error("Trial detail error:", e);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+}


### PR DESCRIPTION
## Summary
- add API route to fetch and normalize ClinicalTrials.gov v2 study data
- expose client utilities to retrieve and format trial details
- intercept NCT detail requests in chat with a fast-path and system prompt hint

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bed2e2734c832fb939c406ee876512