### PR TITLE
Apply MedX theming

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -87,3 +87,72 @@
   z-index: 1;
 }
 
+/* === MedX Theme Tokens (Light & Dark) === */
+:root {
+  --medx-bg-a: #e9efff;   /* light indigo */
+  --medx-bg-b: #d0f3ff;   /* light cyan */
+  --medx-text: #0F172A;
+  --medx-subtext: #334155;
+
+  /* accents from reference */
+  --medx-accent: #2563EB;   /* blue */
+  --medx-accent2: #0891B2;  /* teal */
+  --medx-red: #F97316;      /* orange/red */
+  --medx-teal: #14B8A6;     /* teal */
+  --medx-purple: #7C3AED;   /* purple */
+
+  /* surfaces */
+  --medx-surface: rgba(255,255,255,0.80);
+  --medx-panel: rgba(255,255,255,0.90);
+  --medx-outline: rgba(15, 23, 42, 0.10);
+}
+
+.dark {
+  --medx-bg-a: #342eec;   /* deep indigo */
+  --medx-bg-b: #27b6da;   /* cyan/teal */
+  --medx-text: #E6E9F1;
+  --medx-subtext: #B6C2D0;
+
+  --medx-accent: #60A5FA;   /* blue */
+  --medx-accent2: #22D3EE;  /* cyan */
+  --medx-red: #F97316;      /* orange/red */
+  --medx-teal: #2DD4BF;     /* teal */
+  --medx-purple: #A78BFA;   /* purple */
+
+  --medx-surface: rgba(0,0,0,0.35);
+  --medx-panel: rgba(3, 7, 18, 0.55);
+  --medx-outline: rgba(255,255,255,0.12);
+}
+
+/* Gradient background wrapper */
+.medx-gradient-bg {
+  background: linear-gradient(135deg, var(--medx-bg-a), var(--medx-bg-b));
+}
+
+/* Glass panel helper */
+.medx-glass {
+  background: var(--medx-panel);
+  backdrop-filter: saturate(140%) blur(12px);
+  border: 1px solid var(--medx-outline);
+}
+
+/* Subtle glass (chips/buttons) */
+.medx-surface {
+  background: var(--medx-surface);
+  border: 1px solid var(--medx-outline);
+}
+
+/* Accent buttons */
+.medx-btn-accent {
+  background: var(--medx-accent);
+  color: white;
+}
+.medx-btn-secondary-accent {
+  background: var(--medx-accent2);
+  color: white;
+}
+
+/* Text colors */
+.text-medx { color: var(--medx-text); }
+.text-medx-sub { color: var(--medx-subtext); }
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,15 +18,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <ContextProvider>
             <TopicProvider>
               <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-                <div className="flex">
-                  <Suspense fallback={null}>
-                    <Sidebar />
-                  </Suspense>
-                  <main className="flex-1 md:ml-64 min-h-dvh flex flex-col relative z-0">
-                    {children}
-                    <MemorySnackbar />
-                    <UndoToast />
-                  </main>
+                <div className="medx-gradient-bg min-h-dvh">
+                  <div className="flex">
+                    <Suspense fallback={null}>
+                      <Sidebar />
+                    </Suspense>
+                    <main className="flex-1 md:ml-64 min-h-dvh flex flex-col relative z-0">
+                      {children}
+                      <MemorySnackbar />
+                      <UndoToast />
+                    </main>
+                  </div>
                 </div>
               </ThemeProvider>
             </TopicProvider>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -19,8 +19,8 @@ export default function Header({
   onTherapyChange: (v: boolean) => void;
 }) {
   return (
-    <header className="sticky top-0 z-40 h-14 md:h-16 bg-white/80 dark:bg-gray-900/80 backdrop-blur supports-[backdrop-filter]:bg-white/60 dark:supports-[backdrop-filter]:bg-gray-900/60 border-b border-slate-200 dark:border-gray-800">
-      <div className="max-w-6xl mx-auto h-full px-4 sm:px-6 flex items-center justify-between">
+    <header className="sticky top-0 z-40 h-14 md:h-16 medx-glass flex items-center">
+      <div className="max-w-6xl mx-auto h-full px-4 sm:px-6 flex items-center justify-between w-full">
         <div className="flex items-center gap-2 text-base md:text-lg font-semibold">
           <div>MedX</div>
           <CountryGlobe />
@@ -29,7 +29,7 @@ export default function Header({
           <TherapyToggle onChange={onTherapyChange} />
           <button
             onClick={() => onModeChange(mode === 'patient' ? 'doctor' : 'patient')}
-            className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm bg-slate-100 text-slate-800 border-slate-200 hover:bg-slate-200 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700 dark:hover:bg-gray-700"
+            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-xl text-sm medx-surface text-medx"
           >
             {mode === 'patient' ? (
               <>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Plus, Search, Settings } from 'lucide-react';
+import { Search, Settings } from 'lucide-react';
 import Tabs from './sidebar/Tabs';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
@@ -32,51 +32,68 @@ export default function Sidebar() {
   };
   const filtered = threads.filter(t => t.title.toLowerCase().includes(q.toLowerCase()));
   return (
-    <nav className="sidebar-click-guard hidden md:flex md:flex-col !fixed inset-y-0 left-0 w-64 bg-white dark:bg-gray-900 border-r border-slate-200 dark:border-gray-800">
-      <button type="button" onClick={handleNew} className="mx-3 my-3 h-10 rounded-xl bg-slate-100 hover:bg-slate-200 dark:bg-gray-800 dark:hover:bg-gray-700 flex items-center justify-center gap-2">
-        <Plus size={16} /> New Chat
-      </button>
+    <aside
+      className="sidebar-click-guard hidden md:flex md:flex-col !fixed inset-y-0 left-0 h-full justify-between medx-glass"
+      style={{ width: 280, color: "var(--medx-text)" }}
+    >
+      <div>
+        <button
+          type="button"
+          onClick={handleNew}
+          className="w-full text-left px-4 py-3 rounded-xl mb-4 font-medium medx-btn-accent"
+        >
+          + New Chat
+        </button>
 
-      <div className="px-3">
-        <div className="relative">
-          <input className="w-full h-10 rounded-lg pl-3 pr-8 bg-slate-100 dark:bg-gray-800 placeholder:text-slate-500 dark:placeholder:text-slate-500 text-sm" placeholder="Search chats" onChange={e => handleSearch(e.target.value)} />
-          <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500" />
-        </div>
-        <Tabs />
-      </div>
-
-      <div className="mt-3 space-y-1 px-2 flex-1 overflow-y-auto">
-        {filtered.map(t => (
-          <div
-            key={t.id}
-            className="flex items-center gap-2 rounded-md px-2 py-1 hover:bg-muted"
-          >
-            <button
-              onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
-              className="flex-1 text-left truncate text-sm"
-              title={t.title}
-            >
-              {t.title}
-            </button>
-            <ThreadKebab
-              id={t.id}
-              title={t.title}
-              onRenamed={nt => {
-                setThreads(prev =>
-                  prev.map(x => (x.id === t.id ? { ...x, title: nt, updatedAt: Date.now() } : x))
-                );
-              }}
-              onDeleted={() => {
-                setThreads(prev => prev.filter(x => x.id !== t.id));
-              }}
+        <div className="px-3">
+          <div className="relative">
+            <input
+              className="w-full h-10 rounded-lg pl-3 pr-8 bg-slate-100 dark:bg-gray-800 placeholder:text-slate-500 dark:placeholder:text-slate-500 text-sm"
+              placeholder="Search chats"
+              onChange={e => handleSearch(e.target.value)}
             />
+            <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500" />
           </div>
-        ))}
+          <Tabs />
+        </div>
+
+        <div className="mt-3 space-y-1 px-2 flex-1 overflow-y-auto">
+          {filtered.map(t => (
+            <div
+              key={t.id}
+              className="flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm mb-1.5 hover:opacity-90 cursor-pointer medx-surface"
+              style={{ color: "var(--medx-text)" }}
+            >
+              <button
+                onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
+                className="flex-1 text-left truncate text-sm"
+                title={t.title}
+              >
+                {t.title}
+              </button>
+              <ThreadKebab
+                id={t.id}
+                title={t.title}
+                onRenamed={nt => {
+                  setThreads(prev =>
+                    prev.map(x => (x.id === t.id ? { ...x, title: nt, updatedAt: Date.now() } : x))
+                  );
+                }}
+                onDeleted={() => {
+                  setThreads(prev => prev.filter(x => x.id !== t.id));
+                }}
+              />
+            </div>
+          ))}
+        </div>
       </div>
 
-      <button type="button" className="mx-3 mt-auto mb-3 h-10 rounded-lg px-3 text-left hover:bg-slate-100 dark:hover:bg-gray-800 flex items-center gap-2">
+      <button
+        type="button"
+        className="mx-3 mt-auto mb-3 h-10 rounded-lg px-3 text-left hover:bg-slate-100 dark:hover:bg-gray-800 flex items-center gap-2"
+      >
         <Settings size={16} /> Preferences
       </button>
-    </nav>
+    </aside>
   );
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -7,7 +7,7 @@ import ResearchFilters from '@/components/ResearchFilters';
 import TrialsTable from "@/components/TrialsTable";
 import type { TrialRow } from "@/types/trials";
 import { useResearchFilters } from '@/store/researchFilters';
-import { Send, Paperclip, Clipboard, Stethoscope, Users, ChevronDown, ChevronUp } from 'lucide-react';
+import { Paperclip, Clipboard, Stethoscope, Users, ChevronDown, ChevronUp } from 'lucide-react';
 import { useCountry } from '@/lib/country';
 import { getRandomWelcome } from '@/lib/welcomeMessages';
 import { useActiveContext } from '@/lib/context';
@@ -1554,12 +1554,10 @@ ${systemCommon}` + baseSys;
               e.preventDefault();
               onSubmit();
             }}
-            className="w-full flex items-center gap-3 rounded-full border border-slate-200 dark:border-gray-800 bg-slate-100 dark:bg-gray-900 px-3 py-2"
+            className="w-full flex items-center gap-3 rounded-2xl medx-glass px-3 py-2"
           >
             <label
-              className="cursor-pointer inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-md
-                         bg-white hover:bg-slate-50 border border-slate-200
-                         dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 dark:border-gray-700"
+              className="cursor-pointer inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-md medx-surface text-medx"
               title="Upload PDF or image"
             >
               <Paperclip size={16} aria-hidden="true" />
@@ -1592,7 +1590,7 @@ ${systemCommon}` + baseSys;
             <textarea
               ref={inputRef as unknown as RefObject<HTMLTextAreaElement>}
               rows={1}
-              className="flex-1 resize-none bg-transparent outline-none text-sm md:text-base leading-6 placeholder:text-slate-400 dark:placeholder:text-slate-500 px-2"
+              className="flex-1 resize-none bg-transparent outline-none text-sm md:text-base leading-6 px-2 text-medx placeholder:text-slate-500 dark:placeholder:text-slate-400"
               placeholder={
                 pendingFile
                   ? 'Add a note or question for this document (optional)'
@@ -1612,12 +1610,11 @@ ${systemCommon}` + baseSys;
               }}
             />
             <button
-              className="px-3 py-1.5 rounded-full bg-slate-200 text-slate-800 hover:bg-slate-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600 disabled:opacity-50"
-              onClick={onSubmit}
-              disabled={busy || (!pendingFile && !note.trim())}
+              type="submit"
+              className="w-10 h-10 rounded-full flex items-center justify-center text-lg medx-btn-accent"
               aria-label="Send"
             >
-              <Send size={16} />
+              ➤
             </button>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- Introduce MedX CSS variables and utility classes for light/dark palettes.
- Wrap layout with gradient background and update header, sidebar, and chat composer with glassy MedX styles.

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bedbda75a0832f8deffb0e7e304521