### PR TITLE
Add context helpers, RAG index, and safety guards

### DIFF
--- a/lib/compute/guard.ts
+++ b/lib/compute/guard.ts
@@ -1,0 +1,3 @@
+export function requireUnits(_: string) {
+  return "\n\nREQUIREMENT: If a numeric result exists, include units and a one-line unit check.";
+}

--- a/lib/context/compose.ts
+++ b/lib/context/compose.ts
@@ -1,0 +1,6 @@
+export function buildContextBlock(fullChat: string, profile?: string) {
+  const parts: string[] = [];
+  if (profile) parts.push(`USER PROFILE:\n${profile}`);
+  if (fullChat) parts.push(`RECENT CHAT:\n${fullChat.slice(0, 15000)}`);
+  return parts.length ? `\n\nCONTEXT\n${parts.join('\n\n')}` : "";
+}

--- a/lib/context/profile.ts
+++ b/lib/context/profile.ts
@@ -1,0 +1,9 @@
+export function getProfileSnapshot() {
+  try {
+    if (typeof window === "undefined") return ""; // SSR guard
+    const v = localStorage.getItem("profile:snapshot");
+    return v ? (JSON.parse(v).pretty || String(v)) : "";
+  } catch {
+    return "";
+  }
+}

--- a/lib/intents/router.ts
+++ b/lib/intents/router.ts
@@ -1,0 +1,14 @@
+// Soft-depend on domains detector: if not present, return []
+let _detectDomain: ((t: string) => string | null) | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  _detectDomain = require("@/lib/intents/domains").detectDomain as (t: string)=>string|null;
+} catch { /* optional */ }
+
+export function chooseStyles(userText: string, mode: "patient" | "doctor") {
+  const d = _detectDomain ? _detectDomain(userText) : null;
+  const styles: string[] = [];
+  if (mode === "doctor") styles.push("DOCTOR_STYLE"); // OK if missing
+  if (d) styles.push((d.toUpperCase() + "_STYLE") as string);
+  return styles;
+}

--- a/lib/postprocess/answer.ts
+++ b/lib/postprocess/answer.ts
@@ -1,0 +1,8 @@
+export function normalizeAnswer(md: string) {
+  let out = (md || "").replace(/\n{3,}/g, "\n\n");
+  if (!/\bSources\b/i.test(out) && /\bhttps?:\/\//.test(out) &&
+      /\b(science|history|trial|guideline|study|randomized)\b/i.test(out)) {
+    out += `\n\n_Sources requested but none detected — consider adding._`;
+  }
+  return out;
+}

--- a/lib/prompts/grounding.ts
+++ b/lib/prompts/grounding.ts
@@ -1,0 +1,6 @@
+export const REQUIRE_SOURCES = `
+If answering science, history, or medical facts:
+- Add a final "Sources" list with 2–5 named authorities.
+- Use clickable titles [Name](https://...).
+- If uncertain: say so and suggest verification.
+`.trim();

--- a/lib/rag/threadIndex.ts
+++ b/lib/rag/threadIndex.ts
@@ -1,0 +1,27 @@
+import MiniSearch from "minisearch";
+
+const store = new Map<string, MiniSearch>();
+
+export function ensureIndex(tid: string) {
+  if (!store.has(tid)) {
+    store.set(
+      tid,
+      new MiniSearch({
+        fields: ["text", "tags"],
+        storeFields: ["text", "id"],
+        idField: "id",
+      })
+    );
+  }
+  return store.get(tid)!;
+}
+
+export function indexTurn(tid: string, id: string, text: string, tags: string[] = []) {
+  ensureIndex(tid).add({ id, text, tags: tags.join(" ") });
+}
+
+export function searchTurns(tid: string, q: string, limit = 5) {
+  const idx = store.get(tid);
+  if (!idx) return [];
+  return idx.search(q, { prefix: true, fuzzy: 0.2 }).slice(0, limit);
+}

--- a/lib/safety/redflags.ts
+++ b/lib/safety/redflags.ts
@@ -1,0 +1,4 @@
+export function detectRedFlags(text: string) {
+  const s = text.toLowerCase();
+  return /(acute chest pain|shortness of breath|stroke symptoms|suicidal|anaphylaxis|severe bleeding)\b/.test(s);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lucide-react": "0.441.0",
         "marked": "12.0.2",
         "mathjs": "^14.7.0",
+        "minisearch": "^7.1.0",
         "next": "14.2.4",
         "next-auth": "^4.24.11",
         "next-themes": "0.3.0",
@@ -6960,6 +6961,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.1.2.tgz",
+      "integrity": "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==",
+      "license": "MIT"
     },
     "node_modules/minizlib": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "undici": "^5.29.0",
     "xml2js": "^0.6.2",
     "zod": "^3.25.76",
-    "zustand": "^5.0.8"
+    "zustand": "^5.0.8",
+    "minisearch": "^7.1.0"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",


### PR DESCRIPTION
## Summary
- add MiniSearch and RAG thread index utilities
- capture profile snapshot and build context block for chats
- normalize answers, require units/sources, and flag critical red phrases

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68bee1b97904832faa75ae35acb47ed0