### PR TITLE
fix: ensure country selector overlay sits above sidebar

### DIFF
--- a/components/CountryGlobe.tsx
+++ b/components/CountryGlobe.tsx
@@ -35,7 +35,7 @@ export default function CountryGlobe() {
         <div
           role="dialog"
           aria-label="Select country"
-          className="absolute right-0 mt-2 w-80 rounded-xl border border-slate-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-xl p-3 z-50"
+          className="absolute right-0 mt-2 w-80 rounded-xl border border-slate-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-xl p-3 z-[70]"
         >
           <div className="mb-2">
             <input


### PR DESCRIPTION
## Summary
- ensure CountryGlobe dropdown sits above sidebar using `z-[70]`

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68beeea3b2d0832fb13fbe89fc146213