### PR TITLE
Require explicit boot for AI-Doc and isolate therapy mode

### DIFF
--- a/app/api/aidoc/chat/route.ts
+++ b/app/api/aidoc/chat/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '../../chat/stream/route';

--- a/app/api/aidoc/message/route.ts
+++ b/app/api/aidoc/message/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const { text = "", boot = false } = await req.json();
+  // Only emit canned welcome on explicit boot; never on user greetings
+  if (boot === true) {
+    return NextResponse.json({
+      messages: [
+        { role: "assistant", content: "Hi! 👋 How can I help today? You can describe symptoms or upload a report." }
+      ]
+    });
+  }
+  // Otherwise: do nothing (caller should use normal chat route)
+  return NextResponse.json({ messages: [] });
+}

--- a/app/api/therapy/route.ts
+++ b/app/api/therapy/route.ts
@@ -185,6 +185,10 @@ export async function POST(req: NextRequest) {
       body = {};
     }
 
+    if (body?.mode && body.mode !== 'therapy') {
+      return NextResponse.json({ error: 'Wrong mode for /api/therapy' }, { status: 400 });
+    }
+
     if (body?.wantStarter) {
       return NextResponse.json({
         starter: "Hi, I’m here with you. Want to tell me what’s on your mind today? 💙",

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -426,13 +426,22 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     bootedRef.current[threadId] = true;
     (async () => {
       try {
-        // warm greeting from Doc AI
-        const boot = await fetch('/api/aidoc/message', {
-          method:'POST', headers:{'Content-Type':'application/json'},
-          body: JSON.stringify({ text: "" })
-        }).then(r=>r.json()).catch(()=>null);
-        if (boot?.messages?.length) {
-          setMessages(prev => [...prev, ...boot.messages.map((m:any)=>({ id: uid(), role:m.role, kind:'chat', content:m.content, pending:false }))]);
+        if (therapyMode) {
+          // Therapy Mode: never call AI-Doc boot
+          const intro = 'Hi, I’m here with you. Want to tell me what’s on your mind today? 💙';
+          setMessages(prev => [...prev, { id: uid(), role:'assistant', kind:'chat', content:intro, pending:false }]);
+        } else {
+          // Profile/Doc path: explicitly request boot
+          const boot = await fetch('/api/aidoc/message', {
+            method: 'POST',
+            headers: { 'Content-Type':'application/json' },
+            body: JSON.stringify({ text: "", boot: true })
+          }).then(r=>r.json()).catch(()=>null);
+          if (boot?.messages?.length) {
+            setMessages(prev => [...prev, ...boot.messages.map((m:any) => ({
+              id: uid(), role:m.role, kind:'chat', content:m.content, pending:false
+            }))]);
+          }
         }
         // single readiness nudge (skip if asked recently)
         if (askedRecently(threadId, 'proactive', 60)) return;
@@ -450,7 +459,7 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
         }
       } catch {}
     })();
-  }, [isProfileThread, threadId]);
+  }, [isProfileThread, threadId, therapyMode]);
 
   useEffect(() => {
     if (!isProfileThread && messages.length === 0) {
@@ -684,10 +693,11 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
           { role: 'user', content: `${userText}${contextBlock}` }
         ];
 
-        const res = await fetch('/api/chat/stream', {
+        const endpoint = '/api/aidoc/chat';
+        const res = await fetch(endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ messages: thread, threadId, context })
+          body: JSON.stringify({ mode: mode === 'doctor' ? 'doctor' : 'patient', messages: thread, threadId, context })
         });
         if (!res.ok || !res.body) throw new Error(`Chat API error ${res.status}`);
         const reader = res.body.getReader();
@@ -738,7 +748,7 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
             fetch('/api/therapy', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ messages: thread })
+              body: JSON.stringify({ mode: 'therapy', messages: thread })
             })
           );
         } catch (e: any) {
@@ -982,7 +992,7 @@ ${systemCommon}` + baseSys;
       const res = await fetch('/api/chat/stream', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages: chatMessages, threadId, context })
+        body: JSON.stringify({ mode: mode === 'doctor' ? 'doctor' : 'patient', messages: chatMessages, threadId, context })
       });
       if (!res.ok || !res.body) throw new Error(`Chat API error ${res.status}`);
 


### PR DESCRIPTION
## Summary
- require explicit `boot:true` flag for AI-Doc welcome and ignore casual greetings
- route profile chats through dedicated AI-Doc endpoint with mode flag
- ensure therapy API only accepts `therapy` mode requests and bootstrap therapy sessions directly

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bf22986d2c832fa7e02b47cdd3ad11