### PR TITLE
Handle therapy-specific greetings and skip social auto-replies

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -556,9 +556,10 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     }
 
     // --- social intent fast path: greet/thanks/yes/no/maybe/repeat/simpler/shorter/longer/next ---
-    const social = detectSocialIntent(userText);
+    const social = therapyMode ? null : detectSocialIntent(userText);
     if (social) {
-      const msgBase = replyForSocialIntent(social, mode);
+      // Use the unified mode that accounts for therapy/research
+      const msgBase = replyForSocialIntent(social, currentMode);
 
       // Optionally use last assistant message for repeat/shorter (lightweight, no LLM)
       const lastAssistant = [...messages].reverse().find(m =>

--- a/lib/social.ts
+++ b/lib/social.ts
@@ -97,6 +97,9 @@ export function detectSocialIntent(text: string): SocialIntent {
 export function replyForSocialIntent(kind: SocialIntent, mode: "patient"|"doctor"|"research"|"therapy" = "patient"): string {
   switch (kind) {
     case "greeting":
+      if (mode === "therapy") {
+        return "Hi, I’m here with you. Want to tell me what’s on your mind today? 💙";
+      }
       return mode === "doctor"
         ? "Hi! How can I help today? Share a condition or report, and I’ll keep it concise."
         : "Hi! 👋 How can I help today? You can describe symptoms or upload a report.";


### PR DESCRIPTION
## Summary
- Add therapy-mode greeting response in `replyForSocialIntent`
- Skip social intent fast-path in therapy mode and use `currentMode`

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bf297a4b1c832f84d7b861ce1139e8