### PR TITLE
feat: add therapy notes continuity

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -518,14 +518,23 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
               const sess = await safeJson(fetch('/api/auth/session'));
               const userId = sess?.user?.id;
               if (userId) {
-                const r = await fetch(`/api/therapy/notes?userId=${userId}`);
-                const { note } = await r.json();
-                if (note?.summary) {
-                  const line = `Last time we explored: ${note.summary} — would you like to continue from there or talk about something new?`;
-                  setMessages((prev: any[]) => [
-                    ...prev,
-                    { id: uid(), role: 'assistant', kind: 'chat', content: line, pending: false }
-                  ]);
+                const r = await fetch(`/api/therapy/notes?userId=${userId}&limit=3`);
+                const { notes } = await r.json();
+
+                if (Array.isArray(notes) && notes.length > 0) {
+                  const pieces = notes
+                    .map((n: any) => (n?.summary || '').trim())
+                    .filter(Boolean)
+                    .slice(0, 3);
+
+                  if (pieces.length > 0) {
+                    const gist = pieces.length === 1 ? pieces[0] : pieces.slice(0, 2).join('; ');
+                    const line = `Last time we explored: ${gist} — want to continue from there or talk about something new?`;
+                    setMessages((prev: any[]) => [
+                      ...prev,
+                      { id: uid(), role: 'assistant', kind: 'chat', content: line, pending: false }
+                    ]);
+                  }
                 }
               }
             } catch {}


### PR DESCRIPTION
## Summary
- expand therapy notes API to return up to 5 recent notes and handle limit parameter
- show last therapy summaries when entering therapy chat to maintain continuity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf348795cc832f92c716edd6a5aaea