### PR TITLE
Use aggregated trials search with source chips

### DIFF
--- a/app/api/trials/route.ts
+++ b/app/api/trials/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { searchTrials, dedupeTrials, rankValue } from "@/lib/trials/search";
-import { byCode3 } from "@/data/countries";
+import { byCode3, byName } from "@/data/countries";
 
 export const runtime = "nodejs";
 
@@ -8,26 +8,43 @@ export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
     const condition = (searchParams.get("condition") || "").trim();
-    if (!condition) return NextResponse.json({ error: "condition is required" }, { status: 400 });
+    if (!condition) {
+      return NextResponse.json({ error: "condition is required" }, { status: 400 });
+    }
 
-    const code3   = (searchParams.get("country") || "").trim();   // "IND", "USA", "" (Worldwide)
-    const status  = searchParams.get("status") || undefined;
-    const phaseUI = searchParams.get("phase") || undefined;
+    const rawCountry = (searchParams.get("country") || "").trim(); // "" | "IND" | "India" | "USA"
+    const status = searchParams.get("status") || undefined; // e.g., "Recruiting,Enrolling by invitation"
+    const phaseUI = searchParams.get("phase") || undefined; // e.g., "Phase 2,Phase 3"
 
-    const wantCountry = code3 ? byCode3(code3)?.name : undefined; // "India" | "United States" | undefined
+    // Accept both code3 and name; blank = Worldwide
+    let wantCountry: string | undefined = undefined;
+    if (rawCountry) {
+      const byCode = byCode3(rawCountry);
+      wantCountry = byCode?.name || byName(rawCountry)?.name || rawCountry;
+    }
+
+    // Normalize phases to digits "2,3"
     const wantPhase = phaseUI
-      ? phaseUI.split(",").map(s => s.replace(/[^0-9/]/g, "")).filter(Boolean).join(",")
+      ? phaseUI
+          .split(",")
+          .map((s) => s.replace(/[^0-9/]/g, ""))
+          .filter(Boolean)
+          .join(",")
       : undefined;
 
+    // Aggregated search (CT.gov + CTRI + EUCTR + ISRCTN)
     const trials = await searchTrials({
       query: condition,
       phase: wantPhase as any,
       status: status as any,
-      country: wantCountry,
+      country: wantCountry, // undefined => Worldwide
     });
 
-    const ranked = dedupeTrials(trials).sort((a,b)=>rankValue(b)-rankValue(a));
-    const rows = ranked.map(t => ({
+    // Rank & de-dup
+    const ranked = dedupeTrials(trials).sort((a, b) => rankValue(b) - rankValue(a));
+
+    // Map to table rows
+    const rows = ranked.map((t) => ({
       id: t.id,
       title: t.title,
       conditions: [],
@@ -42,10 +59,39 @@ export async function GET(req: NextRequest) {
       source: t.source || "",
     }));
 
+    // Fallback: if strict country yields 0, retry Worldwide once
+    if (rows.length === 0 && wantCountry) {
+      const global = await searchTrials({
+        query: condition,
+        phase: wantPhase as any,
+        status: status as any,
+        country: undefined,
+      });
+      const ranked2 = dedupeTrials(global).sort((a, b) => rankValue(b) - rankValue(a));
+      const rows2 = ranked2.map((t) => ({
+        id: t.id,
+        title: t.title,
+        conditions: [],
+        interventions: [],
+        status: t.status || "",
+        phase: t.phase ? (t.phase.includes("/") ? t.phase : `Phase ${t.phase}`) : "",
+        studyType: "",
+        sponsor: "",
+        locations: [],
+        url: t.url || "",
+        country: t.country || "",
+        source: t.source || "",
+      }));
+      return NextResponse.json({ rows: rows2, page: 1, pageSize: rows2.length });
+    }
+
     return NextResponse.json({ rows, page: 1, pageSize: rows.length });
   } catch (err) {
     console.error("Trials API GET error", err);
-    return NextResponse.json({ rows: [], page: 1, pageSize: 0, error: "Trials fetch failed" }, { status: 500 });
+    return NextResponse.json(
+      { rows: [], page: 1, pageSize: 0, error: "Trials fetch failed" },
+      { status: 500 }
+    );
   }
 }
 

--- a/components/TrialsTable.tsx
+++ b/components/TrialsTable.tsx
@@ -37,7 +37,11 @@ export default function TrialsTable({ rows }: { rows: TrialRow[] }) {
               <td className="border px-2 py-1">{t.status}</td>
               <td className="border px-2 py-1">{t.city}</td>
               <td className="border px-2 py-1">{t.country}</td>
-              <td className="border px-2 py-1">{t.source || "—"}</td>
+              <td className="border px-2 py-1">
+                <span className="inline-flex items-center rounded-full border border-slate-200 dark:border-gray-700 px-2 py-0.5 text-[10px] leading-4 text-slate-600 dark:text-slate-300">
+                  {t.source || "Source"}
+                </span>
+              </td>
             </tr>
           ))}
         </tbody>

--- a/components/panels/TrialsPane.tsx
+++ b/components/panels/TrialsPane.tsx
@@ -9,8 +9,7 @@ import type { TrialRow } from "@/types/trials";
 export default function TrialsPane() {
   const [form, setForm] = useState({
     condition: "",
-    country: "", // "" = Worldwide; e.g., "IND" or "USA"
-    city: "",
+    country: "", // "" = Worldwide; code3 like "IND" or "USA"
     status: "Recruiting,Enrolling by invitation",
     phase: "Phase 2,Phase 3",
   });
@@ -58,10 +57,13 @@ export default function TrialsPane() {
       <div className="grid grid-cols-2 gap-2">
         <input className="border rounded p-2" placeholder="Condition (e.g., Type 2 Diabetes)"
           value={form.condition} onChange={e=>setForm({...form, condition:e.target.value})}/>
-        <input className="border rounded p-2" placeholder="Country (optional)" value={form.country||""}
-          onChange={e=>setForm({...form, country:e.target.value||undefined})}/>
-        <input className="border rounded p-2" placeholder="City (optional)" value={form.city||""}
-          onChange={e=>setForm({...form, city:e.target.value||undefined})}/>
+        <input
+          className="border rounded p-2"
+          placeholder="Country code (optional)"
+          value={form.country}
+          onChange={e=>setForm({...form, country:e.target.value.toUpperCase()})}
+          maxLength={3}
+        />
         <input className="border rounded p-2" placeholder="Status (e.g., Recruiting,Active)"
           value={form.status||""} onChange={e=>setForm({...form, status:e.target.value||undefined})}/>
         <input className="border rounded p-2" placeholder="Phase (e.g., Phase 2,Phase 3)"
@@ -99,9 +101,7 @@ export default function TrialsPane() {
                   </td>
                   <td className="p-2 text-center">{r.phase || "—"}</td>
                   <td className="p-2 text-center">{r.status || "—"}</td>
-                  <td className="p-2 text-center">
-                    {[r.city, r.country].filter(Boolean).join(", ") || "—"}
-                  </td>
+                  <td className="p-2 text-center">{r.country || "—"}</td>
                   <td className="p-2 text-center">
                     {r.id ? (
                       <a className="underline" href={r.url} target="_blank" rel="noreferrer">


### PR DESCRIPTION
## Summary
- aggregate trial search across multiple registries and accept country code or name
- keep TrialsPane country input to code3 and show country only
- render source as tiny chip in trials table

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3d5f23a4832f9673139a2c758fbf