### PR TITLE
Add mood normalization and mood history API

### DIFF
--- a/app/api/therapy/mood/route.ts
+++ b/app/api/therapy/mood/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { supabaseServer } from "@/lib/supabaseServer";
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get("userId");
+    const rawLimit = Number(searchParams.get("limit") || 10);
+    const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 1), 50) : 10;
+
+    if (!userId) {
+      return NextResponse.json({ error: "userId required" }, { status: 400 });
+    }
+
+    const sb = supabaseServer();
+    const { data, error } = await sb
+      .from("therapy_notes")
+      .select("mood, created_at")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ moods: data || [] });
+  } catch (e: any) {
+    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+  }
+}

--- a/app/api/therapy/route.ts
+++ b/app/api/therapy/route.ts
@@ -13,6 +13,8 @@ const OAI_URL = (process.env.OPENAI_BASE_URL || "https://api.openai.com/v1").rep
 const MODEL   = process.env.OPENAI_TEXT_MODEL || "gpt-5";
 const ENABLED = String(process.env.THERAPY_MODE_ENABLED || "").toLowerCase() === "true";
 
+const moodList = ["calm","hopeful","content","neutral","anxious","sad","angry","tired","overwhelmed","stressed"];
+
 const STYLE = `One short reflection (≤1 line) of the user’s last message.
 Then ask exactly one clear question; end with a single “?”.
 Progress gradually through stages S0…S8:
@@ -245,7 +247,7 @@ export async function POST(req: NextRequest) {
             user_id: userId,
             summary: note.summary,
             meta: { topics: note.topics, triggers: note.triggers, emotions: note.emotions },
-            mood: note.mood,
+            mood: (note.mood && moodList.includes(note.mood)) ? note.mood : "neutral",
             breakthrough: note.breakthrough,
             next_step: note.nextStep
           });
@@ -256,7 +258,7 @@ export async function POST(req: NextRequest) {
             user_id: userId,
             summary: fallback.summary,
             meta: fallback.meta,
-            mood: fallback.mood,
+            mood: (fallback.mood && moodList.includes(fallback.mood)) ? fallback.mood : "neutral",
             breakthrough: fallback.breakthrough,
             next_step: fallback.nextStep
           });


### PR DESCRIPTION
## Summary
- normalize therapy note moods against a fixed list, defaulting to neutral
- add `/api/therapy/mood` endpoint to return recent moods with timestamps

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3e16b1c8832fa3cb215a832665ce