### PR TITLE
feat: add therapy profile aggregation

### DIFF
--- a/app/api/therapy/profile/rebuild/route.ts
+++ b/app/api/therapy/profile/rebuild/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { supabaseServer } from "@/lib/supabaseServer";
+import { aggregateNotes, type ProfileUpdate } from "@/lib/therapy/aggregate";
+
+export async function POST(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get("userId");
+    const rawLimit = Number(searchParams.get("limit") || 50); // consider last 50 sessions
+    const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 5), 200) : 50;
+
+    if (!userId) {
+      return NextResponse.json({ error: "userId required" }, { status: 400 });
+    }
+
+    const sb = supabaseServer();
+    const { data: notes, error: e1 } = await sb
+      .from("therapy_notes")
+      .select("summary, meta, mood, next_step, created_at")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+
+    if (e1) return NextResponse.json({ error: e1.message }, { status: 500 });
+
+    const agg: ProfileUpdate = aggregateNotes(notes || []);
+
+    // UPSERT therapy_profile
+    const { error: e2 } = await sb
+      .from("therapy_profile")
+      .upsert({
+        user_id: userId,
+        personality: agg.personality,
+        topics: agg.topics,
+        triggers: agg.triggers,
+        values: agg.values,
+        supports: agg.supports,
+        mood_stats: agg.mood_stats,
+        recent_goals: agg.recent_goals,
+        updated_at: new Date().toISOString()
+      }, { onConflict: "user_id" });
+
+    if (e2) return NextResponse.json({ error: e2.message }, { status: 500 });
+
+    // Append snapshot to therapy_insights (optional audit trail)
+    const summary = makePlainSummary(agg);
+    const { error: e3 } = await sb
+      .from("therapy_insights")
+      .insert({
+        user_id: userId,
+        version: "v1",
+        summary,
+        aggregates: agg,
+        provenance: { source: "aggregateNotes", limit }
+      });
+
+    if (e3) {
+      // Do not fail the request if insight insert fails
+    }
+
+    return NextResponse.json({ ok: true, profile: agg });
+  } catch (e: any) {
+    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+  }
+}
+
+// tiny textual summary for audit/history
+function makePlainSummary(agg: ProfileUpdate): string {
+  const topTopic = Object.entries(agg.topics).sort((a,b)=>b[1]-a[1])[0]?.[0];
+  const topTrigger = Object.entries(agg.triggers).sort((a,b)=>b[1]-a[1])[0]?.[0];
+  const mood = agg.mood_stats?.baseline || "neutral";
+  const goal = agg.recent_goals?.[agg.recent_goals.length - 1];
+  const bits = [];
+  if (topTopic) bits.push(`topic: ${topTopic}`);
+  if (topTrigger) bits.push(`trigger: ${topTrigger}`);
+  bits.push(`mood: ${mood}`);
+  if (goal) bits.push(`goal: ${goal}`);
+  return bits.join(" | ");
+}

--- a/app/api/therapy/profile/route.ts
+++ b/app/api/therapy/profile/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { supabaseServer } from "@/lib/supabaseServer";
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const userId = searchParams.get("userId");
+    if (!userId) {
+      return NextResponse.json({ error: "userId required" }, { status: 400 });
+    }
+
+    const sb = supabaseServer();
+    const { data, error } = await sb
+      .from("therapy_profile")
+      .select("*")
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ profile: data || null });
+  } catch (e: any) {
+    return NextResponse.json({ error: String(e?.message || e) }, { status: 500 });
+  }
+}

--- a/lib/therapy/aggregate.ts
+++ b/lib/therapy/aggregate.ts
@@ -1,0 +1,73 @@
+// lib/therapy/aggregate.ts
+
+type Note = {
+  summary: string;
+  meta?: { topics?: string[]; triggers?: string[]; emotions?: string[]; goals?: string[] } | null;
+  mood?: string | null;
+  next_step?: string | null;
+  created_at?: string;
+};
+
+export type ProfileUpdate = {
+  personality: Record<string, any>;
+  topics: Record<string, number>;
+  triggers: Record<string, number>;
+  values: Record<string, boolean>;
+  supports: Record<string, number>;
+  mood_stats: { baseline: string; counts: Record<string, number> };
+  recent_goals: string[];
+};
+
+// simple lower-casing + count helper
+function countStrings(arr: (string | null | undefined)[] = []) {
+  const map: Record<string, number> = {};
+  for (const x of arr) {
+    const k = (x || "").trim().toLowerCase();
+    if (!k) continue;
+    map[k] = (map[k] || 0) + 1;
+  }
+  return map;
+}
+
+export function aggregateNotes(notes: Note[]): ProfileUpdate {
+  const topics: string[] = [];
+  const triggers: string[] = [];
+  const emotions: string[] = [];
+  const goals: string[] = [];
+  const moods: string[] = [];
+  const supports: string[] = []; // placeholder (can be filled by smarter extraction later)
+
+  for (const n of notes) {
+    if (n.meta?.topics) topics.push(...n.meta.topics);
+    if (n.meta?.triggers) triggers.push(...n.meta.triggers);
+    if (n.meta?.emotions) emotions.push(...n.meta.emotions);
+    if (n.meta?.goals) goals.push(...n.meta.goals);
+    if (n.next_step) goals.push(n.next_step);
+    if (n.mood) moods.push(n.mood);
+  }
+
+  const topicCounts = countStrings(topics);
+  const triggerCounts = countStrings(triggers);
+  const moodCounts = countStrings(moods);
+
+  // naive baseline = most frequent mood, else neutral
+  const baseline =
+    Object.entries(moodCounts).sort((a, b) => b[1] - a[1])[0]?.[0] || "neutral";
+
+  // values/personality are placeholders for now; filled by GPT step later
+  const values: Record<string, boolean> = {};
+  const personality: Record<string, any> = {};
+
+  // keep last 5 distinct goals
+  const recentGoals = Array.from(new Set(goals.map(g => (g || "").trim()).filter(Boolean))).slice(-5);
+
+  return {
+    personality,
+    topics: topicCounts,
+    triggers: triggerCounts,
+    values,
+    supports: countStrings(supports),
+    mood_stats: { baseline, counts: moodCounts },
+    recent_goals: recentGoals,
+  };
+}

--- a/lib/therapy/useProfile.ts
+++ b/lib/therapy/useProfile.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+export function useTherapyProfile(userId?: string) {
+  const [data, setData] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!userId) return;
+    setLoading(true);
+    fetch(`/api/therapy/profile?userId=${userId}`)
+      .then(r => r.json())
+      .then(j => { setData(j.profile || null); setErr(null); })
+      .catch(e => setErr(String(e?.message || e)))
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  return { data, loading, err };
+}


### PR DESCRIPTION
## Summary
- add note aggregation utility for therapy profiles
- build API endpoints to rebuild and fetch therapy profiles
- include React hook for accessing therapy profile data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf43276a5c832fafddfcc25fccb86e