### PR TITLE
feat: add session wrap-up in therapy mode

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -774,6 +774,19 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
             try { pushFullMem(stableThreadId, "assistant", content); } catch {}
           }
         }
+        if (j?.wrapup) {
+          setMessages(prev => [
+            ...prev,
+            { id: uid(), role: 'assistant', kind: 'chat', content: j.wrapup, pending: false }
+          ]);
+          if (threadId && j.wrapup.trim()) {
+            pushFullMem(threadId, 'assistant', j.wrapup);
+            maybeIndexStructured(threadId, j.wrapup);
+          }
+          if (stableThreadId) {
+            try { pushFullMem(stableThreadId, 'assistant', j.wrapup); } catch {}
+          }
+        }
         return;
       }
       const intent = detectFollowupIntent(text);


### PR DESCRIPTION
## Summary
- support wrap-up text generation on therapy API responses
- show wrap-up bubble at end of chat session and persist to memory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf4d4371dc832fbde9a8f031c430be