### PR TITLE
feat: support registry-agnostic trial IDs and source chips

### DIFF
--- a/components/TrialsTable.tsx
+++ b/components/TrialsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { TrialRow } from "@/types/trials";
+import { registryIdLabel } from "@/lib/registry";
 
 export default function TrialsTable({ rows }: { rows: TrialRow[] }) {
   if (!rows || rows.length === 0) return null;
@@ -10,7 +11,7 @@ export default function TrialsTable({ rows }: { rows: TrialRow[] }) {
       <table className="w-full border-collapse border border-gray-300 text-sm">
         <thead>
           <tr className="bg-gray-100">
-            <th className="border px-2 py-1">NCT ID</th>
+            <th className="border px-2 py-1">Registry ID</th>
             <th className="border px-2 py-1">Title</th>
             <th className="border px-2 py-1">Phase</th>
             <th className="border px-2 py-1">Status</th>
@@ -20,14 +21,23 @@ export default function TrialsTable({ rows }: { rows: TrialRow[] }) {
         </thead>
         <tbody>
           {rows.map((t) => (
-            <tr key={t.id}>
-              <td className="border px-2 py-1">{t.id}</td>
-              <td className="border px-2 py-1 whitespace-nowrap">
+            <tr key={`${t.source || "src"}:${t.id || t.url}`}>
+              <td className="border px-2 py-1 whitespace-nowrap text-xs text-slate-700 dark:text-slate-200">
+                {t.id ? (
+                  <span className="font-mono px-1.5 py-0.5 rounded bg-white/40 dark:bg-white/5 border border-slate-200 dark:border-gray-800">
+                    {t.id}
+                  </span>
+                ) : (
+                  <span className="text-slate-400">—</span>
+                )}
+                <span className="ml-2 text-[10px] text-slate-500">{registryIdLabel(t.source)}</span>
+              </td>
+              <td className="border px-2 py-1 min-w-[24rem]">
                 <a
                   href={t.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-blue-600 underline"
+                  className="underline underline-offset-2"
                 >
                   {t.title}
                 </a>

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -1,0 +1,8 @@
+export function registryIdLabel(source?: string) {
+  const s = (source || "").toUpperCase();
+  if (s === "CTGOV") return "NCT ID";
+  if (s === "CTRI") return "CTRI ID";
+  if (s === "EUCTR") return "EUCTR ID";
+  if (s === "ISRCTN") return "ISRCTN";
+  return "Registry ID";
+}

--- a/types/trials.ts
+++ b/types/trials.ts
@@ -1,5 +1,5 @@
 export type TrialRow = {
-  id: string;                      // NCT id
+  id: string;                      // Registry id
   title: string;
   conditions: string[];
   interventions: string[];


### PR DESCRIPTION
## Summary
- add `registryIdLabel` helper for mapping source codes to display labels
- update TrialsTable to show registry IDs with monospace styling and source chips
- note trial type comment now reflects generic registry IDs

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5022af1c832f97789f1d92914398