### PR TITLE
feat: render trials table without NCT filtering

### DIFF
--- a/components/TrialsTable.tsx
+++ b/components/TrialsTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import type { TrialRow } from "@/types/trials";
 import { registryIdLabel } from "@/lib/registry";
 
@@ -15,44 +16,77 @@ export default function TrialsTable({ rows }: { rows: TrialRow[] }) {
             <th className="border px-2 py-1">Title</th>
             <th className="border px-2 py-1">Phase</th>
             <th className="border px-2 py-1">Status</th>
-            <th className="border px-2 py-1">City</th>
             <th className="border px-2 py-1">Country</th>
           </tr>
         </thead>
+
+        {/* debug: counts per source */}
+        {process.env.NODE_ENV !== "production" && (
+          <div className="mb-2 text-xs text-slate-500">
+            Source counts: {JSON.stringify(
+              rows.reduce((m: Record<string, number>, r: any) => {
+                const s = (r.source || "unknown").toUpperCase();
+                m[s] = (m[s] || 0) + 1;
+                return m;
+              }, {})
+            )}
+          </div>
+        )}
+
         <tbody>
-          {rows.map((t) => (
-            <tr key={`${t.source || "src"}:${t.id || t.url}`}>
-              <td className="border px-2 py-1 whitespace-nowrap text-xs text-slate-700 dark:text-slate-200">
-                {t.id ? (
-                  <span className="font-mono px-1.5 py-0.5 rounded bg-white/40 dark:bg-white/5 border border-slate-200 dark:border-gray-800">
-                    {t.id}
-                  </span>
-                ) : (
-                  <span className="text-slate-400">—</span>
-                )}
-                <span className="ml-2 text-[10px] text-slate-500">{registryIdLabel(t.source)}</span>
-              </td>
-              <td className="border px-2 py-1 min-w-[24rem]">
-                <a
-                  href={t.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline underline-offset-2"
-                >
-                  {t.title}
-                </a>
-                {t.source && (
-                  <span className="ml-2 inline-flex items-center rounded-full border border-slate-200 dark:border-gray-700 px-2 py-0.5 text-[10px] leading-4 text-slate-600 dark:text-slate-300">
-                    {t.source}
-                  </span>
-                )}
-              </td>
-              <td className="border px-2 py-1">{t.phase}</td>
-              <td className="border px-2 py-1">{t.status}</td>
-              <td className="border px-2 py-1">{t.city}</td>
-              <td className="border px-2 py-1">{t.country}</td>
-            </tr>
-          ))}
+          {rows.map((row, i) => {
+            const key = `${row.source || "src"}:${row.id || row.url || i}`;
+            return (
+              <tr key={key}>
+                {/* Registry ID */}
+                <td className="border px-2 py-1 whitespace-nowrap align-top">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] text-slate-500">
+                      {registryIdLabel(row.source)}
+                    </span>
+                    {row.id ? (
+                      <span className="font-mono text-xs px-1.5 py-0.5 rounded bg-white/40 dark:bg-white/5 border border-slate-200 dark:border-gray-800">
+                        {row.id}
+                      </span>
+                    ) : (
+                      <span className="text-slate-400 text-xs">—</span>
+                    )}
+                  </div>
+                </td>
+
+                {/* Title + Source chip (always clickable if url present) */}
+                <td className="border px-2 py-1 align-top min-w-[24rem]">
+                  {row.url ? (
+                    <a
+                      href={row.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline underline-offset-2"
+                    >
+                      {row.title}
+                    </a>
+                  ) : (
+                    <span>{row.title}</span>
+                  )}
+                  {row.source && (
+                    <span className="ml-2 inline-flex items-center rounded-full border border-slate-200 dark:border-gray-700 px-2 py-0.5 text-[10px] leading-4 text-slate-600 dark:text-slate-300">
+                      {row.source}
+                    </span>
+                  )}
+                </td>
+
+                <td className="border px-2 py-1 whitespace-nowrap align-top">
+                  {row.phase || "—"}
+                </td>
+                <td className="border px-2 py-1 whitespace-nowrap align-top">
+                  {row.status || "—"}
+                </td>
+                <td className="border px-2 py-1 whitespace-nowrap align-top">
+                  {row.country || "—"}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- render registry-agnostic ID and title cells
- drop city column and keep source information
- add debug counts to expose non-CTgov sources

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf54ab0798832fb2507a94df0851f1