### PR TITLE
Expose research orchestrator via bundle API and thread citations to chat

### DIFF
--- a/app/api/research/bundle/route.ts
+++ b/app/api/research/bundle/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { orchestrateResearch } from "@/lib/research/orchestrator";
+
+export const runtime = "edge";
+
+export async function POST(req: NextRequest) {
+  const { query, filters, audience } = await req.json();
+  if (!query || typeof query !== "string") {
+    return NextResponse.json({ citations: [], followUps: [] });
+  }
+  try {
+    const pack = await orchestrateResearch(query, {
+      mode: audience === "patient" ? "patient" : "doctor",
+      filters: filters || {}
+    });
+    return NextResponse.json({
+      citations: (pack?.citations || []).slice(0, 12),
+      followUps: pack?.followUps || [],
+      tookMs: pack?.meta?.tookMs || 0
+    });
+  } catch {
+    return NextResponse.json({ citations: [], followUps: [] });
+  }
+}

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1009,6 +1009,22 @@ ${systemCommon}` + baseSys;
           m.id === pendingId ? { ...m, content: main, followUps, pending: false } : m
         )
       );
+      if (researchMode) {
+        const lastUserMsg = text;
+        const audience = mode;
+        try {
+          const r = await fetch('/api/research/bundle', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ query: lastUserMsg, filters, audience })
+          });
+          const data = await r.json();
+          const cites = Array.isArray(data?.citations) ? data.citations : [];
+          setMessages(prev => prev.map(msg =>
+            msg.id === pendingId ? { ...msg, citations: cites } : msg
+          ));
+        } catch {}
+      }
       if (threadId && main && main.trim()) {
         pushFullMem(threadId, "assistant", main);
         maybeIndexStructured(threadId, main);

--- a/lib/pubmed.ts
+++ b/lib/pubmed.ts
@@ -1,1 +1,0 @@
-const BASE="https://eutils.ncbi.nlm.nih.gov/entrez/eutils";export async function searchPubmed(term:string){const url=`${BASE}/esearch.fcgi?db=pubmed&term=${encodeURIComponent(term)}&retmax=5&api_key=${process.env.NCBI_API_KEY||''}`;const res=await fetch(url,{next:{revalidate:300}});if(!res.ok) throw new Error("PubMed search error");return res.text();}

--- a/lib/pubmed.ts.ts
+++ b/lib/pubmed.ts.ts
@@ -1,7 +1,0 @@
-const BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils";
-export async function searchPubmed(term: string) {
-  const url = `${BASE}/esearch.fcgi?db=pubmed&term=${encodeURIComponent(term)}&retmax=5&api_key=${process.env.NCBI_API_KEY||''}`;
-  const res = await fetch(url, { next: { revalidate: 300 }});
-  if (!res.ok) throw new Error("PubMed search error");
-  return res.text();
-}


### PR DESCRIPTION
## Summary
- expose `orchestrateResearch` through new `/api/research/bundle` edge route
- fetch citation bundle after chat replies in research mode and attach to assistant message
- remove stray PubMed utility duplications

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6e7e0df8832f945dcfcfe25e6535