### PR TITLE
feat: surface red-flag alerts in plan

### DIFF
--- a/app/api/research/bundle/route.ts
+++ b/app/api/research/bundle/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { orchestrateResearch } from "@/lib/research/orchestrator";
 
-export const runtime = "edge";
+// Uses xml2js under the hood which depends on Node core modules
+// so ensure this route runs in a Node.js environment rather than Edge.
+export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
   const { query, filters, audience } = await req.json();

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -345,6 +345,11 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   const [commitError, setCommitError] = useState<string | null>(null);
   const [aidoc, setAidoc] = useState<any | null>(null);
   const [loadingAidoc, setLoadingAidoc] = useState(false);
+  const topAlerts = Array.isArray(aidoc?.softAlerts) ? aidoc.softAlerts : [];
+  const planAlerts = Array.isArray(aidoc?.plan?.softAlerts)
+    ? aidoc.plan.softAlerts
+    : [];
+  const softAlerts = Array.from(new Set([...topAlerts, ...planAlerts]));
   const posted = useRef(new Set<string>());
   const bootedRef = useRef<{[k:string]:boolean}>({});
   const askedKey = (thread?: string|null, kind?: string)=> `aidoc:${thread||'med-profile'}:asked:${kind||'any'}`;
@@ -1546,20 +1551,17 @@ ${systemCommon}` + baseSys;
               </>
             )}
 
-            {/* Accept alerts from either the top level or inside plan */}
-            {(() => {
-              const alerts = (aidoc?.softAlerts ?? aidoc?.plan?.softAlerts ?? []) as string[];
-              return Array.isArray(alerts) && alerts.length > 0 ? (
-                <div className="mt-2 rounded-md border border-red-300 p-2">
-                  <div className="text-sm font-semibold text-red-700">Important</div>
-                  <ul className="list-disc pl-5 text-red-800">
-                    {alerts.map((a: string, i: number) => (
-                      <li key={i} className="text-sm">{a}</li>
-                    ))}
-                  </ul>
-                </div>
-              ) : null;
-            })()}
+            {/* Show alerts from both the top level and plan, deduplicated */}
+            {softAlerts.length > 0 && (
+              <div className="mt-2 rounded-md border border-red-300 p-2">
+                <div className="text-sm font-semibold text-red-700">Important</div>
+                <ul className="list-disc pl-5 text-red-800">
+                  {softAlerts.map((a: string, i: number) => (
+                    <li key={i} className="text-sm">{a}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
 
             {Array.isArray(aidoc?.rulesFired) && aidoc.rulesFired.length > 0 && (
               <details className="mt-2">

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1546,16 +1546,20 @@ ${systemCommon}` + baseSys;
               </>
             )}
 
-            {Array.isArray(aidoc?.softAlerts) && aidoc.softAlerts.length > 0 && (
-              <div className="mt-2 rounded-md border border-red-300 p-2">
-                <div className="text-sm font-semibold text-red-700">Important</div>
-                <ul className="list-disc pl-5 text-red-800">
-                  {aidoc.softAlerts.map((a: string, i: number) => (
-                    <li key={i} className="text-sm">{a}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
+            {/* Accept alerts from either the top level or inside plan */}
+            {(() => {
+              const alerts = (aidoc?.softAlerts ?? aidoc?.plan?.softAlerts ?? []) as string[];
+              return Array.isArray(alerts) && alerts.length > 0 ? (
+                <div className="mt-2 rounded-md border border-red-300 p-2">
+                  <div className="text-sm font-semibold text-red-700">Important</div>
+                  <ul className="list-disc pl-5 text-red-800">
+                    {alerts.map((a: string, i: number) => (
+                      <li key={i} className="text-sm">{a}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null;
+            })()}
 
             {Array.isArray(aidoc?.rulesFired) && aidoc.rulesFired.length > 0 && (
               <details className="mt-2">

--- a/lib/aidoc/planner.ts
+++ b/lib/aidoc/planner.ts
@@ -1,15 +1,41 @@
 import type { RulesOut } from "./rules";
-import { redflagChecks } from "./rules/redflags";
+import { redflagChecks } from "./rules/redflags"; // Additive import: red-flag library (local to AI Doc only)
 
-export function buildPersonalPlan(r: RulesOut, mem:any, extra?: { vitals?: any; symptomsText?: string }) {
-  const timePref = (mem?.prefs||[]).find((p:any)=>p.key==="pref_test_time")?.value;
-  const steps = r.steps.map(s => s.replace("Prefer morning", `Prefer ${timePref||"morning"}`));
-  const softAlerts = [...r.softAlerts, ...redflagChecks(extra || {})];
-  return {
+export function buildPersonalPlan(
+  r: RulesOut,
+  mem: any,
+  extra?: { vitals?: any; symptomsText?: string }
+) {
+  const timePref = (mem?.prefs || []).find(
+    (p: any) => p.key === "pref_test_time"
+  )?.value;
+  const steps = r.steps.map((s) =>
+    s.replace("Prefer morning", `Prefer ${timePref || "morning"}`)
+  );
+
+  const plan: any = {
     title: "Personalized next steps",
     steps: Array.from(new Set(steps)),
     nudges: r.nudges,
     rulesFired: r.fired,
-    softAlerts,
   };
+
+  try {
+    const vitals = (extra as any)?.vitals ?? undefined;
+    const symptomsText = (extra as any)?.symptomsText ?? "";
+    const alerts = redflagChecks({ vitals, symptomsText });
+    if (alerts && alerts.length) {
+      const existing = ((plan as any).softAlerts ?? r.softAlerts ?? []) as string[];
+      (plan as any).softAlerts = Array.from(new Set([...existing, ...alerts]));
+    } else if (r.softAlerts && r.softAlerts.length) {
+      (plan as any).softAlerts = Array.from(new Set(r.softAlerts));
+    }
+  } catch {
+    if (r.softAlerts && r.softAlerts.length) {
+      (plan as any).softAlerts = Array.from(new Set(r.softAlerts));
+    }
+    // never throw from planner for alerts
+  }
+
+  return plan;
 }

--- a/lib/aidoc/planner.ts
+++ b/lib/aidoc/planner.ts
@@ -1,5 +1,5 @@
 import type { RulesOut } from "./rules";
-import { redflagChecks } from "./rules/redflags"; // Additive import: red-flag library (local to AI Doc only)
+import { redflagChecks } from "./rules/redflags"; // local red-flag checks
 
 export function buildPersonalPlan(
   r: RulesOut,
@@ -23,15 +23,13 @@ export function buildPersonalPlan(
   try {
     const vitals = (extra as any)?.vitals ?? undefined;
     const symptomsText = (extra as any)?.symptomsText ?? "";
-    const alerts = redflagChecks({ vitals, symptomsText });
-    if (alerts && alerts.length) {
-      const existing = ((plan as any).softAlerts ?? r.softAlerts ?? []) as string[];
-      (plan as any).softAlerts = Array.from(new Set([...existing, ...alerts]));
-    } else if (r.softAlerts && r.softAlerts.length) {
-      (plan as any).softAlerts = Array.from(new Set(r.softAlerts));
+    const alerts = redflagChecks({ vitals, symptomsText }) || [];
+    const merged = [...(r.softAlerts ?? []), ...alerts];
+    if (merged.length) {
+      (plan as any).softAlerts = Array.from(new Set(merged));
     }
   } catch {
-    if (r.softAlerts && r.softAlerts.length) {
+    if (r.softAlerts?.length) {
       (plan as any).softAlerts = Array.from(new Set(r.softAlerts));
     }
     // never throw from planner for alerts


### PR DESCRIPTION
## Summary
- include red-flag checks when building personalized plan
- display soft alerts from top-level or plan in ChatPane

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bfedc7e084832fbcec10477b8de652