### PR TITLE
feat(trials): add registry-agnostic trial search and UI

### DIFF
--- a/app/api/research/bundle/route.ts
+++ b/app/api/research/bundle/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { orchestrateResearch } from "@/lib/research/orchestrator";
+import { orchestrateResearch, orchestrateTrials } from "@/lib/research/orchestrator";
 
 export const runtime = "edge";
 
@@ -9,14 +9,27 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ citations: [], followUps: [] });
   }
   try {
-    const pack = await orchestrateResearch(query, {
+    const trialsPromise = orchestrateTrials(query, { country: filters?.countries?.[0] });
+    const packPromise = orchestrateResearch(query, {
       mode: audience === "patient" ? "patient" : "doctor",
-      filters: filters || {}
+      filters: filters || {},
     });
+
+    const [trials, pack] = await Promise.all([trialsPromise, packPromise]);
+
+    const trialCitations = (trials || []).slice(0, 6).map((t) => ({
+      title: `${t.registry}:${t.registry_id} — ${t.title}`.slice(0, 140),
+      url: t.url,
+      source: "trials",
+      snippet: [t.phase, t.status].filter(Boolean).join(" · "),
+    }));
+
+    const citations = [...trialCitations, ...(pack?.citations || [])];
+
     return NextResponse.json({
-      citations: (pack?.citations || []).slice(0, 12),
+      citations: citations.slice(0, 12),
       followUps: pack?.followUps || [],
-      tookMs: pack?.meta?.tookMs || 0
+      tookMs: pack?.meta?.tookMs || 0,
     });
   } catch {
     return NextResponse.json({ citations: [], followUps: [] });

--- a/app/api/research/bundle/route.ts
+++ b/app/api/research/bundle/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { orchestrateResearch, orchestrateTrials } from "@/lib/research/orchestrator";
 
-export const runtime = "edge";
+export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
   const { query, filters, audience } = await req.json();

--- a/components/panels/TrialsPane.tsx
+++ b/components/panels/TrialsPane.tsx
@@ -79,53 +79,47 @@ export default function TrialsPane() {
       <div className="text-sm text-gray-500">Informational only; not medical advice. Confirm eligibility with the sponsor.</div>
 
       {rows.length > 0 && (
-        <div className="overflow-auto border rounded">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="p-2 text-left">Title</th>
-                <th className="p-2">Phase</th>
-                <th className="p-2">Status</th>
-                <th className="p-2">Location</th>
-                <th className="p-2">ID</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((r) => (
-                <tr key={r.id} className="border-t">
-                  <td className="p-2">
-                    {r.title}
-                    {r.hints && r.hints.length > 0 && (
-                      <span className="ml-1" title={r.hints.join('; ')}>⚑</span>
-                    )}
-                  </td>
-                  <td className="p-2 text-center">{r.phase || "—"}</td>
-                  <td className="p-2 text-center">{r.status || "—"}</td>
-                  <td className="p-2 text-center">{r.country || "—"}</td>
-                  <td className="p-2">
-                    <div className="flex items-center justify-center gap-2">
-                      <span className="text-[11px] px-1.5 py-0.5 rounded border">
-                        {(r.source || "").toUpperCase()}
-                      </span>
-                      {r.id ? (
-                        <a
-                          className="underline font-semibold"
-                          href={r.url}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          {r.id}
-                        </a>
-                      ) : (
-                        "—"
-                      )}
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <ul className="space-y-2">
+          {rows.map((r) => (
+            <li
+              key={`${r.source}:${r.id}`}
+              className="rounded border p-3 dark:border-gray-700"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-[11px] px-1.5 py-0.5 rounded border">
+                  {(r.source || "").toUpperCase()}
+                </span>
+                <a
+                  className="font-semibold hover:underline"
+                  href={r.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {r.id}
+                </a>
+              </div>
+
+              <div className="text-sm mt-1">{r.title}</div>
+
+              <div className="flex flex-wrap gap-2 mt-2">
+                {r.phase && (
+                  <span className="text-[11px] px-1.5 py-0.5 rounded border">
+                    {r.phase}
+                  </span>
+                )}
+                {r.status && (
+                  <span className="text-[11px] px-1.5 py-0.5 rounded border">
+                    {r.status}
+                  </span>
+                )}
+              </div>
+
+              {r.country ? (
+                <div className="text-xs text-slate-500 mt-1">{r.country}</div>
+              ) : null}
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,5 @@
+export const FEATURES = {
+  TRIALS_DEDUPE: true,
+  TRIALS_GEO_ROUTING: true,
+  TRIALS_PHASE_NORMALIZE: true,
+};

--- a/lib/research/sources/nct.ts
+++ b/lib/research/sources/nct.ts
@@ -1,0 +1,38 @@
+import type { TrialRecord } from "@/types/research";
+
+export async function searchNCT(query: string): Promise<TrialRecord[]> {
+  const url = `https://clinicaltrials.gov/api/v2/studies?format=json&query.term=${encodeURIComponent(query)}&pageSize=25`;
+  let data: any;
+  try {
+    const res = await fetch(url, { next: { revalidate: 3600 } });
+    if (!res.ok) throw new Error(`NCT HTTP ${res.status}`);
+    data = await res.json();
+  } catch {
+    return [];
+  }
+  return (data?.studies || [])
+    .map((s: any): TrialRecord => {
+      const id = s.protocolSection?.identificationModule?.nctId || "";
+      const locations = (s.protocolSection?.contactsLocationsModule?.locations || []).map((loc: any) => {
+        const city = loc.city;
+        const country = loc.country;
+        return [city, country].filter(Boolean).join(", ");
+      });
+      return {
+        registry: "NCT",
+        registry_id: String(id).trim(),
+        title: String(s.protocolSection?.identificationModule?.briefTitle || "").trim(),
+        condition: String(s.protocolSection?.conditionsModule?.conditions?.[0] || "").trim() || undefined,
+        phase: String(s.protocolSection?.designModule?.phases?.[0] || "").trim() || undefined,
+        status: String(s.protocolSection?.statusModule?.overallStatus || "").trim() || undefined,
+        locations,
+        url: id ? `https://clinicaltrials.gov/study/${encodeURIComponent(id)}` : "",
+        when: {
+          registered: s.protocolSection?.statusModule?.studyFirstPostDateStruct?.date,
+          updated: s.protocolSection?.statusModule?.lastUpdatePostDateStruct?.date,
+        },
+        snippet: String(s.protocolSection?.descriptionModule?.briefSummary || "").slice(0, 200),
+      };
+    })
+    .filter((t: TrialRecord) => t.registry_id && t.title);
+}

--- a/types/research.ts
+++ b/types/research.ts
@@ -35,13 +35,14 @@ export type Trial = {
 };
 
 export type TrialRecord = {
-  registry: "NCT" | "CTRI" | "EUCTR" | "IRCT" | string;
-  registry_id: string;          // e.g. NCT01234567 or CTRI/2024/08/012345
+  registry: "NCT" | "CTRI" | "EUCTR" | string;
+  registry_id: string;                 // e.g. NCT01234567 or CTRI/2024/08/012345
   title: string;
   condition?: string;
-  phase?: string;
-  status?: string;
-  locations?: string[];
-  url: string;                   // deep link to the registry page
-  when?: { registered?: string; updated?: string };
+  phase?: string;                      // "Phase 2" / "Phase III" etc.
+  status?: string;                     // "Recruiting" / "Active" / "Completed"
+  locations?: string[];                // ["Mumbai, India", "Delhi, India"]
+  url: string;                         // deep link to registry page
+  when?: { registered?: string; updated?: string }; // ISO strings preferred
+  snippet?: string;                    // optional short blurb
 };


### PR DESCRIPTION
## Summary
- add flexible `TrialRecord` type with snippet field
- normalize CTRI and NCT sources to unified records
- orchestrate and expose registry-agnostic trials with dedupe, geo hinting, and UI badges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfee0e15b0832fac86d08fd3691122