### PR TITLE
feat: improve chat markdown rendering

### DIFF
--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -8,17 +8,84 @@ import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 import { LinkBadge } from "./SafeLink";
 
+/**
+ * 1) If the whole message is in a single ```fence```, unwrap it
+ * 2) Convert ASCII rulers (====, ----, ____ lines) to <hr/>
+ * 3) Fix accidental centered blocks, compress blank lines
+ * 4) Upgrade solo "**Title**" lines into proper ### headings
+ * 5) Ensure list bullets render as real lists (lines starting with "* " -> "- ")
+ */
+function normalizeContent(raw: string): string {
+  if (!raw) return "";
+
+  let s = raw.trim();
+
+  // 1) Unwrap a single full-message fence (no language or plain text)
+  const fence = /^```([a-zA-Z0-9_-]*)\s*\n([\s\S]*?)\n```$/m.exec(s);
+  if (fence) {
+    const lang = (fence[1] || "").toLowerCase();
+    if (!lang || lang === "text" || lang === "txt") s = fence[2];
+  }
+
+  // 2) ASCII rulers -> <hr/> (we'll map to '---' which markdown rehype renders as <hr/>)
+  s = s
+    .split("\n")
+    .map((line) =>
+      /^[=\-_]{6,}\s*$/.test(line) ? "---" : line
+    )
+    .join("\n");
+
+  // 3) Compress blank lines (avoid huge gaps)
+  s = s.replace(/\n{3,}/g, "\n\n");
+
+  // 4) Upgrade standalone bold lines to headings (### Title)
+  //    Example: "**Characteristics of Stage 2 Cancer**" -> "### Characteristics of Stage 2 Cancer"
+  s = s.replace(
+    /^(?:\*\*|__)\s*([^*\n][^*\n]+?)\s*(?:\*\*|__)\s*$/gm,
+    "### $1"
+  );
+
+  // 5) Normalize list bullets (some replies use "* " inconsistently)
+  s = s.replace(/^\*\s+/gm, "- ");
+
+  // 6) Trim trailing spaces
+  s = s.trim() + "\n";
+  return s;
+}
+
 export default function ChatMarkdown({ content }: { content: string }) {
+  const prepared = normalizeContent(content || "");
+
   return (
-    <div className="prose prose-sm prose-slate dark:prose-invert prose-medx max-w-none prose-headings:font-semibold prose-headings:mb-2 prose-headings:mt-3 prose-h1:text-chat-lg prose-h2:text-chat-base prose-h3:text-chat-sm prose-p:text-chat-base prose-li:text-chat-base prose-strong:font-semibold">
+    <div
+      // Typography tuned for medical text (compact, calm)
+      className="
+        text-left
+        prose prose-slate dark:prose-invert max-w-none
+        prose-headings:font-semibold prose-headings:leading-tight
+        prose-h1:text-xl prose-h2:text-lg prose-h3:text-base
+        prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-1
+        leading-7 text-[15px]
+        [word-break:break-word]
+      "
+    >
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex]}
         components={{
-          a: ({ href, children }) => <LinkBadge href={href as string}>{children as any}</LinkBadge>,
+          a: ({ href, children }) => (
+            <LinkBadge href={href as string}>{children as any}</LinkBadge>
+          ),
+          // Slightly tighter lists
+          ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
+          ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
+          // Softer horizontal rule for the old "====" separators
+          hr: () => <hr className="my-3 border-dashed opacity-40" />,
+          // Prevent accidental center alignment from model text
+          p: ({ children }) => <p className="text-left">{children}</p>,
         }}
       >
-        {content}
+        {prepared}
       </ReactMarkdown>
     </div>
   );

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -180,7 +180,7 @@ function PendingAnalysisCard({ label }: { label: string }) {
 
 function PendingChatCard({ label }: { label: string }) {
   return (
-    <article className="mr-auto max-w-[90%] rounded-2xl p-4 md:p-6 shadow-sm bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800">
+    <article className="mr-auto max-w-3xl rounded-2xl p-4 md:p-6 shadow-sm bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800 text-left whitespace-normal">
       <div className="text-sm text-slate-600 dark:text-slate-300">{label}</div>
     </article>
   );
@@ -190,7 +190,7 @@ function AnalysisCard({ m, researchOn, onQuickAction, busy }: { m: Extract<ChatM
   const header = titleForCategory(m.category);
   if (m.pending) return <PendingAnalysisCard label="Analyzing file…" />;
   return (
-    <article className="mr-auto max-w-[90%] rounded-2xl p-4 md:p-6 shadow-sm space-y-2 bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800">
+    <article className="mr-auto max-w-3xl rounded-2xl p-4 md:p-6 shadow-sm space-y-2 bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800 text-left whitespace-normal">
       <header className="flex items-center gap-2">
         <h2 className="text-lg md:text-xl font-semibold">{header}</h2>
         {researchOn && (
@@ -243,7 +243,7 @@ function AnalysisCard({ m, researchOn, onQuickAction, busy }: { m: Extract<ChatM
 function ChatCard({ m, therapyMode, onFollowUpClick, simple }: { m: Extract<ChatMessage, { kind: "chat" }>; therapyMode: boolean; onFollowUpClick: (text: string) => void; simple: boolean }) {
   if (m.pending) return <PendingChatCard label="Thinking…" />;
   return (
-    <article className="mr-auto max-w-[90%] rounded-2xl p-4 md:p-6 shadow-sm space-y-2 bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800">
+    <article className="mr-auto max-w-3xl rounded-2xl p-4 md:p-6 shadow-sm space-y-2 bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800 text-left whitespace-normal">
       <ChatMarkdown content={m.content} />
       {m.role === "assistant" && (m.citations?.length || 0) > 0 && (
         <div className="mt-2 flex flex-wrap gap-2">
@@ -1503,7 +1503,7 @@ ${systemCommon}` + baseSys;
             m.role === 'user' ? (
               <div
                 key={m.id}
-                className="ml-auto max-w-[85%] rounded-2xl px-4 py-3 shadow-sm bg-slate-200 text-slate-900 dark:bg-gray-700 dark:text-gray-100"
+                className="ml-auto max-w-3xl rounded-2xl px-4 py-3 shadow-sm bg-slate-200 text-slate-900 dark:bg-gray-700 dark:text-gray-100 text-left whitespace-normal"
               >
                 <ChatMarkdown content={m.content} />
               </div>


### PR DESCRIPTION
## Summary
- normalize and enhance ChatMarkdown rendering for cleaner messages
- left-align chat bubbles and allow wrapping link chips

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bffd86bbfc832fbc2bfc65acc44846