### PR TITLE
Normalize markdown text and tidy chat bubble styling

### DIFF
--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -8,65 +8,49 @@ import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 import { LinkBadge } from "./SafeLink";
 
-/**
- * 1) If the whole message is in a single ```fence```, unwrap it
- * 2) Convert ASCII rulers (====, ----, ____ lines) to <hr/>
- * 3) Fix accidental centered blocks, compress blank lines
- * 4) Upgrade solo "**Title**" lines into proper ### headings
- * 5) Ensure list bullets render as real lists (lines starting with "* " -> "- ")
- */
-function normalizeContent(raw: string): string {
+// --- Normalizer ---
+function normalize(raw: string): string {
   if (!raw) return "";
 
   let s = raw.trim();
 
-  // 1) Unwrap a single full-message fence (no language or plain text)
+  // unwrap accidental full-message fences
   const fence = /^```([a-zA-Z0-9_-]*)\s*\n([\s\S]*?)\n```$/m.exec(s);
   if (fence) {
     const lang = (fence[1] || "").toLowerCase();
-    if (!lang || lang === "text" || lang === "txt") s = fence[2];
+    if (!lang || lang === "txt" || lang === "text") s = fence[2];
   }
 
-  // 2) ASCII rulers -> <hr/> (we'll map to '---' which markdown rehype renders as <hr/>)
-  s = s
-    .split("\n")
-    .map((line) =>
-      /^[=\-_]{6,}\s*$/.test(line) ? "---" : line
-    )
-    .join("\n");
+  // convert ====, ----, ____ to markdown horizontal rule
+  s = s.replace(/^[=\-_]{4,}$/gm, "\n---\n");
 
-  // 3) Compress blank lines (avoid huge gaps)
-  s = s.replace(/\n{3,}/g, "\n\n");
-
-  // 4) Upgrade standalone bold lines to headings (### Title)
-  //    Example: "**Characteristics of Stage 2 Cancer**" -> "### Characteristics of Stage 2 Cancer"
+  // bold-only lines -> headings
   s = s.replace(
     /^(?:\*\*|__)\s*([^*\n][^*\n]+?)\s*(?:\*\*|__)\s*$/gm,
     "### $1"
   );
 
-  // 5) Normalize list bullets (some replies use "* " inconsistently)
+  // force bullet points
   s = s.replace(/^\*\s+/gm, "- ");
 
-  // 6) Trim trailing spaces
-  s = s.trim() + "\n";
-  return s;
+  // compress extra newlines
+  s = s.replace(/\n{3,}/g, "\n\n");
+
+  return s.trim() + "\n";
 }
 
+// --- Renderer ---
 export default function ChatMarkdown({ content }: { content: string }) {
-  const prepared = normalizeContent(content || "");
+  const prepared = normalize(content);
 
   return (
     <div
-      // Typography tuned for medical text (compact, calm)
       className="
-        text-left
         prose prose-slate dark:prose-invert max-w-none
-        prose-headings:font-semibold prose-headings:leading-tight
-        prose-h1:text-xl prose-h2:text-lg prose-h3:text-base
-        prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-1
-        leading-7 text-[15px]
-        [word-break:break-word]
+        prose-headings:font-semibold prose-headings:mb-2 prose-headings:mt-3
+        prose-h3:text-lg prose-h4:text-base
+        prose-p:my-2 prose-li:my-1 prose-strong:font-medium
+        leading-relaxed text-[15px]
       "
     >
       <ReactMarkdown
@@ -76,12 +60,9 @@ export default function ChatMarkdown({ content }: { content: string }) {
           a: ({ href, children }) => (
             <LinkBadge href={href as string}>{children as any}</LinkBadge>
           ),
-          // Slightly tighter lists
           ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
           ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
-          // Softer horizontal rule for the old "====" separators
           hr: () => <hr className="my-3 border-dashed opacity-40" />,
-          // Prevent accidental center alignment from model text
           p: ({ children }) => <p className="text-left">{children}</p>,
         }}
       >
@@ -90,3 +71,4 @@ export default function ChatMarkdown({ content }: { content: string }) {
     </div>
   );
 }
+

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import Header from '../Header';
 import ChatMarkdown from '@/components/ChatMarkdown';
 import ResearchFilters from '@/components/ResearchFilters';
+import { LinkBadge } from '@/components/SafeLink';
 import TrialsTable from "@/components/TrialsTable";
 import type { TrialRow } from "@/types/trials";
 import { useResearchFilters } from '@/store/researchFilters';
@@ -172,17 +173,17 @@ No fabricated IDs. Provide themes, not specific trial numbers unless confident.`
 
 function PendingAnalysisCard({ label }: { label: string }) {
   return (
-    <article className="mr-auto max-w-[90%] rounded-2xl p-4 md:p-6 shadow-sm bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800">
+    <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl">
       <div className="text-sm text-slate-600 dark:text-slate-300">{label}</div>
-    </article>
+    </div>
   );
 }
 
 function PendingChatCard({ label }: { label: string }) {
   return (
-    <article className="mr-auto max-w-3xl rounded-2xl p-4 md:p-6 shadow-sm bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800 text-left whitespace-normal">
+    <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl">
       <div className="text-sm text-slate-600 dark:text-slate-300">{label}</div>
-    </article>
+    </div>
   );
 }
 
@@ -190,7 +191,7 @@ function AnalysisCard({ m, researchOn, onQuickAction, busy }: { m: Extract<ChatM
   const header = titleForCategory(m.category);
   if (m.pending) return <PendingAnalysisCard label="Analyzing file…" />;
   return (
-    <article className="mr-auto max-w-3xl rounded-2xl p-4 md:p-6 shadow-sm space-y-2 bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800 text-left whitespace-normal">
+    <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl space-y-2">
       <header className="flex items-center gap-2">
         <h2 className="text-lg md:text-xl font-semibold">{header}</h2>
         {researchOn && (
@@ -236,33 +237,26 @@ function AnalysisCard({ m, researchOn, onQuickAction, busy }: { m: Extract<ChatM
       <p className="text-xs text-amber-500/90 pt-2">
         AI assistance only — not a medical diagnosis. Confirm with a clinician.
       </p>
-    </article>
+    </div>
   );
 }
-
 function ChatCard({ m, therapyMode, onFollowUpClick, simple }: { m: Extract<ChatMessage, { kind: "chat" }>; therapyMode: boolean; onFollowUpClick: (text: string) => void; simple: boolean }) {
   if (m.pending) return <PendingChatCard label="Thinking…" />;
   return (
-    <article className="mr-auto max-w-3xl rounded-2xl p-4 md:p-6 shadow-sm space-y-2 bg-slate-50 dark:bg-gray-800 border border-slate-200 dark:border-gray-800 text-left whitespace-normal">
+    <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl">
       <ChatMarkdown content={m.content} />
       {m.role === "assistant" && (m.citations?.length || 0) > 0 && (
-        <div className="mt-2 flex flex-wrap gap-2">
+        <div className="mt-3 flex flex-wrap gap-2">
           {(m.citations || []).slice(0, simple ? 3 : 6).map((c, i) => (
-            <a
-              key={i}
-              href={c.url}
-              target="_blank"
-              rel="noreferrer"
-              className="rounded-full border px-3 py-1 text-xs hover:bg-gray-100"
-            >
+            <LinkBadge key={i} href={c.url}>
               {c.source.toUpperCase()}
               {c.extra?.evidenceLevel ? ` · ${c.extra.evidenceLevel}` : ""}
-            </a>
+            </LinkBadge>
           ))}
         </div>
       )}
       {!therapyMode && (m.followUps?.length || 0) > 0 && (
-        <div className="mt-2 flex flex-wrap gap-2">
+        <div className="mt-3 flex flex-wrap gap-2">
           {(m.followUps || []).map((f, i) => (
             <button
               key={i}
@@ -274,7 +268,7 @@ function ChatCard({ m, therapyMode, onFollowUpClick, simple }: { m: Extract<Chat
           ))}
         </div>
       )}
-    </article>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Normalize incoming chat text by unwrapping code fences, converting ASCII rulers to markdown rules, upgrading bold lines to headings, and smoothing lists/newlines
- Simplify chat bubble container with left-aligned, whitespace-normal layout and safe LinkBadge citations

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c0054a68d4832f9c4352b05d965ca3