### PR TITLE
feat(aidoc): add anemia rules and tests

### DIFF
--- a/lib/aidoc/rules/anemia.ts
+++ b/lib/aidoc/rules/anemia.ts
@@ -1,0 +1,104 @@
+export type AnemiaRuleOut = {
+  steps: string[];
+  nudges: string[];
+  fired: string[];
+  softAlerts?: string[];
+};
+
+type Lab = {
+  name: string;
+  value?: number | string;
+  unit?: string;
+  normalLow?: number | null;
+  normalHigh?: number | null;
+};
+
+function parseNumber(x: unknown): number | null {
+  if (x === null || x === undefined) return null;
+  const n = Number(x);
+  return Number.isFinite(n) ? n : null;
+}
+
+function pickLab(allLabs: Lab[] = [], keys: string[]): Lab | undefined {
+  const needle = keys.map((k) => k.toLowerCase());
+  return allLabs.find((l) => {
+    const n = (l?.name || "").toLowerCase();
+    return needle.some((k) => n.includes(k));
+  });
+}
+
+// Rough anemia thresholds (adult, generic; local refs vary)
+const REF = {
+  Hb: { low: 12 }, // g/dL
+  MCV: { low: 80, high: 100 }, // fL
+};
+
+export function anemiaRules(input: any): AnemiaRuleOut {
+  const out: AnemiaRuleOut = { steps: [], nudges: [], fired: [], softAlerts: [] };
+  const labs: Lab[] =
+    (input?.labs as Lab[]) ??
+    (input?.profile?.labs as Lab[]) ??
+    [];
+
+  const hbLab = pickLab(labs, ["hb", "hemoglobin"]);
+  const mcvLab = pickLab(labs, ["mcv"]);
+  const ferritinLab = pickLab(labs, ["ferritin"]);
+  const b12Lab = pickLab(labs, ["b12", "vitamin b12"]);
+  const folateLab = pickLab(labs, ["folate"]);
+
+  const hb = parseNumber(hbLab?.value);
+  const mcv = parseNumber(mcvLab?.value);
+  const ferritin = parseNumber(ferritinLab?.value);
+  const b12 = parseNumber(b12Lab?.value);
+  const folate = parseNumber(folateLab?.value);
+
+  if (hb !== null && hb < REF.Hb.low) {
+    out.fired.push("anemia.present");
+    out.steps.push(
+      `Anemia detected (Hb ${hbLab?.value}${hbLab?.unit || "g/dL"}).`,
+      "Assess clinical symptoms: fatigue, pallor, dyspnea, chest pain.",
+    );
+
+    // Microcytic
+    if (mcv !== null && mcv < REF.MCV.low) {
+      out.fired.push("anemia.microcytic");
+      out.steps.push("Microcytic anemia pattern (MCV < 80 fL).");
+      if (ferritin !== null && ferritin < 15) {
+        out.steps.push("Low ferritin: iron deficiency anemia likely.");
+        out.nudges.push("Evaluate diet, bleeding sources (GI losses, menstruation).");
+      } else {
+        out.nudges.push("Consider thalassemia trait or chronic disease if ferritin normal/high.");
+      }
+    }
+
+    // Macrocytic
+    else if (mcv !== null && mcv > REF.MCV.high) {
+      out.fired.push("anemia.macrocytic");
+      out.steps.push("Macrocytic anemia pattern (MCV > 100 fL).");
+      if (b12 !== null && b12 < 200) {
+        out.steps.push("Low B12 suggests B12 deficiency anemia.");
+        out.nudges.push("Check for pernicious anemia, malabsorption, diet issues.");
+      }
+      if (folate !== null && folate < 3) {
+        out.steps.push("Low folate suggests folate deficiency anemia.");
+        out.nudges.push("Assess diet, alcohol use, medications (e.g. methotrexate).");
+      }
+    }
+
+    // Normocytic
+    else {
+      out.fired.push("anemia.normocytic");
+      out.steps.push("Normocytic anemia pattern.");
+      out.nudges.push("Consider chronic disease, renal function, acute blood loss.");
+    }
+
+    // Soft alert for very low Hb
+    if (hb < 8) {
+      out.softAlerts ||= [];
+      out.softAlerts.push("Severe anemia (Hb < 8 g/dL) → urgent evaluation/transfusion consideration.");
+    }
+  }
+
+  return out;
+}
+

--- a/lib/aidoc/rules/index.ts
+++ b/lib/aidoc/rules/index.ts
@@ -2,6 +2,7 @@ import { diabetesRules } from "./diabetes";
 import { lipidsRules } from "./lipids";
 import { htnRules } from "./htn";
 import { thyroidRules } from "./thyroid";
+import { anemiaRules } from "./anemia";
 
 export type RulesOut = { steps:string[]; nudges:string[]; fired:string[]; softAlerts:any[] };
 
@@ -11,6 +12,7 @@ export function runRules(ctx:{labs:any[]; meds:any[]; conditions:any[]; vitals?:
     lipidsRules(ctx),
     htnRules(ctx),
     thyroidRules(ctx),
+    anemiaRules(ctx),
   ];
   return {
     steps: Array.from(new Set(buckets.flatMap(b=>b.steps))),

--- a/test/aidoc.anemia.test.ts
+++ b/test/aidoc.anemia.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { anemiaRules } from "../lib/aidoc/rules/anemia";
+
+describe("anemiaRules", () => {
+  it("detects iron deficiency microcytic anemia", () => {
+    const out = anemiaRules({
+      labs: [
+        { name: "Hb", value: 9, unit: "g/dL" },
+        { name: "MCV", value: 70, unit: "fL" },
+        { name: "Ferritin", value: 10, unit: "ng/mL" }
+      ]
+    });
+    expect(out.fired).toContain("anemia.microcytic");
+    expect(out.steps.some(s => /iron deficiency/i.test(s))).toBe(true);
+  });
+
+  it("fires soft alert for severe anemia", () => {
+    const out = anemiaRules({ labs: [{ name: "Hemoglobin", value: 6.5, unit: "g/dL" }] });
+    expect(out.softAlerts?.length).toBeGreaterThan(0);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add anemia rule pack for microcytic/macrocytic/normocytic detection and severe anemia alerts
- integrate anemia rules into rule runner
- cover anemia detection with unit tests

## Testing
- `npm test`
- `npx vitest run test/aidoc.anemia.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c00b27a53c832fa667f3cce3a8088b