### PR TITLE
Stabilize doctor mode responses with deterministic and idempotent chat handling

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -2,15 +2,28 @@ import { NextRequest } from 'next/server';
 import { profileChatSystem } from '@/lib/profileChatSystem';
 export const runtime = 'edge';
 
+const recentReqs = new Map<string, number>();
+
 export async function POST(req: NextRequest) {
-  const { messages = [], threadId, context } = await req.json();
+  const { messages = [], context, clientRequestId } = await req.json();
+  const now = Date.now();
+  for (const [id, ts] of recentReqs.entries()) {
+    if (now - ts > 60_000) recentReqs.delete(id);
+  }
+  if (clientRequestId) {
+    const ts = recentReqs.get(clientRequestId);
+    if (ts && now - ts < 60_000) {
+      return new Response(null, { status: 409 });
+    }
+    recentReqs.set(clientRequestId, now);
+  }
   const base  = process.env.LLM_BASE_URL!;
   const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
   const key   = process.env.LLM_API_KEY!;
   const url = `${base.replace(/\/$/,'')}/chat/completions`;
 
-  let finalMessages = messages;
-  if (threadId === 'med-profile' || context === 'profile') {
+  let finalMessages = messages.filter((m: any) => m.role !== 'system');
+  if (context === 'profile') {
     try {
       const origin = req.nextUrl.origin;
       const headers = { cookie: req.headers.get('cookie') || '' } as any;
@@ -25,14 +38,22 @@ export async function POST(req: NextRequest) {
         profile: p?.profile || p || null,
         packet: pk.text || '',
       });
-      finalMessages = [{ role: 'system', content: sys }, ...messages];
+      finalMessages = [{ role: 'system', content: sys }, ...finalMessages];
     } catch {}
   }
 
   const upstream = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
-    body: JSON.stringify({ model, stream: true, temperature: 0.2, messages: finalMessages })
+    body: JSON.stringify({
+      model,
+      stream: true,
+      temperature: 0,
+      top_p: 1,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+      messages: finalMessages,
+    })
   });
 
   if (!upstream.ok) {

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -663,10 +663,17 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
         ];
 
         const endpoint = '/api/aidoc/chat';
+        const rid = crypto.randomUUID();
         const res = await fetch(endpoint, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ mode: mode === 'doctor' ? 'doctor' : 'patient', messages: thread, threadId, context })
+          body: JSON.stringify({
+            mode: mode === 'doctor' ? 'doctor' : 'patient',
+            messages: thread,
+            threadId,
+            context,
+            clientRequestId: rid
+          })
         });
         if (!res.ok || !res.body) throw new Error(`Chat API error ${res.status}`);
         const reader = res.body.getReader();


### PR DESCRIPTION
## Summary
- Force deterministic chat completions with temperature 0 and zero penalties
- Guard prompt order and add profile system prompt only when explicitly requested
- Add clientRequestId tracking to deduplicate doctor chat requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c00c6f8a38832f868ad460603d7890