### PR TITLE
feat: add country filter and trial query aliases

### DIFF
--- a/components/panels/TrialsPane.tsx
+++ b/components/panels/TrialsPane.tsx
@@ -9,10 +9,10 @@ import type { TrialRow } from "@/types/trials";
 export default function TrialsPane() {
   const [form, setForm] = useState({
     condition: "",
-    country: "", // "" = Worldwide; code3 like "IND" or "USA"
     status: "Recruiting,Enrolling by invitation",
     phase: "Phase 2,Phase 3",
   });
+  const [country, setCountry] = useState<string>("auto");
   const [rows, setRows] = useState<(TrialRow & { hints?: string[] })[]>([]);
   const [loading, setLoading] = useState(false);
   const [profile, setProfile] = useState<{ age?: number; sex?: "male"|"female"|"other"; comorbids?: string[] }>({});
@@ -32,7 +32,7 @@ export default function TrialsPane() {
     try {
       const res = await getTrials({
         condition: form.condition,
-        country: form.country,
+        country: country === "auto" ? undefined : country,
         status: form.status,
         phase: form.phase,
         page: 1,
@@ -55,19 +55,34 @@ export default function TrialsPane() {
   return (
     <div className="space-y-3">
       <div className="grid grid-cols-2 gap-2">
-        <input className="border rounded p-2" placeholder="Condition (e.g., Type 2 Diabetes)"
-          value={form.condition} onChange={e=>setForm({...form, condition:e.target.value})}/>
         <input
           className="border rounded p-2"
-          placeholder="Country code (optional)"
-          value={form.country}
-          onChange={e=>setForm({...form, country:e.target.value.toUpperCase()})}
-          maxLength={3}
+          placeholder="Condition (e.g., Type 2 Diabetes)"
+          value={form.condition}
+          onChange={(e) => setForm({ ...form, condition: e.target.value })}
         />
-        <input className="border rounded p-2" placeholder="Status (e.g., Recruiting,Active)"
-          value={form.status||""} onChange={e=>setForm({...form, status:e.target.value||undefined})}/>
-        <input className="border rounded p-2" placeholder="Phase (e.g., Phase 2,Phase 3)"
-          value={form.phase||""} onChange={e=>setForm({...form, phase:e.target.value||undefined})}/>
+        <select
+          className="border rounded px-2 py-1 text-sm"
+          value={country}
+          onChange={(e) => setCountry(e.target.value)}
+        >
+          <option value="auto">Auto</option>
+          <option value="India">India</option>
+          <option value="USA">USA</option>
+          <option value="EU">EU</option>
+        </select>
+        <input
+          className="border rounded p-2"
+          placeholder="Status (e.g., Recruiting,Active)"
+          value={form.status || ""}
+          onChange={(e) => setForm({ ...form, status: e.target.value || undefined })}
+        />
+        <input
+          className="border rounded p-2"
+          placeholder="Phase (e.g., Phase 2,Phase 3)"
+          value={form.phase || ""}
+          onChange={(e) => setForm({ ...form, phase: e.target.value || undefined })}
+        />
       </div>
 
       <div className="flex gap-2">

--- a/lib/research/aliases.ts
+++ b/lib/research/aliases.ts
@@ -1,0 +1,18 @@
+export const ALIASES: Record<string, string[]> = {
+  "non small cell lung cancer": ["nsclc", "non-small cell lung carcinoma"],
+  "acute myeloid leukemia": ["aml"],
+  "breast cancer": ["mammary carcinoma"],
+  "colorectal cancer": ["crc", "colon cancer", "rectal cancer"],
+};
+
+export function expandQuery(q: string): string[] {
+  const base = q.toLowerCase();
+  const extras = new Set<string>();
+  for (const [k, vals] of Object.entries(ALIASES)) {
+    if (base.includes(k) || vals.some((v) => base.includes(v))) {
+      extras.add(k);
+      vals.forEach((v) => extras.add(v));
+    }
+  }
+  return [q, ...Array.from(extras)];
+}

--- a/lib/research/cache.ts
+++ b/lib/research/cache.ts
@@ -1,0 +1,12 @@
+const mem = new Map<string, { data: any; exp: number }>();
+export async function getCached<T>(key: string): Promise<T | undefined> {
+  const hit = mem.get(key);
+  if (!hit || Date.now() > hit.exp) return undefined;
+  return hit.data as T;
+}
+export async function setCached<T>(key: string, data: T, ttlSec = 900) {
+  mem.set(key, { data, exp: Date.now() + ttlSec * 1000 });
+}
+export function tkey(source: string, q: string) {
+  return `${source}:${q.toLowerCase()}`.slice(0, 500);
+}


### PR DESCRIPTION
## Summary
- add country dropdown in Trials pane to manually select Auto/India/USA/EU
- orchestrateTrials now expands query aliases and supports cached, timeout-limited registry calls
- introduce in-memory cache utilities and alias map

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c00d46b54c832fbc23fd83eb16e44a