### PR TITLE
feat: add AI Doc intake preflight

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,6 @@ AIDOC_UI=0
 
 # Optional: show AI Doc “Next steps” UI in Doctor mode
 NEXT_PUBLIC_AIDOC_UI=0
+
+# Ask “new or existing patient?” before AI Doc runs
+NEXT_PUBLIC_AIDOC_PREFLIGHT=0

--- a/lib/ai/prompts/aidoc.ts
+++ b/lib/ai/prompts/aidoc.ts
@@ -21,7 +21,7 @@ export function buildAiDocPrompt({ profile, labs, meds, conditions }: BuildInput
     "- Avoid generic test batteries (e.g., 'vitamin D, CRP, etc.') unless clearly warranted by active conditions or recent findings.",
     "",
     "Patient Snapshot:",
-    `- Demographics: name=${profile?.name ?? ""}, sex=${profile?.sex ?? ""}, bloodGroup=${profile?.bloodGroup ?? ""}`,
+    `- Demographics: Name: ${profile?.name || "—"}. Age: ${profile?.age ?? "—"}, Sex: ${profile?.sex ?? "—"}, Pregnant: ${profile?.pregnant ?? "—"}.`,
     `- Active Conditions: ${(conditions||[]).filter((c:any)=>c.status==='active').map((c:any)=>c.label).join(', ') || 'none recorded'}`,
     `- Meds: ${(meds||[]).map((m:any)=>m.name + (m.dose?(" "+m.dose):"")).join(', ') || 'none recorded'}`,
     `- Recent Labs (≤90d): ${recentLabs.map((l:any)=>`${l.name} ${l.value??""}${l.unit??""} (${new Date(l.takenAt).toISOString().slice(0,10)})`).join('; ') || 'none'}`,


### PR DESCRIPTION
## Summary
- add NEXT_PUBLIC_AIDOC_PREFLIGHT flag
- add AI Doc preflight modal and mini intake in ChatPane
- allow ai-doc API to create quick profiles and seed basic notes
- include patient name and demographics in AI Doc prompt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c011984540832f9df953636f6eaca2