### PR TITLE
feat: add clinical calculators and lab extraction

### DIFF
--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -8,67 +8,25 @@ import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 import { LinkBadge } from "./SafeLink";
 
-// --- Normalizer ---
-function normalize(raw: string): string {
-  if (!raw) return "";
-
-  let s = raw.trim();
-
-  // unwrap accidental full-message fences
-  const fence = /^```([a-zA-Z0-9_-]*)\s*\n([\s\S]*?)\n```$/m.exec(s);
-  if (fence) {
-    const lang = (fence[1] || "").toLowerCase();
-    if (!lang || lang === "txt" || lang === "text") s = fence[2];
-  }
-
-  // convert ====, ----, ____ to markdown horizontal rule
-  s = s.replace(/^[=\-_]{4,}$/gm, "\n---\n");
-
-  // bold-only lines -> headings
-  s = s.replace(
-    /^(?:\*\*|__)\s*([^*\n][^*\n]+?)\s*(?:\*\*|__)\s*$/gm,
-    "### $1"
-  );
-
-  // force bullet points
-  s = s.replace(/^\*\s+/gm, "- ");
-
-  // compress extra newlines
-  s = s.replace(/\n{3,}/g, "\n\n");
-
-  return s.trim() + "\n";
-}
-
-// --- Renderer ---
 export default function ChatMarkdown({ content }: { content: string }) {
-  const prepared = normalize(content);
-
+  const prepared = normalize(content || "");
   return (
-    <div
-      className="
-        prose prose-slate dark:prose-invert max-w-none
-        prose-headings:font-semibold prose-headings:mb-2 prose-headings:mt-3
-        prose-h3:text-lg prose-h4:text-base
-        prose-p:my-2 prose-li:my-1 prose-strong:font-medium
-        leading-relaxed text-[15px]
-      "
-    >
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkMath]}
-        rehypePlugins={[rehypeKatex]}
-        components={{
-          a: ({ href, children }) => (
-            <LinkBadge href={href as string}>{children as any}</LinkBadge>
-          ),
-          ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
-          ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
-          hr: () => <hr className="my-3 border-dashed opacity-40" />,
-          p: ({ children }) => <p className="text-left">{children}</p>,
-        }}
-      >
+    <div className="prose prose-slate dark:prose-invert max-w-none prose-p:my-2 prose-li:my-1 prose-headings:mb-2 prose-headings:font-semibold text-[15px] leading-7">
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>
         {prepared}
       </ReactMarkdown>
     </div>
   );
+}
+
+function normalize(raw: string){
+  let s = (raw||"").trim();
+  const f = /^```([a-z0-9_-]*)\s*\n([\s\S]*?)\n```$/i.exec(s);
+  if (f && (!f[1] || /^(txt|text)$/.test(f[1]))) s = f[2];
+  s = s.replace(/^[=\-_]{4,}$/gm, "\n---\n");
+  s = s.replace(/^(?:\*\*|__)\s*([^*\n][^*\n]+?)\s*(?:\*\*|__)\s*$/gm, "### $1");
+  s = s.replace(/^\*\s+/gm, "- ");
+  s = s.replace(/\n{3,}/g, "\n\n");
+  return s + "\n";
 }
 

--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -6,7 +6,6 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
-import { LinkBadge } from "./SafeLink";
 
 export default function ChatMarkdown({ content }: { content: string }) {
   const prepared = normalize(content || "");

--- a/lib/medical/calculators.ts
+++ b/lib/medical/calculators.ts
@@ -1,0 +1,33 @@
+export type Labs = {
+  Na?: number; K?: number; Cl?: number; HCO3?: number;
+  glucose_mgdl?: number; glucose_mmol?: number;
+  BUN?: number; creatinine?: number; albumin?: number;
+};
+
+export function mgdlFromMmol(gluMmol?: number) {
+  return gluMmol != null ? gluMmol * 18 : undefined;
+}
+
+export function computeAnionGap({ Na, K, Cl, HCO3 }: Labs) {
+  if (Na == null || Cl == null || HCO3 == null) return undefined;
+  const kPart = K ?? 0;
+  return (Na + kPart) - (Cl + HCO3);
+}
+
+export function correctSodiumForGlucose(Na?: number, glucoseMgdl?: number, factor: 1.6 | 2.4 = 1.6) {
+  if (Na == null || glucoseMgdl == null) return undefined;
+  return Na + factor * ((glucoseMgdl - 100) / 100);
+}
+
+export function effectiveOsmolality({ Na, glucose_mgdl, BUN }: Labs) {
+  if (Na == null) return undefined;
+  const glu = glucose_mgdl ?? 0;
+  const bun = BUN ?? 0;
+  // 2*Na + glucose/18 + BUN/2.8
+  return 2*Na + (glu/18) + (bun/2.8);
+}
+
+export function needsKBeforeInsulin(K?: number) {
+  return K != null && K < 3.3; // ADA
+}
+

--- a/lib/medical/extractLabs.ts
+++ b/lib/medical/extractLabs.ts
@@ -1,0 +1,30 @@
+import type { Labs } from "./calculators";
+
+const NUM = /([0-9]+(?:\.[0-9]+)?)/;
+
+export function extractLabsFromText(s: string): Labs {
+  const labs: Labs = {};
+  const lower = s.toLowerCase();
+
+  const pick = (key: keyof Labs, rx: RegExp, toNum: (x:string)=>number = Number) => {
+    const m = lower.match(rx);
+    if (m) (labs as any)[key] = toNum(m[1]);
+  };
+
+  pick("Na", /na[^0-9\-]*?[:=]?\s*?([0-9.]+)/);
+  pick("K", /k[^a-z0-9]?[^0-9\-]*?[:=]?\s*?([0-9.]+)/);
+  pick("Cl", /cl[^a-z0-9]?[^0-9\-]*?[:=]?\s*?([0-9.]+)/);
+  pick("HCO3", /(hco3|bicarb)[^0-9\-]*?[:=]?\s*?([0-9.]+)/);
+  pick("glucose_mmol", /(glucose|fpg|fasting)[^0-9\-]*?[:=]?\s*?([0-9.]+)\s*mmol/);
+  pick("glucose_mgdl", /(glucose|fpg|fasting)[^0-9\-]*?[:=]?\s*?([0-9.]+)\s*mg\/?dl/);
+  pick("BUN", /bun[^0-9\-]*?[:=]?\s*?([0-9.]+)/);
+  pick("creatinine", /creatinine[^0-9\-]*?[:=]?\s*?([0-9.]+)/);
+  pick("albumin", /albumin[^0-9\-]*?[:=]?\s*?([0-9.]+)/);
+
+  // prefer mg/dL if present; else convert mmol to mg/dL
+  if (!labs.glucose_mgdl && labs.glucose_mmol != null) {
+    labs.glucose_mgdl = labs.glucose_mmol * 18;
+  }
+  return labs;
+}
+


### PR DESCRIPTION
## Summary
- add medical calculators for sodium correction, anion gap, osmolality, and K warning
- extract labs from chat text and prepend computed notes to LLM messages
- simplify chat markdown rendering and normalize formatting

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c014c627cc832f8b9a5c6a154b5d55