### PR TITLE
feat: unify medical calculators and extraction

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -1,26 +1,11 @@
 import { NextRequest } from 'next/server';
 import { profileChatSystem } from '@/lib/profileChatSystem';
-import * as calc from '@/lib/medical/calculators';
+import { extractAll } from '@/lib/medical/extract';
+import { computeAll } from '@/lib/medical/calculators';
 export const runtime = 'edge';
 
 const recentReqs = new Map<string, number>();
 
-type Labs = { Na?: number; K?: number; Cl?: number; HCO3?: number; glucose?: number };
-
-function extractLabs(messages: any[]): Labs {
-  const text = messages.map((m: any) => m.content || '').join(' ');
-  const pick = (re: RegExp) => {
-    const match = text.match(re);
-    return match ? parseFloat(match[1]) : undefined;
-  };
-  return {
-    Na: pick(/\b(?:Na|Sodium)\s*(\d+(?:\.\d+)?)/i),
-    K: pick(/\b(?:K|Potassium)\s*(\d+(?:\.\d+)?)/i),
-    Cl: pick(/\b(?:Cl|Chloride)\s*(\d+(?:\.\d+)?)/i),
-    HCO3: pick(/\b(?:HCO3|Bicarb(?:onate)?)\s*(\d+(?:\.\d+)?)/i),
-    glucose: pick(/\b(?:glucose|glu)\s*(\d+(?:\.\d+)?)/i),
-  };
-}
 
 export async function POST(req: NextRequest) {
   const { messages = [], context, clientRequestId, mode } = await req.json();
@@ -42,30 +27,20 @@ export async function POST(req: NextRequest) {
 
   let finalMessages = messages.filter((m: any) => m.role !== 'system');
 
-  if (mode === 'doctor' || mode === 'patient') {
-    const labs = extractLabs(finalMessages);
-    const notes: string[] = [];
-    if (labs.Na && labs.Cl && labs.HCO3) {
-      const ag = calc.computeAnionGap({ Na: labs.Na, K: labs.K, Cl: labs.Cl, HCO3: labs.HCO3 });
-      notes.push(`Computed Anion Gap: ${ag.toFixed(1)} mmol/L`);
-    }
-    if (labs.Na && labs.glucose) {
-      const corr = calc.correctSodiumForGlucose(labs.Na, labs.glucose);
-      notes.push(`Corrected Sodium: ${corr.toFixed(1)} mmol/L`);
-    }
-    if (labs.K !== undefined) {
-      if (calc.needsKBeforeInsulin(labs.K)) {
-        notes.push(`⚠️ Potassium ${labs.K} < 3.3 → Replete K before insulin`);
-      }
-    }
-    if (notes.length) {
-      finalMessages = [
-        { role: 'system', content: 'Use provided computed values (do not recalc by hand).' },
-        { role: 'system', content: 'These deterministic calculations are pre-computed:' },
-        { role: 'system', content: notes.join('\n') },
-        ...finalMessages,
-      ];
-    }
+  const userText = (messages || []).map((m: any) => m?.content || '').join('\n');
+  const labs = extractAll(userText);
+  const computedLines = computeAll(labs);
+
+  if (computedLines.length) {
+    finalMessages = [
+      {
+        role: 'system',
+        content:
+          'These clinical calculations are pre-computed by code. Use them exactly; do not re-calculate. If inputs are missing, state which values are required.'
+      },
+      { role: 'system', content: computedLines.join('\n') },
+      ...finalMessages,
+    ];
   }
   if (context === 'profile') {
     try {

--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -9,34 +9,16 @@ import "katex/dist/katex.min.css";
 import { LinkBadge } from "./SafeLink";
 
 // --- Normalizer ---
-function normalize(raw: string): string {
-  if (!raw) return "";
-
-  let s = raw.trim();
-
-  // unwrap accidental full-message fences
-  const fence = /^```([a-zA-Z0-9_-]*)\s*\n([\s\S]*?)\n```$/m.exec(s);
-  if (fence) {
-    const lang = (fence[1] || "").toLowerCase();
-    if (!lang || lang === "txt" || lang === "text") s = fence[2];
-  }
-
-  // convert ====, ----, ____ to markdown horizontal rule
+// normalize: unwrap full-message fences, convert ==== to <hr>, bold-lines → headings, list bullets
+function normalize(raw: string){
+  let s = (raw||"").trim();
+  const f = /^```([a-z0-9_-]*)\s*\n([\s\S]*?)\n```$/i.exec(s);
+  if (f && (!f[1] || /^(txt|text)$/.test(f[1]))) s = f[2];
   s = s.replace(/^[=\-_]{4,}$/gm, "\n---\n");
-
-  // bold-only lines -> headings
-  s = s.replace(
-    /^(?:\*\*|__)\s*([^*\n][^*\n]+?)\s*(?:\*\*|__)\s*$/gm,
-    "### $1"
-  );
-
-  // force bullet points
+  s = s.replace(/^(?:\*\*|__)\s*([^*\n][^*\n]+?)\s*(?:\*\*|__)\s*$/gm, "### $1");
   s = s.replace(/^\*\s+/gm, "- ");
-
-  // compress extra newlines
   s = s.replace(/\n{3,}/g, "\n\n");
-
-  return s.trim() + "\n";
+  return s + "\n";
 }
 
 // --- Renderer ---

--- a/lib/medical/calculators.ts
+++ b/lib/medical/calculators.ts
@@ -1,14 +1,155 @@
-export function computeAnionGap({ Na, K, Cl, HCO3 }: { Na: number; K?: number; Cl: number; HCO3: number }) {
-  const kPart = K ?? 0;
-  return (Na + kPart) - (Cl + HCO3);
+export type Labs = {
+  // core labs
+  Na?: number; K?: number; Cl?: number; HCO3?: number;
+  glucose_mgdl?: number; glucose_mmol?: number;
+  Mg?: number; Ca?: number; BUN?: number; creatinine?: number; albumin?: number;
+  // ECG
+  QTms?: number; HR?: number;
+  // vitals
+  age?: number; sex?: "male" | "female";
+  sbp?: number; dbp?: number; rr?: number; tempC?: number; spo2?: number; fio2?: number;
+  // history flags for scores
+  hx_af?: boolean; hx_htn?: boolean; hx_dm?: boolean; hx_stroke_tia?: boolean; hx_vascular?: boolean;
+  hx_bleed?: boolean; labile_inr?: boolean; alcohol?: boolean; nsaid?: boolean;
+  chf?: boolean; renal_impair?: boolean; liver_impair?: boolean;
+};
+
+// ---------- Helpers ----------
+export const mgdlFromMmol = (mmol?: number) => (mmol != null ? mmol * 18 : undefined);
+export const rrSeconds = (hr: number) => 60 / hr;
+
+// ---------- Electrolytes / Acid-Base ----------
+export function anionGap(l: Labs) {
+  if (l.Na == null || l.Cl == null || l.HCO3 == null) return undefined;
+  const k = l.K ?? 0;
+  return (l.Na + k) - (l.Cl + l.HCO3);
+}
+export function correctedSodium(l: Labs, factor: 1.6 | 2.4 = 1.6) {
+  const glu = l.glucose_mgdl ?? mgdlFromMmol(l.glucose_mmol);
+  if (l.Na == null || glu == null) return undefined;
+  return l.Na + factor * ((glu - 100) / 100);
+}
+export function effectiveOsmolality(l: Labs) {
+  if (l.Na == null) return undefined;
+  const glu = l.glucose_mgdl ?? mgdlFromMmol(l.glucose_mmol) ?? 0;
+  const bun = l.BUN ?? 0;
+  return 2 * l.Na + glu / 18 + bun / 2.8;
+}
+export function needsKBeforeInsulin(l: Labs): boolean;
+export function needsKBeforeInsulin(K: number): boolean;
+export function needsKBeforeInsulin(arg: Labs | number): boolean {
+  if (typeof arg === "number") return arg < 3.3;
+  return arg.K != null && arg.K < 3.3;
 }
 
+// ---------- ECG ----------
+export function qtcFridericia(l: Labs) {
+  if (l.QTms == null || l.HR == null) return undefined;
+  const rr = rrSeconds(l.HR);
+  return l.QTms / Math.cbrt(rr);
+}
+export function qtcBazett(l: Labs) {
+  if (l.QTms == null || l.HR == null) return undefined;
+  const rr = rrSeconds(l.HR);
+  return l.QTms / Math.sqrt(rr);
+}
+export function qtcElectrolyteAdjusted(fridMs?: number, k?: number, mg?: number) {
+  if (fridMs == null) return undefined;
+  let add = 0;
+  if (k != null && k < 3.5) add += 10;
+  if (mg != null && mg < 1.7) add += 5;
+  return fridMs + add;
+}
+
+// ---------- Renal / Liver ----------
+export function egfrCkdEpi(l: Labs) {
+  // Minimal CKD-EPI (creatinine-only) rougher variant; extend with race when/if needed.
+  if (l.creatinine == null || l.age == null || !l.sex) return undefined;
+  const Scr = l.creatinine;
+  const k = l.sex === "female" ? 0.7 : 0.9;
+  const a = l.sex === "female" ? -0.241 : -0.302;
+  const min = Math.min(Scr / k, 1);
+  const max = Math.max(Scr / k, 1);
+  const sexCoef = l.sex === "female" ? 1.012 : 1;
+  return 142 * Math.pow(min, a) * Math.pow(max, -1.200) * Math.pow(0.9938, l.age) * sexCoef;
+}
+export function meld(l: Labs) {
+  // MELD: 3.78*ln(bili) + 11.2*ln(INR) + 9.57*ln(creat) + 6.43; MELD-Na optional
+  // Placeholders unless INR/bilirubin provided in future; keep function for future extension.
+  return undefined;
+}
+
+// ---------- Risk Scores ----------
+export function chads2vasc(l: Labs) {
+  // Needs AF status + flags; compute if available.
+  if (!l.hx_af) return undefined;
+  let score = 0;
+  if (l.chf) score += 1;
+  if (l.hx_htn) score += 1;
+  if (l.age != null && l.age >= 75) score += 2;
+  else if (l.age != null && l.age >= 65) score += 1;
+  if (l.hx_dm) score += 1;
+  if (l.hx_stroke_tia) score += 2;
+  if (l.hx_vascular) score += 1;
+  // sex category
+  if (l.sex === "female") score += 1;
+  return score;
+}
+export function hasBled(l: Labs) {
+  // Minimal subset: HTN, renal/liver impairment, stroke, bleeding, labile INR, elderly (>65), drugs/alcohol
+  let s = 0;
+  if (l.hx_htn) s += 1;
+  if (l.renal_impair) s += 1;
+  if (l.liver_impair) s += 1;
+  if (l.hx_stroke_tia) s += 1;
+  if (l.hx_bleed) s += 1;
+  if (l.age != null && l.age > 65) s += 1;
+  if (l.labile_inr) s += 1;
+  if (l.nsaid) s += 1;
+  if (l.alcohol) s += 1;
+  return s;
+}
+
+// ---------- Aggregator ----------
+export function computeAll(l: Labs): string[] {
+  const out: string[] = [];
+
+  const ag = anionGap(l);
+  if (ag != null) out.push(`Anion gap: ${ag.toFixed(1)} mmol/L`);
+
+  const cNa16 = correctedSodium(l, 1.6);
+  if (cNa16 != null) out.push(`Corrected Na (1.6): ${cNa16.toFixed(1)} mmol/L`);
+  const effOsm = effectiveOsmolality(l);
+  if (effOsm != null) out.push(`Effective osmolality: ${effOsm.toFixed(0)} mOsm/kg`);
+
+  if (needsKBeforeInsulin(l)) out.push(`⚠️ K ${l.K} < 3.3 → replete K before insulin`);
+
+  const frid = qtcFridericia(l);
+  if (frid != null) out.push(`QTc (Fridericia): ${frid.toFixed(0)} ms`);
+  const baz = qtcBazett(l);
+  if (baz != null) out.push(`QTc (Bazett): ${baz.toFixed(0)} ms`);
+  const adj = qtcElectrolyteAdjusted(frid, l.K, l.Mg);
+  if (adj != null && frid != null && Math.round(adj) !== Math.round(frid))
+    out.push(`QTc (Fridericia, adjusted for K/Mg): ${adj.toFixed(0)} ms`);
+
+  const egfr = egfrCkdEpi(l);
+  if (egfr != null) out.push(`eGFR (CKD-EPI): ${egfr.toFixed(0)} mL/min/1.73m²`);
+
+  const chads = chads2vasc(l);
+  if (chads != null) out.push(`CHA₂DS₂-VASc: ${chads}`);
+  const hbled = hasBled(l);
+  if (hbled != null) out.push(`HAS-BLED: ${hbled}`);
+
+  return out;
+}
+
+// --- Backward compatibility helpers ---
+export function computeAnionGap(vals: { Na: number; K?: number; Cl: number; HCO3: number }) {
+  return anionGap(vals) as number;
+}
 export function correctSodiumForGlucose(Na: number, glucoseMgDl: number, factor: 1.6 | 2.4 = 1.6) {
-  return Na + factor * ((glucoseMgDl - 100) / 100);
+  return correctedSodium({ Na, glucose_mgdl: glucoseMgDl }, factor) as number;
 }
-
-export function needsKBeforeInsulin(K: number) {
-  return K < 3.3; // per ADA guidelines
+export function needsKBeforeInsulinLegacy(K: number) {
+  return needsKBeforeInsulin(K);
 }
-
-// add more calculators: BMI, DeltaGap, Osmolality, etc.

--- a/lib/medical/extract.ts
+++ b/lib/medical/extract.ts
@@ -1,0 +1,55 @@
+import type { Labs } from "./calculators";
+
+const num = /([0-9]+(?:\.[0-9]+)?)/;
+
+export function extractAll(s: string): Labs {
+  const t = (s || "").toLowerCase();
+  const pickNum = (rx: RegExp) => {
+    const m = t.match(rx);
+    return m ? Number(m[1]) : undefined;
+  };
+
+  const labs: Labs = {
+    Na: pickNum(/\bna[^0-9]*[:=]?\s*([0-9.]+)/),
+    K: pickNum(/\bk[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/),
+    Cl: pickNum(/\bcl[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/),
+    HCO3: pickNum(/\b(hco3|bicarb)[^0-9]*[:=]?\s*([0-9.]+)/),
+    Mg: pickNum(/\bmg[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/),
+    Ca: pickNum(/\bca[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/),
+    glucose_mgdl: pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mg\/?dl/),
+    glucose_mmol: pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mmol/),
+    BUN: pickNum(/\bbun[^0-9]*[:=]?\s*([0-9.]+)/),
+    creatinine: pickNum(/\bcreatinine[^0-9]*[:=]?\s*([0-9.]+)/),
+    albumin: pickNum(/\balbumin[^0-9]*[:=]?\s*([0-9.]+)/),
+
+    QTms: pickNum(/\bqt[^0-9]*[:=]?\s*([0-9]{3,4})\s*ms/),
+    HR: pickNum(/\b(heart\s*rate|hr)[^0-9]*[:=]?\s*([0-9]{2,3})/),
+
+    age: pickNum(/\bage[^0-9]*[:=]?\s*([0-9]{1,3})/),
+    sbp: pickNum(/\bsbp[^0-9]*[:=]?\s*([0-9]{2,3})/),
+    dbp: pickNum(/\bdbp[^0-9]*[:=]?\s*([0-9]{2,3})/),
+    rr: pickNum(/\brr[^0-9]*[:=]?\s*([0-9]{1,3})/),
+    tempC: pickNum(/\btemp[^0-9]*[:=]?\s*([0-9]{2}(?:\.[0-9]+)?)\s*°?c/),
+    spo2: pickNum(/\bspo2[^0-9]*[:=]?\s*([0-9]{2,3})/),
+    fio2: pickNum(/\bfio2[^0-9]*[:=]?\s*([0-9]{1,3})/),
+  };
+
+  // flags (very light detection; extend later)
+  const has = (w: RegExp) => w.test(t);
+  labs.hx_af = has(/\batrial\s*fibrillation\b|\bafib\b|\baf\b/);
+  labs.hx_htn = has(/\bhypertension\b|\bhtn\b/);
+  labs.hx_dm = has(/\bdiabetes\b|\bdm\b/);
+  labs.hx_stroke_tia = has(/\bstroke\b|\btia\b/);
+  labs.hx_vascular = has(/\bmi\b|\bischemic\b|\bpad\b|\bvascular\b/);
+  labs.hx_bleed = has(/\bbleed\b|\bhemorrhage\b/);
+  labs.renal_impair = has(/\bckd\b|\brenal\b/);
+  labs.liver_impair = has(/\bcirrhosis\b|\bliver\b/);
+  labs.alcohol = has(/\balcohol\b|\betoh\b/);
+  labs.nsaid = has(/\bnsaid\b/);
+
+  // sex
+  if (/\bmale\b|\bman\b/.test(t)) labs.sex = "male";
+  else if (/\bfemale\b|\bwoman\b/.test(t)) labs.sex = "female";
+
+  return labs;
+}

--- a/test/medical.calculators.test.ts
+++ b/test/medical.calculators.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "vitest";
+import { computeAll, qtcFridericia } from "../lib/medical/calculators";
+
+test("QTc Fridericia matches example", ()=>{
+  const ms = qtcFridericia({ QTms:480, HR:92 });
+  expect(Math.round(ms!)).toBeCloseTo(554, 0);
+});
+
+test("Anion gap basic", ()=>{
+  const out = computeAll({ Na:140, Cl:104, HCO3:24 });
+  expect(out.find(s => s.startsWith("Anion gap:"))).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- add comprehensive clinical calculator library with electrolytes, ECG, renal, and risk score helpers
- parse user messages for labs/vitals and inject pre-computed results into chat and AI-Doc prompts
- normalize chat markdown rendering and add unit tests for calculators

## Testing
- `npm test`
- `npx vitest run test/medical.calculators.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c01982ce30832fa6a91e5462c9e4e4