### PR TITLE
feat(trials): add Country filter (Auto/India/USA/EU) and alias expansion (NSCLC/AML/etc)

### DIFF
--- a/components/panels/TrialsPane.tsx
+++ b/components/panels/TrialsPane.tsx
@@ -116,6 +116,11 @@ export default function TrialsPane() {
                 {t.status && (
                   <span className="text-[11px] px-1.5 py-0.5 rounded border">{t.status}</span>
                 )}
+                {t.when?.updated && (
+                  <span className="text-[11px] px-1.5 py-0.5 rounded border">
+                    Updated: {t.when.updated.slice(0, 10)}
+                  </span>
+                )}
               </div>
             </li>
           ))}

--- a/lib/research/aliases.ts
+++ b/lib/research/aliases.ts
@@ -1,8 +1,10 @@
 export const ALIASES: Record<string, string[]> = {
   "non small cell lung cancer": ["nsclc", "non-small cell lung carcinoma"],
   "acute myeloid leukemia": ["aml"],
-  "breast cancer": ["mammary carcinoma"],
+  "multiple myeloma": ["mm"],
   "colorectal cancer": ["crc", "colon cancer", "rectal cancer"],
+  "hepatocellular carcinoma": ["hcc", "liver cancer"],
+  "triple negative breast cancer": ["tnbc"],
 };
 
 export function expandQuery(q: string): string[] {


### PR DESCRIPTION
## Summary
- add country selector to TrialsPane and forward to API
- implement alias expansion for oncology terms and update orchestrator with phase/status filters
- simplify trials API to call orchestrator and support country filtering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c01dcba68c832f8a770e69ac0598d9