### PR TITLE
Add acid-base calculators to medical engine

### DIFF
--- a/lib/medical/engine/calculators/acid_base.ts
+++ b/lib/medical/engine/calculators/acid_base.ts
@@ -1,0 +1,196 @@
+import { register } from "../registry";
+
+// ===== Anion Gap (±K) =====
+register({
+  id: "anion_gap",
+  label: "Anion gap",
+  tags: ["electrolytes", "acid-base"],
+  inputs: [
+    { key: "Na", required: true },
+    { key: "Cl", required: true },
+    { key: "HCO3", required: true },
+    { key: "K" },
+  ],
+  run: ({ Na, Cl, HCO3, K }) => {
+    if (Na == null || Cl == null || HCO3 == null) return null;
+    const ag = (Na + (K ?? 0)) - (Cl + HCO3);
+    return { id: "anion_gap", label: "Anion gap", value: ag, unit: "mmol/L", precision: 1 };
+  },
+  priority: 10,
+});
+
+// ===== Albumin-corrected Anion Gap =====
+// AG_corr = AG + 2.5 × (4.0 − albumin g/dL)
+register({
+  id: "anion_gap_albumin_corrected",
+  label: "Anion gap (albumin-corrected)",
+  tags: ["electrolytes", "acid-base"],
+  inputs: [
+    { key: "Na", required: true },
+    { key: "Cl", required: true },
+    { key: "HCO3", required: true },
+    { key: "K" },
+    { key: "albumin" },
+  ],
+  run: ({ Na, Cl, HCO3, K, albumin }) => {
+    if (Na == null || Cl == null || HCO3 == null || albumin == null) return null;
+    const ag = (Na + (K ?? 0)) - (Cl + HCO3);
+    const agc = ag + 2.5 * (4 - albumin);
+    const notes: string[] = [];
+    if (agc >= 16) notes.push("elevated corrected AG");
+    return {
+      id: "anion_gap_albumin_corrected",
+      label: "Anion gap (albumin-corrected)",
+      value: agc,
+      unit: "mmol/L",
+      precision: 1,
+      notes,
+    };
+  },
+  priority: 11,
+});
+
+// ===== Delta Gap & Delta–Delta =====
+// deltaAG = AG_corr - 12 (use corrected if available; else raw)
+// expected HCO3 = 24 - deltaAG; delta-delta = (Observed HCO3 - expected HCO3)
+register({
+  id: "delta_gap",
+  label: "Delta gap",
+  tags: ["acid-base"],
+  inputs: [
+    { key: "Na", required: true },
+    { key: "Cl", required: true },
+    { key: "HCO3", required: true },
+    { key: "K" },
+    { key: "albumin" },
+  ],
+  run: ({ Na, Cl, HCO3, K, albumin }) => {
+    if (Na == null || Cl == null || HCO3 == null) return null;
+    const ag = (Na + (K ?? 0)) - (Cl + HCO3);
+    const agCorr = albumin != null ? ag + 2.5 * (4 - albumin) : ag;
+    const dAG = agCorr - 12;
+    const expectedHCO3 = 24 - dAG;
+    const deltaDelta = HCO3 - expectedHCO3;
+
+    const notes: string[] = [];
+    if (deltaDelta > 3) notes.push("concurrent metabolic alkalosis (↑ HCO₃)");
+    if (deltaDelta < -3) notes.push("concurrent non-AG metabolic acidosis (↓ HCO₃)");
+
+    return {
+      id: "delta_gap",
+      label: "Delta gap (ΔAG), Δ–Δ",
+      value: Number.isFinite(dAG) ? dAG : undefined,
+      unit: "mmol/L",
+      precision: 1,
+      notes: [
+        `ΔAG: ${Number.isFinite(dAG) ? dAG.toFixed(1) : "—"}`,
+        `Expected HCO₃: ${Number.isFinite(expectedHCO3) ? expectedHCO3.toFixed(1) : "—"} mmol/L`,
+        `Δ–Δ: ${Number.isFinite(deltaDelta) ? deltaDelta.toFixed(1) : "—"} mmol/L`,
+        ...notes,
+      ],
+    };
+  },
+  priority: 12,
+});
+
+// ===== Corrected Sodium for Hyperglycemia =====
+register({
+  id: "corrected_na_1_6",
+  label: "Corrected Na (1.6 factor)",
+  tags: ["electrolytes"],
+  inputs: [
+    { key: "Na", required: true },
+    { key: "glucose_mgdl" },
+    { key: "glucose_mmol" },
+  ],
+  run: ({ Na, glucose_mgdl, glucose_mmol }) => {
+    const glu = glucose_mgdl ?? (glucose_mmol != null ? glucose_mmol * 18 : undefined);
+    if (Na == null || glu == null) return null;
+    const val = Na + 1.6 * ((glu - 100) / 100);
+    return { id: "corrected_na_1_6", label: "Corrected Na (1.6)", value: val, unit: "mmol/L", precision: 1 };
+  },
+  priority: 20,
+});
+
+register({
+  id: "corrected_na_2_4",
+  label: "Corrected Na (2.4 factor)",
+  tags: ["electrolytes"],
+  inputs: [
+    { key: "Na", required: true },
+    { key: "glucose_mgdl" },
+    { key: "glucose_mmol" },
+  ],
+  run: ({ Na, glucose_mgdl, glucose_mmol }) => {
+    const glu = glucose_mgdl ?? (glucose_mmol != null ? glucose_mmol * 18 : undefined);
+    if (Na == null || glu == null) return null;
+    const val = Na + 2.4 * ((glu - 100) / 100);
+    return { id: "corrected_na_2_4", label: "Corrected Na (2.4)", value: val, unit: "mmol/L", precision: 1 };
+  },
+  priority: 21,
+});
+
+// ===== Winter's Formula (expected pCO₂ in metabolic acidosis) =====
+// pCO2_expected = 1.5 × HCO3 + 8 ± 2
+register({
+  id: "winters_formula",
+  label: "Expected pCO₂ (Winter’s formula)",
+  tags: ["acid-base"],
+  inputs: [{ key: "HCO3", required: true }],
+  run: ({ HCO3 }) => {
+    if (HCO3 == null) return null;
+    const exp = 1.5 * HCO3 + 8;
+    return {
+      id: "winters_formula",
+      label: "Expected pCO₂ (Winter’s)",
+      value: exp,
+      unit: "mmHg",
+      precision: 1,
+      notes: ["±2 mmHg range"],
+    };
+  },
+  priority: 30,
+});
+
+// ===== Compensation heuristics (simple linear rules) =====
+// Metabolic alkalosis expected pCO₂: pCO₂ ≈ 0.7 × ΔHCO₃ + 40 ± 5
+register({
+  id: "metabolic_alk_compensation",
+  label: "Expected pCO₂ in metabolic alkalosis",
+  tags: ["acid-base"],
+  inputs: [{ key: "HCO3", required: true }],
+  run: ({ HCO3 }) => {
+    if (HCO3 == null || HCO3 < 28) return null;
+    const delta = HCO3 - 24;
+    const exp = 0.7 * delta + 40;
+    return {
+      id: "metabolic_alk_compensation",
+      label: "Expected pCO₂ (metabolic alkalosis)",
+      value: exp,
+      unit: "mmHg",
+      precision: 1,
+      notes: ["±5 mmHg range"],
+    };
+  },
+  priority: 31,
+});
+
+// Acute respiratory acidosis: ΔHCO₃ ≈ +1 mmol/L per +10 mmHg pCO₂ (chronic ≈ +3.5)
+// Acute respiratory alkalosis: ΔHCO₃ ≈ −2 mmol/L per −10 mmHg pCO₂ (chronic ≈ −5)
+register({
+  id: "resp_comp_rules",
+  label: "Respiratory compensation (heuristics)",
+  tags: ["acid-base"],
+  inputs: [{ key: "pCO2" }, { key: "HCO3" }],
+  run: ({ pCO2, HCO3 }) => {
+    if (pCO2 == null || HCO3 == null) return null;
+    const notes = [
+      "Acute resp. acidosis: +1 HCO₃ per +10 pCO₂",
+      "Chronic resp. acidosis: +3.5 HCO₃ per +10 pCO₂",
+      "Acute resp. alkalosis: −2 HCO₃ per −10 pCO₂",
+      "Chronic resp. alkalosis: −5 HCO₃ per −10 pCO₂",
+    ];
+    return { id: "resp_comp_rules", label: "Respiratory compensation", value: "", notes };
+  },
+  priority: 40,
+});

--- a/lib/medical/engine/calculators/index.ts
+++ b/lib/medical/engine/calculators/index.ts
@@ -1,0 +1,1 @@
+import "./acid_base";

--- a/lib/medical/engine/computeAll.ts
+++ b/lib/medical/engine/computeAll.ts
@@ -1,0 +1,15 @@
+import { CalcResult, getRegistry } from "./registry";
+import "./calculators";
+
+export function computeAll(ctx: Record<string, any>): CalcResult[] {
+  const out: CalcResult[] = [];
+  for (const calc of getRegistry()) {
+    try {
+      const res = calc.run(ctx);
+      if (res) out.push(res);
+    } catch {
+      // ignore individual calculator errors
+    }
+  }
+  return out;
+}

--- a/lib/medical/engine/extract.ts
+++ b/lib/medical/engine/extract.ts
@@ -5,17 +5,49 @@ export function extractAll(s: string): Context {
   const pickNum = (rx: RegExp) => {
     const m = t.match(rx);
     return m ? Number(m[1]) : undefined;
-    };
+  };
 
   const ctx: Context = {};
   ctx.Na = ctx.Na ?? pickNum(/\bna[^0-9]*[:=]?\s*([0-9.]+)/);
   ctx.K = ctx.K ?? pickNum(/\bk[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/);
   ctx.Cl = ctx.Cl ?? pickNum(/\bcl[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/);
   ctx.HCO3 = ctx.HCO3 ?? pickNum(/\b(hco3|bicarb)[^0-9]*[:=]?\s*([0-9.]+)/);
+  ctx.Mg = ctx.Mg ?? pickNum(/\bmg[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/);
+  ctx.Ca = ctx.Ca ?? pickNum(/\bca[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/);
+  ctx.BUN = ctx.BUN ?? pickNum(/\bbun[^0-9]*[:=]?\s*([0-9.]+)/);
+  ctx.creatinine = ctx.creatinine ?? pickNum(/\bcreatinine[^0-9]*[:=]?\s*([0-9.]+)/);
   ctx.albumin = ctx.albumin ?? pickNum(/\balbumin[^0-9]*[:=]?\s*([0-9.]+)/);
   ctx.pCO2 = ctx.pCO2 ?? pickNum(/\b(pco2|pco₂)[^0-9]*[:=]?\s*([0-9.]+)/);
   ctx.glucose_mgdl = ctx.glucose_mgdl ?? pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mg\/?dl/);
   ctx.glucose_mmol = ctx.glucose_mmol ?? pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mmol/);
+
+  ctx.QTms = ctx.QTms ?? pickNum(/\bqt[^0-9]*[:=]?\s*([0-9]{3,4})\s*ms/);
+  ctx.HR = ctx.HR ?? pickNum(/\b(heart\s*rate|hr)[^0-9]*[:=]?\s*([0-9]{2,3})/);
+
+  ctx.age = ctx.age ?? pickNum(/\bage[^0-9]*[:=]?\s*([0-9]{1,3})/);
+  ctx.sbp = ctx.sbp ?? pickNum(/\bsbp[^0-9]*[:=]?\s*([0-9]{2,3})/);
+  ctx.dbp = ctx.dbp ?? pickNum(/\bdbp[^0-9]*[:=]?\s*([0-9]{2,3})/);
+  ctx.rr = ctx.rr ?? pickNum(/\brr[^0-9]*[:=]?\s*([0-9]{1,3})/);
+  ctx.tempC = ctx.tempC ?? pickNum(/\btemp[^0-9]*[:=]?\s*([0-9]{2}(?:\.[0-9]+)?)\s*°?c/);
+  ctx.spo2 = ctx.spo2 ?? pickNum(/\bspo2[^0-9]*[:=]?\s*([0-9]{2,3})/);
+  ctx.fio2 = ctx.fio2 ?? pickNum(/\bfio2[^0-9]*[:=]?\s*([0-9]{1,3})/);
+
+  const has = (w: RegExp) => w.test(t);
+  ctx.hx_af = ctx.hx_af ?? has(/\batrial\s*fibrillation\b|\bafib\b|\baf\b/);
+  ctx.hx_htn = ctx.hx_htn ?? has(/\bhypertension\b|\bhtn\b/);
+  ctx.hx_dm = ctx.hx_dm ?? has(/\bdiabetes\b|\bdm\b/);
+  ctx.hx_stroke_tia = ctx.hx_stroke_tia ?? has(/\bstroke\b|\btia\b/);
+  ctx.hx_vascular = ctx.hx_vascular ?? has(/\bmi\b|\bischemic\b|\bpad\b|\bvascular\b/);
+  ctx.hx_bleed = ctx.hx_bleed ?? has(/\bbleed\b|\bhemorrhage\b/);
+  ctx.renal_impair = ctx.renal_impair ?? has(/\bckd\b|\brenal\b/);
+  ctx.liver_impair = ctx.liver_impair ?? has(/\bcirrhosis\b|\bliver\b/);
+  ctx.alcohol = ctx.alcohol ?? has(/\balcohol\b|\betoh\b/);
+  ctx.nsaid = ctx.nsaid ?? has(/\bnsaid\b/);
+
+  if (ctx.sex == null) {
+    if (/\bmale\b|\bman\b/.test(t)) ctx.sex = "male";
+    else if (/\bfemale\b|\bwoman\b/.test(t)) ctx.sex = "female";
+  }
 
   return ctx;
 }

--- a/lib/medical/engine/extract.ts
+++ b/lib/medical/engine/extract.ts
@@ -1,0 +1,21 @@
+export type Context = Record<string, any>;
+
+export function extractAll(s: string): Context {
+  const t = (s || "").toLowerCase();
+  const pickNum = (rx: RegExp) => {
+    const m = t.match(rx);
+    return m ? Number(m[1]) : undefined;
+    };
+
+  const ctx: Context = {};
+  ctx.Na = ctx.Na ?? pickNum(/\bna[^0-9]*[:=]?\s*([0-9.]+)/);
+  ctx.K = ctx.K ?? pickNum(/\bk[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/);
+  ctx.Cl = ctx.Cl ?? pickNum(/\bcl[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/);
+  ctx.HCO3 = ctx.HCO3 ?? pickNum(/\b(hco3|bicarb)[^0-9]*[:=]?\s*([0-9.]+)/);
+  ctx.albumin = ctx.albumin ?? pickNum(/\balbumin[^0-9]*[:=]?\s*([0-9.]+)/);
+  ctx.pCO2 = ctx.pCO2 ?? pickNum(/\b(pco2|pco₂)[^0-9]*[:=]?\s*([0-9.]+)/);
+  ctx.glucose_mgdl = ctx.glucose_mgdl ?? pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mg\/?dl/);
+  ctx.glucose_mmol = ctx.glucose_mmol ?? pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mmol/);
+
+  return ctx;
+}

--- a/lib/medical/engine/registry.ts
+++ b/lib/medical/engine/registry.ts
@@ -1,0 +1,32 @@
+export interface CalcInput {
+  key: string;
+  required?: boolean;
+}
+
+export interface CalcResult {
+  id: string;
+  label: string;
+  value?: number | string;
+  unit?: string;
+  precision?: number;
+  notes?: string[];
+}
+
+export interface Calculator {
+  id: string;
+  label: string;
+  tags?: string[];
+  inputs: CalcInput[];
+  run: (ctx: Record<string, any>) => CalcResult | null | undefined;
+  priority?: number;
+}
+
+const registry: Calculator[] = [];
+
+export function register(calc: Calculator) {
+  registry.push(calc);
+}
+
+export function getRegistry(): Calculator[] {
+  return registry.slice().sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+}

--- a/test/engine.acid_base.spec.ts
+++ b/test/engine.acid_base.spec.ts
@@ -1,0 +1,24 @@
+import { computeAll } from "../lib/medical/engine/computeAll";
+import { expect, test } from "vitest";
+
+test("anion gap & corrected Na", () => {
+  const out = computeAll({ Na: 128, Cl: 104, HCO3: 18, glucose_mgdl: 256, albumin: 3.0 });
+  const ag = out.find(r => r.id === "anion_gap")!;
+  expect(ag.value).toBeCloseTo(6.0, 1); // (128 + 0) - (104 + 18) = 6
+  const cna = out.find(r => r.id === "corrected_na_1_6")!;
+  expect(cna.value).toBeCloseTo(130.5, 1); // 1.6 factor
+});
+
+test("albumin-corrected AG & delta gap", () => {
+  const out = computeAll({ Na: 140, Cl: 104, HCO3: 18, albumin: 3.0 });
+  const agc = out.find(r => r.id === "anion_gap_albumin_corrected")!;
+  expect(agc.value as number).toBeCloseTo(((140)-(104+18)) + 2.5*(4-3), 1); // 18 + 2.5 = 20.5
+  const dg = out.find(r => r.id === "delta_gap")!;
+  expect((dg.notes||[]).some(n => n.startsWith("ΔAG"))).toBeTruthy();
+});
+
+test("Winter's formula", () => {
+  const out = computeAll({ HCO3: 18 });
+  const w = out.find(r => r.id === "winters_formula")!;
+  expect(w.value as number).toBeCloseTo(1.5*18+8, 1); // 35 mmHg
+});


### PR DESCRIPTION
## Summary
- build registry-driven medical engine with computeAll
- add electrolyte and acid–base calculators including anion gap, delta gap, corrected sodium, Winter's formula, and compensation heuristics
- extend extraction to capture albumin and pCO₂

## Testing
- `npm test`
- `npx vitest run test/medical.calculators.test.ts test/engine.acid_base.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c02430ed34832fb7cc9e36d9aa5ee7