### PR TITLE
Add renal and ICU helper calculators with extraction fixes

### DIFF
--- a/lib/medical/engine/calculators/icu_helpers.ts
+++ b/lib/medical/engine/calculators/icu_helpers.ts
@@ -1,0 +1,29 @@
+import { register } from "../registry";
+
+// Mean arterial pressure
+register({
+  id: "map",
+  label: "Mean arterial pressure",
+  inputs: [{ key: "SBP", required: true }, { key: "DBP", required: true }],
+  run: ({ SBP, DBP }) => {
+    if (SBP == null || DBP == null) return null;
+    const val = (SBP + 2 * DBP) / 3;
+    const notes: string[] = [];
+    if (val < 65) notes.push("MAP < 65 (low perfusion)");
+    return { id: "map", label: "Mean arterial pressure", value: val, unit: "mmHg", precision: 0, notes };
+  },
+});
+
+// Shock index
+register({
+  id: "shock_index",
+  label: "Shock index",
+  inputs: [{ key: "HR", required: true }, { key: "SBP", required: true }],
+  run: ({ HR, SBP }) => {
+    if (HR == null || SBP == null || SBP === 0) return null;
+    const val = HR / SBP;
+    const notes: string[] = [];
+    if (val >= 0.9) notes.push("elevated (hemodynamic concern)");
+    return { id: "shock_index", label: "Shock index", value: val, precision: 2, notes };
+  },
+});

--- a/lib/medical/engine/calculators/index.ts
+++ b/lib/medical/engine/calculators/index.ts
@@ -8,3 +8,4 @@ import "./pulmonary";
 import "./endocrine";
 import "./toxicology";
 import "./icu";
+import "./icu_helpers";

--- a/lib/medical/engine/calculators/renal.ts
+++ b/lib/medical/engine/calculators/renal.ts
@@ -54,3 +54,42 @@ register({
     };
   },
 });
+
+// FENa
+register({
+  id: "fena",
+  label: "FENa",
+  inputs: [
+    { key: "urine_na", required: true },
+    { key: "urine_cr", required: true },
+    { key: "Na", required: true },
+    { key: "creatinine", required: true },
+  ],
+  run: ({ urine_na, urine_cr, Na, creatinine }) => {
+    if ([urine_na, urine_cr, Na, creatinine].some(v => v == null || v === 0)) return null;
+    const val = (urine_na * creatinine) / (Na * urine_cr) * 100;
+    const notes: string[] = [];
+    if (val < 1) notes.push("prerenal likely");
+    else if (val > 2) notes.push("intrinsic renal likely");
+    return { id: "fena", label: "FENa", value: val, unit: "%", precision: 1, notes };
+  },
+});
+
+// FEUrea
+register({
+  id: "feurea",
+  label: "FEUrea",
+  inputs: [
+    { key: "urine_urea", required: true },
+    { key: "urine_cr", required: true },
+    { key: "BUN", required: true },
+    { key: "creatinine", required: true },
+  ],
+  run: ({ urine_urea, urine_cr, BUN, creatinine }) => {
+    if ([urine_urea, urine_cr, BUN, creatinine].some(v => v == null || v === 0)) return null;
+    const val = (urine_urea * creatinine) / (BUN * urine_cr) * 100;
+    const notes: string[] = [];
+    if (val < 35) notes.push("prerenal (esp. on diuretics) likely");
+    return { id: "feurea", label: "FEUrea", value: val, unit: "%", precision: 0, notes };
+  },
+});

--- a/lib/medical/engine/computeAll.ts
+++ b/lib/medical/engine/computeAll.ts
@@ -7,7 +7,9 @@ export function computeAll(ctx: Record<string, any>) {
     try {
       const res = f.run(ctx);
       if (res && res.value != null) {
-        const v = typeof res.value === "number" && res.precision != null ? Number(res.value.toFixed(res.precision)) : res.value;
+        const v = (typeof res.value === "number" && typeof res.precision === "number")
+          ? Number(res.value.toFixed(res.precision))
+          : res.value;
         out.push({ id: res.id, label: res.label, value: v, unit: res.unit, notes: res.notes ?? [] });
       }
     } catch {}
@@ -19,7 +21,7 @@ export function renderResultsBlock(results: { id: string; label: string; value: 
   if (!results.length) return "";
   const lines = results.map(r => {
     const val = r.unit ? `${r.value} ${r.unit}` : String(r.value);
-    const notes = r.notes && r.notes.length ? ` — ${r.notes.join('; ')}` : "";
+    const notes = r.notes && r.notes.length ? ` — ${r.notes.join("; ")}` : "";
     return `${r.label}: ${val}${notes}`;
   });
   return lines.join("\n");

--- a/lib/medical/engine/extract.ts
+++ b/lib/medical/engine/extract.ts
@@ -16,39 +16,35 @@ function pickNum(rx: RegExp, s: string): number | undefined {
 
 export function extractAll(s: string): Record<string, any> {
   const t = (s || "").toLowerCase();
-  const pickNum = (rx: RegExp) => {
-    const m = t.match(rx);
-    return m ? Number(m[1]) : undefined;
-  };
 
   const out: Record<string, any> = {
-    Na: pickNum(/\bna[^0-9]*[:=]?\s*([0-9.]+)/),
-    K: pickNum(/\bk[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/),
-    Cl: pickNum(/\bcl[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/),
-    HCO3: pickNum(/\b(hco3|bicarb)[^0-9]*[:=]?\s*([0-9.]+)/),
-    Mg: pickNum(/\bmg[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/),
-    Ca: pickNum(/\bca[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/),
-    glucose_mgdl: pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mg\/?dl/),
-    glucose_mmol: pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mmol/),
-    BUN: pickNum(/\bbun[^0-9]*[:=]?\s*([0-9.]+)/),
-    creatinine: pickNum(/\bcreatinine[^0-9]*[:=]?\s*([0-9.]+)/),
-    albumin: pickNum(/\balbumin[^0-9]*[:=]?\s*([0-9.]+)/),
-    bilirubin: pickNum(/\bbili[^0-9]*[:=]?\s*([0-9.]+)/),
-    INR: pickNum(/\binr[^0-9]*[:=]?\s*([0-9.]+)/),
-    ethanol_mgdl: pickNum(/\b(etoh|ethanol)[^0-9]*[:=]?\s*([0-9.]+)/),
-    measured_osm: pickNum(/\bmeasured\s*osmolality[^0-9]*[:=]?\s*([0-9.]+)/),
-    pH: pickNum(/\bpH[^0-9]*[:=]?\s*([0-9.]+)/i),
-    PaO2: pickNum(/\bpa?o2[^0-9]*[:=]?\s*([0-9.]+)/),
-    FiO2: pickNum(/\bfio2[^0-9]*[:=]?\s*([0-9.]+)/),
-    PaCO2: pickNum(/\bpaco2[^0-9]*[:=]?\s*([0-9.]+)/),
-    SBP: pickNum(/\bsbp[^0-9]*[:=]?\s*([0-9.]+)/),
-    DBP: pickNum(/\bdbp[^0-9]*[:=]?\s*([0-9.]+)/),
-    RR: pickNum(/\brr[^0-9]*[:=]?\s*([0-9.]+)/),
-    HR: pickNum(/\b(heart\s*rate|hr)[^0-9]*[:=]?\s*([0-9.]+)/),
-    QTms: pickNum(/\bqt[^0-9]*[:=]?\s*([0-9]{3,4})\s*ms/),
-    GCS: pickNum(/\bgcs[^0-9]*[:=]?\s*([0-9]{1,2})/),
-    age: pickNum(/\bage[^0-9]*[:=]?\s*([0-9]{1,3})/),
-    weight_kg: pickNum(/\bweight[^0-9]*[:=]?\s*([0-9.]+)\s*kg/),
+    Na: pickNum(/\bna[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    K: pickNum(/\bk[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    Cl: pickNum(/\bcl[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    HCO3: pickNum(/\b(hco3|bicarb)[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    Mg: pickNum(/\bmg[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    Ca: pickNum(/\bca[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    glucose_mgdl: pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mg\/?dl/, t),
+    glucose_mmol: pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mmol/, t),
+    BUN: pickNum(/\bbun[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    creatinine: pickNum(/\bcreatinine[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    albumin: pickNum(/\balbumin[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    bilirubin: pickNum(/\bbili[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    INR: pickNum(/\binr[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    ethanol_mgdl: pickNum(/\b(etoh|ethanol)[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    measured_osm: pickNum(/\bmeasured\s*osmolality[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    pH: pickNum(/\bpH[^0-9]*[:=]?\s*([0-9.]+)/i, t),
+    PaO2: pickNum(/\bpa?o2[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    FiO2: pickNum(/\bfio2[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    PaCO2: pickNum(/\bpaco2[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    SBP: pickNum(/\bsbp[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    DBP: pickNum(/\bdbp[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    RR: pickNum(/\brr[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    HR: pickNum(/\b(heart\s*rate|hr)[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    QTms: pickNum(/\bqt[^0-9]*[:=]?\s*([0-9]{3,4})\s*ms/, t),
+    GCS: pickNum(/\bgcs[^0-9]*[:=]?\s*([0-9]{1,2})/, t),
+    age: pickNum(/\bage[^0-9]*[:=]?\s*([0-9]{1,3})/, t),
+    weight_kg: pickNum(/\bweight[^0-9]*[:=]?\s*([0-9.]+)\s*kg/, t),
   };
 
   const has = (w: RegExp) => w.test(t);
@@ -79,38 +75,44 @@ export function extractAll(s: string): Record<string, any> {
   }
 
   // === [MEDX_CALC_INPUTS_START] ===
-  if (out.Na == null)       out.Na       = pickNum(/\bna[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.K == null)        out.K        = pickNum(/\bk[^a-z0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.Cl == null)       out.Cl       = pickNum(/\bcl[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.HCO3 == null)     out.HCO3     = pickNum(/\b(hco3|bicarb)[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.albumin == null)  out.albumin  = pickNum(/\balb(?:umin)?[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.Ca == null)       out.Ca       = pickNum(/\bca[^0-9]*[:=]?\s*([0-9.]+)/);
+  if (out.Na == null)       out.Na       = pickNum(/\bna[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.K == null)        out.K        = pickNum(/\bk[^a-z0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.Cl == null)       out.Cl       = pickNum(/\bcl[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.HCO3 == null)     out.HCO3     = pickNum(/\b(hco3|bicarb)[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.albumin == null)  out.albumin  = pickNum(/\balb(?:umin)?[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.Ca == null)       out.Ca       = pickNum(/\bca[^0-9]*[:=]?\s*([0-9.]+)/, t);
 
-  if (out.creatinine == null) out.creatinine = pickNum(/\bcreat(?:inine)?[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.BUN == null)        out.BUN        = pickNum(/\bbun[^0-9]*[:=]?\s*([0-9.]+)/);
+  if (out.creatinine == null) out.creatinine = pickNum(/\bcreat(?:inine)?[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.BUN == null)        out.BUN        = pickNum(/\bbun[^0-9]*[:=]?\s*([0-9.]+)/, t);
 
-  if (out.bilirubin == null) out.bilirubin = pickNum(/\bbili(?:rubin)?[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.INR == null)       out.INR       = pickNum(/\binr[^0-9]*[:=]?\s*([0-9.]+)/);
+  if (out.bilirubin == null) out.bilirubin = pickNum(/\bbili(?:rubin)?[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.INR == null)       out.INR       = pickNum(/\binr[^0-9]*[:=]?\s*([0-9.]+)/, t);
 
-  if (out.glucose_mgdl == null) out.glucose_mgdl = pickNum(/\b(glu|glucose)[^0-9]*[:=]?\s*([0-9.]+)/);
+  if (out.glucose_mgdl == null) out.glucose_mgdl = pickNum(/\b(glu|glucose)[^0-9]*[:=]?\s*([0-9.]+)/, t);
 
-  if (out.PaO2 == null)  out.PaO2  = pickNum(/\bpao2[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.PaCO2 == null) out.PaCO2 = pickNum(/\bpaco2[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.FiO2 == null)  out.FiO2  = pickNum(/\bfio2[^0-9]*[:=]?\s*([0-9.]+)/);
+  if (out.PaO2 == null)  out.PaO2  = pickNum(/\bpao2[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.PaCO2 == null) out.PaCO2 = pickNum(/\bpaco2[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.FiO2 == null)  out.FiO2  = pickNum(/\bfio2[^0-9]*[:=]?\s*([0-9.]+)/, t);
 
-  if (out.QT == null) out.QT = pickNum(/\bqt[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.RR == null) out.RR = pickNum(/\brr[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.HR == null) out.HR = pickNum(/\bhr[^0-9]*[:=]?\s*([0-9.]+)/);
+  if (out.QT == null) out.QT = pickNum(/\bqt[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.RR == null) out.RR = pickNum(/\brr[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.HR == null) out.HR = pickNum(/\bhr[^0-9]*[:=]?\s*([0-9.]+)/, t);
 
-  if (out.SBP == null) out.SBP = pickNum(/\b(sbp|sys)t?[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.DBP == null) out.DBP = pickNum(/\b(dbp|dia)t?[^0-9]*[:=]?\s*([0-9.]+)/);
-  if (out.RRr == null) out.RRr = pickNum(/\bresp[^0-9]*[:=]?\s*([0-9.]+)/);
+  if (out.SBP == null) out.SBP = pickNum(/\b(sbp|sys)t?[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.DBP == null) out.DBP = pickNum(/\b(dbp|dia)t?[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.RRr == null) out.RRr = pickNum(/\bresp[^0-9]*[:=]?\s*([0-9.]+)/, t);
 
-  if (out.ethanol_mgdl == null) out.ethanol_mgdl = pickNum(/\b(etoh|ethanol)[^0-9]*[:=]?\s*([0-9.]+)/);
+  if (out.ethanol_mgdl == null) out.ethanol_mgdl = pickNum(/\b(etoh|ethanol)[^0-9]*[:=]?\s*([0-9.]+)/, t);
 
   // Repo compatibility: if you have measured_osm, mirror it to osm_meas expected by calcs
   if (out.osm_meas == null && (out.measured_osm != null)) out.osm_meas = out.measured_osm;
   // === [MEDX_CALC_INPUTS_END] ===
+
+  // === [MEDX_CALC_URINE_START] ===
+  if (out.urine_na == null)   out.urine_na   = pickNum(/\burine\s*na[^0-9]*[:=]?\s*([0-9.]+)/, s);
+  if (out.urine_cr == null)   out.urine_cr   = pickNum(/\burine\s*creat(?:inine)?[^0-9]*[:=]?\s*([0-9.]+)/, s);
+  if (out.urine_urea == null) out.urine_urea = pickNum(/\burine\s*urea[^0-9]*[:=]?\s*([0-9.]+)/, s);
+  // === [MEDX_CALC_URINE_END] ===
 
   return out;
 }


### PR DESCRIPTION
## Summary
- remove inner `pickNum` usage and add urine lab parsing in extractor
- refine precision handling and result rendering in engine
- add MAP and Shock Index ICU helpers
- add FENa and FEUrea renal calculators and wire into registry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0409c285c832fad8a4b6b5ead37e1