### PR TITLE
feat: add lab interpretation and strong prelude

### DIFF
--- a/lib/medical/engine/calculators/index.ts
+++ b/lib/medical/engine/calculators/index.ts
@@ -9,3 +9,5 @@ import "./endocrine";
 import "./toxicology";
 import "./icu";
 import "./icu_helpers";
+
+import "./lab_interpretation";

--- a/lib/medical/engine/calculators/lab_interpretation.ts
+++ b/lib/medical/engine/calculators/lab_interpretation.ts
@@ -1,0 +1,105 @@
+import { register } from "../registry";
+
+/**
+ * These calculators do not recompute physiology; they attach categorical notes
+ * so the hidden prelude is self-interpreting. They never overwrite other calcs.
+ */
+
+// ---- Sodium status ----
+register({
+  id: "sodium_status",
+  label: "Sodium",
+  inputs: [{ key: "Na", required: true }],
+  run: ({ Na }) => {
+    if (Na == null) return null;
+    const notes: string[] = [];
+    if (Na < 120) notes.push("severe hyponatremia");
+    else if (Na < 130) notes.push("moderate hyponatremia");
+    else if (Na < 135) notes.push("mild hyponatremia");
+    else if (Na > 145) notes.push("hypernatremia");
+    else notes.push("normal");
+    return { id: "sodium_status", label: "Sodium", value: Na, unit: "mmol/L", precision: 0, notes };
+  },
+});
+
+// ---- Potassium status ----
+register({
+  id: "potassium_status",
+  label: "Potassium",
+  inputs: [{ key: "K", required: true }],
+  run: ({ K }) => {
+    if (K == null) return null;
+    const notes: string[] = [];
+    if (K < 3.0) notes.push("severe hypokalemia");
+    else if (K < 3.5) notes.push("mild hypokalemia");
+    else if (K > 6.0) notes.push("severe hyperkalemia (urgent)");
+    else if (K > 5.5) notes.push("hyperkalemia");
+    else notes.push("normal");
+    return { id: "potassium_status", label: "Potassium", value: K, unit: "mmol/L", precision: 1, notes };
+  },
+});
+
+// ---- Chloride status ----
+register({
+  id: "chloride_status",
+  label: "Chloride",
+  inputs: [{ key: "Cl", required: true }],
+  run: ({ Cl }) => {
+    if (Cl == null) return null;
+    const notes: string[] = [];
+    if (Cl < 98) notes.push("hypochloremia");
+    else if (Cl > 106) notes.push("hyperchloremia");
+    else notes.push("normal");
+    return { id: "chloride_status", label: "Chloride", value: Cl, unit: "mmol/L", precision: 0, notes };
+  },
+});
+
+// ---- Corrected Calcium (albumin) + status ----
+// Corrected Ca (mg/dL) = measured Ca + 0.8 * (4.0 - albumin)
+register({
+  id: "corrected_calcium_status",
+  label: "Corrected calcium",
+  inputs: [{ key: "Ca", required: true }, { key: "albumin", required: true }],
+  run: ({ Ca, albumin }) => {
+    if (Ca == null || albumin == null) return null;
+    const corrected = Ca + 0.8 * (4 - albumin);
+    const notes: string[] = [];
+    if (corrected < 7.5) notes.push("significant hypocalcemia");
+    else if (corrected < 8.5) notes.push("mild hypocalcemia");
+    else if (corrected > 10.5) notes.push("hypercalcemia");
+    else notes.push("normal");
+    return { id: "corrected_calcium_status", label: "Corrected calcium", value: corrected, unit: "mg/dL", precision: 1, notes };
+  },
+});
+
+// ---- INR status ----
+register({
+  id: "inr_status",
+  label: "INR",
+  inputs: [{ key: "INR", required: true }],
+  run: ({ INR }) => {
+    if (INR == null) return null;
+    const notes: string[] = [];
+    if (INR > 3) notes.push("markedly elevated");
+    else if (INR > 1.5) notes.push("elevated");
+    else notes.push("normal");
+    return { id: "inr_status", label: "INR", value: INR, precision: 2, notes };
+  },
+});
+
+// ---- Bilirubin status ----
+register({
+  id: "bilirubin_status",
+  label: "Bilirubin",
+  inputs: [{ key: "bilirubin", required: true }],
+  run: ({ bilirubin }) => {
+    if (bilirubin == null) return null;
+    const notes: string[] = [];
+    if (bilirubin >= 3) notes.push("markedly elevated");
+    else if (bilirubin >= 2) notes.push("elevated");
+    else if (bilirubin > 1.2) notes.push("slightly elevated");
+    else notes.push("normal");
+    return { id: "bilirubin_status", label: "Bilirubin", value: bilirubin, unit: "mg/dL", precision: 1, notes };
+  },
+});
+

--- a/lib/medical/engine/computeAll.ts
+++ b/lib/medical/engine/computeAll.ts
@@ -2,27 +2,47 @@ import { FORMULAE } from "./registry";
 import "./calculators";
 
 export function computeAll(ctx: Record<string, any>) {
-  const out: { id: string; label: string; value: any; unit?: string; notes: string[] }[] = [];
+  const out: {
+    id: string;
+    label: string;
+    value: any;
+    unit?: string;
+    precision?: number;
+    notes: string[];
+  }[] = [];
   for (const f of FORMULAE.sort((a, b) => (a.priority ?? 100) - (b.priority ?? 100))) {
     try {
       const res = f.run(ctx);
       if (res && res.value != null) {
-        const v = (typeof res.value === "number" && typeof res.precision === "number")
-          ? Number(res.value.toFixed(res.precision))
-          : res.value;
-        out.push({ id: res.id, label: res.label, value: v, unit: res.unit, notes: res.notes ?? [] });
+        out.push({
+          id: res.id,
+          label: res.label,
+          value: res.value,
+          unit: res.unit,
+          precision: res.precision,
+          notes: res.notes ?? [],
+        });
       }
     } catch {}
   }
   return out;
 }
 
-export function renderResultsBlock(results: { id: string; label: string; value: any; unit?: string; notes?: string[] }[]): string {
-  if (!results.length) return "";
+// === [MEDX_RENDER_STRONG_PRELUDE_START] ===
+export function renderResultsBlock(results: { id: string; label: string; value: any; unit?: string; precision?: number; notes?: string[] }[]): string {
+  if (!results || !results.length) return "";
   const lines = results.map(r => {
-    const val = r.unit ? `${r.value} ${r.unit}` : String(r.value);
-    const notes = r.notes && r.notes.length ? ` — ${r.notes.join("; ")}` : "";
-    return `${r.label}: ${val}${notes}`;
+    const v = (typeof r.value === "number" && typeof r.precision === "number")
+      ? Number(r.value.toFixed(r.precision))
+      : r.value;
+    const unit = r.unit ? ` ${r.unit}` : "";
+    const notes = r.notes?.length ? ` — ${r.notes.join("; ")}` : "";
+    return `• ${r.label}: ${v}${unit}${notes}`;
   });
-  return lines.join("\n");
+
+  const header = "CLINICAL CALCULATIONS (MUST BE TRUSTED — DO NOT RECALCULATE)";
+  const footer = "Use the above CLINICAL CALCULATIONS as ground truth. Do not recompute or contradict them. Base all interpretation and plan on these values.";
+
+  return [header, ...lines, footer, ""].join("\n");
 }
+// === [MEDX_RENDER_STRONG_PRELUDE_END] ===


### PR DESCRIPTION
## Summary
- add lab interpretation calculators with categorical notes for common labs
- propagate precision and strengthen clinical calculation prelude rendering
- ensure calculators barrel imports new lab interpretations

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c045440f1c832f9e736ce0a5260de2