### PR TITLE
Expand lab interpretation and reinforce results prelude

### DIFF
--- a/lib/medical/engine/calculators/lab_interpretation.ts
+++ b/lib/medical/engine/calculators/lab_interpretation.ts
@@ -103,3 +103,52 @@ register({
   },
 });
 
+/** Albumin status — hypoalbuminemia flag */
+register({
+  id: "albumin_status",
+  label: "Albumin",
+  inputs: [{ key: "albumin", required: true }],
+  run: ({ albumin }) => {
+    if (albumin == null) return null;
+    const notes: string[] = [];
+    if (albumin < 2.5) notes.push("marked hypoalbuminemia");
+    else if (albumin < 3.5) notes.push("hypoalbuminemia");
+    else notes.push("normal");
+    return { id: "albumin_status", label: "Albumin", value: albumin, unit: "g/dL", precision: 1, notes };
+  },
+});
+
+/** Bicarbonate status — acidosis flag */
+register({
+  id: "bicarbonate_status",
+  label: "Bicarbonate (HCO₃⁻)",
+  inputs: [{ key: "HCO3", required: true }],
+  run: ({ HCO3 }) => {
+    if (HCO3 == null) return null;
+    const notes: string[] = [];
+    if (HCO3 < 10) notes.push("severe metabolic acidosis");
+    else if (HCO3 < 18) notes.push("metabolic acidosis");
+    else if (HCO3 > 28) notes.push("metabolic alkalosis");
+    else notes.push("normal");
+    return { id: "bicarbonate_status", label: "Bicarbonate (HCO₃⁻)", value: HCO3, unit: "mmol/L", precision: 0, notes };
+  },
+});
+
+/** Renal summary — BUN/Cr qualitative impairment cue (does NOT replace eGFR calcs) */
+register({
+  id: "renal_bun_cr_summary",
+  label: "Renal (BUN/Cr)",
+  inputs: [{ key: "BUN", required: true }, { key: "creatinine", required: true }],
+  run: ({ BUN, creatinine }) => {
+    if (BUN == null || creatinine == null) return null;
+    const notes: string[] = [];
+    // Simple qualitative buckets
+    if (creatinine >= 3 || BUN >= 80) notes.push("significant azotemia / renal impairment");
+    else if (creatinine >= 2 || BUN >= 40) notes.push("moderate azotemia / renal impairment");
+    else if (creatinine >= 1.3 || BUN >= 25) notes.push("mild renal impairment");
+    else notes.push("no azotemia by BUN/Cr");
+    // Show combined for clinician context
+    const value = Number.isFinite(BUN / Math.max(0.1, creatinine)) ? BUN / Math.max(0.1, creatinine) : 0;
+    return { id: "renal_bun_cr_summary", label: "Renal (BUN/Cr)", value, notes };
+  },
+});

--- a/lib/medical/engine/computeAll.ts
+++ b/lib/medical/engine/computeAll.ts
@@ -37,11 +37,16 @@ export function renderResultsBlock(results: { id: string; label: string; value: 
       : r.value;
     const unit = r.unit ? ` ${r.unit}` : "";
     const notes = r.notes?.length ? ` — ${r.notes.join("; ")}` : "";
-    return `• ${r.label}: ${v}${unit}${notes}`;
+    // Tag every line as pre-computed so the model doesn’t try to redo it
+    return `• ${r.label}: ${v}${unit}${notes} (pre-computed)`;
   });
 
   const header = "CLINICAL CALCULATIONS (MUST BE TRUSTED — DO NOT RECALCULATE)";
-  const footer = "Use the above CLINICAL CALCULATIONS as ground truth. Do not recompute or contradict them. Base all interpretation and plan on these values.";
+  const footer = [
+    "Use the above CLINICAL CALCULATIONS as ground truth.",
+    "Do not re-compute, re-state with different numbers, or contradict them.",
+    "Base all clinical reasoning, differentials, and plans on these values only."
+  ].join(" ");
 
   return [header, ...lines, footer, ""].join("\n");
 }


### PR DESCRIPTION
## Summary
- add albumin, bicarbonate, and renal BUN/Cr qualitative notes to lab interpretation calculator
- strengthen hidden results prelude with explicit pre-computed annotations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c048f0746c832faa0f5189edad67be