### PR TITLE
feat: prioritize derived metrics and strengthen calcium override

### DIFF
--- a/lib/medical/engine/calculators/lab_interpretation.ts
+++ b/lib/medical/engine/calculators/lab_interpretation.ts
@@ -56,6 +56,7 @@ register({
 
 // ---- Corrected Calcium (albumin) + status ----
 // Corrected Ca (mg/dL) = measured Ca + 0.8 * (4.0 - albumin)
+// === [MEDX_CORRECTED_CALCIUM_START] ===
 register({
   id: "corrected_calcium_status",
   label: "Corrected calcium",
@@ -68,9 +69,12 @@ register({
     else if (corrected < 8.5) notes.push("mild hypocalcemia");
     else if (corrected > 10.5) notes.push("hypercalcemia");
     else notes.push("normal");
+    // Explicitly override raw calcium interpretation
+    notes.push("corrected value overrides raw calcium");
     return { id: "corrected_calcium_status", label: "Corrected calcium", value: corrected, unit: "mg/dL", precision: 1, notes };
   },
 });
+// === [MEDX_CORRECTED_CALCIUM_END] ===
 
 // ---- INR status ----
 register({

--- a/lib/medical/engine/computeAll.ts
+++ b/lib/medical/engine/computeAll.ts
@@ -31,23 +31,29 @@ export function computeAll(ctx: Record<string, any>) {
 // === [MEDX_RENDER_STRONG_PRELUDE_START] ===
 export function renderResultsBlock(results: { id: string; label: string; value: any; unit?: string; precision?: number; notes?: string[] }[]): string {
   if (!results || !results.length) return "";
-  const lines = results.map(r => {
+
+  // Split derived/calculated vs raw interpreters
+  const derivedOrder = ["anion_gap", "anion_gap_corrected", "winters", "pf_ratio", "map", "shock_index", "meld_na", "child_pugh_helper", "qtc_bazett", "osmolal_gap"];
+  const derived = results.filter(r => derivedOrder.includes(r.id));
+  const rest = results.filter(r => !derivedOrder.includes(r.id));
+
+  function fmt(r: any): string {
     const v = (typeof r.value === "number" && typeof r.precision === "number")
       ? Number(r.value.toFixed(r.precision))
       : r.value;
     const unit = r.unit ? ` ${r.unit}` : "";
     const notes = r.notes?.length ? ` — ${r.notes.join("; ")}` : "";
-    // Tag every line as pre-computed so the model doesn’t try to redo it
     return `• ${r.label}: ${v}${unit}${notes} (pre-computed)`;
-  });
+  }
 
   const header = "CLINICAL CALCULATIONS (MUST BE TRUSTED — DO NOT RECALCULATE)";
   const footer = [
-    "Use the above CLINICAL CALCULATIONS as ground truth.",
-    "Do not re-compute, re-state with different numbers, or contradict them.",
-    "Base all clinical reasoning, differentials, and plans on these values only."
+    "Use ONLY the above CLINICAL CALCULATIONS as ground truth.",
+    "Do not re-compute, invent, or contradict values.",
+    "Corrected values (e.g., calcium, anion gap) OVERRIDE raw measurements.",
+    "Base all reasoning, differentials, and plans strictly on this block."
   ].join(" ");
 
-  return [header, ...lines, footer, ""].join("\n");
+  return [header, ...derived.map(fmt), ...rest.map(fmt), footer, ""].join("\n");
 }
 // === [MEDX_RENDER_STRONG_PRELUDE_END] ===


### PR DESCRIPTION
## Summary
- override raw calcium interpretation with corrected value and explicit note
- render derived calculations before raw metrics with a stronger prelude block

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c04ce17c34832f9361a9491f9d3639