### PR TITLE
feat: integrate Winter's compensation and deterministic sepsis risk

### DIFF
--- a/lib/medical/engine/computeAll.ts
+++ b/lib/medical/engine/computeAll.ts
@@ -22,6 +22,8 @@ export function computeAll(ctx: Record<string, any>) {
           precision: res.precision,
           notes: res.notes ?? [],
         });
+        // Make downstream calculators see upstream results (e.g., 'winters' inside acid_base_summary)
+        (ctx as any)[res.id] = res.value;
       }
     } catch {}
   }
@@ -57,6 +59,7 @@ export function renderResultsBlock(results: { id: string; label: string; value: 
   const footer = [
     "Use ONLY the above pre-computed values and syndrome summaries as ground truth.",
     "Do not re-compute, invent, or contradict these values.",
+    "Do not generate or propose raw formula outputs (e.g., A–a gradient, recalculated anion gap, re-derived PF ratio); rely only on the pre-computed values above.",
     "Corrected values (e.g., calcium, anion gap) OVERRIDE raw measurements.",
     "Do not suggest outdated or non-guideline therapies (e.g., dopamine for renal perfusion).",
     "Base all reasoning, differentials, and management strictly on this block."


### PR DESCRIPTION
## Summary
- propagate computed values into context so calculators can chain results and tighten footer guidance
- add Winter's formula output to acid–base summary with respiratory compensation note
- make sepsis risk headline deterministic with lactate and PF ratio triggers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c05e512454832f8cc4d649c332bbbb