### PR TITLE
Isolate new chats by conversation id

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1002,7 +1002,11 @@ ${systemCommon}` + baseSys;
 
       const res = await fetch('/api/chat/stream', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'x-conversation-id': conversationId,
+          'x-new-chat': messages.length === 0 ? 'true' : 'false'
+        },
         body: JSON.stringify({ mode: mode === 'doctor' ? 'doctor' : 'patient', messages: chatMessages, threadId, context })
       });
       if (!res.ok || !res.body) throw new Error(`Chat API error ${res.status}`);


### PR DESCRIPTION
## Summary
- create and log conversation ids for each chat request
- route chat handling by conversation id when NEW_CHAT_ISOLATION is enabled
- send conversation headers from ChatPane to keep UI and server in sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1fd3dacb0832fa79d7d3f898da12d