### PR TITLE
Implement medication source and policy guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,8 @@ MEDS_FILE_CACHE=true
 MEDS_CACHE_TTL_DAYS=90
 MEDS_SOURCE_WHITELIST=true
 APPLY_MEDICAL_POLICY=true
+MEDS_WHITELIST_PATH=./data/whitelist_domains.json
+COUNTRY_RULES_PATH=./data/country_rules.json
 DEFAULT_REGION=IN
 
 # Pediatric flow

--- a/app/api/meds/summary/route.ts
+++ b/app/api/meds/summary/route.ts
@@ -21,8 +21,8 @@ export async function GET(req: NextRequest) {
     console.log("meds_summary", { name, country, refs: data.card.references.length });
     return NextResponse.json(data);
   } catch (e: any) {
-    const msg = e?.message === "normalize_failed" ? "normalize_failed" : e?.message || "error";
-    const status = msg === "normalize_failed" ? 404 : 500;
+    const msg = e?.message || "error";
+    const status = ["normalize_failed", "no_valid_refs"].includes(msg) ? 404 : 500;
     return NextResponse.json({ error: msg }, { status });
   }
 }

--- a/data/country_rules.json
+++ b/data/country_rules.json
@@ -1,0 +1,10 @@
+{
+  "US": {
+    "acetaminophen": "OTC",
+    "metformin": "Rx"
+  },
+  "IN": {
+    "paracetamol": "OTC",
+    "metformin": "Rx"
+  }
+}

--- a/data/whitelist_domains.json
+++ b/data/whitelist_domains.json
@@ -1,0 +1,5 @@
+[
+  "rxnav.nlm.nih.gov",
+  "dailymed.nlm.nih.gov",
+  "www.myupchar.com"
+]


### PR DESCRIPTION
## Summary
- Enforce whitelisted medication references and log non-whitelist attempts
- Apply country-specific OTC/Rx rules with fallback and conflict handling
- Extend meds summary API with new config paths and improved error responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c20c4ec290832f963a0abdd4f85918