### PR TITLE
feat: add chronic medication education endpoint

### DIFF
--- a/app/api/chronic-med-edu/route.ts
+++ b/app/api/chronic-med-edu/route.ts
@@ -1,0 +1,27 @@
+export const runtime = "nodejs";
+import { NextRequest, NextResponse } from "next/server";
+import { chronicMedEducation, CHRONIC_MED_EDU_ENABLED } from "@/lib/meds/chronicEdu";
+
+export async function POST(req: NextRequest) {
+  if (!CHRONIC_MED_EDU_ENABLED) {
+    return NextResponse.json({ error: "disabled" }, { status: 404 });
+  }
+  try {
+    const body = await req.json();
+    const meds = Array.isArray(body?.meds) ? body.meds.map((m: any) => String(m)) : [];
+    if (meds.length === 0) {
+      return NextResponse.json({ error: "meds_required" }, { status: 400 });
+    }
+    const data = chronicMedEducation(meds);
+    const response: any = {
+      chronicMeds: data.chronicMeds,
+      interactionWarning: data.interactionWarning,
+    };
+    if (data.unrecognized.length) {
+      response.unrecognized = data.unrecognized;
+    }
+    return NextResponse.json(response);
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+}

--- a/lib/meds/chronicEdu.ts
+++ b/lib/meds/chronicEdu.ts
@@ -1,0 +1,74 @@
+export interface ChronicMedEntry {
+  name: string;
+  purpose: string;
+  cautions: string[];
+  references: string[];
+}
+
+const BRAND_TO_GENERIC: Record<string, string> = {
+  glucophage: "metformin",
+  zestril: "lisinopril",
+  synthroid: "levothyroxine",
+};
+
+const DATA: Record<string, ChronicMedEntry> = {
+  metformin: {
+    name: "Metformin",
+    purpose: "Lowers liver glucose output",
+    cautions: ["GI upset", "avoid if severe kidney disease"],
+    references: ["https://www.nhs.uk/medicines/metformin/"]
+  },
+  lisinopril: {
+    name: "Lisinopril",
+    purpose: "ACE inhibitor to lower blood pressure",
+    cautions: ["may cause cough", "monitor potassium levels"],
+    references: ["https://www.nhs.uk/medicines/lisinopril/"]
+  },
+  levothyroxine: {
+    name: "Levothyroxine",
+    purpose: "Replaces thyroid hormone",
+    cautions: ["take on empty stomach", "overdose may cause palpitations"],
+    references: ["https://www.nhs.uk/medicines/levothyroxine/"]
+  },
+  amlodipine: {
+    name: "Amlodipine",
+    purpose: "Calcium-channel blocker for hypertension",
+    cautions: ["ankle swelling", "dizziness"],
+    references: ["https://www.nhs.uk/medicines/amlodipine/"]
+  }
+};
+
+function normalize(name: string): string | null {
+  const lower = name.trim().toLowerCase();
+  const generic = BRAND_TO_GENERIC[lower] || lower;
+  return DATA[generic] ? generic : null;
+}
+
+export function chronicMedEducation(names: string[]) {
+  const results: ChronicMedEntry[] = [];
+  const unrecognized: string[] = [];
+  const seen = new Set<string>();
+  let successes = 0;
+
+  for (const n of names) {
+    const key = normalize(n);
+    if (!key) {
+      unrecognized.push(n);
+      continue;
+    }
+    successes++;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    results.push(DATA[key]);
+  }
+
+  console.log("chronicMedEdu_norm_rate", { total: names.length, normalized: successes });
+
+  return {
+    chronicMeds: results,
+    unrecognized,
+    interactionWarning: "Medication interactions can be complex; ask your clinician about interactions.",
+  };
+}
+
+export const CHRONIC_MED_EDU_ENABLED = (process.env.CHRONIC_MED_EDU || "").toLowerCase() === "true";

--- a/test/medx.test.ts
+++ b/test/medx.test.ts
@@ -3,6 +3,7 @@ import { strict as assert } from 'node:assert';
 import { normalizeTopic } from '@/lib/topic/normalize';
 import { routeIntent } from '@/lib/intent-router';
 import { buildMedicationShortSummary } from '@/lib/meds/shortSummary';
+import { chronicMedEducation } from '@/lib/meds/chronicEdu';
 
 describe('topic normalize', () => {
   it('maps slip disk to canonical', () => {
@@ -40,5 +41,14 @@ describe('medication micro-summary', () => {
     assert.ok(out.summary.split('\n').length >= 2);
     assert.ok(out.serious.startsWith('Serious side-effects'));
     assert.ok(out.summary.length <= parseInt(process.env.MEDS_SHORT_SUMMARY_MAX_CHARS || '320'));
+  });
+});
+
+describe('chronic medication education', () => {
+  it('normalizes names, dedups and notes unknown', () => {
+    const res = chronicMedEducation(['Glucophage', 'metformin', 'UnknownMed']);
+    assert.equal(res.chronicMeds.length, 1);
+    assert.equal(res.chronicMeds[0].name, 'Metformin');
+    assert.deepEqual(res.unrecognized, ['UnknownMed']);
   });
 });


### PR DESCRIPTION
## Summary
- add chronic medication education helper with static data, logging, and env guard
- expose POST `/api/chronic-med-edu` to return purpose and cautions for normalized meds
- test normalization, deduplication, and unknown handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c227dc502c832f84f8e19aee080b78