### PR TITLE
feat: add first aid guidance cards

### DIFF
--- a/lib/firstaid/cards.ts
+++ b/lib/firstaid/cards.ts
@@ -1,0 +1,110 @@
+const BASE_REFS = [
+  'https://www.redcross.org/first-aid',
+  'https://www.who.int/health-topics/first-aid'
+];
+const LEGAL = 'General information only — not medical advice.';
+
+export type FirstAidCard = {
+  card: {
+    title: string;
+    steps: string[];
+    donts: string[];
+    red_flags: string[];
+    references: string[];
+    legal: string;
+  };
+};
+
+export function firstAidCard(text: string): FirstAidCard | null {
+  const enabled = (process.env.FIRST_AID_FLOW || '').toLowerCase() === 'true';
+  if (!enabled) return null;
+  const t = text.toLowerCase();
+
+  let scenario: 'bee_sting' | 'nosebleed' | 'burn' | 'cut' | 'generic';
+  if (/bee|wasp/.test(t) && /sting|stung/.test(t)) scenario = 'bee_sting';
+  else if (/nosebleed|nose bleed|epistaxis/.test(t)) scenario = 'nosebleed';
+  else if (/burn/.test(t)) scenario = 'burn';
+  else if (/cut|laceration|scrape|bleed/.test(t)) scenario = 'cut';
+  else if (/injur|hurt|wound|bite/.test(t)) scenario = 'generic';
+  else return null;
+
+  const cards: Record<'bee_sting' | 'nosebleed' | 'burn' | 'cut' | 'generic', Omit<FirstAidCard['card'], 'references' | 'legal'>> = {
+    bee_sting: {
+      title: 'First Aid: Bee Sting',
+      steps: [
+        'Remove stinger quickly',
+        'Wash area with soap and water',
+        'Apply cold pack to reduce swelling'
+      ],
+      donts: ['Do not squeeze the venom sac', 'Avoid scratching the area'],
+      red_flags: [
+        'Difficulty breathing',
+        'Swelling of face or throat',
+        'Dizziness or fainting'
+      ]
+    },
+    nosebleed: {
+      title: 'First Aid: Nosebleed',
+      steps: [
+        'Sit upright and lean forward',
+        'Pinch soft part of nose for 10 minutes',
+        'Apply cool compress to nose bridge'
+      ],
+      donts: ['Do not lean back', 'Avoid stuffing tissues deep inside nostril'],
+      red_flags: [
+        'Bleeding longer than 20 minutes',
+        'Nosebleed after head injury',
+        'Trouble breathing'
+      ]
+    },
+    burn: {
+      title: 'First Aid: Minor Burn',
+      steps: [
+        'Cool burn under running water for 20 minutes',
+        'Remove tight items like rings',
+        'Cover with sterile, non-stick dressing'
+      ],
+      donts: ['Do not apply ice directly', 'Avoid popping blisters'],
+      red_flags: [
+        'Burn larger than palm',
+        'Burn on face, hands, or genitals',
+        'Signs of infection'
+      ]
+    },
+    cut: {
+      title: 'First Aid: Minor Cut',
+      steps: [
+        'Wash hands and clean wound',
+        'Apply gentle pressure to stop bleeding',
+        'Cover with sterile bandage'
+      ],
+      donts: ['Do not blow on wound', 'Avoid using hydrogen peroxide repeatedly'],
+      red_flags: [
+        'Bleeding does not stop after 10 minutes',
+        'Deep or gaping wound',
+        'Signs of infection'
+      ]
+    },
+    generic: {
+      title: 'First Aid: General Advice',
+      steps: [
+        'Keep person safe and monitor condition',
+        'Call emergency services for severe symptoms'
+      ],
+      donts: ['Do not delay seeking help for serious injuries'],
+      red_flags: [
+        'Uncontrolled bleeding',
+        'Breathing difficulties',
+        'Loss of consciousness'
+      ]
+    }
+  };
+
+  const data = cards[scenario];
+  const card: FirstAidCard = {
+    card: { ...data, references: BASE_REFS, legal: LEGAL }
+  };
+  console.log('first aid card', { scenario });
+  return card;
+}
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint || true",
-    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts"
+    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.78",

--- a/test/firstAidCards.test.ts
+++ b/test/firstAidCards.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { firstAidCard } from '@/lib/firstaid/cards';
+
+describe('first aid cards', () => {
+  beforeEach(() => {
+    process.env.FIRST_AID_FLOW = 'true';
+  });
+
+  it('returns bee sting card', () => {
+    const r = firstAidCard('I have a bee sting');
+    assert.ok(r);
+    assert.equal(r?.card.title, 'First Aid: Bee Sting');
+    assert.ok(r.card.steps.length <= 5);
+    assert.ok(r.card.legal.includes('General information only'));
+  });
+
+  it('returns generic card for unknown injury', () => {
+    const r = firstAidCard('I hurt myself');
+    assert.ok(r);
+    assert.equal(r?.card.title, 'First Aid: General Advice');
+  });
+
+  it('returns null when disabled', () => {
+    process.env.FIRST_AID_FLOW = 'false';
+    const r = firstAidCard('bee sting');
+    assert.equal(r, null);
+  });
+});


### PR DESCRIPTION
## Summary
- provide first aid info cards for bee stings, nosebleeds, minor burns, cuts, or generic injuries
- include steps, don'ts, red flags, references, and legal disclaimer; gated by `FIRST_AID_FLOW`
- add tests for first aid card utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c22ddbd4a0832f97a575f52d2c87f8