### PR TITLE
feat: add mental health resources

### DIFF
--- a/CODEX_CHANGELOG.md
+++ b/CODEX_CHANGELOG.md
@@ -33,6 +33,7 @@
 - gcs_total.test.ts
 - pao2_alveolar.test.ts
 - sf_ratio.test.ts
+- mentalHealthResources.test.ts
 
 ## Items skipped (tests already present)
 - bsa_rule_of_nines

--- a/lib/mentalhealth/resources.ts
+++ b/lib/mentalhealth/resources.ts
@@ -1,0 +1,40 @@
+export type MentalHealthCard = {
+  mental_health: {
+    tips: string[];
+    helplines: string[];
+    red_flags: string[];
+  };
+};
+
+const HELPLINES: Record<string, string[]> = {
+  india: ['India: iCall 9152987821'],
+  us: ['US: 988 Suicide & Crisis Lifeline'],
+  uk: ['UK: Samaritans 116123'],
+  global: [
+    'WHO: https://www.who.int/teams/mental-health-and-substance-use',
+    'Befrienders Worldwide: https://www.befrienders.org/'
+  ]
+};
+
+export function mentalHealthResources(text: string, region?: string): MentalHealthCard | null {
+  const enabled = (process.env.MENTAL_HEALTH_RESOURCES || '').toLowerCase() === 'true';
+  if (!enabled) return null;
+  const t = (text || '').toLowerCase();
+  const hit = /(panic attack|anxiety|anxious|depressed|depression|grief|grieving|stress|stressed|can\'t sleep|cant sleep|insomnia)/.test(t);
+  if (!hit) return null;
+  const regionKey = (region || '').toLowerCase();
+  const helplines = HELPLINES[regionKey] || HELPLINES.global;
+  const card: MentalHealthCard = {
+    mental_health: {
+      tips: [
+        'Box breathing: inhale 4s, hold 4s, exhale 4s',
+        '5-4-3-2-1 grounding: notice 5 things you see, 4 you feel, 3 you hear, 2 you smell, 1 you taste'
+      ],
+      helplines,
+      red_flags: ['Suicidal thoughts \u2192 call emergency services']
+    }
+  };
+  const suicide = /suicid|kill myself|end my life|hurt myself/.test(t);
+  console.log('mental health resources', { region: regionKey, suicide });
+  return card;
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint || true",
-    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts"
+    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/mentalHealthResources.test.ts"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.78",

--- a/test/mentalHealthResources.test.ts
+++ b/test/mentalHealthResources.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mentalHealthResources } from '@/lib/mentalhealth/resources';
+
+describe('mental health resources', () => {
+  beforeEach(() => {
+    process.env.MENTAL_HEALTH_RESOURCES = 'true';
+  });
+
+  it('returns card for anxiety keywords', () => {
+    const r = mentalHealthResources('I am having a panic attack and feel anxious', 'india');
+    assert.ok(r);
+    assert.ok(r?.mental_health.tips[0].includes('Box breathing'));
+    assert.ok(r?.mental_health.helplines.some(h => h.includes('iCall')));
+    assert.ok(r?.mental_health.red_flags[0].includes('Suicidal thoughts'));
+  });
+
+  it('falls back to global helplines when region unknown', () => {
+    const r = mentalHealthResources("Can't sleep from stress", 'unknown');
+    assert.ok(r);
+    assert.ok(r.mental_health.helplines[0].includes('WHO'));
+  });
+
+  it('returns null when disabled', () => {
+    process.env.MENTAL_HEALTH_RESOURCES = 'false';
+    const r = mentalHealthResources('I feel depressed', 'us');
+    assert.equal(r, null);
+  });
+});


### PR DESCRIPTION
## Summary
- detect mental health keywords and provide coping tips, helplines, and red flag guidance
- cover region-specific helplines with global fallback
- test coverage for anxiety detection, region fallback, and feature toggle

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c231d7de64832fb4ee56ab0e99acb1