### PR TITLE
feat: add lifestyle tips endpoint

### DIFF
--- a/app/api/lifestyle/route.ts
+++ b/app/api/lifestyle/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { detectLifestyleQuery, getLifestyleTips } from "@/lib/lifestyleTips";
+
+export async function POST(req: NextRequest) {
+  if (process.env.LIFESTYLE_TIPS_ENABLED !== "true") {
+    return NextResponse.json({ disabled: true });
+  }
+  const { text } = await req.json();
+  if (!text) {
+    return NextResponse.json({ error: "text required" }, { status: 400 });
+  }
+  if (!detectLifestyleQuery(text)) {
+    return NextResponse.json({ match: false });
+  }
+  return NextResponse.json(getLifestyleTips());
+}

--- a/lib/lifestyleTips.ts
+++ b/lib/lifestyleTips.ts
@@ -1,0 +1,16 @@
+export function detectLifestyleQuery(text: string): boolean {
+  if (process.env.LIFESTYLE_TIPS_ENABLED !== "true") return false;
+  const re = /(healthy|immunity|fitness|wellness|diet|exercise|sleep|stress)/i;
+  return re.test(text);
+}
+
+export function getLifestyleTips() {
+  return {
+    lifestyle: {
+      nutrition: ["Eat whole grains, fruits, vegetables"],
+      exercise: ["150 min/week brisk walking"],
+      stress: ["10 min meditation daily"],
+      references: ["https://www.who.int/diet-physical-activity"],
+    },
+  };
+}

--- a/test/lifestyle.test.ts
+++ b/test/lifestyle.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import { strict as assert } from 'assert';
+import { detectLifestyleQuery, getLifestyleTips } from '../lib/lifestyleTips';
+
+test('detects wellness query when enabled', () => {
+  process.env.LIFESTYLE_TIPS_ENABLED = 'true';
+  assert.equal(detectLifestyleQuery('How to stay healthy?'), true);
+});
+
+test('returns false when disabled', () => {
+  delete process.env.LIFESTYLE_TIPS_ENABLED;
+  assert.equal(detectLifestyleQuery('How to stay healthy?'), false);
+});
+
+test('lifestyle tips structure', () => {
+  const tips = getLifestyleTips();
+  assert.ok(tips.lifestyle);
+  assert.ok(Array.isArray(tips.lifestyle.nutrition));
+});


### PR DESCRIPTION
## Summary
- add lifestyle tips detection and data helper
- expose POST `/api/lifestyle` to return neutral wellness advice when enabled
- test detection helper

## Testing
- `npx tsx --test test/lifestyle.test.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2370f2078832f99c83291a0f3ecf8