### PR TITLE
feat: add pediatric growth info

### DIFF
--- a/lib/medical/engine/calculators/pediatric_growth.ts
+++ b/lib/medical/engine/calculators/pediatric_growth.ts
@@ -1,0 +1,77 @@
+export interface PediatricGrowthInput {
+  age_months: number; // age in months
+  weight_kg?: number;
+}
+
+export interface PediatricGrowthResult {
+  age: string;
+  weight?: string;
+  percentile?: string;
+  nutrition: string[];
+  red_flags: string[];
+}
+
+function ageLabel(months: number): string {
+  const years = months / 12;
+  if (years >= 1) {
+    return `${Number(years.toFixed(1))} years`;
+  }
+  return `${months} months`;
+}
+
+function nutritionTips(months: number): string[] {
+  const years = months / 12;
+  if (years < 1) return ["Exclusive breastfeeding", "Introduce iron-rich foods at 6 months"];
+  if (years <= 3) return ["3 meals + 2 snacks/day", "Include protein foods"];
+  return ["Balanced meals", "Limit sugary drinks"];
+}
+
+const weight50Table: Record<number, number> = {
+  0: 3.3,
+  12: 9.6,
+  24: 12.2,
+  36: 14.3,
+  48: 16.3,
+  60: 18.3,
+};
+
+function interpolatedWeight50(months: number): number {
+  const keys = Object.keys(weight50Table).map(Number).sort((a, b) => a - b);
+  let lower = keys[0];
+  let upper = keys[keys.length - 1];
+  for (const k of keys) {
+    if (k <= months) lower = k;
+    if (k >= months) {
+      upper = k;
+      break;
+    }
+  }
+  const wLower = weight50Table[lower];
+  const wUpper = weight50Table[upper];
+  if (lower === upper) return wLower;
+  const ratio = (months - lower) / (upper - lower);
+  return wLower + (wUpper - wLower) * ratio;
+}
+
+export function runPediatricGrowth(i: PediatricGrowthInput): PediatricGrowthResult | null {
+  if (process.env.PEDIATRIC_GROWTH_INFO !== 'true') return null;
+  const age = ageLabel(i.age_months);
+  const nutrition = nutritionTips(i.age_months);
+  if (typeof i.weight_kg !== 'number') {
+    console.log('metric_pediatric_growth_percentile', { computed: false });
+    return { age, nutrition, red_flags: ['Add weight to compute growth percentile'] };
+  }
+  const weight50 = interpolatedWeight50(i.age_months);
+  const rawPercentile = Math.min(100, Math.max(0, (i.weight_kg / weight50) * 50));
+  const percentile = Math.round(rawPercentile / 5) * 5;
+  const red_flags = percentile < 3 ? ['Weight < 3rd percentile → pediatrician visit'] : [];
+  console.log('metric_pediatric_growth_percentile', { computed: true });
+  return {
+    age,
+    weight: `${i.weight_kg}kg`,
+    percentile: `${percentile}th`,
+    nutrition,
+    red_flags,
+  };
+}
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint || true",
-    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/drugInteractions.test.ts test/mentalHealthResources.test.ts"
+    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/drugInteractions.test.ts test/mentalHealthResources.test.ts test/pediatricGrowthInfo.test.ts"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.78",

--- a/test/pediatricGrowthInfo.test.ts
+++ b/test/pediatricGrowthInfo.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { runPediatricGrowth } from '@/lib/medical/engine/calculators/pediatric_growth';
+
+describe('pediatric growth info', () => {
+  beforeEach(() => {
+    process.env.PEDIATRIC_GROWTH_INFO = 'true';
+  });
+
+  it('returns tips when weight missing', () => {
+    const r = runPediatricGrowth({ age_months: 36 });
+    assert.ok(r);
+    assert.equal(r?.percentile, undefined);
+    assert.ok(r?.nutrition.length);
+    assert.ok(r?.red_flags.includes('Add weight to compute growth percentile'));
+  });
+
+  it('computes percentile and red flags', () => {
+    const r = runPediatricGrowth({ age_months: 36, weight_kg: 12 });
+    assert.ok(r);
+    assert.equal(r?.percentile, '40th');
+    assert.ok(r?.nutrition.includes('3 meals + 2 snacks/day'));
+    assert.ok(!r?.red_flags.length);
+  });
+
+  it('triggers red flag for low weight', () => {
+    const r = runPediatricGrowth({ age_months: 36, weight_kg: 0.3 });
+    assert.ok(r);
+    assert.ok(r?.red_flags.find(f => f.includes('3rd percentile')));
+  });
+});
+


### PR DESCRIPTION
## Summary
- compute pediatric growth percentile with nutrition tips and red flags
- add tests for pediatric growth info

## Testing
- `npm test` *(fails: drug interaction checker)*

------
https://chatgpt.com/codex/tasks/task_e_68c2395679b4832f9f42523411f2cbc2