### PR TITLE
feat: add allergy checker

### DIFF
--- a/data/allergens.json
+++ b/data/allergens.json
@@ -1,0 +1,8 @@
+[
+  {
+    "allergen": "peanut",
+    "cross": ["soy"],
+    "severity": "high",
+    "reference": "https://example.com/peanut"
+  }
+]

--- a/data/drug_classes.json
+++ b/data/drug_classes.json
@@ -1,0 +1,8 @@
+[
+  {
+    "allergen": "aspirin",
+    "cross": ["ibuprofen"],
+    "severity": "moderate",
+    "reference": "https://example.com/nsaid"
+  }
+]

--- a/lib/allergy/check.ts
+++ b/lib/allergy/check.ts
@@ -1,0 +1,115 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+interface AllergyRule {
+  allergen: string;
+  cross: string[];
+  severity: string;
+  reference: string;
+}
+
+export interface AllergyRecord {
+  item: string;
+  risk: string;
+  severity: string;
+  reference: string;
+}
+
+export interface AllergyCheckResult {
+  allergyCheck: AllergyRecord[];
+  note: string;
+}
+
+const ALLERGENS_PATH = process.env.ALLERGENS_DATA_PATH || path.join(process.cwd(), 'data/allergens.json');
+const DRUG_CLASSES_PATH = process.env.DRUG_CLASSES_DATA_PATH || path.join(process.cwd(), 'data/drug_classes.json');
+
+let cachedRules: AllergyRule[] | null = null;
+
+async function loadRules(): Promise<AllergyRule[]> {
+  if (cachedRules) return cachedRules;
+  const readJson = async (p: string) => {
+    try {
+      const raw = await fs.readFile(p, 'utf8');
+      const data = JSON.parse(raw);
+      return Array.isArray(data) ? data as AllergyRule[] : [];
+    } catch {
+      return [];
+    }
+  };
+  const [foods, drugs] = await Promise.all([
+    readJson(ALLERGENS_PATH),
+    readJson(DRUG_CLASSES_PATH)
+  ]);
+  cachedRules = [...foods, ...drugs].map(r => ({
+    allergen: r.allergen.toLowerCase(),
+    cross: (r.cross || []).map(c => c.toLowerCase()),
+    severity: r.severity || 'unknown',
+    reference: r.reference || ''
+  }));
+  return cachedRules;
+}
+
+function normalize(arr: string[]): string[] {
+  return arr.filter(Boolean).map(a => a.trim().toLowerCase());
+}
+
+function title(t: string) {
+  return t.charAt(0).toUpperCase() + t.slice(1);
+}
+
+export async function checkAllergies(items: string[], allergies: string[]): Promise<AllergyCheckResult> {
+  const enabled = (process.env.ALLERGY_CHECKER || 'true').toLowerCase() === 'true';
+  if (!enabled) return { allergyCheck: [], note: 'Allergy checker disabled' };
+
+  const rules = await loadRules();
+  const ruleMap: Record<string, AllergyRule> = {};
+  for (const r of rules) ruleMap[r.allergen] = r;
+
+  const normItems = normalize(items);
+  const normAllergies = normalize(allergies);
+
+  const out: AllergyRecord[] = [];
+  for (const it of normItems) {
+    let matched = false;
+
+    // direct allergen check if no allergies on file
+    if (!normAllergies.length && ruleMap[it]) {
+      const r = ruleMap[it];
+      out.push({
+        item: title(it),
+        risk: 'Common allergen',
+        severity: r.severity,
+        reference: r.reference
+      });
+      matched = true;
+    }
+
+    for (const al of normAllergies) {
+      const r = ruleMap[al];
+      if (r && (r.cross || []).includes(it)) {
+        out.push({
+          item: title(it),
+          risk: `Possible cross-reactivity with ${title(al)} allergy`,
+          severity: r.severity,
+          reference: r.reference
+        });
+        matched = true;
+      }
+    }
+
+    if (!matched) {
+      out.push({
+        item: title(it),
+        risk: 'No data available',
+        severity: 'unknown',
+        reference: ''
+      });
+    }
+  }
+
+  const note = normAllergies.length
+    ? 'Screening based on recorded allergies. Consult a professional for medical advice.'
+    : 'No allergies on file. Add allergies for personalized checks.';
+
+  return { allergyCheck: out, note };
+}

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -25,6 +25,7 @@ export const flags = {
   // Nutrition & safety
   enableUSDA: true,
   enableVAERS: true,
+  enableAllergyChecker: (process.env.ALLERGY_CHECKER || 'true').toLowerCase() === 'true',
 
   // Geodata
   enableNominatim: true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint || true",
-    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/drugInteractions.test.ts test/mentalHealthResources.test.ts test/womensHealthBasics.test.ts test/pediatricGrowthInfo.test.ts test/conditionCarePack.test.ts test/labExplainers.test.ts"
+    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/drugInteractions.test.ts test/mentalHealthResources.test.ts test/womensHealthBasics.test.ts test/pediatricGrowthInfo.test.ts test/conditionCarePack.test.ts test/labExplainers.test.ts test/allergyChecker.test.ts"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.78",

--- a/test/allergyChecker.test.ts
+++ b/test/allergyChecker.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkAllergies } from '@/lib/allergy/check';
+
+describe('allergy checker', () => {
+  it('flags cross-reactive medications', async () => {
+    const res = await checkAllergies(['Ibuprofen'], ['Aspirin']);
+    assert.equal(res.allergyCheck[0].item, 'Ibuprofen');
+    assert.match(res.allergyCheck[0].risk, /aspirin/i);
+    assert.equal(res.allergyCheck[0].severity, 'moderate');
+  });
+
+  it('notes unknown items', async () => {
+    const res = await checkAllergies(['Quinoa'], ['Peanut']);
+    assert.equal(res.allergyCheck[0].risk, 'No data available');
+  });
+
+  it('prompts to add allergies when none recorded', async () => {
+    const res = await checkAllergies(['Peanut'], []);
+    assert.match(res.note, /add allergies/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add allergy cross-reactivity checker with sample datasets
- expose ALLERGY_CHECKER feature flag
- test cross-reactive meds and unknown items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2529a3ba0832faf787aa153ecd1ba