### PR TITLE
feat: add second opinion mode for report summaries

### DIFF
--- a/data/questions/generic.json
+++ b/data/questions/generic.json
@@ -1,0 +1,15 @@
+{
+  "questions": [
+    "Are there any warning signs I should watch for?",
+    "What follow-up tests might be needed?",
+    "How could these findings affect my current treatments?",
+    "When should I schedule a follow-up appointment?",
+    "Is there anything in my lifestyle that could influence these results?"
+  ],
+  "monitoring": [
+    "Keep track of any new or worsening symptoms"
+  ],
+  "references": [
+    "https://medlineplus.gov/"
+  ]
+}

--- a/data/questions/liver_tests_high.json
+++ b/data/questions/liver_tests_high.json
@@ -1,0 +1,13 @@
+{
+  "questions": [
+    "Could these liver tests indicate fatty liver or another condition?",
+    "Do I need an ultrasound to investigate my liver?",
+    "Could any medications be affecting these liver results?"
+  ],
+  "monitoring": [
+    "Repeat liver function tests in 2–4 weeks"
+  ],
+  "references": [
+    "https://www.cdc.gov/hepatitis/faqs/index.htm"
+  ]
+}

--- a/lib/secondOpinion.ts
+++ b/lib/secondOpinion.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import path from 'path';
+
+export interface ReportSummary {
+  flags?: string[];
+}
+
+export interface SecondOpinionOutput {
+  secondOpinion: {
+    questions: string[];
+    monitoring: string[];
+    references: string[];
+  };
+}
+
+function loadQuestionBank() {
+  const dir = path.join(process.cwd(), 'data', 'questions');
+  const bank: Record<string, { questions: string[]; monitoring?: string[]; references?: string[] }> = {};
+  if (!fs.existsSync(dir)) return bank;
+  for (const file of fs.readdirSync(dir)) {
+    if (file.endsWith('.json')) {
+      const key = path.basename(file, '.json');
+      try {
+        const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf-8'));
+        bank[key] = data;
+      } catch {
+        // ignore bad json
+      }
+    }
+  }
+  return bank;
+}
+
+export function generateSecondOpinion(summary: ReportSummary = {}, condition?: string, concerns?: string[]): SecondOpinionOutput | null {
+  if (process.env.SECOND_OPINION_MODE !== 'true') return null;
+
+  const bank = loadQuestionBank();
+  const result = { questions: [] as string[], monitoring: [] as string[], references: [] as string[] };
+  const flags = summary.flags || [];
+
+  for (const flag of flags) {
+    const entry = bank[flag];
+    if (entry) {
+      result.questions.push(...(entry.questions || []));
+      if (entry.monitoring) result.monitoring.push(...entry.monitoring);
+      if (entry.references) result.references.push(...entry.references);
+    }
+  }
+
+  // If not enough questions, supplement with generic
+  const generic = bank['generic'];
+  if (result.questions.length < 5 && generic) {
+    const needed = 5 - result.questions.length;
+    result.questions.push(...generic.questions.slice(0, needed));
+    if (generic.monitoring) result.monitoring.push(...generic.monitoring);
+    if (generic.references) result.references.push(...generic.references);
+  }
+
+  // Fallback to generic entirely if no questions
+  if (result.questions.length === 0 && generic) {
+    result.questions.push(...generic.questions);
+    if (generic.monitoring) result.monitoring.push(...generic.monitoring);
+    if (generic.references) result.references.push(...generic.references);
+  }
+
+  // Deduplicate and cap
+  result.questions = Array.from(new Set(result.questions)).slice(0, 10);
+  result.monitoring = Array.from(new Set(result.monitoring));
+  result.references = Array.from(new Set(result.references));
+
+  return { secondOpinion: result };
+}

--- a/test/secondOpinion.test.ts
+++ b/test/secondOpinion.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import { strict as assert } from 'assert';
+import { generateSecondOpinion } from '../lib/secondOpinion';
+
+test('maps flags to questions when enabled', () => {
+  process.env.SECOND_OPINION_MODE = 'true';
+  const summary = { flags: ['liver_tests_high'] };
+  const out = generateSecondOpinion(summary);
+  assert.ok(out);
+  assert.ok(out!.secondOpinion.questions.some(q => q.includes('liver tests')));
+});
+
+test('falls back to generic when no flags', () => {
+  process.env.SECOND_OPINION_MODE = 'true';
+  const out = generateSecondOpinion({});
+  assert.ok(out);
+  assert.ok(out!.secondOpinion.questions.length >= 5);
+});
+
+test('disabled mode returns null', () => {
+  delete process.env.SECOND_OPINION_MODE;
+  const out = generateSecondOpinion({ flags: ['liver_tests_high'] });
+  assert.equal(out, null);
+});


### PR DESCRIPTION
## Summary
- generate second opinion questions and monitoring suggestions from report summary flags
- include question bank for liver-test flag and generic fallback entries
- test coverage for flag-specific, generic, and disabled scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c26669c980832f9c18c80334c9c272