### PR TITLE
Add region-based emergency call buttons

### DIFF
--- a/components/EmergencyCallButtons.tsx
+++ b/components/EmergencyCallButtons.tsx
@@ -1,0 +1,19 @@
+import { emergencyNumbers } from '@/lib/emergency';
+
+export default function EmergencyCallButtons({ country }: { country?: string }) {
+  const numbers = emergencyNumbers(country);
+  if (!numbers) return null;
+  return (
+    <div className="flex gap-2">
+      {Object.values(numbers).map((num, i) => (
+        <a
+          key={i}
+          href={`tel:${num}`}
+          className="rounded bg-red-600 px-4 py-2 text-white"
+        >
+          Call {num}
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/data/emergency.json
+++ b/data/emergency.json
@@ -1,0 +1,6 @@
+{
+  "US": { "ambulance": "911", "police": "911", "fire": "911" },
+  "IN": { "ambulance": "108", "police": "100", "fire": "101" },
+  "UK": { "ambulance": "999", "police": "999", "fire": "999" },
+  "CA": { "ambulance": "911", "police": "911", "fire": "911" }
+}

--- a/lib/emergency.ts
+++ b/lib/emergency.ts
@@ -1,0 +1,11 @@
+import data from '@/data/emergency.json';
+
+export type EmergencyNumbers = Record<string, string>;
+
+export function emergencyNumbers(region?: string): EmergencyNumbers | null {
+  const enabled = (process.env.EMERGENCY_CALL_BUTTONS || '').toLowerCase() === 'true';
+  if (!enabled) return null;
+  const key = (region || '').toUpperCase();
+  const numbers = (data as Record<string, EmergencyNumbers>)[key];
+  return numbers || null;
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint || true",
-    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/drugInteractions.test.ts test/mentalHealthResources.test.ts test/womensHealthBasics.test.ts test/pediatricGrowthInfo.test.ts test/conditionCarePack.test.ts test/labExplainers.test.ts test/vaccineReminders.test.ts test/allergyChecker.test.ts"
+    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/drugInteractions.test.ts test/mentalHealthResources.test.ts test/womensHealthBasics.test.ts test/pediatricGrowthInfo.test.ts test/conditionCarePack.test.ts test/labExplainers.test.ts test/vaccineReminders.test.ts test/allergyChecker.test.ts test/emergencyNumbers.test.ts"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.78",

--- a/test/emergencyNumbers.test.ts
+++ b/test/emergencyNumbers.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { emergencyNumbers } from '@/lib/emergency';
+
+describe('emergency numbers', () => {
+  beforeEach(() => {
+    process.env.EMERGENCY_CALL_BUTTONS = 'true';
+  });
+
+  it('returns numbers for US', () => {
+    const nums = emergencyNumbers('us');
+    assert.ok(nums);
+    assert.equal(nums?.ambulance, '911');
+  });
+
+  it('returns null when disabled', () => {
+    process.env.EMERGENCY_CALL_BUTTONS = 'false';
+    const nums = emergencyNumbers('us');
+    assert.equal(nums, null);
+  });
+});


### PR DESCRIPTION
## Summary
- add `data/emergency.json` mapping country codes to emergency numbers
- expose `emergencyNumbers` helper and `EmergencyCallButtons` component gated by `EMERGENCY_CALL_BUTTONS`
- cover helper with tests and include new file in test suite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c267a3e9a4832fbc84383fec0f7994