### PR TITLE
feat: nearby care search (Overpass API, 5 km default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,12 @@ NEXT_PUBLIC_AIDOC_UI=0
 
 # Ask “new or existing patient?” before AI Doc runs
 NEXT_PUBLIC_AIDOC_PREFLIGHT=0
+
+# Nearby care search
+FEATURE_NEARBY=true
+NEARBY_DEFAULT_RADIUS_KM=5
+NEARBY_MAX_RESULTS=40
+NEARBY_CACHE_TTL_SEC=300
+OVERPASS_API_URL=https://overpass-api.de/api/interpreter
+OVERPASS_USER_AGENT=medx-app/1.0 (support@yourdomain)
+NEXT_PUBLIC_NEARBY_DEFAULT_RADIUS_KM=5

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project includes:
 - Dark/Light theme, PWA manifest
 - Minimal UI with Patient/Clinician toggle
 - API wrappers for PubMed, openFDA, ClinicalTrials, DailyMed, RxNorm, ICD-11
+- Nearby care search powered by OpenStreetMap's Overpass API
 
 ## Run
 1. Copy `.env.example` → `.env.local` and fill:
@@ -19,6 +20,7 @@ This project includes:
    - optional: `HF_CHEST_MODEL` `HF_BONE_MODEL`
    - for OpenAI summaries: `OPENAI_API_KEY`, `OPENAI_TEXT_MODEL`, `OPENAI_VISION_MODEL`
    - optional meds micro-summary: `MEDS_SHORT_SUMMARY` (`true|false`), `MEDS_SHORT_SUMMARY_MAX_CHARS`
+   - nearby care: `FEATURE_NEARBY`, `OVERPASS_API_URL`, `OVERPASS_USER_AGENT`, `NEARBY_DEFAULT_RADIUS_KM`, `NEARBY_MAX_RESULTS`, `NEARBY_CACHE_TTL_SEC`, `NEXT_PUBLIC_NEARBY_DEFAULT_RADIUS_KM`
 2. `npm install`
 3. `npm run dev`
 

--- a/app/api/nearby/route.ts
+++ b/app/api/nearby/route.ts
@@ -1,49 +1,64 @@
-import { NextResponse } from 'next/server';
+export const runtime = "nodejs";
 
-export async function POST(req: Request) {
-  try {
-    const { lat, lng, type = 'pharmacy', radiusKm = 5, countryCode2 } = await req.json();
-    const overpass = 'https://overpass-api.de/api/interpreter';
+import { NextRequest, NextResponse } from "next/server";
+import { buildOverpassQuery, callOverpass } from "@/lib/nearby/overpass";
+import { mapOverpassElements } from "@/lib/nearby/normalize";
+import type { NearbyType, NearbyResponse } from "@/lib/nearby/types";
 
-    let query: string;
-    if (lat != null && lng != null) {
-      query = `
-[out:json];
-(
-  node[amenity="${type}"](around:${radiusKm * 1000},${lat},${lng});
-  way[amenity="${type}"](around:${radiusKm * 1000},${lat},${lng});
-  relation[amenity="${type}"](around:${radiusKm * 1000},${lat},${lng});
-);
-out center tags;`;
-    } else if (countryCode2) {
-      query = `
-[out:json];
-area["ISO3166-1"="${countryCode2}"][admin_level=2]->.searchArea;
-(
-  node[amenity="${type}"](area.searchArea);
-  way[amenity="${type}"](area.searchArea);
-  relation[amenity="${type}"](area.searchArea);
-);
-out center tags;`;
-    } else {
-      return NextResponse.json({ error: 'lat/lng or countryCode2 required' }, { status: 400 });
-    }
+const ON = (k: string) => (process.env[k] || "").toLowerCase() === "true";
+const FEATURE = ON("FEATURE_NEARBY");
 
-    const res = await fetch(overpass, {
-      method: 'POST',
-      headers: { 'Content-Type': 'text/plain' },
-      body: query,
-    });
-    const data = await res.json();
-    const results = (data.elements || []).map((el: any) => ({
-      id: el.id,
-      lat: el.lat || el.center?.lat,
-      lng: el.lon || el.center?.lon,
-      name: el.tags?.name || '',
-      tags: el.tags || {},
-    }));
-    return NextResponse.json({ results });
-  } catch (e: any) {
-    return NextResponse.json({ error: e?.message || 'nearby failed' }, { status: 500 });
+const DEF_RADIUS = Number(process.env.NEARBY_DEFAULT_RADIUS_KM || 5);
+const MAX_RESULTS = Number(process.env.NEARBY_MAX_RESULTS || 40);
+const TTL = Number(process.env.NEARBY_CACHE_TTL_SEC || 300);
+
+function clamp(n: number, min: number, max: number) {
+  return isNaN(n) ? min : Math.max(min, Math.min(max, n));
+}
+
+export async function GET(req: NextRequest) {
+  if (!FEATURE) return NextResponse.json({ error: "disabled" }, { status: 404 });
+
+  const { searchParams } = new URL(req.url);
+  const type = (searchParams.get("type") || "doctor") as NearbyType;
+  const specialty = (searchParams.get("specialty") || "").trim();
+  const lat = Number(searchParams.get("lat"));
+  const lng = Number(searchParams.get("lng"));
+  const radiusKm = clamp(Number(searchParams.get("radius_km") || DEF_RADIUS), 1, 20);
+  const limit = clamp(Number(searchParams.get("limit") || MAX_RESULTS), 1, MAX_RESULTS);
+
+  if (!isFinite(lat) || !isFinite(lng)) {
+    return NextResponse.json({ error: "coords_required" }, { status: 400 });
   }
+
+  const key = `nearby:${type}:${specialty}:${lat.toFixed(3)}:${lng.toFixed(3)}:${radiusKm}`;
+  // const cached = await kv.get<NearbyResponse>(key);
+  // if (cached) return NextResponse.json({ ...cached, meta: { ...cached.meta, cached: true } });
+
+  const q = buildOverpassQuery(lat, lng, radiusKm * 1000, type, specialty);
+  let data;
+  try {
+    data = await callOverpass(q);
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || "overpass_error" }, { status: 502 });
+  }
+
+  const elements = Array.isArray(data?.elements) ? data.elements : [];
+  let items = mapOverpassElements(elements, { lat, lng }, type);
+
+  if (type === "specialist" && specialty) {
+    const rx = new RegExp(`(^|;)\\s*${specialty}\\s*($|;)`, "i");
+    items = items.filter((i) => rx.test(i.specialty || ""));
+  }
+
+  items.sort((a, b) => a.distance_km - b.distance_km);
+  items = items.slice(0, limit);
+
+  const payload: NearbyResponse = {
+    meta: { provider: "overpass", radius_km: radiusKm, total: items.length, cached: false },
+    items,
+  };
+
+  // await kv.set(key, payload, { ex: TTL });
+  return NextResponse.json(payload, { status: 200 });
 }

--- a/components/nearby/NearbyFinder.tsx
+++ b/components/nearby/NearbyFinder.tsx
@@ -1,0 +1,140 @@
+"use client";
+import { useEffect, useState } from "react";
+
+type Coords = { lat: number; lng: number };
+type Item = {
+  id: string;
+  type: string;
+  name: string;
+  specialty?: string;
+  address: string;
+  phone?: string;
+  distance_km: number;
+  location: { lat: number; lng: number };
+};
+
+export default function NearbyFinder() {
+  const [coords, setCoords] = useState<Coords | null>(null);
+  const [type, setType] = useState("doctor");
+  const [specialty, setSpecialty] = useState("");
+  const [radius, setRadius] = useState(
+    Number(process.env.NEXT_PUBLIC_NEARBY_DEFAULT_RADIUS_KM || 5)
+  );
+  const [items, setItems] = useState<Item[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!("geolocation" in navigator)) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+      () => setCoords(null),
+      { enableHighAccuracy: true, timeout: 8000 }
+    );
+  }, []);
+
+  useEffect(() => {
+    const fetcher = async () => {
+      if (!coords) return;
+      setLoading(true);
+      setErr(null);
+      const u = new URL("/api/nearby", window.location.origin);
+      u.searchParams.set("type", type);
+      u.searchParams.set("lat", String(coords.lat));
+      u.searchParams.set("lng", String(coords.lng));
+      u.searchParams.set("radius_km", String(radius));
+      if (type === "specialist" && specialty) u.searchParams.set("specialty", specialty);
+      const r = await fetch(u.toString());
+      if (!r.ok) {
+        setErr("Couldn’t load results");
+        setLoading(false);
+        return;
+      }
+      const j = await r.json();
+      setItems(j.items || []);
+      setLoading(false);
+    };
+    fetcher();
+  }, [coords, type, specialty, radius]);
+
+  return (
+    <div className="space-y-3">
+      {!coords && (
+        <div className="text-sm opacity-80">
+          Please allow location access or enter your location manually.
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2 items-center">
+        <select
+          value={type}
+          onChange={(e) => setType(e.target.value)}
+          className="border rounded px-2 py-1"
+        >
+          <option value="doctor">Doctors</option>
+          <option value="specialist">Specialists</option>
+          <option value="hospital">Hospitals</option>
+          <option value="clinic">Clinics</option>
+          <option value="lab">Labs</option>
+          <option value="pharmacy">Pharmacies</option>
+        </select>
+        {type === "specialist" && (
+          <input
+            className="border rounded px-2 py-1"
+            placeholder="e.g. gynaecology, cardiology"
+            value={specialty}
+            onChange={(e) => setSpecialty(e.target.value)}
+          />
+        )}
+        <label className="text-sm">Radius: {radius} km</label>
+        <input
+          type="range"
+          min={1}
+          max={20}
+          value={radius}
+          onChange={(e) => setRadius(Number(e.target.value))}
+        />
+      </div>
+
+      {loading && <div>Searching…</div>}
+      {err && <div className="text-red-600 text-sm">{err}</div>}
+
+      <div className="divide-y">
+        {items.map((i) => (
+          <div key={i.id} className="py-3">
+            <div className="font-medium">
+              {i.name}{" "}
+              <span className="text-xs opacity-70">
+                • {i.type}
+                {i.specialty ? ` • ${i.specialty}` : ""}
+              </span>
+            </div>
+            <div className="text-sm opacity-80">
+              {i.address || "Address unavailable"}
+            </div>
+            <div className="text-sm flex gap-3">
+              {i.phone && (
+                <a href={`tel:${i.phone}`} className="underline">
+                  Call
+                </a>
+              )}
+              <a
+                className="underline"
+                target="_blank"
+                href={`https://maps.google.com/?q=${i.location.lat},${i.location.lng}`}
+              >
+                Open in Maps
+              </a>
+              <span className="opacity-70">{i.distance_km} km</span>
+            </div>
+          </div>
+        ))}
+        {!loading && items.length === 0 && (
+          <div className="py-6 text-sm opacity-70">
+            No results found within {radius} km.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/nearby/normalize.ts
+++ b/lib/nearby/normalize.ts
@@ -1,0 +1,63 @@
+import type { NearbyItem, NearbyType } from "./types";
+
+function haversineKm(a: { lat: number; lng: number }, b: { lat: number; lng: number }) {
+  const toRad = (x: number) => (x * Math.PI) / 180;
+  const R = 6371,
+    dLat = toRad(b.lat - a.lat),
+    dLng = toRad(b.lng - a.lng);
+  const s =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(a.lat)) *
+      Math.cos(toRad(b.lat)) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.asin(Math.sqrt(s));
+}
+
+function oneLineAddress(tags: any) {
+  const parts = [
+    tags["addr:housenumber"],
+    tags["addr:street"],
+    tags["addr:suburb"] || tags["addr:neighbourhood"],
+    tags["addr:city"] || tags["addr:town"] || tags["addr:village"],
+    tags["addr:state"],
+    tags["addr:postcode"],
+  ].filter(Boolean);
+  return parts.join(", ");
+}
+
+function inferType(tags: any): NearbyType | null {
+  if (tags.amenity === "hospital" || tags.healthcare === "hospital") return "hospital";
+  if (tags.amenity === "clinic" || tags.healthcare === "clinic") return "clinic";
+  if (tags.amenity === "doctors" || tags.healthcare === "doctor") return "doctor";
+  if (tags.healthcare === "laboratory" || tags.amenity === "laboratory") return "lab";
+  if (tags.amenity === "pharmacy") return "pharmacy";
+  return null;
+}
+
+export function mapOverpassElements(
+  els: any[],
+  center: { lat: number; lng: number },
+  requested: NearbyType
+): NearbyItem[] {
+  return els.map((e: any) => {
+    const lat = e.lat ?? e.center?.lat;
+    const lng = e.lon ?? e.center?.lon;
+    const tags = e.tags || {};
+    const t = requested === "specialist" ? "specialist" : inferType(tags) || requested;
+    const spec = tags["healthcare:speciality"]?.split(";")?.[0];
+    const item: NearbyItem = {
+      id: `${e.type}/${e.id}`,
+      osmType: e.type,
+      type: t,
+      name: tags.name || "Unnamed",
+      specialty: spec,
+      address: oneLineAddress(tags),
+      phone: tags.phone || tags["contact:phone"],
+      website: tags.website || tags["contact:website"],
+      hours: tags.opening_hours,
+      location: { lat, lng },
+      distance_km: lat && lng ? Number(haversineKm(center, { lat, lng }).toFixed(2)) : 0,
+    };
+    return item;
+  });
+}

--- a/lib/nearby/overpass.ts
+++ b/lib/nearby/overpass.ts
@@ -1,0 +1,56 @@
+const OVERPASS_URL = process.env.OVERPASS_API_URL!;
+const UA = process.env.OVERPASS_USER_AGENT || "medx-app";
+
+type Filter =
+  | { k: "amenity"; v: string }
+  | { k: "healthcare"; v: string }
+  | { k: "healthcare:speciality"; v: string };
+
+const BASE_FILTERS: Record<import("./types").NearbyType, Filter[]> = {
+  doctor: [{ k: "amenity", v: "doctors" }, { k: "healthcare", v: "doctor" }],
+  specialist: [{ k: "amenity", v: "doctors" }, { k: "healthcare", v: "doctor" }],
+  hospital: [{ k: "amenity", v: "hospital" }, { k: "healthcare", v: "hospital" }],
+  clinic: [{ k: "amenity", v: "clinic" }, { k: "healthcare", v: "clinic" }],
+  lab: [{ k: "healthcare", v: "laboratory" }, { k: "amenity", v: "laboratory" }],
+  pharmacy: [{ k: "amenity", v: "pharmacy" }],
+};
+
+export function buildOverpassQuery(
+  lat: number,
+  lng: number,
+  radiusM: number,
+  type: import("./types").NearbyType,
+  speciality?: string
+) {
+  const filters = BASE_FILTERS[type];
+  const blocks = filters.map(
+    (f) =>
+      `node["${f.k}"="${f.v}"](around:${radiusM},${lat},${lng});\n` +
+      `way["${f.k}"="${f.v}"](around:${radiusM},${lat},${lng});\n` +
+      `relation["${f.k}"="${f.v}"](around:${radiusM},${lat},${lng});`
+  );
+
+  const specialityClause =
+    type === "specialist" && speciality
+      ? `  nwr["healthcare:speciality"~"${speciality}", i](around:${radiusM},${lat},${lng});\n`
+      : "";
+
+  return `
+[out:json][timeout:30];
+(
+${blocks.join("\n")}
+${specialityClause}
+);
+out center tags;`;
+}
+
+export async function callOverpass(query: string) {
+  const r = await fetch(OVERPASS_URL, {
+    method: "POST",
+    headers: { "Content-Type": "text/plain", "User-Agent": UA },
+    body: query,
+  });
+  const txt = await r.text();
+  if (!r.ok) throw new Error(`overpass_${r.status}`);
+  return JSON.parse(txt);
+}

--- a/lib/nearby/types.ts
+++ b/lib/nearby/types.ts
@@ -1,0 +1,18 @@
+export type NearbyType = "doctor" | "specialist" | "hospital" | "clinic" | "lab" | "pharmacy";
+export type NearbyItem = {
+  id: string; // osm:id (node/way/relation)
+  osmType: "node" | "way" | "relation";
+  type: NearbyType;
+  name: string;
+  specialty?: string; // parsed from healthcare:speciality
+  address: string; // one-line
+  phone?: string;
+  location: { lat: number; lng: number };
+  distance_km: number;
+  website?: string;
+  hours?: string;
+};
+export type NearbyResponse = {
+  meta: { provider: "overpass"; radius_km: number; total: number; cached: boolean };
+  items: NearbyItem[];
+};


### PR DESCRIPTION
## Summary
- add Overpass-based nearby care search API
- normalize OSM results and present client-side nearby finder UI
- document environment flags for nearby care search

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c272f050ec832fac1d8056622a9313