### PR TITLE
feat: add carepacks and allergy checker api

### DIFF
--- a/app/api/allergy/check/route.ts
+++ b/app/api/allergy/check/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkMedicationAllergies } from "@/lib/allergy/meds";
+
+export async function POST(req: NextRequest) {
+  if ((process.env.ALLERGY_CHECKER || "true").toLowerCase() !== "true") {
+    return NextResponse.json({ error: "disabled" }, { status: 404 });
+  }
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+  const { allergies, meds, region } = body || {};
+  if (!Array.isArray(allergies) || !allergies.length || !Array.isArray(meds) || !meds.length) {
+    return NextResponse.json({ error: "allergies and meds required" }, { status: 400 });
+  }
+  const res = await checkMedicationAllergies(allergies, meds, region || "");
+  console.log({ allergies_n: allergies.length, meds_n: meds.length, conflicts_n: res.conflicts.length });
+  return NextResponse.json(res);
+}

--- a/app/api/carepacks/[condition]/route.ts
+++ b/app/api/carepacks/[condition]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 min
+const cache: Record<string, { expires: number; data: any }> = {};
+
+async function loadPack(condition: string, lang: string) {
+  const dir = path.join(process.cwd(), "data", "carepacks");
+  const indexPath = path.join(dir, "index.json");
+  let allow: string[] = [];
+  try {
+    const idx = JSON.parse(await fs.readFile(indexPath, "utf8"));
+    allow = Array.isArray(idx.conditions) ? idx.conditions : [];
+  } catch {
+    return null;
+  }
+  if (!allow.includes(condition)) return null;
+  try {
+    const raw = JSON.parse(await fs.readFile(path.join(dir, `${condition}.json`), "utf8"));
+    const defLang = process.env.CARE_PACKS_DEFAULT_LANG || "en";
+    const data = raw[lang] || raw[defLang];
+    if (!data) return null;
+    return {
+      sections: [
+        { type: "summary", title: data.summary.title, items: data.summary.items },
+        { type: "labs", title: data.labs.title, labs: data.labs.labs },
+        { type: "vaccines", title: data.vaccines.title, items: data.vaccines.items },
+        { type: "red_flags", title: data.red_flags.title, items: data.red_flags.items },
+      ],
+      references: data.references || [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(req: NextRequest, { params }: { params: { condition: string } }) {
+  if (process.env.CARE_PACKS_ENABLED !== "true") {
+    return NextResponse.json({ error: "disabled" }, { status: 404 });
+  }
+  const { condition } = params;
+  const url = new URL(req.url);
+  const lang = (url.searchParams.get("lang") || process.env.CARE_PACKS_DEFAULT_LANG || "en").toLowerCase();
+  const region = (url.searchParams.get("region") || "").toUpperCase();
+  const key = `${condition}:${lang}:${region}`;
+  const start = Date.now();
+  let data = cache[key];
+  let cached = false;
+  if (data && data.expires > Date.now()) {
+    cached = true;
+  } else {
+    const pack = await loadPack(condition, lang);
+    if (!pack) {
+      return NextResponse.json({ error: "condition not found" }, { status: 404 });
+    }
+    data = { expires: Date.now() + CACHE_TTL_MS, data: pack };
+    cache[key] = data;
+  }
+  console.log({ condition, lang, region, cached, ms: Date.now() - start });
+  const out = data.data;
+  return NextResponse.json({
+    meta: { condition, lang, region, cached },
+    sections: out.sections,
+    references: out.references,
+  });
+}

--- a/app/api/reports/export/file/[file]/route.ts
+++ b/app/api/reports/export/file/[file]/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+
+export async function GET(req: NextRequest, { params }: { params: { file: string } }) {
+  const filePath = path.join("/tmp", params.file);
+  try {
+    const data = await fs.readFile(filePath, "utf8");
+    return new NextResponse(data, {
+      headers: { "Content-Type": "text/csv" }
+    });
+  } catch {
+    return NextResponse.json({ error: "not found" }, { status: 404 });
+  }
+}

--- a/app/api/reports/export/route.ts
+++ b/app/api/reports/export/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+import crypto from "crypto";
+
+const RANGE_MAP: Record<string, { low: number; high: number }> = {
+  ALT: { low: 0, high: 40 },
+  AST: { low: 0, high: 40 },
+};
+
+const cache: Record<string, { expires: number; payload: any }> = {};
+
+export async function POST(req: NextRequest) {
+  if ((process.env.REPORT_STRUCTURED_EXPORT || "false").toLowerCase() !== "true") {
+    return NextResponse.json({ error: "disabled" }, { status: 404 });
+  }
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid json" }, { status: 400 });
+  }
+  const { panels, patient } = body || {};
+  if (!Array.isArray(panels) || panels.length === 0) {
+    return NextResponse.json({ error: "panels required" }, { status: 400 });
+  }
+  for (const p of panels) {
+    if (!Array.isArray(p.tests) || p.tests.length === 0) {
+      return NextResponse.json({ error: "tests required" }, { status: 400 });
+    }
+    for (const t of p.tests) {
+      if (typeof t.value !== "number") {
+        return NextResponse.json({ error: "numeric value required" }, { status: 400 });
+      }
+    }
+  }
+
+  const hash = crypto.createHash("md5").update(JSON.stringify(body)).digest("hex");
+  const ttl = Number(process.env.REPORT_EXPORT_TTL_SEC || "900") * 1000;
+  const now = Date.now();
+  if (cache[hash] && cache[hash].expires > now) {
+    const cached = cache[hash].payload;
+    return NextResponse.json({ ...cached, meta: { ...cached.meta, cached: true } });
+  }
+
+  const rows: any[] = [];
+  let withRange = 0;
+  for (const p of panels) {
+    for (const t of p.tests) {
+      const name = String(t.name || "").toUpperCase();
+      const unit = t.unit || "unknown";
+      const range = RANGE_MAP[name];
+      let ref_low: number | null = null;
+      let ref_high: number | null = null;
+      let flag = "N";
+      if (range) {
+        ref_low = range.low;
+        ref_high = range.high;
+        if (t.value < range.low) flag = "L";
+        else if (t.value > range.high) flag = "H";
+        withRange++;
+      }
+      rows.push({ panel: p.panel, test: name, value: t.value, unit, ref_low, ref_high, flag });
+    }
+  }
+  const coverage_pct = rows.length ? Math.round((withRange / rows.length) * 100) : 0;
+  const csvHeader = "panel,test,value,unit,ref_low,ref_high,flag\n";
+  const csvRows = rows.map(r => `${r.panel},${r.test},${r.value},${r.unit},${r.ref_low ?? ''},${r.ref_high ?? ''},${r.flag}`).join("\n");
+  const csv = csvHeader + csvRows + "\n";
+  const fileId = `${hash}.csv`;
+  const filePath = path.join("/tmp", fileId);
+  await fs.writeFile(filePath, csv, "utf8");
+
+  const payload = {
+    json: { rows, coverage_pct },
+    csv_url: `/api/reports/export/file/${fileId}`,
+    meta: { cached: false, ttl_sec: Number(process.env.REPORT_EXPORT_TTL_SEC || "900") },
+  };
+  cache[hash] = { expires: now + ttl, payload };
+
+  console.log({ rows: rows.length, coverage_pct });
+  return NextResponse.json(payload);
+}

--- a/data/carepacks/diabetes.json
+++ b/data/carepacks/diabetes.json
@@ -1,0 +1,23 @@
+{
+  "en": {
+    "summary": {
+      "title": "At a glance",
+      "items": ["What it is", "Key risks", "When to see a doctor"]
+    },
+    "labs": {
+      "title": "Key labs to know",
+      "labs": [
+        { "name": "HbA1c", "why": "3-month sugar control", "target": "<7% (individualized)" }
+      ]
+    },
+    "vaccines": {
+      "title": "Vaccines to discuss",
+      "items": ["Influenza", "Pneumococcal (per age/risk)"]
+    },
+    "red_flags": {
+      "title": "Red flags",
+      "items": ["Chest pain", "Severe breathlessness"]
+    },
+    "references": ["calc:diabetes-basics", "guideline:ADA-2024"]
+  }
+}

--- a/data/carepacks/index.json
+++ b/data/carepacks/index.json
@@ -1,0 +1,3 @@
+{
+  "conditions": ["diabetes"]
+}

--- a/data/drug_classes.json
+++ b/data/drug_classes.json
@@ -4,5 +4,11 @@
     "cross": ["ibuprofen"],
     "severity": "moderate",
     "reference": "https://example.com/nsaid"
+  },
+  {
+    "allergen": "penicillin",
+    "cross": ["amoxicillin"],
+    "severity": "high",
+    "reference": "https://example.com/penicillin"
   }
 ]

--- a/lib/allergy/meds.ts
+++ b/lib/allergy/meds.ts
@@ -1,0 +1,65 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+interface Rule { allergen: string; cross: string[]; }
+
+let cached: Rule[] | null = null;
+async function loadRules(): Promise<Rule[]> {
+  if (cached) return cached;
+  const p = process.env.DRUG_CLASSES_DATA_PATH || path.join(process.cwd(), 'data/drug_classes.json');
+  try {
+    const raw = JSON.parse(await fs.readFile(p, 'utf8'));
+    cached = Array.isArray(raw) ? raw.map(r => ({ allergen: r.allergen.toLowerCase(), cross: (r.cross || []).map((c: string) => c.toLowerCase()) })) : [];
+  } catch {
+    cached = [];
+  }
+  return cached;
+}
+
+function norm(s: string) { return s.trim().toLowerCase(); }
+function title(s: string) { return s.charAt(0).toUpperCase() + s.slice(1); }
+
+export async function checkMedicationAllergies(allergies: string[], meds: { name: string }[], region = '') {
+  const rules = await loadRules();
+  const map: Record<string, Rule> = {};
+  for (const r of rules) map[r.allergen] = r;
+
+  const normAll = allergies.map(norm);
+  const expanded = new Set<string>();
+  for (const a of normAll) {
+    expanded.add(a);
+    const r = map[a];
+    if (r) for (const c of r.cross) expanded.add(c);
+  }
+
+  const conflicts: any[] = [];
+  const safe: any[] = [];
+
+  for (const m of meds) {
+    const active = norm(m.name.split(/\s+/)[0]);
+    let conflictReason: string | null = null;
+    for (const a of normAll) {
+      const r = map[a];
+      if (active === a) {
+        conflictReason = `${title(a)}-class allergy`;
+        break;
+      }
+      if (r && r.cross.includes(active)) {
+        conflictReason = `${title(a)}-class allergy`;
+        break;
+      }
+    }
+    if (conflictReason) {
+      conflicts.push({ med: m.name, actives: [active], reason: conflictReason });
+    } else {
+      safe.push({ med: m.name, actives: [active] });
+    }
+  }
+
+  return {
+    meta: { region },
+    conflicts,
+    safe,
+    notes: ['Cross-reactivity checked via class map']
+  };
+}


### PR DESCRIPTION
## Summary
- serve condition-specific care packs via GET /api/carepacks/[condition]
- add medication allergy checker API
- provide structured lab report export with CSV output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2eade500c832f962b498e27f7c077