### PR TITLE
feat: add coach tip caching and research summary

### DIFF
--- a/app/api/coach/today/route.ts
+++ b/app/api/coach/today/route.ts
@@ -1,20 +1,63 @@
-import { NextResponse } from 'next/server';
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+const ON = (k: string) => (process.env[k] || "").toLowerCase() === "true";
+const featureOn = () => ON("AI_HEALTH_COACH");
+const DEF_LANG = process.env.COACH_DEFAULT_LANG || "en";
+
+const FALLBACK_TIP = "Stay active today.";
 
 const TIPS = [
-  'Take a short walk today to keep active.',
-  'Stay hydrated—drink a glass of water now.',
-  'Choose a fruit for a healthy snack.'
+  "Take a short walk today to keep active.",
+  "Stay hydrated—drink a glass of water now.",
+  "Choose a fruit for a healthy snack.",
 ];
 
-function pickTip(date: string) {
+function hash(str: string) {
   let h = 0;
-  for (const ch of date) h = (h * 31 + ch.charCodeAt(0)) | 0;
-  const idx = Math.abs(h) % TIPS.length;
+  for (const ch of str) h = (h * 31 + ch.charCodeAt(0)) | 0;
+  return h;
+}
+
+async function generateTip(key: string) {
+  if (process.env.COACH_FORCE_ERROR === "1") throw new Error("forced");
+  const idx = Math.abs(hash(key)) % TIPS.length;
   return TIPS[idx];
 }
 
-export async function GET() {
-  const today = new Date().toISOString().slice(0,10);
-  const tip = pickTip(today);
-  return NextResponse.json({ tip });
+function getStore() {
+  const g = globalThis as any;
+  if (!g.__coachTips) g.__coachTips = new Map();
+  return g.__coachTips as Map<string, string>;
+}
+
+function fallbackTip() {
+  return FALLBACK_TIP;
+}
+
+export async function GET(req: NextRequest) {
+  if (!featureOn()) return NextResponse.json({ error: "disabled" }, { status: 404 });
+
+  const { searchParams } = new URL(req.url);
+  const lang = searchParams.get("lang") || DEF_LANG;
+  const userId = req.headers.get("x-user-id") || "anon";
+  const today = new Date().toISOString().slice(0, 10);
+  const key = `${userId}:${today}:${lang}`;
+
+  const store = getStore();
+  let tip = store.get(key);
+  let generated = false;
+
+  if (!tip) {
+    try {
+      tip = await generateTip(key);
+      generated = true;
+    } catch {
+      tip = fallbackTip();
+    }
+    store.set(key, tip);
+  }
+
+  console.log(JSON.stringify({ user_id: userId, generated }));
+  return NextResponse.json({ date: today, lang, tip });
 }

--- a/app/api/nearby/labs/route.ts
+++ b/app/api/nearby/labs/route.ts
@@ -1,0 +1,55 @@
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { buildOverpassQuery, callOverpass } from "@/lib/nearby/overpass";
+import { mapOverpassElements } from "@/lib/nearby/normalize";
+import type { NearbyResponse } from "@/lib/nearby/types";
+
+const ON = (k: string) => (process.env[k] || "").toLowerCase() === "true";
+const featureOn = () => ON("FEATURE_NEARBY");
+
+const DEF_RADIUS = Number(process.env.NEARBY_DEFAULT_RADIUS_KM || 5);
+const MAX_RESULTS = Number(process.env.NEARBY_MAX_RESULTS || 40);
+
+function clamp(n: number, min: number, max: number) {
+  return isNaN(n) ? min : Math.max(min, Math.min(max, n));
+}
+
+export async function GET(req: NextRequest) {
+  if (!featureOn()) return NextResponse.json({ error: "disabled" }, { status: 404 });
+
+  const { searchParams } = new URL(req.url);
+  const lat = Number(searchParams.get("lat"));
+  const lng = Number(searchParams.get("lng"));
+  const radiusKm = clamp(Number(searchParams.get("radius_km") || DEF_RADIUS), 1, 20);
+  const limit = clamp(Number(searchParams.get("limit") || MAX_RESULTS), 1, MAX_RESULTS);
+
+  if (!isFinite(lat) || !isFinite(lng)) {
+    return NextResponse.json({ error: "coords_required" }, { status: 400 });
+  }
+
+  const rM = radiusKm * 1000;
+  try {
+    const [labData, clinicData] = await Promise.all([
+      callOverpass(buildOverpassQuery(lat, lng, rM, "lab")),
+      callOverpass(buildOverpassQuery(lat, lng, rM, "clinic", "radiology|imaging")),
+    ]);
+
+    const items = [
+      ...mapOverpassElements(Array.isArray(labData?.elements) ? labData.elements : [], { lat, lng }, "lab"),
+      ...mapOverpassElements(Array.isArray(clinicData?.elements) ? clinicData.elements : [], { lat, lng }, "clinic"),
+    ];
+
+    items.sort((a, b) => a.distance_km - b.distance_km);
+    const sliced = items.slice(0, limit);
+    const payload: NearbyResponse = {
+      meta: { provider: "overpass", radius_km: radiusKm, total: sliced.length, cached: false },
+      items: sliced,
+    };
+
+    return NextResponse.json(payload, { status: 200 });
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || "overpass_error" }, { status: 502 });
+  }
+}
+

--- a/app/api/research/summary/route.ts
+++ b/app/api/research/summary/route.ts
@@ -1,32 +1,60 @@
-import type { NextRequest } from 'next/server';
-import { NextResponse } from 'next/server';
-import { parseStringPromise } from 'xml2js';
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { parseStringPromise } from "xml2js";
+
+const ON = (k: string) => (process.env[k] || "").toLowerCase() === "true";
+const featureOn = () => ON("RESEARCH_SUMMARIZER");
+const DEF_LANG = process.env.RESEARCH_DEFAULT_LANG || "en";
 
 export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const pmid = (searchParams.get('pmid') || '').trim();
-  if (!pmid) return NextResponse.json({ error: 'Missing pmid' }, { status: 400 });
+  if (!featureOn()) return NextResponse.json({ error: "disabled" }, { status: 404 });
 
-  const apiKey = process.env.NCBI_API_KEY || '';
-  const link = `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`;
+  const { searchParams } = new URL(req.url);
+  const lang = searchParams.get("lang") || DEF_LANG;
+  const pmid = (searchParams.get("pmid") || "").trim();
+  const nct = (searchParams.get("nct_id") || "").trim();
+  const id = pmid || nct;
+  const idType = pmid ? "pmid" : nct ? "nct_id" : null;
+  if (!idType) return NextResponse.json({ error: "id_required" }, { status: 400 });
+
+  console.log(JSON.stringify({ id_type: idType, id }));
+
+  const apiKey = process.env.NCBI_API_KEY || "";
+  const link = pmid
+    ? `https://pubmed.ncbi.nlm.nih.gov/${pmid}/`
+    : `https://clinicaltrials.gov/study/${nct}`;
+
   try {
+    if (!pmid) throw new Error("unsupported_id");
     const efetch = await fetch(
-      `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=${encodeURIComponent(pmid)}&retmode=xml${apiKey ? `&api_key=${apiKey}` : ''}`,
-      { headers: { 'Accept': 'application/xml' }, cache: 'no-store' }
+      `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=pubmed&id=${encodeURIComponent(
+        pmid
+      )}&retmode=xml${apiKey ? `&api_key=${apiKey}` : ""}`,
+      { headers: { Accept: "application/xml" }, cache: "no-store" }
     );
-    if (!efetch.ok) throw new Error('NCBI efetch error');
+    if (!efetch.ok) throw new Error("NCBI efetch error");
     const xml = await efetch.text();
     const parsed = await parseStringPromise(xml, { explicitArray: false, ignoreAttrs: false });
     const article = parsed?.PubmedArticleSet?.PubmedArticle?.MedlineCitation?.Article;
-    const title: string = article?.ArticleTitle || '';
+    const title: string = article?.ArticleTitle || "";
     const abstractBlocks: any = article?.Abstract?.AbstractText;
     const abstractText: string = Array.isArray(abstractBlocks)
-      ? abstractBlocks.map((b: any) => (typeof b === 'string' ? b : b?._ || '')).join(' ')
-      : (typeof abstractBlocks === 'string' ? abstractBlocks : (abstractBlocks?._ || ''));
-    const sentences = (title + '. ' + abstractText).replace(/\s+/g, ' ').split(/(?<=[.?!])\s+/).filter(Boolean).slice(0, 8);
-    const bullets = sentences.slice(0, 5).map(s => s.length > 220 ? s.slice(0, 217) + '…' : s);
-    return NextResponse.json({ bullets, link });
+      ? abstractBlocks.map((b: any) => (typeof b === "string" ? b : b?._ || "")).join(" ")
+      : typeof abstractBlocks === "string"
+      ? abstractBlocks
+      : abstractBlocks?._ || "";
+    const sentences = (title + ". " + abstractText)
+      .replace(/\s+/g, " ")
+      .split(/(?<=[.?!])\s+/)
+      .filter(Boolean)
+      .slice(0, 8);
+    const bullets = sentences
+      .filter((s) => !/recommend/i.test(s))
+      .slice(0, 5)
+      .map((s) => (s.length > 220 ? s.slice(0, 217) + "…" : s));
+    return NextResponse.json({ title, bullets, link, lang });
   } catch {
-    return NextResponse.json({ bullets: [], link, note: 'Failed to fetch PubMed summary' }, { status: 200 });
+    return NextResponse.json({ title: "", bullets: [], link, lang }, { status: 502 });
   }
 }
+

--- a/lib/nearby/overpass.ts
+++ b/lib/nearby/overpass.ts
@@ -11,7 +11,12 @@ const BASE_FILTERS: Record<import("./types").NearbyType, Filter[]> = {
   specialist: [{ k: "amenity", v: "doctors" }, { k: "healthcare", v: "doctor" }],
   hospital: [{ k: "amenity", v: "hospital" }, { k: "healthcare", v: "hospital" }],
   clinic: [{ k: "amenity", v: "clinic" }, { k: "healthcare", v: "clinic" }],
-  lab: [{ k: "healthcare", v: "laboratory" }, { k: "amenity", v: "laboratory" }],
+  lab: [
+    { k: "healthcare", v: "laboratory" },
+    { k: "amenity", v: "laboratory" },
+    { k: "amenity", v: "diagnostic_centre" },
+    { k: "healthcare", v: "diagnostic_centre" },
+  ],
   pharmacy: [{ k: "amenity", v: "pharmacy" }],
 };
 
@@ -31,7 +36,7 @@ export function buildOverpassQuery(
   );
 
   const specialityClause =
-    type === "specialist" && speciality
+    speciality
       ? `  nwr["healthcare:speciality"~"${speciality}", i](around:${radiusM},${lat},${lng});\n`
       : "";
 


### PR DESCRIPTION
## Summary
- cache daily coach tips per user with fallback and logging
- enhance research summary with title output, id validation, and env gating
- support diagnostic centers in Overpass queries and add labs search endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c30958c340832fbb4eebeac04561cd