### PR TITLE
Fix chat thread reuse and hide patient calculators

### DIFF
--- a/lib/medical/engine/extract.ts
+++ b/lib/medical/engine/extract.ts
@@ -18,12 +18,12 @@ export function extractAll(s: string): Record<string, any> {
   const t = (s || "").toLowerCase();
 
   const out: Record<string, any> = {
-    Na: pickNum(/\bna[^0-9]*[:=]?\s*([0-9.]+)/, t),
-    K: pickNum(/\bk[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/, t),
-    Cl: pickNum(/\bcl[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    Na: pickNum(/\b(?:na|sodium)\b[^0-9:=]*[:=]?\s*([0-9.]+)/i, t),
+    K: pickNum(/\b(?:k|potassium)\b[^0-9:=]*[:=]?\s*([0-9.]+)/i, t),
+    Cl: pickNum(/\b(?:chloride|cl)\b[^0-9:=]*[:=]?\s*([0-9.]+)/i, t),
     HCO3: pickNum(/\b(hco3|bicarb)[^0-9]*[:=]?\s*([0-9.]+)/, t),
     Mg: pickNum(/\bmg[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/, t),
-    Ca: pickNum(/\bca[^a-z0-9]?[^0-9]*[:=]?\s*([0-9.]+)/, t),
+    Ca: pickNum(/\b(?:calcium|ca)\b[^0-9:=]*[:=]?\s*([0-9.]+)/i, t),
     glucose_mgdl: pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mg\/?dl/, t),
     glucose_mmol: pickNum(/\b(glucose|fpg)[^0-9]*[:=]?\s*([0-9.]+)\s*mmol/, t),
     BUN: pickNum(/\bbun[^0-9]*[:=]?\s*([0-9.]+)/, t),
@@ -75,12 +75,12 @@ export function extractAll(s: string): Record<string, any> {
   }
 
   // === [MEDX_CALC_INPUTS_START] ===
-  if (out.Na == null)       out.Na       = pickNum(/\bna[^0-9]*[:=]?\s*([0-9.]+)/, t);
-  if (out.K == null)        out.K        = pickNum(/\bk[^a-z0-9]*[:=]?\s*([0-9.]+)/, t);
-  if (out.Cl == null)       out.Cl       = pickNum(/\bcl[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.Na == null)       out.Na       = pickNum(/\b(?:na|sodium)\b[^0-9:=]*[:=]?\s*([0-9.]+)/i, t);
+  if (out.K == null)        out.K        = pickNum(/\b(?:k|potassium)\b[^0-9:=]*[:=]?\s*([0-9.]+)/i, t);
+  if (out.Cl == null)       out.Cl       = pickNum(/\b(?:chloride|cl)\b[^0-9:=]*[:=]?\s*([0-9.]+)/i, t);
   if (out.HCO3 == null)     out.HCO3     = pickNum(/\b(hco3|bicarb)[^0-9]*[:=]?\s*([0-9.]+)/, t);
   if (out.albumin == null)  out.albumin  = pickNum(/\balb(?:umin)?[^0-9]*[:=]?\s*([0-9.]+)/, t);
-  if (out.Ca == null)       out.Ca       = pickNum(/\bca[^0-9]*[:=]?\s*([0-9.]+)/, t);
+  if (out.Ca == null)       out.Ca       = pickNum(/\b(?:calcium|ca)\b[^0-9:=]*[:=]?\s*([0-9.]+)/i, t);
 
   if (out.creatinine == null) out.creatinine = pickNum(/\bcreat(?:inine)?[^0-9]*[:=]?\s*([0-9.]+)/, t);
   if (out.BUN == null)        out.BUN        = pickNum(/\bbun[^0-9]*[:=]?\s*([0-9.]+)/, t);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint || true",
-    "test": "vitest run test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts test/engine.nanFilter.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/drugInteractions.test.ts test/mentalHealthResources.test.ts test/womensHealthBasics.test.ts test/pediatricGrowthInfo.test.ts test/conditionCarePack.test.ts test/labExplainers.test.ts test/vaccineReminders.test.ts test/allergyChecker.test.ts test/newFeatures.test.ts test/emergencyNumbers.test.ts test/symptomTracker.test.ts"
+    "test": "vitest run test/extract.noFalsePositives.test.ts test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts test/engine.nanFilter.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/drugInteractions.test.ts test/mentalHealthResources.test.ts test/womensHealthBasics.test.ts test/pediatricGrowthInfo.test.ts test/conditionCarePack.test.ts test/labExplainers.test.ts test/vaccineReminders.test.ts test/allergyChecker.test.ts test/newFeatures.test.ts test/emergencyNumbers.test.ts test/symptomTracker.test.ts"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.78",

--- a/test/extract.noFalsePositives.test.ts
+++ b/test/extract.noFalsePositives.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../lib/medical/engine/calculators', () => ({}));
+import { extractAll } from '../lib/medical/engine/extract';
+
+describe('extractAll avoids false positives from plain-English text', () => {
+  it('does not interpret "cold 4 days" as chloride=4', () => {
+    const ctx = extractAll('I have a cold 4 days with dry cough. non-febrile.');
+    expect(ctx.Cl == null || ctx.Cl === undefined).toBeTruthy();
+    expect(ctx.Na == null || ctx.Na === undefined).toBeTruthy();
+    expect(ctx.K == null || ctx.K === undefined).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- avoid reusing default chat thread by creating a fresh thread and ephemeral conversation id
- show clinical calculator prelude only in doctor/research modes and tighten lab number extraction
- add regression test to ensure plain text like "cold 4 days" doesn't trigger lab parsing

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c30bf4e5cc832fa22328844a33d318