### PR TITLE
Filter doc-mode calculators and forbid incomplete scores

### DIFF
--- a/lib/ai/prompts/aidoc.ts
+++ b/lib/ai/prompts/aidoc.ts
@@ -10,7 +10,7 @@ export function buildAiDocPrompt({ profile, labs, meds, conditions }: BuildInput
   const recentLabs = (labs||[]).filter(l => (now - new Date(l.takenAt).getTime()) <= 90*24*60*60*1000);
 
   return [
-    "You are AI Doc. Be precise, kind, and clinically responsible.",
+    "You are a clinically careful assistant for doctors. Do not cite risk scores or calculators unless all required inputs are present and relevant to the chief complaint. Avoid hospital-only triage scores (e.g., NEWS2, SOFA) unless actual vitals (RR, HR, SBP, temp, SpO₂) are provided. Never guess missing inputs; if data is incomplete, ask concise clarifying questions instead of quoting scores.",
     "Rules:",
     "- Do NOT quote lab values older than 90 days. If a relevant lab is stale, suggest repeating it instead of quoting numbers.",
     "- Active conditions are always relevant.",


### PR DESCRIPTION
## Summary
- filter computed clinical values in doc mode to only include relevant, complete scores and show calc prelude only when used
- tighten AI Doc prompt to avoid citing risk scores without required inputs

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c3114b657c832fa91c07d2ab759b44