### PR TITLE
Refine Doc Mode calculations and guardrails

### DIFF
--- a/lib/ai/prompts/aidoc.ts
+++ b/lib/ai/prompts/aidoc.ts
@@ -28,6 +28,12 @@ export function buildAiDocPrompt({ profile, labs, meds, conditions }: BuildInput
     "",
     "When you need a lab to decide but it's stale or missing, ask: 'Would you like to repeat <panel>?'",
     "",
-    "Output JSON only with: { reply, save:{medications,conditions,labs,notes,prefs}, observations:{short,long} }"
+    "Output JSON only with: { reply, save:{medications,conditions,labs,notes,prefs}, observations:{short,long} }",
+    "- Output policy:",
+    "  • Start with a 2–4 line clinical summary (problem + cause + immediate risk).",
+    "  • Then list 3–6 prioritized actions with rationale.",
+    "  • Only mention risk scores that materially change management.",
+    "  • Never dump large lists of unrelated scores unless the user explicitly asks.",
+    "  • If a required input is missing, state the missing item instead of guessing.",
   ].join("\n");
 }

--- a/lib/medical/engine/calculators/acid_base.ts
+++ b/lib/medical/engine/calculators/acid_base.ts
@@ -1,46 +1,24 @@
 import { register } from "../registry";
+import "./acid_base_summary";
 
 register({
-  id: "anion_gap_albumin_corrected",
-  label: "Anion gap (albumin-corrected)",
-  inputs: [
-    { key: "Na", required: true },
-    { key: "Cl", required: true },
-    { key: "HCO3", required: true },
-    { key: "albumin", required: true },
-    { key: "K" },
-  ],
-  run: ({ Na, Cl, HCO3, albumin, K }) => {
-    if (Na == null || Cl == null || HCO3 == null || albumin == null) return null;
-    const ag = Na + (K ?? 0) - (Cl + HCO3);
-    const val = ag + 2.5 * (4 - albumin);
-    return {
-      id: "anion_gap_albumin_corrected",
-      label: "Anion gap (albumin-corrected)",
-      value: val,
-      unit: "mmol/L",
-      precision: 1,
-    };
-  },
-});
-
-register({
-  id: "winters_pco2",
-  label: "Expected pCO₂ (Winter's)",
+  id: "winters_expected_paco2",
+  label: "Expected PaCO₂ (Winter’s)",
+  tags: ["acid-base"],
   inputs: [{ key: "HCO3", required: true }],
   run: ({ HCO3 }) => {
     if (HCO3 == null) return null;
-    const val = 1.5 * HCO3 + 8;
-    return { id: "winters_pco2", label: "Expected pCO₂", value: val, unit: "mmHg", precision: 1 };
-  },
-});
-
-register({
-  id: "winters",
-  label: "Expected pCO₂ (Winter’s)",
-  inputs: [{ key: "HCO3", required: true }],
-  run: ({ HCO3 }) => {
-    const exp = 1.5 * (HCO3!) + 8;
-    return { id: "winters", label: "Expected pCO₂ (Winter’s)", value: exp, unit: "mmHg", precision: 0, notes: ["±2 mmHg"] };
+    const expected = 1.5 * HCO3 + 8;
+    const low = expected - 2;
+    const high = expected + 2;
+    const notes = [`Expected ${low.toFixed(1)}–${high.toFixed(1)} mmHg`];
+    return {
+      id: "winters_expected_paco2",
+      label: "Expected PaCO₂ (Winter’s)",
+      value: Number(expected.toFixed(1)),
+      unit: "mmHg",
+      precision: 1,
+      notes,
+    };
   },
 });

--- a/lib/medical/engine/calculators/acid_base_summary.ts
+++ b/lib/medical/engine/calculators/acid_base_summary.ts
@@ -1,0 +1,38 @@
+import { register } from "../registry";
+
+register({
+  id: "acid_base_summary",
+  label: "Acid–base summary",
+  tags: ["acid-base"],
+  inputs: [
+    { key: "Na", required: true },
+    { key: "Cl", required: true },
+    { key: "HCO3", required: true },
+    { key: "albumin" },
+    { key: "pH" },
+    { key: "pCO2" },
+    { key: "glucose_mgdl" },
+    { key: "BUN" },
+    { key: "Osm_measured" },
+  ],
+  run: ({ Na, Cl, HCO3, albumin, pH, pCO2, glucose_mgdl, BUN, Osm_measured }) => {
+    if (Na == null || Cl == null || HCO3 == null) return null;
+
+    const ag = Na - (Cl + HCO3);
+    const agc = albumin != null ? ag + 2.5 * (4 - albumin) : ag;
+    const exp = 1.5 * HCO3 + 8;
+    const comp = (pCO2 != null)
+      ? (pCO2 < exp - 2 ? "± resp. alkalosis" : pCO2 > exp + 2 ? "± resp. acidosis" : "appropriate")
+      : "respiratory compensation not evaluated";
+    const calcOsm = (glucose_mgdl != null && BUN != null) ? (2 * Na + glucose_mgdl / 18 + BUN / 2.8) : undefined;
+    const gap = (calcOsm != null && Osm_measured != null) ? (Osm_measured - calcOsm) : undefined;
+
+    const notes: string[] = [];
+    if (ag > 12) notes.push("HAGMA");
+    if (albumin != null && agc > 12) notes.push("HAGMA (albumin-corrected)");
+    notes.push(`Winter’s exp ~${exp.toFixed(1)} mmHg (${comp})`);
+    if (gap != null) notes.push(`Osm gap ${gap.toFixed(0)} mOsm/kg`);
+
+    return { id: "acid_base_summary", label: "Acid–base summary", value: agc.toFixed(1), unit: "AG (corr) mmol/L", precision: 1, notes };
+  },
+});

--- a/lib/medical/engine/calculators/electrolytes.ts
+++ b/lib/medical/engine/calculators/electrolytes.ts
@@ -1,8 +1,29 @@
 import { register } from "../registry";
 
+// --- Canonical AG (no K) ---
 register({
   id: "anion_gap",
   label: "Anion gap",
+  tags: ["electrolytes", "acid-base"],
+  inputs: [
+    { key: "Na", required: true },
+    { key: "Cl", required: true },
+    { key: "HCO3", required: true },
+  ],
+  run: ({ Na, Cl, HCO3 }) => {
+    if (Na == null || Cl == null || HCO3 == null) return null;
+    const ag = Na - (Cl + HCO3); // no K
+    const notes: string[] = [];
+    if (ag > 12) notes.push("elevated anion gap");
+    return { id: "anion_gap", label: "Anion gap", value: ag, unit: "mmol/L", precision: 1, notes };
+  },
+});
+
+// --- Optional AG including K (distinct id) ---
+register({
+  id: "anion_gap_with_k",
+  label: "Anion gap (+K⁺)",
+  tags: ["electrolytes", "acid-base"],
   inputs: [
     { key: "Na", required: true },
     { key: "Cl", required: true },
@@ -11,31 +32,30 @@ register({
   ],
   run: ({ Na, Cl, HCO3, K }) => {
     if (Na == null || Cl == null || HCO3 == null) return null;
-    const val = Na + (K ?? 0) - (Cl + HCO3);
-    return { id: "anion_gap", label: "Anion gap", value: val, unit: "mmol/L", precision: 1 };
+    const agk = Na + (K ?? 0) - (Cl + HCO3);
+    const notes: string[] = [];
+    if (agk > 16) notes.push("elevated anion gap (+K)");
+    return { id: "anion_gap_with_k", label: "Anion gap (+K⁺)", value: agk, unit: "mmol/L", precision: 1, notes };
   },
 });
 
+// --- Albumin-corrected AG (based on AG without K) ---
 register({
   id: "anion_gap_corrected",
   label: "Anion gap (albumin-corrected)",
+  tags: ["electrolytes", "acid-base"],
   inputs: [
     { key: "Na", required: true },
     { key: "Cl", required: true },
     { key: "HCO3", required: true },
-    { key: "albumin", required: true },
-    { key: "K" },
+    { key: "albumin", required: true }, // g/dL
   ],
-  run: ({ Na, Cl, HCO3, albumin, K }) => {
-    const ag = Na! + (K ?? 0) - (Cl! + HCO3!);
-    const corrected = ag + 2.5 * (4 - albumin!);
-    return {
-      id: "anion_gap_corrected",
-      label: "Anion gap (albumin-corrected)",
-      value: corrected,
-      unit: "mmol/L",
-      precision: 1,
-    };
+  run: ({ Na, Cl, HCO3, albumin }) => {
+    if (Na == null || Cl == null || HCO3 == null || albumin == null) return null;
+    const ag = Na - (Cl + HCO3);
+    const corrected = ag + 2.5 * (4 - albumin);
+    const notes = [`AG=${ag.toFixed(1)}`, `corrected for albumin`];
+    return { id: "anion_gap_corrected", label: "Anion gap (albumin-corrected)", value: corrected, unit: "mmol/L", precision: 1, notes };
   },
 });
 

--- a/lib/medical/engine/calculators/icu.ts
+++ b/lib/medical/engine/calculators/icu.ts
@@ -1,25 +1,6 @@
 import { register } from "../registry";
 
 register({
-  id: "qsofa",
-  label: "qSOFA",
-  inputs: [
-    { key: "RR", required: true },
-    { key: "SBP", required: true },
-    { key: "GCS", required: true },
-  ],
-  run: ({ RR, SBP, GCS }) => {
-    if (RR == null || SBP == null || GCS == null) return null;
-    let s = 0;
-    if (RR >= 22) s++;
-    if (SBP <= 100) s++;
-    if (GCS < 15) s++;
-    const notes = s >= 2 ? ["high risk"] : [];
-    return { id: "qsofa", label: "qSOFA", value: s, notes };
-  },
-});
-
-register({
   id: "qsofa_partial",
   label: "qSOFA (partial)",
   inputs: [

--- a/lib/medical/engine/calculators/index.ts
+++ b/lib/medical/engine/calculators/index.ts
@@ -32,7 +32,7 @@ const SKIP = new Set<string>([
   "toxicology.ts",
   "icu.ts",
   "icu_helpers.ts",
-  "lab_interpretation.ts",
+  "lab_interpretation.ts", // ensure full name here
   // Helper cores that might contain shared logic
   "acid_base_core.ts",
 ]);

--- a/lib/medical/engine/calculators/lab_interpretation.ts
+++ b/lib/medical/engine/calculators/lab_interpretation.ts
@@ -1224,6 +1224,7 @@ register({
     { key: "age", required: true },            // years
   ],
   run: ({ confusion, BUN, RRr, SBP, DBP, age }) => {
+    if ([confusion, BUN, RRr, SBP, DBP, age].some(v => v == null)) return null;
     const pts =
       (confusion ? 1 : 0) +
       ((BUN ?? 0) >= 20 ? 1 : 0) +
@@ -1873,6 +1874,7 @@ register({
     { key: "conscious_level", required: true }, // "A" | "V" | "P" | "U"
   ],
   run: ({ RRr, SaO2, on_o2, temp_c, SBP, HR, conscious_level }) => {
+    if ([RRr, SaO2, on_o2, temp_c, SBP, HR, conscious_level].some(v => v == null)) return null;
     const pRR = RRr <= 8 ? 3 : RRr <= 11 ? 1 : RRr <= 20 ? 0 : RRr <= 24 ? 2 : 3;
     const pO2 = SaO2 < 86 ? 3 : SaO2 <= 90 ? 2 : SaO2 <= 92 ? 1 : SaO2 <= 94 ? 1 : SaO2 <= 96 ? 0 : 0;
     const pT  = temp_c < 35 ? 3 : temp_c <= 36 ? 1 : temp_c <= 38 ? 0 : temp_c <= 39 ? 1 : 2;
@@ -4445,6 +4447,7 @@ register({
     { key: "gcs_le_14", required: true },
   ],
   run: (x) => {
+    if (x.sbp_le_100 == null || x.rr_ge_22 == null || x.gcs_le_14 == null) return null;
     const score = [x.sbp_le_100, x.rr_ge_22, x.gcs_le_14].filter(Boolean).length;
     return { id: "qsofa", label: "qSOFA", value: score, unit: "points", precision: 0, notes: [score>=2?"high risk":"lower risk"] };
   },

--- a/lib/medical/engine/calculators/news2.ts
+++ b/lib/medical/engine/calculators/news2.ts
@@ -1,3 +1,5 @@
+import { register } from "../registry";
+
 // NEWS2 calculator (Scale 1). Returns total score and risk band.
 export type NEWS2Inputs = {
   rr: number;               // breaths/min
@@ -35,5 +37,26 @@ export function calc_news2(i: NEWS2Inputs): { score: number; risk: "low"|"medium
 
   return { score: total, risk };
 }
+
+register({
+  id: "news2",
+  label: "NEWS2",
+  inputs: [
+    { key: "rr", required: true },
+    { key: "spo2_percent", required: true },
+    { key: "temp_c", required: true },
+    { key: "sbp", required: true },
+    { key: "hr", required: true },
+    { key: "consciousness", required: true },
+    { key: "on_supplemental_o2" },
+  ],
+  run: (args: NEWS2Inputs) => {
+    for (const k of ["rr","spo2_percent","temp_c","sbp","hr","consciousness"]) {
+      if ((args as any)[k] == null) return null;
+    }
+    const r = calc_news2(args);
+    return { id: "news2", label: "NEWS2", value: r.score, unit: "points", precision: 0, notes: [r.risk] };
+  },
+});
 
 export default calc_news2;

--- a/lib/medical/engine/calculators/qsofa.ts
+++ b/lib/medical/engine/calculators/qsofa.ts
@@ -1,6 +1,8 @@
-export type qSOFAInputs = { rr:number; sbp:number; gcs:number };
+import { register } from "../registry";
 
-export function calc_qsofa(i: qSOFAInputs): { score:number; high_risk:boolean } {
+export type qSOFAInputs = { rr: number; sbp: number; gcs: number };
+
+export function calc_qsofa(i: qSOFAInputs): { score: number; high_risk: boolean } {
   let s = 0;
   if (i.rr >= 22) s++;
   if (i.sbp <= 100) s++;
@@ -8,19 +10,22 @@ export function calc_qsofa(i: qSOFAInputs): { score:number; high_risk:boolean } 
   return { score: s, high_risk: s >= 2 };
 }
 
-const def = {
+register({
   id: "qsofa",
   label: "qSOFA",
   inputs: [
-    { id: "rr", label: "Respiratory rate (breaths/min)", type: "number", min: 0 },
-    { id: "sbp", label: "Systolic BP (mmHg)", type: "number", min: 0 },
-    { id: "gcs", label: "GCS", type: "number", min: 3, max: 15 }
+    { key: "rr", required: true },
+    { key: "sbp", required: true },
+    { key: "gcs", required: true },
   ],
   run: (args: qSOFAInputs) => {
+    for (const k of ["rr", "sbp", "gcs"]) {
+      if ((args as any)[k] == null) return null;
+    }
     const r = calc_qsofa(args);
-    const notes = [r.high_risk ? "High risk (≥2)" : ""];
-    return { id: "qsofa", label: "qSOFA", value: r.score, unit: "criteria", precision: 0, notes: notes.filter(Boolean), extra: r };
+    const notes = r.high_risk ? ["High risk (≥2)"] : [];
+    return { id: "qsofa", label: "qSOFA", value: r.score, unit: "criteria", precision: 0, notes, extra: r };
   },
-};
+});
 
-export default def;
+export default calc_qsofa;


### PR DESCRIPTION
## Summary
- Filter Doc Mode system prompt to surface only critical pre-computed lines and reduce score noise
- Correct anion gap calculators and expose Winter's expected PaCO₂ and acid–base summary
- Harden triage/risk calculators to require complete vitals and extend AI Doc output policy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c373fa8b64832f8ad9978110b11338