### PR TITLE
Add OpenPass location support for “near me” chat queries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,9 @@ OVERPASS_API_URL=https://overpass-api.de/api/interpreter
 OVERPASS_USER_AGENT=medx-app/1.0 (support@yourdomain)
 NEXT_PUBLIC_NEARBY_DEFAULT_RADIUS_KM=5
 
+# OpenPass
+OPENPASS_API_KEY=
+
 # Symptom triage (enable cough/fever/etc. self-care + red flags)
 SYMPTOM_TRIAGE_ENABLED=true
 

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+OPENPASS_API_KEY=your_key_here

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -35,6 +35,7 @@ import { fetchTrialByNct } from "@/lib/trials/byId";
 import { singleTrialPatientPrompt, singleTrialClinicianPrompt } from "@/lib/prompts/trials";
 import { searchTrials, dedupeTrials, rankValue } from "@/lib/trials/search";
 import { byName } from "@/data/countries";
+import { searchNearby } from "@/lib/openpass";
 
 async function getFeedbackSummary(conversationId: string) {
   try {
@@ -60,6 +61,11 @@ function contextStringFrom(messages: ChatCompletionMessageParam[]): string {
 
 export async function POST(req: Request) {
   const body = await req.json();
+  const { query, locationToken } = body;
+  if (query && /near me/i.test(query) && locationToken) {
+    const results = await searchNearby(locationToken, query);
+    return NextResponse.json({ results });
+  }
   const { messages: incomingMessages, mode: rawMode, thread_id } = body;
   const mode = normalizeMode(rawMode);
   const userMessage = incomingMessages?.[incomingMessages.length - 1]?.content || "";

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { useChatStore } from "@/lib/state/chatStore";
+import { useOpenPass } from "@/hooks/useOpenPass";
 
-export function ChatInput({ onSend }: { onSend: (text: string)=>Promise<void> }) {
+export function ChatInput({ onSend }: { onSend: (text: string, locationToken?: string)=>Promise<void> }) {
   const [text, setText] = useState("");
   const startNewThread = useChatStore(s => s.startNewThread);
   const currentId = useChatStore(s => s.currentId);
   const addMessage = useChatStore(s => s.addMessage);
+  const openPass = useOpenPass();
 
   // auto-create a new thread when the user starts typing in a fresh session
   useEffect(() => {
@@ -22,7 +24,13 @@ export function ChatInput({ onSend }: { onSend: (text: string)=>Promise<void> })
     // add user message locally (this also sets the title from first words)
     addMessage({ role: "user", content });
     setText("");
-    await onSend(content); // your existing streaming/send logic
+
+    let locationToken: string | undefined;
+    if (/near me/i.test(content)) {
+      locationToken = await openPass.getLocationToken() || undefined;
+    }
+
+    await onSend(content, locationToken); // your existing streaming/send logic
   };
 
   return (

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import { useChatStore } from "@/lib/state/chatStore";
 import { ChatInput } from "@/components/ChatInput";
 import { persistIfTemp } from "@/lib/chat/persist";
@@ -6,13 +7,25 @@ import { persistIfTemp } from "@/lib/chat/persist";
 export function ChatWindow() {
   const messages = useChatStore(s => s.currentId ? s.threads[s.currentId]?.messages ?? [] : []);
   const addMessage = useChatStore(s => s.addMessage);
+  const [results, setResults] = useState<any[]>([]);
 
-  const handleSend = async (content: string) => {
+  const handleSend = async (content: string, locationToken?: string) => {
     // after sending user message, persist thread if needed
     await persistIfTemp();
-    // For now, echo the user's message as the assistant reply
-    // In a real implementation, replace this with a call to your backend/AI service
-    addMessage({ role: "assistant", content: `You said: ${content}` });
+    if (locationToken) {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: content, locationToken }),
+      });
+      const data = await res.json();
+      setResults(data.results || []);
+      addMessage({ role: "assistant", content: data.results ? "Here are some places nearby:" : "" });
+    } else {
+      // For now, echo the user's message as the assistant reply
+      // In a real implementation, replace this with a call to your backend/AI service
+      addMessage({ role: "assistant", content: `You said: ${content}` });
+    }
   };
 
   return (
@@ -23,6 +36,21 @@ export function ChatWindow() {
             <strong>{m.role}:</strong> {m.content}
           </div>
         ))}
+        {results.length > 0 && (
+          <div className="p-2 space-y-2">
+            {results.map((place) => (
+              <div key={place.id} className="result-card border p-2 rounded">
+                <p>{place.name}</p>
+                <p className="text-sm opacity-80">{place.address}</p>
+                {place.mapLink && (
+                  <a className="text-blue-600 underline" href={place.mapLink} target="_blank" rel="noopener noreferrer">
+                    Directions
+                  </a>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
       <ChatInput onSend={handleSend} />
     </div>

--- a/hooks/useOpenPass.ts
+++ b/hooks/useOpenPass.ts
@@ -1,0 +1,31 @@
+import { useRef } from "react";
+
+/**
+ * Small wrapper around the OpenPass SDK. Assumes the global `OpenPass`
+ * object has already been loaded on the page. Provides a helper to fetch
+ * a location token, triggering the permission popup if necessary.
+ */
+export function useOpenPass() {
+  const openPassRef = useRef<any>();
+
+  if (typeof window !== "undefined" && !openPassRef.current) {
+    const OpenPass = (window as any).OpenPass;
+    if (OpenPass) {
+      openPassRef.current = new OpenPass();
+    }
+  }
+
+  const getLocationToken = async (): Promise<string | null> => {
+    const sdk = openPassRef.current;
+    if (!sdk) return null;
+    try {
+      const token = await sdk.getLocationToken();
+      return token || null;
+    } catch {
+      return null;
+    }
+  };
+
+  return { getLocationToken };
+}
+

--- a/lib/openpass.ts
+++ b/lib/openpass.ts
@@ -1,0 +1,15 @@
+export async function searchNearby(locationToken: string, query: string) {
+  const res = await fetch("https://api.openpass.io/v1/nearby/search", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${process.env.OPENPASS_API_KEY}`,
+    },
+    body: JSON.stringify({ locationToken, query }),
+  });
+  if (!res.ok) {
+    throw new Error(`OpenPass search failed: ${res.status}`);
+  }
+  return res.json();
+}
+


### PR DESCRIPTION
## Summary
- detect “near me” queries in chat and request OpenPass location token
- send location token to backend and call OpenPass Nearby Search API
- render nearby results in chat UI and document OPENPASS_API_KEY env var

## Testing
- `npm test`
- `npm run lint` *(fails: asks for interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c37586d014832f8bef34e795ac7d42