### PR TITLE
Fix clinical bands + osmolality + doc-prelude visibility

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -13,7 +13,7 @@ function filterComputedForDocMode(items: any[], latestUser: string) {
   const needsPEContext = mentions('chest pain') || mentions('pleur') || mentions('shortness of breath') || /\bsob\b/.test(msg);
   return items
     // basic sanity
-    .filter((r: any) => r && Number.isFinite(r.value))
+    .filter((r: any) => r && (Number.isFinite(r.value) || typeof r.value === 'string'))
     // avoid placeholders/surrogates/partials
     .filter((r: any) => {
       const noteStr = (r.notes || []).join(' ').toLowerCase();

--- a/lib/medical/engine/calculators/lab_interpretation.ts
+++ b/lib/medical/engine/calculators/lab_interpretation.ts
@@ -32,8 +32,8 @@ register({
     const notes: string[] = [];
     if (K < 3.0) notes.push("severe hypokalemia");
     else if (K < 3.5) notes.push("mild hypokalemia");
-    else if (K > 6.0) notes.push("severe hyperkalemia (urgent)");
-    else if (K > 5.5) notes.push("hyperkalemia");
+    else if (K >= 6.0) notes.push("severe hyperkalemia (urgent)");
+    else if (K >= 5.5) notes.push("hyperkalemia");
     else notes.push("normal");
     return { id: "potassium_status", label: "Potassium", value: K, unit: "mmol/L", precision: 1, notes };
   },
@@ -2762,14 +2762,30 @@ register({
   },
 });
 
+/** Measured serum osmolality status */
+register({
+  id: "measured_osm_status",
+  label: "Measured osmolality",
+  tags: ["electrolytes", "toxicology"],
+  inputs: [{ key: "measured_osm", required: true }], // mOsm/kg
+  run: ({ measured_osm }) => {
+    if (measured_osm == null || measured_osm <= 0) return null;
+    const notes: string[] = [];
+    if (measured_osm < 275) notes.push("hypo-osmolar");
+    else if (measured_osm > 295) notes.push("hyperosmolar");
+    else notes.push("within reference (275–295)");
+    return { id: "measured_osm_status", label: "Measured osmolality", value: measured_osm, unit: "mOsm/kg", precision: 0, notes };
+  },
+});
+
 /** Osmolar gap = measured − calculated; flags for toxic alcohol concern (no therapy advice) */
 register({
   id: "osmolar_gap",
   label: "Osmolar gap",
   tags: ["toxicology", "acid-base"],
   inputs: [
-    { key: "measured_osm", required: true },      // mOsm/kg
-    { key: "serum_osm_calc", required: true },    // from above
+    { key: "measured_osm", aliases: ["measured_osm_mOsm_kg"], required: true },      // mOsm/kg
+    { key: "serum_osm_calc", aliases: ["serum_osmolality","serum_osm_calculated"], required: true },    // from above
     { key: "anion_gap" },                         // optional
     { key: "HCO3" },                              // optional
     { key: "pH" },                                // optional
@@ -3208,7 +3224,7 @@ register({
   tags: ["renal"],
   inputs: [
     { key: "urine_osm_measured", required: true },
-    { key: "measured_osm", required: true },
+    { key: "measured_osm", aliases: ["measured_osm_mOsm_kg"], required: true },
   ],
   run: ({ urine_osm_measured, measured_osm }) => {
     if (measured_osm == null || measured_osm <= 0) return null;
@@ -3961,7 +3977,7 @@ register({
   tags: ["electrolytes", "endocrine"],
   inputs: [
     { key: "Na", required: true },             // mmol/L
-    { key: "measured_osm", required: true },   // mOsm/kg
+    { key: "measured_osm", aliases: ["measured_osm_mOsm_kg"], required: true },   // mOsm/kg
   ],
   run: ({ Na, measured_osm }) => {
     let cls = "normotonic";
@@ -6391,7 +6407,7 @@ register({
   tags: ["electrolytes"],
   inputs: [
     { key:"Na", required:true },
-    { key:"glucose", required:true } // mg/dL
+    { key:"glucose", aliases:["glucose_mg_dl"], required:true } // mg/dL
   ],
   run: ({Na,glucose})=>{
     const eff=2*Na+glucose/18;


### PR DESCRIPTION
## Summary
- Correct potassium hyperkalemia thresholds
- Add measured serum osmolality status and key aliases
- Show string-valued calculator results in Doc Mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c37b13a514832f973cea20ab4c914f