### PR TITLE
feat: add GPT-5 verification before Groq composition

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -1,88 +1,196 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { profileChatSystem } from '@/lib/profileChatSystem';
-import { extractAll } from '@/lib/medical/engine/extract';
+import { extractAll, normalizeCtx } from '@/lib/medical/engine/extract';
 import { computeAll } from '@/lib/medical/engine/computeAll';
-// === [MEDX_CALC_ROUTE_IMPORTS_START] ===
-import { composeCalcPrelude } from '@/lib/medical/engine/prelude';
-// === [MEDX_CALC_ROUTE_IMPORTS_END] ===
-// Keep doc-mode clinical prelude tight & relevant
+import { verifyWithOpenAI, Verdict } from '@/lib/ai/verifyWithOpenAI';
+
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+// ——— Utilities ———
+function corsify(res: Response, extraHeaders?: Record<string, string>) {
+  const h = new Headers(res.headers);
+  h.set('Access-Control-Allow-Origin', '*');
+  h.set('Access-Control-Allow-Methods', 'GET,POST,OPTIONS,HEAD');
+  h.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  h.set('Access-Control-Max-Age', '86400');
+  h.set('Cache-Control', 'no-store');
+  if (extraHeaders) for (const [k, v] of Object.entries(extraHeaders)) h.set(k, v);
+  return new Response(res.body, { status: res.status, headers: h });
+}
+
+const recentReqs = new Map<string, number>(); // dedupe clientRequestId
+const verdictCache = new Map<string, { v: Verdict, exp: number }>(); // 10-min cache
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hash)).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+function cacheGet(key: string) {
+  const hit = verdictCache.get(key);
+  if (!hit) return undefined;
+  if (Date.now() > hit.exp) { verdictCache.delete(key); return undefined; }
+  return hit.v;
+}
+function cacheSet(key: string, v: Verdict, ttlMs: number) {
+  verdictCache.set(key, { v, exp: Date.now() + ttlMs });
+}
+
 function filterComputedForDocMode(items: any[], latestUser: string) {
   const msg = (latestUser || '').toLowerCase();
   const mentions = (s: string) => msg.includes(s);
-  const isRespContext = mentions('cough') || mentions('fever') || mentions('cold') || mentions('breath') || mentions('sore throat');
-  const needsPEContext = mentions('chest pain') || mentions('pleur') || mentions('shortness of breath') || /\bsob\b/.test(msg);
+  const isRespContext =
+    mentions('cough') || mentions('fever') || mentions('cold') ||
+    mentions('breath') || mentions('sore throat');
+  const needsPEContext =
+    mentions('chest pain') || mentions('pleur') ||
+    mentions('shortness of breath') || /\bsob\b/.test(msg);
+
   return items
-    // basic sanity
     .filter((r: any) => r && (Number.isFinite(r.value) || typeof r.value === 'string'))
-    // avoid placeholders/surrogates/partials
     .filter((r: any) => {
       const noteStr = (r.notes || []).join(' ').toLowerCase();
       const lbl = String(r.label || '').toLowerCase();
       return !/surrogate|placeholder|phase-1|inputs? needed|partial/.test(noteStr + ' ' + lbl);
     })
-    // relevance pruning
     .filter((r: any) => {
       const lbl = String(r.label || '').toLowerCase();
-      // allow these in respiratory context
       if (isRespContext && (/(curb-?65|news2|qsofa|sirs|qcsi|sofa)/i.test(lbl))) return true;
-      // PERC only if explicit PE context
       if (/(perc)/i.test(lbl)) return needsPEContext;
-      // drop unrelated rules/noise
       if (/(glasgow-blatchford|ottawa|ankle|knee|head|rockall|apgar|bishop|pasi|burn|maddrey|fib-4|apri|child-?pugh|meld)/i.test(lbl)) return false;
-      // conservative default: keep only a small, high-signal set
       return /(curb-?65|news2|qsofa|sirs)/i.test(lbl);
     });
 }
-export const runtime = 'edge';
 
-const recentReqs = new Map<string, number>();
+// ——— Shared core handler (used by GET/POST) ———
+async function handleChat(req: NextRequest, payload: any) {
+  const { messages = [], context, clientRequestId, mode } = payload || {};
+  const method = req.method || 'GET';
 
-
-export async function POST(req: NextRequest) {
-  const { messages = [], context, clientRequestId, mode } = await req.json();
-  const showClinicalPrelude = (mode === 'doctor' || mode === 'research');
+  // dedupe frequent client requests
   const now = Date.now();
-  for (const [id, ts] of recentReqs.entries()) {
-    if (now - ts > 60_000) recentReqs.delete(id);
-  }
+  for (const [id, ts] of recentReqs.entries()) if (now - ts > 60_000) recentReqs.delete(id);
   if (clientRequestId) {
     const ts = recentReqs.get(clientRequestId);
     if (ts && now - ts < 60_000) {
-      return new Response(null, { status: 409 });
+      return corsify(new Response(null, { status: 409 }));
     }
     recentReqs.set(clientRequestId, now);
   }
-  const base  = process.env.LLM_BASE_URL!;
+
+  // Groq as runtime LLM (composer)
+  const base  = process.env.LLM_BASE_URL || 'https://api.groq.com/openai/v1';
   const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
   const key   = process.env.LLM_API_KEY!;
-  const url = `${base.replace(/\/$/,'')}/chat/completions`;
+  const url   = `${base.replace(/\/$/,'')}/chat/completions`;
 
-  let finalMessages = messages.filter((m: any) => m.role !== 'system');
+  // strip incoming system messages; we control system prompts
+  let finalMessages = (messages || []).filter((m: any) => m.role !== 'system');
 
-  const latestUserMessage = messages.filter((m: any) => m.role === 'user').slice(-1)[0]?.content || "";
-  const userText = (messages || []).map((m: any) => m?.content || '').join('\n');
-  const ctx = extractAll(userText);
+  // ===== Multi-turn extraction (use entire conversation) =====
+  const userText = (messages || [])
+    .filter((m: any) => m.role === 'user')
+    .map((m: any) => m?.content || '')
+    .join('\n');
+
+  const latestUserMessage =
+    (messages || []).filter((m: any) => m.role === 'user').slice(-1)[0]?.content || '';
+
+  const rawCtx = extractAll(userText);
+  const ctx = normalizeCtx(rawCtx);
   const computed = computeAll(ctx);
 
+  // Task mode header (for UI timers)
+  const taskMode = (computed && computed.length > 0) ? 'analyzing' : 'thinking';
+
+  // --- JOINT DECISION PROTOCOL (Groq sees this; GPT-5 is authority) ---
+  const JOINT_DECISION_RULES = [
+    'JOINT DECISION PROTOCOL:',
+    '- You (OpenAI GPT-5) and the Calculators work TOGETHER.',
+    '- Treat calculator outputs as a first pass; correct edge/missing-input errors.',
+    "- Cross-check physiology: Winter’s (expected pCO2), osmolality 275–295 normal, albumin-corrected anion gap, potassium bands, renal flags.",
+    '- If conflict exists, use your corrected values.',
+    '- Be decisive; calculators are data, not directives.',
+    '- Do not output any verification badge or correction line to the user.'
+  ].join('\n');
+
+  // Always include JOINT rules first
+  finalMessages = [{ role: 'system', content: JOINT_DECISION_RULES }, ...finalMessages];
+
+  // ===== GPT-5 verification (ALWAYS; 1-minute timeout; 10-min cache) =====
+  const cacheKey = await sha256Hex(JSON.stringify({ ctx, calculatorsVersion: 'v1' }));
+  let verdict = cacheGet(cacheKey) as Verdict | undefined;
+  if (!verdict) {
+    verdict = await verifyWithOpenAI({
+      mode: String(mode || 'default'),
+      ctx,
+      computed,
+      conversation: (messages || []).map((m: any) => ({ role: m.role, content: m.content })),
+      timeoutMs: 60_000
+    }) || undefined;
+    if (verdict) cacheSet(cacheKey, verdict, 10 * 60 * 1000); // 10 minutes
+  }
+
+  // Overlay corrections (GPT-5 is source of truth)
+  let blended = computed;
+  if (verdict?.corrected_values && typeof verdict.corrected_values === 'object') {
+    const byId = new Map(blended.map((r: any) => [r?.id, r]));
+    for (const [k, v] of Object.entries(verdict.corrected_values)) {
+      const t = byId.get(k);
+      if (t) {
+        if (v && typeof v === 'object' && 'value' in (v as any)) {
+          Object.assign(t, v); // {value, unit, notes[]}
+        } else {
+          (t as any).value = v;
+        }
+        if ((v as any)?.notes && Array.isArray((v as any).notes)) {
+          (t as any).notes = Array.from(new Set([...(t as any).notes || [], ...(v as any).notes]));
+        }
+      } else {
+        byId.set(k, { id: k, label: k, value: (v as any)?.value ?? v, unit: (v as any)?.unit, notes: (v as any)?.notes ?? [] });
+      }
+    }
+    blended = Array.from(byId.values());
+  }
+
+  // Crisis heuristics (+ glucose alias fix) — computed on corrected data
+  const getNum = (x: any) => (typeof x === 'number' ? x : Number(x));
+  const g = getNum((ctx as any).glucose ?? (ctx as any).glucose_mg_dl);
+  const bicarb = getNum((ctx as any).HCO3 ?? (ctx as any).bicarb ?? (ctx as any).bicarbonate);
+  const ph = getNum((ctx as any).pH);
+  const kVal = getNum((ctx as any).K ?? (ctx as any).potassium);
+  const hyperglycemicCrisis =
+    (Number.isFinite(g) && g >= 250) &&
+    ((Number.isFinite(bicarb) && bicarb <= 18) || (Number.isFinite(ph) && ph < 7.30));
+  const hyperkalemiaDanger  = Number.isFinite(kVal) && kVal >= 6.0;
+
+  const mustShow = new Set<string>([
+    'measured_osm_status','osmolar_gap','serum_osm_calc','anion_gap_albumin_corrected',
+    'hyponatremia_tonicity','hyperkalemia_severity','potassium_status','dka_severity','hhs_flags',
+  ]);
+  const promoted = blended.filter((r: any) => r && mustShow.has(r.id));
+  const crisisPromoted = (hyperglycemicCrisis || hyperkalemiaDanger) ? promoted : [];
+
+  // Doctor/Research: data-only prelude (corrected ‘blended’)
+  const showClinicalPrelude =
+    (mode === 'doctor') || (mode === 'research') || /trial|research/i.test(String(mode || ''));
   if (showClinicalPrelude) {
-    const filtered = filterComputedForDocMode(computed, latestUserMessage ?? '');
-    if (filtered.length) {
-      const lines = filtered.map(r => {
-        const val = r.unit ? `${r.value} ${r.unit}` : String(r.value);
-        const notes = r.notes?.length ? ` — ${r.notes.join('; ')}` : '';
-        return `${r.label}: ${val}${notes}`;
-      });
-      finalMessages = [
-        {
-          role: 'system',
-          content:
-            'Use these pre-computed clinical values only if relevant to the question. Do not re-calculate. If inputs are missing, state which values are required and avoid quoting incomplete scores.'
-        },
-        { role: 'system', content: lines.join('\\n') },
-        ...finalMessages,
-      ];
+    const filtered = filterComputedForDocMode(blended, latestUserMessage ?? '');
+    const linesSet = new Map([...crisisPromoted, ...filtered].map((r: any) => [r.id, r]));
+    const lines = Array.from(linesSet.values()).map((r: any) => {
+      const val = r.unit ? `${r.value} ${r.unit}` : String(r.value);
+      const notes = r.notes?.length ? ` — ${r.notes.join('; ')}` : '';
+      return `${r.label}: ${val}${notes}`;
+    });
+    if (lines.length) {
+      finalMessages = [{ role: 'system', content: lines.join('\n') }, ...finalMessages];
     }
   }
+
+  // Profile context
   if (context === 'profile') {
     try {
       const origin = req.nextUrl.origin;
@@ -101,17 +209,14 @@ export async function POST(req: NextRequest) {
       finalMessages = [{ role: 'system', content: sys }, ...finalMessages];
     } catch {}
   }
-  // === [MEDX_CALC_PRELUDE_START] ===
-  const __calcPrelude = composeCalcPrelude(latestUserMessage ?? "");
-  // Only add calc prelude if we actually included filtered computed lines
-  if (showClinicalPrelude && __calcPrelude && finalMessages.length && finalMessages[0]?.role === 'system') {
-    finalMessages = [{ role: 'system', content: __calcPrelude }, ...finalMessages];
-  }
-  // === [MEDX_CALC_PRELUDE_END] ===
 
+  // === Call Groq and stream back ===
   const upstream = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${key}`,
+    },
     body: JSON.stringify({
       model,
       stream: true,
@@ -120,16 +225,65 @@ export async function POST(req: NextRequest) {
       frequency_penalty: 0,
       presence_penalty: 0,
       messages: finalMessages,
-    })
+    }),
   });
 
   if (!upstream.ok) {
     const err = await upstream.text();
-    return new Response(`LLM error: ${err}`, { status: 500 });
+    return corsify(new Response(`LLM error (${method}): ${err}`, { status: 500 }), {
+      'X-Task-Mode': taskMode,
+      'X-Verify-Timeout': '60000',
+      'X-Verify-Used': verdict ? '1' : '0',
+    });
   }
 
-  // Pass-through SSE; frontend parses "data: {delta.content}"
-  return new Response(upstream.body, {
-    headers: { 'Content-Type': 'text/event-stream; charset=utf-8' }
+  const res = new Response(upstream.body, {
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      'Connection': 'keep-alive',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,OPTIONS,HEAD',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Max-Age': '86400',
+      'X-Task-Mode': taskMode,
+      'X-Verify-Timeout': '60000',
+      'X-Verify-Used': verdict ? '1' : '0',
+    },
   });
+  return res;
+}
+
+// ===== Exported HTTP methods =====
+async function readPayloadFromGET(req: NextRequest) {
+  const url = req.nextUrl;
+  const raw = url.searchParams.get('payload');
+  if (raw) {
+    try { return JSON.parse(decodeURIComponent(raw)); } catch { return {}; }
+  }
+  // Legacy query params fallback
+  const mode = url.searchParams.get('mode') || undefined;
+  const context = url.searchParams.get('context') || undefined;
+  const msgs = url.searchParams.get('messages');
+  let messages: any[] | undefined;
+  if (msgs) { try { messages = JSON.parse(msgs); } catch {} }
+  return { mode, context, messages };
+}
+
+export async function GET(req: NextRequest) {
+  const payload = await readPayloadFromGET(req);
+  return handleChat(req, payload);
+}
+
+export async function POST(req: NextRequest) {
+  const payload = await req.json().catch(() => ({}));
+  return handleChat(req, payload);
+}
+
+export async function OPTIONS() {
+  return corsify(new Response(null, { status: 204 }));
+}
+
+export async function HEAD() {
+  return corsify(new Response(null, { status: 200 }));
 }

--- a/lib/ai/verifyWithOpenAI.ts
+++ b/lib/ai/verifyWithOpenAI.ts
@@ -1,0 +1,65 @@
+import { VERIFY_SYSTEM, buildVerifyUserContent } from "./verify_prompt";
+
+export type Verdict = {
+  ok: boolean;
+  version: string;
+  corrected_values?: Record<string, any>;
+  corrections?: string[];
+  final_assertions?: Record<string, any>;
+};
+
+function timeout<T>(p: Promise<T>, ms: number) {
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error("verify-timeout")), ms);
+    p.then(v => { clearTimeout(t); resolve(v); }, e => { clearTimeout(t); reject(e); });
+  });
+}
+
+export async function verifyWithOpenAI(args: {
+  mode: string;
+  ctx: Record<string, any>;
+  computed: Array<any>;
+  conversation?: Array<{role: string; content: string}>;
+  signal?: AbortSignal;
+  timeoutMs?: number;   // default 60_000 (1 minute)
+}): Promise<Verdict | null> {
+  const { mode, ctx, computed, conversation, signal, timeoutMs = 60_000 } = args;
+
+  const base  = process.env.OPENAI_BASE_URL || "https://api.openai.com/v1";
+  const model = process.env.OPENAI_MODEL_ID || "gpt-5";
+  const key   = process.env.OPENAI_API_KEY!;
+  const url   = `${base.replace(/\/$/,'')}/chat/completions`;
+
+  const body = {
+    model,
+    temperature: 0,
+    top_p: 1,
+    response_format: { type: "json_object" },
+    stream: false,
+    messages: [
+      { role: "system", content: VERIFY_SYSTEM },
+      { role: "user", content: buildVerifyUserContent({ mode, ctx, computed, conversation }) }
+    ]
+  };
+
+  try {
+    const res = await timeout(fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Authorization": `Bearer ${key}` },
+      body: JSON.stringify(body),
+      signal
+    }), timeoutMs);
+
+    if (!(res as Response).ok) return null;
+    const data = await (res as Response).json();
+    const content = data?.choices?.[0]?.message?.content;
+    if (!content) return null;
+
+    let parsed: Verdict | null = null;
+    try { parsed = JSON.parse(content); } catch { return null; }
+    if (!parsed || parsed.version !== "v1") return null;
+    return parsed;
+  } catch {
+    return null; // silent fallback
+  }
+}

--- a/lib/ai/verify_prompt.ts
+++ b/lib/ai/verify_prompt.ts
@@ -1,0 +1,39 @@
+export const VERIFY_SYSTEM = `
+You are OpenAI GPT-5 verifying and, if needed, correcting all medically-relevant calculations and interpretations.
+Return STRICT JSON ONLY (no prose), exactly matching the provided schema.
+If calculators or intermediate logic are inconsistent with physiology or guidelines, correct them.
+If inputs are insufficient, omit fields rather than guessing.
+You have final authority on corrected values; these will override calculators system-wide.
+`;
+
+export const VERIFY_SCHEMA = `
+{
+  "ok": boolean,
+  "version": "v1",
+  "corrected_values": {
+    // key: calculator id or canonical field
+    // value: corrected scalar/string OR { "value": any, "unit": string | null, "notes": string[] }
+  },
+  "corrections": [ "short what/why lines" ],
+  "final_assertions": {
+    // decisive labels e.g. "primary_dx", "acid_base", "dka_severity", "hyperosmolar", etc.
+  }
+}
+`;
+
+export function buildVerifyUserContent(payload: {
+  mode: string;
+  ctx: Record<string, any>;
+  computed: Array<any>;
+  conversation?: Array<{role: string; content: string}>;
+}) {
+  return JSON.stringify({
+    instruction:
+      "Validate & correct. Apply physiology cross-checks: Winter’s expected pCO2 (1.5*HCO3 + 8 ±2), serum osmolality (2*Na + Glucose/18 + BUN/2.8; normal 275–295), osmol gap (measured - calculated; >=10 elevated), albumin-corrected anion gap (AG + 2.5*(4 - Alb[g/dL])), potassium bands, renal flags. Reject ad-hoc metrics (e.g., 'lactate:pH ratio'). qSOFA/SIRS only if required vitals/mentation present. No prose.",
+    mode: payload.mode,
+    schema: JSON.parse(VERIFY_SCHEMA),
+    inputs: payload.ctx,
+    calculators: payload.computed,
+    conversation: payload.conversation ?? []
+  });
+}

--- a/lib/medical/engine/extract.ts
+++ b/lib/medical/engine/extract.ts
@@ -125,3 +125,14 @@ export function extractAll(s: string): Record<string, any> {
 
   return out;
 }
+
+export function normalizeCtx(raw: Record<string, any>): Record<string, any> {
+  const ctx: Record<string, any> = { ...raw };
+  if (ctx.glucose_mg_dl == null && ctx.glucose_mgdl != null) {
+    ctx.glucose_mg_dl = ctx.glucose_mgdl;
+  }
+  if (ctx.glucose == null && ctx.glucose_mg_dl != null) {
+    ctx.glucose = ctx.glucose_mg_dl;
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add verification prompts and helper to call GPT-5 for calculator corrections
- cache verified outputs and blend with calculator results before Groq responds
- expose verification state and task mode headers in streaming chat route

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c39b41ad74832f99bc12352e5307dc