### PR TITLE
feat: add thinking indicator HUD

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -85,6 +85,12 @@ export async function POST(req: Request) {
   const respond = (data: any, init?: ResponseInit) => {
     const res = NextResponse.json(data, init);
     res.headers.set("x-conversation-id", conversationId!);
+    res.headers.set("x-medx-provider", "openai");
+    res.headers.set("x-medx-model", process.env.OPENAI_TEXT_MODEL || "gpt-5");
+    res.headers.set(
+      "x-medx-min-delay",
+      String((parseInt(process.env.MIN_OUTPUT_DELAY_SECONDS || "", 10) || 10) * 1000)
+    );
     return res;
   };
   if (isNewChat) {

--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -130,6 +130,11 @@ export async function POST(req: NextRequest) {
 
   // Pass-through SSE; frontend parses "data: {delta.content}"
   return new Response(upstream.body, {
-    headers: { 'Content-Type': 'text/event-stream; charset=utf-8' }
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'x-medx-provider': 'openai',
+      'x-medx-model': process.env.OPENAI_TEXT_MODEL || 'gpt-5',
+      'x-medx-min-delay': String((parseInt(process.env.MIN_OUTPUT_DELAY_SECONDS || '', 10) || 10) * 1000)
+    }
   });
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { TopicProvider } from "@/lib/topic";
 import { Suspense } from "react";
 import MemorySnackbar from "@/components/memory/Snackbar";
 import UndoToast from "@/components/memory/UndoToast";
+import ThinkingIndicator from "@/components/ThinkingIndicator";
 
 export const metadata = { title: "MedX", description: "Global medical AI" };
 
@@ -26,6 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     {children}
                     <MemorySnackbar />
                     <UndoToast />
+                    <ThinkingIndicator />
                   </main>
                 </div>
               </ThemeProvider>

--- a/components/ThinkingIndicator.tsx
+++ b/components/ThinkingIndicator.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React from "react";
+type ThinkingEvent =
+  | { state: "start"; label?: string; minSeconds?: number }
+  | { state: "headers"; minSeconds?: number; provider?: string; model?: string }
+  | { state: "stop" };
+
+export default function ThinkingIndicator() {
+  const [active, setActive] = React.useState(false);
+  const [label, setLabel] = React.useState("Analyzing…");
+  const [elapsed, setElapsed] = React.useState(0);
+  const [min, setMin] = React.useState<number>(() => {
+    // fallbacks: response header (preferred) -> NEXT_PUBLIC_ -> default 10
+    const env = Number(process.env.NEXT_PUBLIC_MIN_OUTPUT_DELAY_SECONDS || "");
+    return Number.isFinite(env) ? env : 10;
+  });
+  const startedAt = React.useRef<number | null>(null);
+  const timer = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    function onEvt(e: Event) {
+      const ce = e as CustomEvent<ThinkingEvent>;
+      const d = ce.detail;
+      if (!d) return;
+      if (d.state === "start") {
+        setLabel(d.label || "Analyzing…");
+        if (Number.isFinite(d.minSeconds as number)) setMin((d.minSeconds as number)!);
+        startedAt.current = Date.now();
+        setElapsed(0);
+        setActive(true);
+        if (timer.current) window.clearInterval(timer.current);
+        timer.current = window.setInterval(() => {
+          if (!startedAt.current) return;
+          setElapsed(Math.floor((Date.now() - startedAt.current) / 1000));
+        }, 250);
+      } else if (d.state === "headers") {
+        if (Number.isFinite(d.minSeconds as number)) setMin((d.minSeconds as number)!);
+      } else if (d.state === "stop") {
+        if (timer.current) window.clearInterval(timer.current);
+        timer.current = null;
+        startedAt.current = null;
+        setActive(false);
+        setElapsed(0);
+      }
+    }
+    window.addEventListener("medx-thinking", onEvt as any);
+    return () => {
+      window.removeEventListener("medx-thinking", onEvt as any);
+      if (timer.current) window.clearInterval(timer.current);
+    };
+  }, []);
+
+  if (!active) return null;
+
+  const mm = String(Math.floor(elapsed / 60)).padStart(2, "0");
+  const ss = String(elapsed % 60).padStart(2, "0");
+  const target = Math.max(0, min);
+  const remaining = Math.max(0, target - elapsed);
+  const rr = String(remaining).padStart(2, "0");
+
+  return (
+    <div className="fixed inset-x-0 top-0 z-[1000] flex justify-center">
+      <div className="mt-2 px-3 py-2 rounded-xl bg-black/80 text-white shadow-lg backdrop-blur-md border border-white/10 flex items-center gap-3">
+        <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-white"></span>
+        <span className="font-medium">{label}</span>
+        <span className="tabular-nums text-sm opacity-80">elapsed {mm}:{ss}</span>
+        <span className="text-sm opacity-60">| min {target}s</span>
+        <span className="text-sm opacity-60">| remaining {rr}s</span>
+      </div>
+    </div>
+  );
+}
+

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -33,6 +33,7 @@ import { detectAdvancedDomain } from "@/lib/intents/advanced";
 // === ADD-ONLY for domain routing ===
 import { detectDomain } from "@/lib/intents/domains";
 import * as DomainStyles from "@/lib/prompts/domains";
+import { thinking } from "@/lib/ux/thinking";
 
 const AIDOC_UI = process.env.NEXT_PUBLIC_AIDOC_UI === '1';
 const AIDOC_PREFLIGHT = process.env.NEXT_PUBLIC_AIDOC_PREFLIGHT === '1';
@@ -1016,6 +1017,7 @@ ${systemCommon}` + baseSys;
         ];
       }
 
+      thinking.start("Analyzing…");
       const res = await fetch('/api/chat/stream', {
         method: 'POST',
         headers: {
@@ -1025,6 +1027,7 @@ ${systemCommon}` + baseSys;
         },
         body: JSON.stringify({ mode: mode === 'doctor' ? 'doctor' : 'patient', messages: chatMessages, threadId, context })
       });
+      thinking.headers(res);
       if (!res.ok || !res.body) throw new Error(`Chat API error ${res.status}`);
 
       const reader = res.body.getReader();
@@ -1107,6 +1110,7 @@ ${systemCommon}` + baseSys;
         try { pushFullMem(stableThreadId, "assistant", content); } catch {}
       }
     } finally {
+      thinking.stop();
       setBusy(false);
     }
   }

--- a/lib/ux/thinking.ts
+++ b/lib/ux/thinking.ts
@@ -1,0 +1,30 @@
+type ThinkingEvent =
+  | { state: "start"; label?: string; minSeconds?: number }
+  | { state: "headers"; minSeconds?: number; provider?: string; model?: string }
+  | { state: "stop" };
+
+function emit(detail: ThinkingEvent) {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent<ThinkingEvent>("medx-thinking", { detail }));
+  }
+}
+
+export const thinking = {
+  start(label = "Analyzing…", minSeconds?: number) {
+    emit({ state: "start", label, minSeconds });
+  },
+  headers(res: Response | { headers?: Headers }) {
+    try {
+      const h = (res as Response).headers;
+      if (!h) return;
+      const min = Number(h.get("x-medx-min-delay") || "");
+      const provider = h.get("x-medx-provider") || undefined;
+      const model = h.get("x-medx-model") || undefined;
+      if (Number.isFinite(min)) emit({ state: "headers", minSeconds: min / 1000, provider, model });
+    } catch {}
+  },
+  stop() {
+    emit({ state: "stop" });
+  },
+};
+


### PR DESCRIPTION
## Summary
- add UX helper and global ThinkingIndicator HUD
- surface server min-delay headers for chat APIs
- wrap chat fetches with thinking timer events

## Testing
- `npm test` *(fails: tests 57, fail 1)*
- `CI=true npm run lint` *(interactive prompt prevents completion)*

------
https://chatgpt.com/codex/tasks/task_e_68c436d8af5c832fb569c53773af5264