### PR TITLE
feat: add final chat routing and thinking timer

### DIFF
--- a/app/api/chat/stream-final/route.ts
+++ b/app/api/chat/stream-final/route.ts
@@ -1,49 +1,56 @@
-import { ensureMinDelay, minDelayMs } from "@/lib/utils/ensureMinDelay";
+import { detectAudience, clinicianStyle, patientStyle, maxTokensFor } from "@/lib/medx/audience";
 import { callOpenAIChat } from "@/lib/medx/providers";
-
-// Optional calculator prelude (safe if engine absent)
-let composeCalcPrelude: any, extractAll: any, canonicalizeInputs: any, computeAll: any;
-try {
-  ({ composeCalcPrelude } = require("@/lib/medical/engine/prelude"));
-  ({ extractAll, canonicalizeInputs } = require("@/lib/medical/engine/extract"));
-  ({ computeAll } = require("@/lib/medical/engine/computeAll"));
-} catch {}
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
-  const { messages = [], mode } = await req.json();
+  const { messages = [], mode, audience: audIn } = await req.json();
+  const audience = detectAudience(mode, audIn);
 
-  // This endpoint is explicitly the OpenAI (final say) stream for non-basic modes.
-  // Keep your current /api/chat/stream for Groq/basic.
-  let system = "Validate all calculations and medical logic before answering. Correct any inconsistencies.";
-  if ((process.env.CALC_AI_DISABLE || "0") !== "1") {
-    try {
-      const lastUser = messages.slice().reverse().find((m: any) => m.role === "user")?.content || "";
-      const extracted = extractAll?.(lastUser);
-      const canonical = canonicalizeInputs?.(extracted);
-      const computed = computeAll?.(canonical);
-      const prelude = composeCalcPrelude?.(computed);
-      if (prelude) system = `Use and verify these pre-computed values first:\n${prelude}`;
-    } catch {}
-  }
+  let system = "Validate calculations & medical logic; correct inconsistencies.\nCRISP: obey hard limits; no preamble; no derivations.";
+  system += audience === "clinician" ? ("\n" + clinicianStyle) : ("\n" + patientStyle);
 
-  const minMs = minDelayMs();
-  const upstream = await ensureMinDelay<Response>(
-    callOpenAIChat([{ role: "system", content: system }, ...messages], { stream: true }),
-    minMs
-  );
+  const upstream = await callOpenAIChat([{ role: "system", content: system }, ...messages], {
+    stream: true,
+    max_tokens: maxTokensFor(audience),
+  });
+  if (!upstream.body) return new Response("OpenAI stream error", { status: 500 });
 
-  if (!upstream?.ok) {
-    const err = upstream ? await upstream.text() : "Upstream error";
-    return new Response(`OpenAI stream error: ${err}`, { status: 500 });
-  }
-  return new Response(upstream.body, {
+  const enc = new TextEncoder();
+  const dec = new TextDecoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      const reader = upstream.body!.getReader();
+      let buf = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        const lines = buf.split("\n");
+        buf = lines.pop() || "";
+        for (const line of lines) {
+          const m = line.match(/^data: (.*)$/);
+          if (!m) continue;
+          if (m[1].trim() === "[DONE]") continue;
+          try {
+            const json = JSON.parse(m[1]);
+            const delta = json.choices?.[0]?.delta?.content;
+            if (delta) controller.enqueue(enc.encode(delta));
+          } catch {}
+        }
+      }
+      controller.close();
+    }
+  });
+
+  return new Response(stream, {
     headers: {
-      "Content-Type": "text/event-stream; charset=utf-8",
+      "Content-Type": "text/plain; charset=utf-8",
       "x-medx-provider": "openai",
-      "x-medx-model": process.env.OPENAI_TEXT_MODEL || "gpt-5"
+      "x-medx-model": process.env.OPENAI_TEXT_MODEL || "gpt-5",
+      "x-medx-audience": audience,
+      "x-medx-min-delay": "0",
     }
   });
 }

--- a/components/ThinkingInline.tsx
+++ b/components/ThinkingInline.tsx
@@ -1,0 +1,50 @@
+"use client";
+import * as React from "react";
+
+export default function ThinkingInline({ className="", showMin=true }: { className?: string; showMin?: boolean }) {
+  const [active, setActive] = React.useState(false);
+  const [label, setLabel] = React.useState("Analyzing…");
+  const [elapsed, setElapsed] = React.useState(0);
+  const [min, setMin] = React.useState<number>(Number(process.env.NEXT_PUBLIC_MIN_OUTPUT_DELAY_SECONDS || 10));
+  const startedAt = React.useRef<number | null>(null);
+  const timer = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    function onEvt(e: Event) {
+      const d: any = (e as CustomEvent).detail;
+      if (!d) return;
+      if (d.state === "start") {
+        setLabel(d.label || "Analyzing…");
+        if (Number.isFinite(d.minSeconds)) setMin(d.minSeconds);
+        startedAt.current = Date.now(); setElapsed(0); setActive(true);
+        if (timer.current) clearInterval(timer.current);
+        timer.current = window.setInterval(() => {
+          if (!startedAt.current) return; setElapsed(Math.floor((Date.now() - startedAt.current) / 1000));
+        }, 250);
+      } else if (d.state === "headers") {
+        if (Number.isFinite(d.minSeconds)) setMin(d.minSeconds);
+      } else if (d.state === "stop") {
+        if (timer.current) clearInterval(timer.current); timer.current = null;
+        startedAt.current = null; setActive(false); setElapsed(0);
+      }
+    }
+    window.addEventListener("medx-thinking", onEvt as any);
+    return () => { window.removeEventListener("medx-thinking", onEvt as any); if (timer.current) clearInterval(timer.current); };
+  }, []);
+
+  if (!active) return null;
+  const mm = String(Math.floor(elapsed/60)).padStart(2,"0");
+  const ss = String(elapsed%60).padStart(2,"0");
+
+  return (
+    <div className={`flex items-center gap-2 text-sm text-gray-500 ${className}`}>
+      <span className="relative inline-flex">
+        <span className="h-2.5 w-2.5 rounded-full bg-gray-400 opacity-70" />
+        <span className="absolute h-2.5 w-2.5 rounded-full animate-ping bg-gray-400 opacity-40" />
+      </span>
+      <span className="font-medium">{label}</span>
+      <span className="tabular-nums">• {mm}:{ss}</span>
+      {showMin && <span className="opacity-70"> (min {min}s)</span>}
+    </div>
+  );
+}

--- a/lib/medx/audience.ts
+++ b/lib/medx/audience.ts
@@ -1,53 +1,43 @@
 export type Audience = "clinician" | "patient";
 
-/**
- * Map your app modes to output audience:
- * - "doctor" -> clinician
- * - "doc ai"/"aidoc"/"doc_ai"/"doc-mode" -> patient explainer
- * - "patient"/"patient mode" -> patient explainer
- * Default -> patient explainer
- */
 export function detectAudience(mode?: string, hint?: string): Audience {
   const raw = (hint || mode || "").toLowerCase().trim();
-  const norm = raw.replace(/[^a-z0-9]/g, ""); // e.g., "doc ai" -> "docai"
-
-  // Explicit hints win
+  const norm = raw.replace(/[^a-z0-9]/g, "");
   if (raw === "clinician") return "clinician";
   if (raw === "patient") return "patient";
-
-  // Doctor-only, clinician-facing
-  if (["doctor", "doctormode", "clinician", "research", "md"].includes(norm)) return "clinician";
-
-  // Doc AI / Patient modes -> patient-facing explainer
-  if (["docai", "aidoc", "aidocmode", "docmode", "docreader", "patient", "patientmode"].includes(norm)) {
-    return "patient";
-  }
-
+  if (["doctor","doctormode","clinician","research","md"].includes(norm)) return "clinician";
+  if (["docai","aidoc","aidocmode","docmode","docreader","patient","patientmode"].includes(norm)) return "patient";
   return "patient";
 }
 
-/** Clinician style — terse, operational, SBAR-ish */
 export const clinicianStyle = `
-Format for a clinician. Be terse and operational. No lay disclaimers, no 911/ambulance language.
+Format for a clinician. Be terse and operational. No lay disclaimers; no 911 language.
+DO NOT show formulas or derivations.
+HARD LIMITS: at most ${process.env.CLINICIAN_MAX_LINES ?? 12} lines; each line ≤ ${process.env.CLINICIAN_MAX_WORDS_PER_LINE ?? 12} words.
 Use these exact single-line sections (in order):
 Acuity: <Critical/High/Moderate> | NEWS2 <n> | qSOFA <n>
 Key abnormalities: <comma-separated vitals/abnormal values>
 Impression: <most likely pathophysiology / top dx cluster>
-Immediate steps: <first-hour actions: O2/IV/fluids/antibiotics etc.>
+Immediate steps: <first-hour actions>
+MDM (concise): <one-line clinical reasoning; no formulas>   // up to 3 lines allowed
 Recommended tests: <ABG/VBG, labs, imaging, scores>
 Disposition: <ED resus / ICU consult / ward / clinic / home with safety-net>
 Keep each line concise. Avoid narrative paragraphs.
 `;
 
-/** Patient/Doc-AI style — simple explainer + “Further tests” */
 export const patientStyle = `
-Format for a general reader. Keep it simple and under ~6 short bullets.
-Include these sections (exact labels):
-Summary: <what the numbers mean in plain language>
-Why this matters: <one brief line; flag if serious>
-What to do now: <clear next action; self-care vs see doctor vs ER>
-Further tests: <only if helpful; list 2–5 likely next tests>
-Safety net: <when to seek urgent/emergency care, if applicable>
-Avoid medical jargon; explain terms briefly when needed.
+Format for a general reader. Be clear and brief.
+HARD LIMITS: ${process.env.PATIENT_MAX_BULLETS ?? 6} bullets; each ≤ ${process.env.PATIENT_MAX_WORDS_PER_BULLET ?? 18} words.
+Include:
+Summary: <plain-language meaning>
+Why this matters: <one brief line>
+What to do now: <clear next action>
+Further tests: <2–5 tests>
+Safety net: <when to seek urgent care>
 `;
 
+export function maxTokensFor(a: Audience): number {
+  const P = parseInt(process.env.PATIENT_MAX_TOKENS || "", 10) || 220;
+  const C = parseInt(process.env.CLINICIAN_MAX_TOKENS || "", 10) || 220;
+  return a === "clinician" ? C : P;
+}

--- a/lib/medx/doctorFormat.ts
+++ b/lib/medx/doctorFormat.ts
@@ -1,0 +1,43 @@
+export type DoctorSBAR = {
+  acuity?: string;
+  abnormalities?: string[];
+  impression?: string;
+  immediate_steps?: string[];
+  summary?: string;             // MDM (concise)
+  recommended_tests?: string[];
+  disposition?: string;
+};
+
+function clipWords(s: string, n: number) {
+  const w = (s || "").trim().split(/\s+/);
+  return w.length <= n ? s || "" : w.slice(0, n).join(" ");
+}
+function joinClip(items: string[] = [], maxItems: number, maxWords: number) {
+  return items.filter(Boolean).slice(0, maxItems).map(x => clipWords(x, maxWords)).join(", ");
+}
+
+export function formatDoctorSBAR(
+  data: DoctorSBAR,
+  opts: { maxWordsPerLine?: number; maxItems?: number; mdmMaxLines?: number } = {}
+) {
+  const maxWords = Number(process.env.CLINICIAN_MAX_WORDS_PER_LINE || 12) || 12;
+  const maxItems = opts.maxItems ?? 5;
+  const mdmMax = Number(process.env.MDM_MAX_LINES || 3) || 3;
+
+  const lines: string[] = [];
+  lines.push(`Acuity: ${clipWords(data.acuity || "", maxWords)}`);
+  lines.push(`Key abnormalities: ${joinClip(data.abnormalities || [], maxItems, maxWords)}`);
+  lines.push(`Impression: ${clipWords(data.impression || "", maxWords)}`);
+  lines.push(`Immediate steps: ${joinClip(data.immediate_steps || [], maxItems, maxWords)}`);
+
+  const mdm = (data.summary || "").split(/\n+/).filter(Boolean).slice(0, mdmMax);
+  for (const m of mdm.length ? mdm : [""]) {
+    lines.push(`MDM (concise): ${clipWords(m, maxWords)}`);
+  }
+
+  lines.push(`Recommended tests: ${joinClip(data.recommended_tests || [], maxItems, maxWords)}`);
+  lines.push(`Disposition: ${clipWords(data.disposition || "", maxWords)}`);
+
+  const maxLines = Number(process.env.CLINICIAN_MAX_LINES || 12) || 12;
+  return lines.slice(0, maxLines).join("\n");
+}

--- a/lib/ux/thinking.ts
+++ b/lib/ux/thinking.ts
@@ -1,0 +1,20 @@
+type ThinkingEvent =
+  | { state: "start"; label?: string; minSeconds?: number }
+  | { state: "headers"; minSeconds?: number; provider?: string; model?: string }
+  | { state: "stop" };
+
+function emit(detail: ThinkingEvent) {
+  if (typeof window !== "undefined") window.dispatchEvent(new CustomEvent("medx-thinking", { detail }));
+}
+
+export const thinking = {
+  start(label = "Analyzing…", minSeconds?: number) { emit({ state: "start", label, minSeconds }); },
+  headers(res: Response) {
+    const h = res.headers;
+    const ms = Number(h.get("x-medx-min-delay") || "");
+    const provider = h.get("x-medx-provider") || undefined;
+    const model = h.get("x-medx-model") || undefined;
+    if (Number.isFinite(ms)) emit({ state: "headers", minSeconds: ms / 1000, provider, model });
+  },
+  stop() { emit({ state: "stop" }); }
+};

--- a/lib/ux/useTypewriterStream.ts
+++ b/lib/ux/useTypewriterStream.ts
@@ -1,0 +1,25 @@
+"use client";
+import * as React from "react";
+import { thinking } from "./thinking";
+
+export function useTypewriterStream() {
+  const [text, setText] = React.useState("");
+  const [isStreaming, setIsStreaming] = React.useState(false);
+
+  const stream = React.useCallback(async (url: string, body: any) => {
+    setText(""); setIsStreaming(true);
+    thinking.start("Analyzing…");
+    const res = await fetch(url, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+    thinking.headers(res);
+    const reader = res.body?.getReader(); const dec = new TextDecoder();
+    if (!reader) { setIsStreaming(false); thinking.stop(); return; }
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      setText(prev => prev + dec.decode(value));
+    }
+    setIsStreaming(false); thinking.stop();
+  }, []);
+
+  return { text, isStreaming, stream, setText };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,44 +1,31 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-// Force non-basic chats to OpenAI final endpoints while preserving your existing routes.
-// If the client sends `x-medx-mode: basic`, we let Groq/basic paths proceed untouched.
-// Memory/context code in existing handlers remains intact, we just rewrite the URL.
-
 export function middleware(req: NextRequest) {
   const url = req.nextUrl.clone();
   const path = url.pathname;
 
-  // Only consider chat routes
+  // Let docs analyzer bypass rewrites
+  const feature = (req.headers.get("x-medx-feature") || "").toLowerCase();
+  if (feature === "docs" || path.startsWith("/api/docs")) return NextResponse.next();
+
+  const defaultOpenAI = (process.env.OPENAI_REWRITE_DEFAULT || "true").toLowerCase() === "true";
+  const modeNorm = (req.headers.get("x-medx-mode") || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+  const isBasic = modeNorm === "basic" || modeNorm === "casual";
+  const isFinalMode = ["doctor","doctormode","clinician","research","docai","aidoc","aidocmode","docmode","patient","patientmode"].includes(modeNorm);
+  const shouldRewrite = defaultOpenAI ? !isBasic : isFinalMode;
+
   if (path === "/api/chat" || path === "/api/chat/stream") {
-    const mode = (req.headers.get("x-medx-mode") || "").toLowerCase();
-
-    const isBasic = mode === "basic" || mode === "casual";
-    if (!isBasic) {
-      // rewrite to final-say versions
-      if (path === "/api/chat") {
-        url.pathname = "/api/chat/final";
-      } else {
-        url.pathname = "/api/chat/stream-final";
-      }
+    if (shouldRewrite) {
+      url.pathname = path === "/api/chat" ? "/api/chat/final" : "/api/chat/stream-final";
       return NextResponse.rewrite(url);
     }
   }
-
-  // Triage paths: if you already post to /api/triage, you can similarly force:
-  if (path === "/api/triage") {
-    const mode = (req.headers.get("x-medx-mode") || "").toLowerCase();
-    const isBasic = mode === "basic" || mode === "casual";
-    if (!isBasic) {
-      url.pathname = "/api/triage-final";
-      return NextResponse.rewrite(url);
-    }
+  if (path === "/api/triage" && shouldRewrite) {
+    url.pathname = "/api/triage-final";
+    return NextResponse.rewrite(url);
   }
-
   return NextResponse.next();
 }
 
-// Limit to API routes for safety
-export const config = {
-  matcher: ["/api/:path*"],
-};
+export const config = { matcher: ["/api/:path*"] };


### PR DESCRIPTION
## Summary
- route non-basic requests to final OpenAI endpoints via middleware
- add audience-aware chat formatting and doctor SBAR utilities
- stream plain text responses with thinking timer hooks and UI component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c448dcebac832f86f17b3067ace8e9