### PR TITLE
feat: add MedX summary formatter

### DIFF
--- a/lib/medx/formatSummary.ts
+++ b/lib/medx/formatSummary.ts
@@ -1,0 +1,97 @@
+export type DoctorSummaryInput = {
+  acuity: 'Critical' | 'High' | 'Moderate';
+  news2?: number | null;
+  qsofa?: number | null;
+  keyAbnormalities: string[];
+  impression: string;
+  immediateSteps: string[];
+  mdm: string[]; // reasoning lines (≤3)
+  recommendedTests: string[];
+  disposition: string;
+  expanded?: boolean;
+};
+
+export type PatientSummaryInput = {
+  summary: string;
+  whyItMatters: string;
+  whatToDoNow: string[];
+  furtherTests: string[];
+  whatToExpect: string;
+  safetyNet: string;
+  expanded?: boolean;
+};
+
+function truncateWords(text: string, maxWords: number): string {
+  const words = text.trim().split(/\s+/);
+  if (words.length <= maxWords) return text.trim();
+  return words.slice(0, maxWords).join(' ');
+}
+
+function countTokens(text: string): number {
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function enforceTokenLimit(lines: string[], limit: number): string[] {
+  while (countTokens(lines.join(' ')) > limit && lines.length > 0) {
+    lines.pop();
+  }
+  return lines;
+}
+
+function formatDoctorSummary(input: DoctorSummaryInput, tokenLimit: number): string {
+  const lines: string[] = [];
+  const news2 = input.news2 ?? '—';
+  const qsofa = input.qsofa ?? '—';
+  lines.push(`Acuity: ${input.acuity} | NEWS2 ${news2} | qSOFA ${qsofa}`);
+  if (input.keyAbnormalities?.length) {
+    lines.push(`Key abnormalities: ${truncateWords(input.keyAbnormalities.join('; '), 12)}`);
+  }
+  lines.push(`Impression: ${truncateWords(input.impression, 12)}`);
+  if (input.immediateSteps?.length) {
+    lines.push(`Immediate steps: ${truncateWords(input.immediateSteps.join('; '), 12)}`);
+  }
+  if (input.mdm?.length) {
+    input.mdm.slice(0, 3).forEach(m => {
+      lines.push(`MDM: ${truncateWords(m, 12)}`);
+    });
+  }
+  if (input.recommendedTests?.length) {
+    lines.push(`Recommended tests: ${truncateWords(input.recommendedTests.join('; '), 12)}`);
+  }
+  lines.push(`Disposition: ${truncateWords(input.disposition, 12)}`);
+
+  const limited = enforceTokenLimit(lines.slice(0, 12).map(l => truncateWords(l, 12)), tokenLimit);
+  return limited.join('\n');
+}
+
+function formatPatientSummary(input: PatientSummaryInput, tokenLimit: number): string {
+  const bullets: string[] = [];
+  bullets.push(`• ${truncateWords(input.summary, 18)}`);
+  bullets.push(`• Why this matters: ${truncateWords(input.whyItMatters, 18)}`);
+  bullets.push(`• What to do now: ${truncateWords(input.whatToDoNow.join('; '), 18)}`);
+  if (input.furtherTests?.length) {
+    bullets.push(`• Further tests: ${truncateWords(input.furtherTests.join('; '), 18)}`);
+  }
+  bullets.push(`• What to expect: ${truncateWords(input.whatToExpect, 18)}`);
+  bullets.push(`• Safety net: ${truncateWords(input.safetyNet, 18)}`);
+
+  const limited = enforceTokenLimit(bullets.slice(0, 6).map(b => truncateWords(b, 18)), tokenLimit);
+  return limited.join('\n');
+}
+
+/**
+ * Format structured summary per MEDX_FORMAT_V1.
+ * @param mode provided mode string (doctor, doc ai, patient). doctor wins if combined.
+ */
+export function formatMedxSummary(mode: string, input: DoctorSummaryInput | PatientSummaryInput): string {
+  const raw = (mode || '').toLowerCase();
+  const expanded = (input as any).expanded || raw.includes('expanded');
+  const tokenLimit = expanded ? 350 : 220;
+  const isDoctor = raw.includes('doctor');
+  const effMode = isDoctor ? 'doctor' : 'patient';
+  return effMode === 'doctor'
+    ? formatDoctorSummary(input as DoctorSummaryInput, tokenLimit)
+    : formatPatientSummary(input as PatientSummaryInput, tokenLimit);
+}
+
+export default formatMedxSummary;

--- a/test/medx.test.ts
+++ b/test/medx.test.ts
@@ -4,6 +4,7 @@ import { normalizeTopic } from '@/lib/topic/normalize';
 import { routeIntent } from '@/lib/intent-router';
 import { buildMedicationShortSummary } from '@/lib/meds/shortSummary';
 import { chronicMedEducation } from '@/lib/meds/chronicEdu';
+import { formatMedxSummary } from '@/lib/medx/formatSummary';
 
 describe('topic normalize', () => {
   it('maps slip disk to canonical', () => {
@@ -50,5 +51,40 @@ describe('chronic medication education', () => {
     assert.equal(res.chronicMeds.length, 1);
     assert.equal(res.chronicMeds[0].name, 'Metformin');
     assert.deepEqual(res.unrecognized, ['UnknownMed']);
+  });
+});
+
+describe('MEDX_FORMAT_V1 formatter', () => {
+  it('formats clinician style summary', () => {
+    const out = formatMedxSummary('doctor', {
+      acuity: 'High',
+      news2: 4,
+      qsofa: 1,
+      keyAbnormalities: ['HR 120', 'Cr 2.1'],
+      impression: 'Sepsis likely from pneumonia',
+      immediateSteps: ['Broad-spectrum antibiotics', 'IV fluids'],
+      mdm: ['Likely sepsis from pneumonia', 'Monitor lactate'],
+      recommendedTests: ['Blood cultures', 'CXR'],
+      disposition: 'ICU if unstable; otherwise ward',
+    });
+    const lines = out.split('\n');
+    assert.ok(lines[0].startsWith('Acuity: High'));
+    assert.ok(lines.some(l => l.startsWith('MDM:')));
+    assert.ok(lines.length <= 12);
+  });
+
+  it('formats patient style summary', () => {
+    const out = formatMedxSummary('patient', {
+      summary: 'You have a chest infection causing cough.',
+      whyItMatters: 'Untreated infections can worsen.',
+      whatToDoNow: ['Rest', 'Drink fluids'],
+      furtherTests: ['Chest X-ray'],
+      whatToExpect: 'Symptoms should improve in a week.',
+      safetyNet: 'Go to ER if breathing worsens.',
+    });
+    const lines = out.split('\n');
+    assert.equal(lines.length, 6);
+    assert.ok(lines[0].startsWith('•'));
+    assert.ok(lines[0].includes('chest infection'));
   });
 });


### PR DESCRIPTION
## Summary
- add `formatMedxSummary` to generate clinician and patient summaries following MEDX_FORMAT_V1
- test doctor and patient mode formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c46295df34832f9e5bb0b9acf917dd