### PR TITLE
feat: add aidoc triage helper and DB

### DIFF
--- a/app/api/aidoc/chat/route.ts
+++ b/app/api/aidoc/chat/route.ts
@@ -1,1 +1,48 @@
-export { POST } from '../../chat/stream/route';
+import { NextRequest, NextResponse } from 'next/server';
+// [AIDOC_TRIAGE_IMPORT] add triage imports
+import { handleDocAITriage, detectExperientialIntent } from "@/lib/aidoc/triage";
+import { POST as streamPOST, runtime } from "../../chat/stream/route";
+
+export { runtime };
+
+export async function POST(req: NextRequest) {
+  const cloned = req.clone();
+  const body = await req.json().catch(() => ({} as any));
+  const message = (body?.message ?? body?.text ?? "").toString();
+  const answers = (body?.answers && typeof body.answers === "object") ? body.answers : null;
+
+  // [AIDOC_TRIAGE_GUARD] intercept before streaming
+  if (process.env.FEATURE_TRIAGE_V2 === "1" && message && detectExperientialIntent(message)) {
+    try {
+      const triage = await handleDocAITriage({ text: message, answers });
+
+      if (triage.stage === "demographics") {
+        return NextResponse.json({
+          role: "assistant",
+          stage: "demographics",
+          prompt: "Hey—let’s get a couple basics first:",
+          questions: triage.questions,
+        });
+      }
+      if (triage.stage === "intake") {
+        return NextResponse.json({
+          role: "assistant",
+          stage: "intake",
+          prompt: "Hey, hang in there—I need a few quick details:",
+          questions: triage.questions,
+        });
+      }
+      return NextResponse.json({
+        role: "assistant",
+        stage: "advice",
+        message: triage.message,
+        soap: triage.soap,
+      });
+    } catch {
+      // fall through to legacy stream
+    }
+  }
+
+  // ... your existing streaming setup continues here
+  return streamPOST(cloned);
+}

--- a/app/api/aidoc/chat/route.ts
+++ b/app/api/aidoc/chat/route.ts
@@ -43,6 +43,6 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  // ... your existing streaming setup continues here
-  return streamPOST(cloned);
+  // existing streaming setup continues here
+  return streamPOST(cloned as any);
 }

--- a/app/api/aidoc/chat/route.ts
+++ b/app/api/aidoc/chat/route.ts
@@ -10,11 +10,29 @@ export async function POST(req: NextRequest) {
   const body = await req.json().catch(() => ({} as any));
   const message = (body?.message ?? body?.text ?? "").toString();
   const answers = (body?.answers && typeof body.answers === "object") ? body.answers : null;
+  const incomingProfile = (body?.profile && typeof body.profile === "object") ? body.profile : null;
+
+  // ensure you have resolved the `profile` object here
+  // profile = { name, age, sex, pregnant }
+  const profile: any = undefined;
+
+  const demoFromAnswers = (answers && typeof (answers as any).demographics === "object") ? (answers as any).demographics : null;
+  const triageProfile = {
+    name: (incomingProfile as any)?.name ?? profile?.name,
+    age: (incomingProfile as any)?.age ?? profile?.age,
+    sex: (incomingProfile as any)?.sex ?? profile?.sex,
+    pregnant: (incomingProfile as any)?.pregnant ?? profile?.pregnant,
+    ...(demoFromAnswers ?? {}),
+  };
 
   // [AIDOC_TRIAGE_GUARD] intercept before streaming
   if (process.env.FEATURE_TRIAGE_V2 === "1" && message && detectExperientialIntent(message)) {
     try {
-      const triage = await handleDocAITriage({ text: message, answers });
+      const triage = await handleDocAITriage({
+        text: message,
+        profile: triageProfile,
+        answers: (answers && typeof (answers as any).intake === "object") ? (answers as any).intake : answers,
+      });
 
       if (triage.stage === "demographics") {
         return NextResponse.json({

--- a/app/api/aidoc/message/route.ts
+++ b/app/api/aidoc/message/route.ts
@@ -6,13 +6,33 @@ export async function POST(req: Request) {
   const body = await req.json().catch(() => ({} as any));
   const message = (body?.message ?? body?.text ?? "").toString();
   const boot = body?.boot === true;
-  // optional structured answers from the UI after intake questions
+  // Structured payloads from UI
   const answers = (body?.answers && typeof body.answers === "object") ? body.answers : null;
+  const incomingProfile = (body?.profile && typeof body.profile === "object") ? body.profile : null;
+
+  // ensure you have resolved the `profile` object here
+  // profile = { name, age, sex, pregnant }
+  const profile: any = undefined;
+
+  // Merge demographics from request (or from answers.demographics) into profile for triage
+  const demoFromAnswers = (answers && typeof (answers as any).demographics === "object") ? (answers as any).demographics : null;
+  const triageProfile = {
+    name: (incomingProfile as any)?.name ?? profile?.name,
+    age: (incomingProfile as any)?.age ?? profile?.age,
+    sex: (incomingProfile as any)?.sex ?? profile?.sex,
+    pregnant: (incomingProfile as any)?.pregnant ?? profile?.pregnant,
+    ...(demoFromAnswers ?? {}),
+  };
 
   // [AIDOC_TRIAGE_GUARD] run triage first; early-return on success
   if (process.env.FEATURE_TRIAGE_V2 === "1" && message && detectExperientialIntent(message)) {
     try {
-      const triage = await handleDocAITriage({ text: message, answers });
+      const triage = await handleDocAITriage({
+        text: message,
+        profile: triageProfile,
+        // Prefer answers.intake if UI separates demographics vs intake
+        answers: (answers && typeof (answers as any).intake === "object") ? (answers as any).intake : answers,
+      });
 
       if (triage.stage === "demographics") {
         return NextResponse.json({

--- a/app/api/aidoc/message/route.ts
+++ b/app/api/aidoc/message/route.ts
@@ -1,7 +1,46 @@
 import { NextResponse } from 'next/server';
+// [AIDOC_TRIAGE_IMPORT] add triage imports
+import { handleDocAITriage, detectExperientialIntent } from "@/lib/aidoc/triage";
 
 export async function POST(req: Request) {
-  const { text = "", boot = false } = await req.json();
+  const body = await req.json().catch(() => ({} as any));
+  const message = (body?.message ?? body?.text ?? "").toString();
+  const boot = body?.boot === true;
+  // optional structured answers from the UI after intake questions
+  const answers = (body?.answers && typeof body.answers === "object") ? body.answers : null;
+
+  // [AIDOC_TRIAGE_GUARD] run triage first; early-return on success
+  if (process.env.FEATURE_TRIAGE_V2 === "1" && message && detectExperientialIntent(message)) {
+    try {
+      const triage = await handleDocAITriage({ text: message, answers });
+
+      if (triage.stage === "demographics") {
+        return NextResponse.json({
+          role: "assistant",
+          stage: "demographics",
+          prompt: "Hey—let’s get a couple basics first:",
+          questions: triage.questions,
+        });
+      }
+      if (triage.stage === "intake") {
+        return NextResponse.json({
+          role: "assistant",
+          stage: "intake",
+          prompt: "Hey, hang in there—I need a few quick details:",
+          questions: triage.questions,
+        });
+      }
+      return NextResponse.json({
+        role: "assistant",
+        stage: "advice",
+        message: triage.message,
+        soap: triage.soap,
+      });
+    } catch {
+      // fall through to legacy behavior
+    }
+  }
+
   // Only emit canned welcome on explicit boot; never on user greetings
   if (boot === true) {
     return NextResponse.json({

--- a/lib/aidoc/data/symptoms_master.json
+++ b/lib/aidoc/data/symptoms_master.json
@@ -1,0 +1,17 @@
+{
+  "fever": {
+    "questions": [
+      "How many days have you had a fever?",
+      "What was the highest temperature recorded?",
+      "Is it constant or does it come and go?"
+    ],
+    "self_care": [
+      "Stay hydrated and rest.",
+      "Light clothing and a cool room."
+    ],
+    "red_flags": [
+      "Fever above 103°F",
+      "Severe headache or neck stiffness"
+    ]
+  }
+}

--- a/lib/aidoc/triage.ts
+++ b/lib/aidoc/triage.ts
@@ -1,18 +1,9 @@
-// Runtime-safe symptom DB load from lib/aidoc/data/symptoms_master.json
-import fs from "node:fs";
-import path from "node:path";
+// Edge-safe static import (bundled at build time)
+// Ensure tsconfig has: "resolveJsonModule": true, "esModuleInterop": true
+import symptomsDB from "@/lib/aidoc/data/symptoms_master.json";
 
 type SymptomRecord = { questions: string[]; self_care: string[]; red_flags: string[] };
 type SymptomDB = Record<string, SymptomRecord>;
-
-let symptomsDB: SymptomDB = {};
-try {
-  const filePath = path.join(process.cwd(), "lib", "aidoc", "data", "symptoms_master.json");
-  if (fs.existsSync(filePath)) {
-    const raw = fs.readFileSync(filePath, "utf-8");
-    symptomsDB = JSON.parse(raw) as SymptomDB;
-  }
-} catch { /* fall back to generic intake */ }
 
 export type Profile = {
   name?: string;

--- a/lib/aidoc/triage.ts
+++ b/lib/aidoc/triage.ts
@@ -1,0 +1,134 @@
+// Runtime-safe symptom DB load from lib/aidoc/data/symptoms_master.json
+import fs from "node:fs";
+import path from "node:path";
+
+type SymptomRecord = { questions: string[]; self_care: string[]; red_flags: string[] };
+type SymptomDB = Record<string, SymptomRecord>;
+
+let symptomsDB: SymptomDB = {};
+try {
+  const filePath = path.join(process.cwd(), "lib", "aidoc", "data", "symptoms_master.json");
+  if (fs.existsSync(filePath)) {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    symptomsDB = JSON.parse(raw) as SymptomDB;
+  }
+} catch { /* fall back to generic intake */ }
+
+export type Profile = {
+  name?: string;
+  age?: number;
+  sex?: "M" | "F" | "Other";
+  pregnant?: boolean | "Yes" | "No" | "Not sure";
+};
+
+export type TriageStage =
+  | { stage: "demographics"; questions: string[] }
+  | { stage: "intake"; questions: string[] }
+  | { stage: "advice"; message: string; soap: any };
+
+export function detectExperientialIntent(text: string): boolean {
+  const t = (text || "").toLowerCase();
+  return /\b(i have|i’m|im|fever|cough|pain|nausea|vomit|diarrhea|rash|shortness of breath)\b/i.test(t);
+}
+
+export function missingDemographics(p: Profile = {}): string[] {
+  const q: string[] = [];
+  if (!p.name) q.push("What is your name?");
+  if (p.age == null) q.push("How old are you?");
+  if (!p.sex) q.push("What is your gender (M/F/Other)?");
+  if (p.sex === "F" && typeof p.age === "number" && p.age >= 12 && p.age <= 50 && p.pregnant == null) {
+    q.push("Are you currently pregnant? (Yes/No/Not sure)");
+  }
+  return q;
+}
+
+function friendly(lines: string[]): string {
+  const soften = (s: string) =>
+    s.replace(/Provide details/gi, "Could you tell me a bit more?")
+     .replace(/Any red flags/gi, "Just checking—any major warning signs?");
+  return lines.map(soften).join("\n");
+}
+
+function buildSOAP({
+  name, age, sex, chiefComplaint, answersSummary,
+}: {
+  name?: string; age?: number; sex?: string; chiefComplaint: string; answersSummary: string;
+}) {
+  return {
+    subjective: `${name ? name + ", " : ""}${age ?? "?"}/${sex ?? "?"}\nCC: ${chiefComplaint}. HPI: ${answersSummary}`,
+    objective: "Self-reported; no physical exam performed.",
+    assessment: "Most consistent with a self-limited illness unless red flags are present.",
+    plan: [
+      "Self-care: fluids, rest, light meals; monitor symptoms.",
+      "Safety: if any warning signs develop, seek urgent care.",
+      "Follow-up: if not improving in 48–72 hours or worsening.",
+    ],
+  };
+}
+
+export async function handleDocAITriage({
+  text,
+  symptom,
+  answers,
+  profile,
+}: {
+  text: string;
+  symptom?: string;
+  answers?: Record<string, any> | null;
+  profile?: Profile;
+}): Promise<TriageStage> {
+  const p = profile || {};
+
+  // 1) Demographics
+  const missing = missingDemographics(p);
+  if (missing.length) return { stage: "demographics", questions: missing };
+
+  // 2) Intake from DB or fallback
+  const key = (symptom || text || "").toLowerCase().trim();
+  const entry = (symptomsDB && symptomsDB[key]) || null;
+
+  const intakeQs: string[] = entry?.questions ?? [
+    "How long has this been going on?",
+    "How severe is it (mild/moderate/severe)?",
+    "Is it constant or does it come and go?",
+    "Anything that makes it better or worse?",
+    "Any other symptoms you’ve noticed?",
+  ];
+
+  if (!answers || Object.keys(answers).length === 0) {
+    return { stage: "intake", questions: intakeQs.slice(0, 6) };
+  }
+
+  // 3) Advice + SOAP
+  const pairs = Object.entries(answers).map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(", ") : v}`);
+  const summary = pairs.join("; ");
+
+  const tips: string[] = entry?.self_care ?? [
+    "Rest as needed and stay hydrated.",
+    "Keep the room comfortably cool; light clothing.",
+    "Monitor symptoms; avoid strenuous activity.",
+  ];
+  const red: string[] = entry?.red_flags ?? [
+    "Severe or rapidly worsening symptoms",
+    "Chest pain, confusion, or difficulty breathing",
+    "Persistent vomiting, dehydration, or bleeding",
+  ];
+
+  const msg = friendly([
+    `Thanks—got it. Considering ${key || "your concern"}: ${summary}.`,
+    "",
+    "Basic steps to feel better (no medications unless you ask):",
+    ...tips.map((t) => `• ${t}`),
+    "",
+    "If any of these occur, seek urgent care:",
+    ...red.map((r) => `• ${r}`),
+    "",
+    "Any more symptoms you’d like to share?",
+  ]);
+
+  const soap = buildSOAP({
+    name: p.name, age: p.age, sex: p.sex, chiefComplaint: key || "symptom", answersSummary: summary,
+  });
+
+  return { stage: "advice", message: msg, soap };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "jsx": "preserve",
     "strict": false,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- add runtime-safe symptom database and triage helper for Doc AI
- integrate triage flow into /api/aidoc message and chat routes
- seed symptom DB with minimal fever entry

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68c50090f240832fb412c7b3de4b1d92