### PR TITLE
Add AI Doc panel and refine mode controls

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,12 @@
 "use client";
+import SearchDock from "@/components/search/SearchDock";
 import { useEffect, useRef } from "react";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
 import Timeline from "@/components/panels/Timeline";
 import AlertsPane from "@/components/panels/AlertsPane";
 import SettingsPane from "@/components/panels/SettingsPane";
+import AiDocPane from "@/components/panels/AiDocPane";
 import { ResearchFiltersProvider } from '@/store/researchFilters';
 
 type Search = { panel?: string; threadId?: string };
@@ -19,8 +21,18 @@ export default function Page({ searchParams }: { searchParams: Search }) {
     return () => window.removeEventListener("focus-chat-input", handler);
   }, []);
 
+  useEffect(() => {
+    if (panel === "ai-doc") {
+      document.dispatchEvent(new CustomEvent("research-mode", { detail: false }));
+      document.dispatchEvent(new CustomEvent("therapy-mode", { detail: false }));
+      try { localStorage.setItem("therapyMode", "off"); } catch {}
+    }
+  }, [panel]);
+
   return (
     <main className="flex-1 overflow-y-auto content-layer">
+      {/* Centered landing search; docks after first submit */}
+      <SearchDock onSubmit={(q)=>window.location.assign(`/?panel=chat&q=${encodeURIComponent(q)}`)} />
       <section className={panel === "chat" ? "block h-full" : "hidden"}>
         <ResearchFiltersProvider>
           <ChatPane inputRef={chatInputRef} />
@@ -41,6 +53,10 @@ export default function Page({ searchParams }: { searchParams: Search }) {
 
       <section className={panel === "settings" ? "block" : "hidden"}>
         <SettingsPane />
+      </section>
+
+      <section className={panel === "ai-doc" ? "block" : "hidden"}>
+        <AiDocPane />
       </section>
     </main>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { User, Stethoscope } from 'lucide-react';
 import ThemeToggle from './ThemeToggle';
 import { ResearchToggle } from './ResearchToggle';
 import TherapyToggle from './TherapyToggle';
@@ -27,22 +26,45 @@ export default function Header({
           <CountryGlobe />
         </div>
         <div className="flex items-center gap-2">
-          <TherapyToggle onChange={onTherapyChange} />
-          <button
-            onClick={() => onModeChange(mode === 'patient' ? 'doctor' : 'patient')}
-            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-xl text-sm medx-surface text-medx"
-          >
-            {mode === 'patient' ? (
-              <>
-                <User size={16} /> Patient
-              </>
-            ) : (
-              <>
-                <Stethoscope size={16} /> Doctor
-              </>
-            )}
-          </button>
-          <ResearchToggle defaultOn={researchOn} onChange={onResearchChange} />
+          <TherapyToggle
+            onChange={(on) => {
+              if (on && mode !== 'patient') {
+                document.dispatchEvent(
+                  new CustomEvent('toast', { detail: { text: 'Therapy works only with Patient mode.' } })
+                );
+                onTherapyChange(false);
+                return;
+              }
+              onTherapyChange(on);
+            }}
+          />
+          <div className="inline-flex rounded-xl border p-1 dark:border-neutral-800">
+            <button
+              onClick={() => onModeChange('patient')}
+              className={`px-3 py-1.5 rounded-lg ${mode==='patient' ? 'bg-blue-600 text-white' : 'bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100'}`}
+            >
+              Patient
+            </button>
+            <button
+              onClick={() => onModeChange('doctor')}
+              className={`px-3 py-1.5 rounded-lg ${mode==='doctor' ? 'bg-blue-600 text-white' : 'bg-white text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100'}`}
+            >
+              Doctor
+            </button>
+          </div>
+          <ResearchToggle
+            defaultOn={researchOn}
+            onChange={(on) => {
+              if (on && !mode) {
+                document.dispatchEvent(
+                  new CustomEvent('toast', { detail: { text: 'Select Patient or Doctor to use Research.' } })
+                );
+                onResearchChange(false);
+                return;
+              }
+              onResearchChange(on);
+            }}
+          />
           <ThemeToggle />
         </div>
       </div>

--- a/components/nav/Brand.tsx
+++ b/components/nav/Brand.tsx
@@ -1,16 +1,14 @@
 "use client";
-
 import Link from "next/link";
-
 export default function Brand() {
   return (
-    <Link href="/" aria-label="MedX Home"
-      onClick={() => {
-        // Optional: reset transient UI session state:
-        try { sessionStorage.removeItem("search_docked"); } catch {}
-      }}
-      className="inline-flex items-center gap-2">
-      <img src="/medx-logo.svg" alt="MedX" className="h-6 w-auto" />
+    <Link
+      href="/"
+      aria-label="MedX Home"
+      onClick={() => { try { sessionStorage.removeItem("search_docked"); } catch {} }}
+      className="text-xl font-semibold tracking-tight"
+    >
+      MedX
     </Link>
   );
 }

--- a/components/panels/AiDocPane.tsx
+++ b/components/panels/AiDocPane.tsx
@@ -18,7 +18,12 @@ export default function AiDocPane() {
 
   useEffect(() => {
     resetForThread(threadId);
-    fetch('/api/aidoc/message', { method: 'POST', body: JSON.stringify({ threadId, op: 'boot' }) });
+    const KEY = "aidoc_booted";
+    const booted = typeof window !== 'undefined' && sessionStorage.getItem(KEY) === '1';
+    if (!booted) {
+      try { sessionStorage.setItem(KEY, '1'); } catch {}
+      fetch('/api/aidoc/message', { method: 'POST', body: JSON.stringify({ threadId, op: 'boot' }) });
+    }
   }, [threadId, resetForThread]);
 
   return <div className="p-4">AI Doc</div>;

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -320,6 +320,20 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     (useRef<HTMLTextAreaElement>(null) as RefObject<HTMLTextAreaElement>);
   const { filters } = useResearchFilters();
 
+  useEffect(() => {
+    const handleResearch = () => setResearchMode(false);
+    const handleTherapy = () => {
+      setTherapyMode(false);
+      try { localStorage.setItem('therapyMode', 'off'); } catch {}
+    };
+    document.addEventListener('research-mode', handleResearch);
+    document.addEventListener('therapy-mode', handleTherapy);
+    return () => {
+      document.removeEventListener('research-mode', handleResearch);
+      document.removeEventListener('therapy-mode', handleTherapy);
+    };
+  }, []);
+
   // Auto-resize the textarea up to a max height
   useEffect(() => {
     const el = (inputRef?.current as unknown as HTMLTextAreaElement | null);

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -12,13 +12,7 @@ type Tab = {
 
 const tabs: Tab[] = [
   { key: "chat", label: "Chat", panel: "chat" },
-  {
-    key: "ai-doc",
-    label: "AI Doc",
-    panel: "chat",
-    threadId: "med-profile",
-    context: "profile",
-  },
+  { key: "ai-doc", label: "AI Doc", panel: "ai-doc" },
   { key: "profile", label: "Medical Profile", panel: "profile" },
   { key: "timeline", label: "Timeline", panel: "timeline" },
   { key: "alerts", label: "Alerts", panel: "alerts" },


### PR DESCRIPTION
## Summary
- Mount SearchDock for centered landing search and add AI Doc panel
- Replace logo image with clickable text brand
- Split Patient/Doctor mode buttons and gate Therapy/Research toggles
- Prevent repeated AI Doc boot greetings and disable modes on AI Doc entry
- Fix sidebar AI Doc tab mapping

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint config prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bf450cf8832faf85f847931b0007