### PR TITLE
Streamline mode handling and AI Doc boot logic

### DIFF
--- a/app/api/aidoc/message/route.ts
+++ b/app/api/aidoc/message/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 // [AIDOC_TRIAGE_IMPORT] add triage imports
 import { handleDocAITriage, detectExperientialIntent } from "@/lib/aidoc/triage";
 import { getUserId } from "@/lib/getUserId";
@@ -6,15 +7,21 @@ import { prisma } from "@/lib/prisma";
 import { wasAskedOnce, markAsked } from "@/lib/aidoc/memory";
 
 export async function POST(req: Request) {
-  const body = await req.json().catch(() => ({} as any));
-  const message = (body?.message ?? body?.text ?? "").toString();
-  const op = body?.op;
-  const boot = body?.boot === true || op === "boot";
+  const payload = await req.json().catch(() => ({} as any));
+  const hasBooted = cookies().get("aidoc_booted")?.value === "1";
+  if (payload.op === "boot" && !hasBooted) {
+    cookies().set("aidoc_booted", "1", { httpOnly: true, sameSite: "lax" });
+    return NextResponse.json({ type: "greeting", text: "Hi, how can I help today?" });
+  }
+
+  const message = (payload?.message ?? payload?.text ?? "").toString();
+  const op = payload?.op;
+  const boot = payload?.boot === true || op === "boot";
   const userId = (await getUserId()) ?? "";
-  const threadId = body.threadId || "aidoc:" + userId;
+  const threadId = payload.threadId || "aidoc:" + userId;
   // Structured payloads from UI
-  const answers = (body?.answers && typeof body.answers === "object") ? body.answers : null;
-  const incomingProfile = (body?.profile && typeof body.profile === "object") ? body.profile : null;
+  const answers = (payload?.answers && typeof payload.answers === "object") ? payload.answers : null;
+  const incomingProfile = (payload?.profile && typeof payload.profile === "object") ? payload.profile : null;
 
   // ensure you have resolved the `profile` object here
   // profile = { name, age, sex, pregnant }
@@ -68,7 +75,8 @@ export async function POST(req: Request) {
   }
 
   // Only emit canned welcome on explicit boot; never on user greetings
-  if (boot === true) {
+  if (boot === true && !hasBooted) {
+    cookies().set("aidoc_booted", "1", { httpOnly: true, sameSite: "lax" });
     return NextResponse.json({
       messages: [
         { role: "assistant", content: "Hi! 👋 How can I help today? You can describe symptoms or upload a report." }
@@ -76,7 +84,7 @@ export async function POST(req: Request) {
     });
   }
   if (!boot) {
-    const title = body.title ?? inferTitleFromText(message);
+    const title = payload.title ?? inferTitleFromText(message);
     await prisma.chatThread.upsert({
       where: { id: threadId },
       create: { id: threadId, userId, type: "aidoc", title },

--- a/components/panels/AiDocPane.tsx
+++ b/components/panels/AiDocPane.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useAidocStore } from '@/stores/useAidocStore';
 
 export default function AiDocPane() {
@@ -8,17 +8,28 @@ export default function AiDocPane() {
   const searchParams = useSearchParams();
   const resetForThread = useAidocStore(s => s.resetForThread);
 
-  function newAidocThread() {
-    const id = `aidoc_${Date.now().toString(36)}`;
-    router.push(`?panel=ai-doc&threadId=${id}&context=profile`);
-    return id;
-  }
+  const threadId = searchParams.get('threadId');
 
-  const threadId = useMemo(() => searchParams.get('threadId') ?? newAidocThread(), [searchParams]);
+  // When opening AiDocPane, reuse existing threadId if present
+  useEffect(() => {
+    if (!threadId) {
+      const saved = sessionStorage.getItem("aidoc_thread");
+      if (saved) {
+        router.push(`?panel=ai-doc&threadId=${saved}&context=profile`);
+      } else {
+        const id = `aidoc_${Date.now().toString(36)}`;
+        sessionStorage.setItem("aidoc_thread", id);
+        router.push(`?panel=ai-doc&threadId=${id}&context=profile`);
+      }
+    }
+  }, [threadId, router]);
 
   useEffect(() => {
+    if (!threadId) return;
     resetForThread(threadId);
-    fetch('/api/aidoc/message', { method: 'POST', body: JSON.stringify({ threadId, op: 'boot' }) });
+    if (sessionStorage.getItem("aidoc_booted")) return;
+    sessionStorage.setItem("aidoc_booted", "1");
+    fetch("/api/aidoc/message", { method: "POST", body: JSON.stringify({ threadId, op: "boot" }) });
   }, [threadId, resetForThread]);
 
   return <div className="p-4">AI Doc</div>;

--- a/lib/modes/controller.ts
+++ b/lib/modes/controller.ts
@@ -6,27 +6,30 @@ export function nextModes(prev: ModeState, action: { type: string; value?: any }
 
   switch (action.type) {
     case "ui:set":
-      s.ui = action.value; // "patient" | "doctor"
-      if (s.ui !== "patient") s.therapy = false;            // a) therapy only with patient
-      if (!s.ui) { s.research = false; }                    // guard
-      if (s.aidoc) { /* aidoc overrides below */ }
+      s.ui = action.value;
+      if (s.ui !== "patient") s.therapy = false;
       break;
+
     case "therapy:toggle":
-      if (s.aidoc) { prompt = "AI Doc is standalone. Turn it off to enable Therapy."; break; }
-      if (s.ui !== "patient") { s.therapy = false; prompt = "Therapy Mode works only with Patient Mode."; break; }
+      if (s.aidoc) { prompt = "AI Doc runs by itself. Turn it off for Therapy."; break; }
+      if (s.ui !== "patient") { prompt = "Therapy works only with Patient mode."; s.therapy = false; break; }
       s.therapy = !s.therapy;
       break;
+
     case "research:toggle":
-      if (s.aidoc) { prompt = "AI Doc is standalone. Turn it off to enable Research."; break; }
-      if (!s.ui) { prompt = "Choose Patient (simple) or Doctor (clinical) to use Research."; break; }
-      s.research = !s.research; // c) allowed with patient/doctor
+      if (s.aidoc) { prompt = "AI Doc runs by itself. Turn it off for Research."; break; }
+      if (!s.ui) { prompt = "Pick Patient or Doctor mode first."; break; }
+      s.research = !s.research;
       break;
+
     case "aidoc:toggle":
-      s.aidoc = !s.aidoc; 
-      if (s.aidoc) { s.therapy = false; s.research = false; /* standalone */ }
+      s.aidoc = !s.aidoc;
+      if (s.aidoc) { s.therapy = false; s.research = false; }
       break;
+
     case "dark:toggle":
       s.dark = !s.dark; break;
   }
+
   return { state: s, prompt };
 }


### PR DESCRIPTION
## Summary
- Simplify mode state controller and enforce UI-specific rules with clear prompts
- Persist AI Doc threads and trigger boot greeting only once per session
- Gate AI Doc boot endpoint with cookie-based check to avoid repeat greetings

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c5736eae7c832fa8051888e13e303d