### PR TITLE
chore: refine MedX UI behavior

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,22 @@
 "use client";
 import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import SearchDock from "@/components/search/SearchDock";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
 import Timeline from "@/components/panels/Timeline";
 import AlertsPane from "@/components/panels/AlertsPane";
 import SettingsPane from "@/components/panels/SettingsPane";
-import { ResearchFiltersProvider } from '@/store/researchFilters';
+import AiDocPane from "@/components/panels/AiDocPane";
+import { ResearchFiltersProvider } from "@/store/researchFilters";
 
 type Search = { panel?: string; threadId?: string };
 
 export default function Page({ searchParams }: { searchParams: Search }) {
-  const panel = (searchParams.panel ?? "chat").toLowerCase();
+  const panel = searchParams.panel?.toLowerCase();
+  const threadId = searchParams.threadId;
   const chatInputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const handler = () => chatInputRef.current?.focus();
@@ -19,29 +24,32 @@ export default function Page({ searchParams }: { searchParams: Search }) {
     return () => window.removeEventListener("focus-chat-input", handler);
   }, []);
 
+  const sendQuery = (q: string) => {
+    router.push(`/?panel=chat&query=${encodeURIComponent(q)}`);
+  };
+
+  if (!panel) {
+    return (
+      <div className="min-h-[80vh] flex items-center justify-center">
+        <SearchDock onSubmit={sendQuery} />
+      </div>
+    );
+  }
+
   return (
     <main className="flex-1 overflow-y-auto content-layer">
-      <section className={panel === "chat" ? "block h-full" : "hidden"}>
-        <ResearchFiltersProvider>
-          <ChatPane inputRef={chatInputRef} />
-        </ResearchFiltersProvider>
-      </section>
-
-      <section className={panel === "profile" ? "block" : "hidden"}>
-        <MedicalProfile />
-      </section>
-
-      <section className={panel === "timeline" ? "block" : "hidden"}>
-        <Timeline />
-      </section>
-
-      <section className={panel === "alerts" ? "block" : "hidden"}>
-        <AlertsPane />
-      </section>
-
-      <section className={panel === "settings" ? "block" : "hidden"}>
-        <SettingsPane />
-      </section>
+      {panel === "chat" && (
+        <section className="block h-full">
+          <ResearchFiltersProvider>
+            <ChatPane inputRef={chatInputRef} />
+          </ResearchFiltersProvider>
+        </section>
+      )}
+      {panel === "profile" && <MedicalProfile />}
+      {panel === "timeline" && <Timeline />}
+      {panel === "alerts" && <AlertsPane />}
+      {panel === "settings" && <SettingsPane />}
+      {panel === "ai-doc" && <AiDocPane threadId={threadId} />}
     </main>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,21 +1,14 @@
 'use client';
-import { User, Stethoscope } from 'lucide-react';
-import ThemeToggle from './ThemeToggle';
-import { ResearchToggle } from './ResearchToggle';
-import TherapyToggle from './TherapyToggle';
 import CountryGlobe from '@/components/CountryGlobe';
 import Brand from '@/components/nav/Brand';
+import ModeBar from '@/components/modes/ModeBar';
 
 export default function Header({
-  mode,
   onModeChange,
-  researchOn,
   onResearchChange,
   onTherapyChange,
 }: {
-  mode: 'patient' | 'doctor';
   onModeChange: (m: 'patient' | 'doctor') => void;
-  researchOn: boolean;
   onResearchChange: (v: boolean) => void;
   onTherapyChange: (v: boolean) => void;
 }) {
@@ -26,25 +19,13 @@ export default function Header({
           <Brand />
           <CountryGlobe />
         </div>
-        <div className="flex items-center gap-2">
-          <TherapyToggle onChange={onTherapyChange} />
-          <button
-            onClick={() => onModeChange(mode === 'patient' ? 'doctor' : 'patient')}
-            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-xl text-sm medx-surface text-medx"
-          >
-            {mode === 'patient' ? (
-              <>
-                <User size={16} /> Patient
-              </>
-            ) : (
-              <>
-                <Stethoscope size={16} /> Doctor
-              </>
-            )}
-          </button>
-          <ResearchToggle defaultOn={researchOn} onChange={onResearchChange} />
-          <ThemeToggle />
-        </div>
+        <ModeBar
+          onChange={(s) => {
+            if (s.ui === 'patient' || s.ui === 'doctor') onModeChange(s.ui);
+            onResearchChange(s.research);
+            onTherapyChange(s.therapy);
+          }}
+        />
       </div>
     </header>
   );

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -3,7 +3,7 @@ import { useRef, useState } from "react";
 import { nextModes } from "@/lib/modes/controller";
 import type { ModeState } from "@/lib/modes/types";
 
-const initial: ModeState = { ui: undefined, therapy: false, research: false, aidoc: false, dark: false };
+const initial: ModeState = { ui: "patient", therapy: false, research: false, aidoc: false, dark: false };
 
 export default function ModeBar({ onChange }: { onChange?: (s: ModeState)=>void }) {
   const [s, setS] = useState<ModeState>(initial);

--- a/components/nav/Brand.tsx
+++ b/components/nav/Brand.tsx
@@ -4,13 +4,13 @@ import Link from "next/link";
 
 export default function Brand() {
   return (
-    <Link href="/" aria-label="MedX Home"
-      onClick={() => {
-        // Optional: reset transient UI session state:
-        try { sessionStorage.removeItem("search_docked"); } catch {}
-      }}
-      className="inline-flex items-center gap-2">
-      <img src="/medx-logo.svg" alt="MedX" className="h-6 w-auto" />
+    <Link
+      href="/"
+      aria-label="MedX Home"
+      onClick={() => sessionStorage.removeItem("search_docked")}
+      className="text-xl font-bold tracking-tight"
+    >
+      MedX
     </Link>
   );
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1423,9 +1423,7 @@ ${systemCommon}` + baseSys;
   return (
     <div className="relative flex h-full flex-col">
       <Header
-        mode={mode}
         onModeChange={setMode}
-        researchOn={researchMode}
         onResearchChange={setResearchMode}
         onTherapyChange={setTherapyMode}
       />

--- a/components/search/SearchDock.tsx
+++ b/components/search/SearchDock.tsx
@@ -10,9 +10,10 @@ export default function SearchDock({ onSubmit }: { onSubmit: (q: string)=>void }
   }, [docked]);
 
   return (
-    <div className={`fixed left-1/2 -translate-x-1/2 transition-all duration-500 ${
-        docked ? "bottom-4 w-[min(720px,92vw)]" : "top-1/3 w-[min(760px,92vw)]"
-      }`}>
+    <div
+      className={`fixed left-1/2 -translate-x-1/2 transition-all duration-500 
+    ${docked ? "bottom-4 w-[min(720px,92vw)]" : "top-1/3 w-[min(760px,92vw)]"}`}
+    >
       <form
         onSubmit={(e)=>{ e.preventDefault(); if (!q.trim()) return; onSubmit(q.trim()); setDocked(true); }}
         className="rounded-2xl border border-neutral-200 bg-white/90 p-2 shadow-lg backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80"

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,6 +1,5 @@
 "use client";
-import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 type Tab = {
   key: string;
@@ -36,6 +35,7 @@ function NavLink({
   threadId?: string;
   context?: string;
 }) {
+  const router = useRouter();
   const params = useSearchParams();
 
   const threadId = threadIdProp;
@@ -48,17 +48,18 @@ function NavLink({
     (threadIdProp ? params.get("threadId") === threadIdProp : !params.get("threadId"));
 
   return (
-    <Link
-      href={href}
-      prefetch={false}
-      scroll={false}
-      onClick={(e) => e.stopPropagation()}
+    <button
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        router.push(href);
+      }}
       className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
       data-testid={`nav-${panel}`}
       aria-current={active ? "page" : undefined}
     >
       {children}
-    </Link>
+    </button>
   );
 }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,36 +1,16 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-// Force non-basic chats to OpenAI final endpoints while preserving your existing routes.
-// If the client sends `x-medx-mode: basic`, we let Groq/basic paths proceed untouched.
-// Memory/context code in existing handlers remains intact, we just rewrite the URL.
-
+// Force non-basic chats to OpenAI final endpoints while preserving existing routes.
 export function middleware(req: NextRequest) {
   const url = req.nextUrl.clone();
   const path = url.pathname;
 
-  // Only consider chat routes
   if (path === "/api/chat" || path === "/api/chat/stream") {
     const mode = (req.headers.get("x-medx-mode") || "").toLowerCase();
-
     const isBasic = mode === "basic" || mode === "casual";
     if (!isBasic) {
-      // rewrite to final-say versions
-      if (path === "/api/chat") {
-        url.pathname = "/api/chat/final";
-      } else {
-        url.pathname = "/api/chat/stream-final";
-      }
-      return NextResponse.rewrite(url);
-    }
-  }
-
-  // Triage paths: if you already post to /api/triage, you can similarly force:
-  if (path === "/api/triage") {
-    const mode = (req.headers.get("x-medx-mode") || "").toLowerCase();
-    const isBasic = mode === "basic" || mode === "casual";
-    if (!isBasic) {
-      url.pathname = "/api/triage-final";
+      url.pathname = path === "/api/chat" ? "/api/chat/final" : "/api/chat/stream-final";
       return NextResponse.rewrite(url);
     }
   }
@@ -38,7 +18,6 @@ export function middleware(req: NextRequest) {
   return NextResponse.next();
 }
 
-// Limit to API routes for safety
 export const config = {
-  matcher: ["/api/chat", "/api/chat/stream", "/api/triage"],
+  matcher: ["/api/chat", "/api/chat/stream", "/api/triage-final"],
 };


### PR DESCRIPTION
## Summary
- center landing search dock and render panels by query
- switch brand to text logo and consolidate mode controls
- prevent sidebar double navigation and limit middleware scope

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c689c92144832fb5a554c840fe1743