### PR TITLE
Remove aidoc feature mode

### DIFF
--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -1,11 +1,13 @@
 "use client";
 import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { nextModes } from "@/lib/modes/controller";
 import type { ModeState } from "@/lib/modes/types";
 
-const initial: ModeState = { ui: undefined, therapy: false, research: false, aidoc: false, dark: false };
+const initial: ModeState = { ui: undefined, therapy: false, research: false, dark: false };
 
 export default function ModeBar({ onChange }: { onChange?: (s: ModeState)=>void }) {
+  const router = useRouter();
   const [s, setS] = useState<ModeState>(initial);
   const promptedRef = useRef<Record<string, number>>({}); // one-time prompts per session
 
@@ -37,8 +39,8 @@ export default function ModeBar({ onChange }: { onChange?: (s: ModeState)=>void 
       <button onClick={()=>act("research:toggle")}
         className={`rounded-lg border px-3 py-1.5 ${s.research?"bg-blue-600 text-white":"border-neutral-300 dark:border-neutral-700"}`}>Research</button>
 
-      <button onClick={()=>act("aidoc:toggle")}
-        className={`rounded-lg border px-3 py-1.5 ${s.aidoc?"bg-violet-600 text-white":"border-neutral-300 dark:border-neutral-700"}`}>AI&nbsp;Doc</button>
+      <button onClick={()=>router.push("/?panel=chat&threadId=med-profile&context=profile")}
+        className="rounded-lg border px-3 py-1.5 border-neutral-300 dark:border-neutral-700">AI&nbsp;Doc</button>
 
       <button onClick={()=>act("dark:toggle")}
         className={`rounded-lg border px-3 py-1.5 ${s.dark?"bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900":"border-neutral-300 dark:border-neutral-700"}`}>Dark</button>

--- a/lib/modes/controller.ts
+++ b/lib/modes/controller.ts
@@ -11,20 +11,13 @@ export function nextModes(prev: ModeState, action: { type: string; value?: any }
       break;
 
     case "therapy:toggle":
-      if (s.aidoc) { prompt = "AI Doc runs by itself. Turn it off for Therapy."; break; }
       if (s.ui !== "patient") { prompt = "Therapy works only with Patient mode."; s.therapy = false; break; }
       s.therapy = !s.therapy;
       break;
 
     case "research:toggle":
-      if (s.aidoc) { prompt = "AI Doc runs by itself. Turn it off for Research."; break; }
       if (!s.ui) { prompt = "Pick Patient or Doctor mode first."; break; }
       s.research = !s.research;
-      break;
-
-    case "aidoc:toggle":
-      s.aidoc = !s.aidoc;
-      if (s.aidoc) { s.therapy = false; s.research = false; }
       break;
 
     case "dark:toggle":

--- a/lib/modes/types.ts
+++ b/lib/modes/types.ts
@@ -1,9 +1,8 @@
 export type UIMode = "patient" | "doctor";
-export type FeatureMode = "therapy" | "research" | "aidoc";
+export type FeatureMode = "therapy" | "research";
 export interface ModeState {
   ui?: UIMode;                // patient | doctor
   therapy: boolean;           // only allowed if ui==='patient'
   research: boolean;          // allowed if ui in ['patient','doctor']
-  aidoc: boolean;             // standalone; disables others
   dark: boolean;
 }


### PR DESCRIPTION
## Summary
- drop `aidoc` from feature mode types and controller logic
- simplify ModeBar by removing aidoc state and routing AI Doc button to chat profile

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c691dae8d8832fbf5b001e7971dbd4