### PR TITLE
feat: persist landing search in chat

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,5 @@
 "use client";
-import { useEffect, useRef } from "react";
-import { useRouter } from "next/navigation";
+import ModeBar from "@/components/modes/ModeBar";
 import SearchDock from "@/components/search/SearchDock";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
@@ -8,47 +7,33 @@ import Timeline from "@/components/panels/Timeline";
 import AlertsPane from "@/components/panels/AlertsPane";
 import SettingsPane from "@/components/panels/SettingsPane";
 import { ResearchFiltersProvider } from "@/store/researchFilters";
-
 import AiDocPane from "@/components/panels/AiDocPane";
-type Search = { panel?: string };
+
+type Search = { panel?: string; threadId?: string; q?: string };
 
 export default function Page({ searchParams }: { searchParams: Search }) {
-  const panel = searchParams.panel?.toLowerCase();
-  const chatInputRef = useRef<HTMLInputElement>(null);
-  const router = useRouter();
-
-  useEffect(() => {
-    const handler = () => chatInputRef.current?.focus();
-    window.addEventListener("focus-chat-input", handler);
-    return () => window.removeEventListener("focus-chat-input", handler);
-  }, []);
-
-  const sendQuery = (q: string) => {
-    router.push(`/?panel=chat&query=${encodeURIComponent(q)}`);
-  };
-
-  if (!panel) {
-    return (
-      <div className="min-h-[80vh] flex items-center justify-center">
-        <SearchDock onSubmit={sendQuery} />
-      </div>
-    );
-  }
+  const panel = (searchParams.panel ?? "chat").toLowerCase();
+  const threadId = searchParams.threadId; // currently unused
+  const initialQ = searchParams.q ?? "";
 
   return (
-    <main className="flex-1 overflow-y-auto content-layer">
-      {panel === "chat" && (
-        <section className="block h-full">
-          <ResearchFiltersProvider>
-            <ChatPane inputRef={chatInputRef} />
-          </ResearchFiltersProvider>
-        </section>
-      )}
-      {panel === "profile" && <MedicalProfile />}
-      {panel === "timeline" && <Timeline />}
-      {panel === "alerts" && <AlertsPane />}
-      {panel === "settings" && <SettingsPane />}
-      {panel === "ai-doc" && <AiDocPane />}
-    </main>
+    <>
+      <ModeBar />
+      <SearchDock />
+      <main className="flex-1 overflow-y-auto content-layer">
+        {panel === "chat" && (
+          <section className="block h-full">
+            <ResearchFiltersProvider>
+              <ChatPane initialQuery={initialQ} />
+            </ResearchFiltersProvider>
+          </section>
+        )}
+        {panel === "profile" && <MedicalProfile />}
+        {panel === "timeline" && <Timeline />}
+        {panel === "alerts" && <AlertsPane />}
+        {panel === "settings" && <SettingsPane />}
+        {panel === "ai-doc" && <AiDocPane />}
+      </main>
+    </>
   );
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -300,7 +300,9 @@ function AssistantMessage({ m, researchOn, onQuickAction, busy, therapyMode, onF
   );
 }
 
-export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: RefObject<HTMLInputElement> } = {}) {
+export default function ChatPane(
+  { initialQuery = "", inputRef: externalInputRef }: { initialQuery?: string; inputRef?: RefObject<HTMLInputElement> } = {}
+) {
 
   const { country } = useCountry();
   const { active, setFromAnalysis, setFromChat, clear: clearContext } = useActiveContext();
@@ -319,6 +321,13 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     (externalInputRef as unknown as RefObject<HTMLTextAreaElement>) ??
     (useRef<HTMLTextAreaElement>(null) as RefObject<HTMLTextAreaElement>);
   const { filters } = useResearchFilters();
+
+  useEffect(() => {
+    if (initialQuery) {
+      setNote(initialQuery);
+      setTimeout(() => onSubmit(), 0);
+    }
+  }, [initialQuery]);
 
   // Auto-resize the textarea up to a max height
   useEffect(() => {

--- a/components/search/SearchDock.tsx
+++ b/components/search/SearchDock.tsx
@@ -1,25 +1,39 @@
 "use client";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 
-export default function SearchDock({ onSubmit }: { onSubmit: (q: string)=>void }) {
+export default function SearchDock() {
   const [q, setQ] = useState("");
-  const [docked, setDocked] = useState<boolean>(()=> typeof window !== "undefined" && !!sessionStorage.getItem("search_docked"));
+  const [docked, setDocked] = useState<boolean>(
+    () => typeof window !== "undefined" && !!sessionStorage.getItem("search_docked")
+  );
+  const router = useRouter();
 
-  useEffect(()=> {
-    if (docked) sessionStorage.setItem("search_docked","1");
+  useEffect(() => {
+    if (docked) sessionStorage.setItem("search_docked", "1");
   }, [docked]);
 
   return (
     <div
-      className={`fixed left-1/2 -translate-x-1/2 transition-all duration-500 
+      className={`fixed z-30 left-1/2 -translate-x-1/2 transition-all duration-500
     ${docked ? "bottom-4 w-[min(720px,92vw)]" : "top-1/3 w-[min(760px,92vw)]"}`}
     >
       <form
-        onSubmit={(e)=>{ e.preventDefault(); if (!q.trim()) return; onSubmit(q.trim()); setDocked(true); }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          const query = q.trim();
+          if (!query) return;
+          router.push(`/?panel=chat&q=${encodeURIComponent(query)}`);
+          setDocked(true);
+        }}
         className="rounded-2xl border border-neutral-200 bg-white/90 p-2 shadow-lg backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80"
       >
-        <input value={q} onChange={e=>setQ(e.target.value)} placeholder="Ask MedX…"
-          className="w-full rounded-xl bg-transparent px-4 py-3 outline-none" />
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Ask MedX…"
+          className="w-full rounded-xl bg-transparent px-4 py-3 outline-none"
+        />
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- plumb `q` from landing search into chat view and auto-send it
- keep top mode bar visible with docked search
- prioritize chat panel when searching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6a187e5d4832fa1109e34dfd9acff