### PR TITLE
refactor: centralize theming tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,18 +6,83 @@
   :root {
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+
+    --primary: 221.2 83.2% 53.3%;
+    --primary-foreground: 210 40% 98%;
+
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --ring: 221.2 83.2% 53.3%;
+
+    --radius: 0.75rem;
+    --overlay: 0 0% 0%;
   }
 
   .dark {
     /* Pick ONE style. Comment the other out. */
 
-    /* Option A: blue-tinted dark (current “blue” look) */
+    /* A) Blue-toned dark (current “blue”) */
     --background: 222.2 47.4% 11.2%;
     --foreground: 210 40% 98%;
+    --card: 222.2 47.4% 12%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 47.4% 12%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 224.3 76.3% 48%;
+    --overlay: 0 0% 0%;
 
-    /* Option B: OLED black */
-    /* --background: 0 0% 0%;
-       --foreground: 0 0% 98%; */
+    /* B) OLED black dark */
+    /*
+    --background: 0 0% 0%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 3%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 3%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 217 91% 60%;
+    --primary-foreground: 0 0% 10%;
+    --secondary: 0 0% 12%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 12%;
+    --muted-foreground: 0 0% 75%;
+    --accent: 0 0% 14%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 80% 40%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 16%;
+    --input: 0 0% 16%;
+    --ring: 217 91% 60%;
+    --overlay: 0 0% 0%;
+    */
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,25 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+  }
+
+  .dark {
+    /* Pick ONE style. Comment the other out. */
+
+    /* Option A: blue-tinted dark (current “blue” look) */
+    --background: 222.2 47.4% 11.2%;
+    --foreground: 210 40% 98%;
+
+    /* Option B: OLED black */
+    /* --background: 0 0% 0%;
+       --foreground: 0 0% 98%; */
+  }
+}
+
 /* smooth theme transitions */
 * { transition: background-color .15s ease, color .15s ease, border-color .15s ease; }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,8 +21,13 @@ const roboto = Roboto({
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={roboto.variable} suppressHydrationWarning>
-      <body className="min-h-screen bg-white dark:bg-slate-950 text-slate-900 dark:text-gray-100 font-sans antialiased">
-        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <body className="min-h-screen bg-background text-foreground font-sans antialiased">
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
           <CountryProvider>
             <ContextProvider>
               <TopicProvider>

--- a/components/UnifiedUpload.tsx
+++ b/components/UnifiedUpload.tsx
@@ -52,7 +52,7 @@ export default function UnifiedUpload() {
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-3">
-        <label className="px-4 py-2 rounded bg-black text-white cursor-pointer">
+        <label className="px-4 py-2 rounded bg-background text-foreground cursor-pointer">
           <span>Upload</span>
           <input type="file" accept="application/pdf,image/*" onChange={onChange} className="hidden" />
         </label>

--- a/components/chat/ThreadKebab.tsx
+++ b/components/chat/ThreadKebab.tsx
@@ -69,7 +69,7 @@ export default function ThreadKebab({ id, title, onRenamed, onDeleted }: {
       {/* Rename dialog (lightweight inline) */}
       {askRename && (
         <div className="fixed inset-0 z-30 flex items-center justify-center">
-          <div className="absolute inset-0 bg-black/40" onClick={()=>setAskRename(false)} />
+          <div className="absolute inset-0 bg-overlay/40" onClick={()=>setAskRename(false)} />
           <div className="relative w-full max-w-sm rounded-lg border bg-white dark:bg-slate-900 dark:border-slate-700 p-4">
             <div className="text-sm font-medium mb-2">Rename chat</div>
             <input

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1804,7 +1804,7 @@ ${systemCommon}` + baseSys;
       </div>
       {/* Preflight chooser (flagged) */}
       {AIDOC_UI && AIDOC_PREFLIGHT && showPatientChooser && (
-        <div className="fixed inset-0 z-50 grid place-items-center bg-black/20">
+        <div className="fixed inset-0 z-50 grid place-items-center bg-overlay/20">
           <div className="w-full max-w-md rounded-xl bg-white p-4 shadow-xl">
             <div className="text-sm font-medium mb-3">Who is this about?</div>
             {activeProfileId ? (
@@ -1828,7 +1828,7 @@ ${systemCommon}` + baseSys;
 
       {/* Mini intake for NEW patient (flagged) */}
       {AIDOC_UI && AIDOC_PREFLIGHT && showNewIntake && (
-        <div className="fixed inset-0 z-50 grid place-items-center bg-black/20">
+        <div className="fixed inset-0 z-50 grid place-items-center bg-overlay/20">
           <div className="w-full max-w-md rounded-xl bg-white p-4 shadow-xl space-y-2">
             <div className="text-sm font-medium">New patient – quick intake</div>
             <input className="w-full rounded border px-2 py-1 text-sm" placeholder="Name"

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -132,7 +132,7 @@ export default function Timeline(){
 
       {open && active && (
         <>
-          <div className="fixed inset-0 bg-black/40 z-40" onClick={() => setOpen(false)} />
+          <div className="fixed inset-0 bg-overlay/40 z-40" onClick={() => setOpen(false)} />
           <aside className="fixed right-0 top-0 bottom-0 z-50 w-full sm:w-[640px] bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 shadow-2xl ring-1 ring-black/5 overflow-y-auto">
             <header className="sticky top-0 bg-white/90 dark:bg-zinc-900/90 backdrop-blur border-b border-zinc-200/70 dark:border-zinc-800/70 px-4 py-3 flex items-center gap-2">
               <h3 className="font-semibold truncate">{active.name || active.meta?.file_name || "Observation"}</h3>

--- a/components/panels/TrialsPane.tsx
+++ b/components/panels/TrialsPane.tsx
@@ -86,7 +86,7 @@ export default function TrialsPane() {
       </div>
 
       <div className="flex gap-2">
-        <button className="px-3 py-2 rounded bg-black text-white" onClick={onSearch} disabled={loading}>Search trials</button>
+        <button className="px-3 py-2 rounded bg-background text-foreground" onClick={onSearch} disabled={loading}>Search trials</button>
         <button className="px-3 py-2 rounded border" onClick={()=>summarize("patient")} disabled={!rows.length}>Summarize (Patient)</button>
         <button className="px-3 py-2 rounded border" onClick={()=>summarize("doctor")} disabled={!rows.length}>Summarize (Doctor)</button>
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,54 @@
 module.exports = {
-  darkMode: "class",
+  darkMode: ["class"],
   content: [
-    "./app/**/*.{js,ts,jsx,tsx}",
-    "./components/**/*.{js,ts,jsx,tsx}",
-    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+    "./pages/**/*.{ts,tsx}",
   ],
   theme: {
     extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        overlay: "hsl(var(--overlay))",
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
       fontSize: {
         'chat-base': ['15px', { lineHeight: '22px' }],
         'chat-sm': ['13px', { lineHeight: '20px' }],


### PR DESCRIPTION
## Summary
- rely on class-based ThemeProvider with transition disabled
- introduce unified light/dark CSS variables
- replace hardcoded black backgrounds with token colors

## Testing
- `npm test`
- `rg "data-theme" -n`
- `rg "className=\"dark\"" -n`
- `rg "bg-black" -n`
- `rg "text-white" -n | head -n 20`
- `rg "text-black" -n`
- `rg "style=\{\{[^}]*background" -n`


------
https://chatgpt.com/codex/tasks/task_e_68c6afa02f4c832f8c21d7fc0a7d0171