### PR TITLE
Normalize therapy surfaces to theme tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -74,6 +74,11 @@
   color: #0b3d91;
 }
 
+html.dark .therapy-surface {
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
+}
+
 .prose table {
   @apply w-full border-collapse border border-gray-300 text-chat-sm;
 }
@@ -89,6 +94,8 @@
 
 /* === MedX Theme Tokens (Light & Dark) === */
 :root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 47.4% 11.2%;
   --medx-bg-a: #e9efff;   /* light indigo */
   --medx-bg-b: #d0f3ff;   /* light cyan */
   --medx-text: #0F172A;
@@ -107,6 +114,8 @@
   --medx-outline: rgba(15, 23, 42, 0.10);
 }
 .dark {
+  --background: 222.2 47.4% 11.2%;
+  --foreground: 210 40% 98%;
   --medx-bg-a: #342eec;   /* deep indigo */
   --medx-bg-b: #27b6da;   /* cyan/teal */
   --medx-text: #E6E9F1;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,19 +36,19 @@ export default function Page({ searchParams }: { searchParams: Search }) {
   }
 
   return (
-    <main className="flex-1 overflow-y-auto content-layer">
+    <div className="flex-1 overflow-y-auto content-layer">
       {panel === "chat" && (
-        <section className="block h-full">
+        <main className="therapy-surface min-h-screen bg-background text-foreground">
           <ResearchFiltersProvider>
             <ChatPane inputRef={chatInputRef} />
           </ResearchFiltersProvider>
-        </section>
+        </main>
       )}
       {panel === "profile" && <MedicalProfile />}
       {panel === "timeline" && <Timeline />}
       {panel === "alerts" && <AlertsPane />}
       {panel === "settings" && <SettingsPane />}
       {panel === "ai-doc" && <AiDocPane />}
-    </main>
+    </div>
   );
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1804,7 +1804,7 @@ ${systemCommon}` + baseSys;
       </div>
       {/* Preflight chooser (flagged) */}
       {AIDOC_UI && AIDOC_PREFLIGHT && showPatientChooser && (
-        <div className="fixed inset-0 z-50 grid place-items-center bg-black/20">
+        <div className="fixed inset-0 z-50 grid place-items-center bg-background/20">
           <div className="w-full max-w-md rounded-xl bg-white p-4 shadow-xl">
             <div className="text-sm font-medium mb-3">Who is this about?</div>
             {activeProfileId ? (
@@ -1828,7 +1828,7 @@ ${systemCommon}` + baseSys;
 
       {/* Mini intake for NEW patient (flagged) */}
       {AIDOC_UI && AIDOC_PREFLIGHT && showNewIntake && (
-        <div className="fixed inset-0 z-50 grid place-items-center bg-black/20">
+        <div className="fixed inset-0 z-50 grid place-items-center bg-background/20">
           <div className="w-full max-w-md rounded-xl bg-white p-4 shadow-xl space-y-2">
             <div className="text-sm font-medium">New patient – quick intake</div>
             <input className="w-full rounded border px-2 py-1 text-sm" placeholder="Name"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,10 @@ module.exports = {
         // Use with className="font-sans"
         sans: ["var(--font-roboto)", "system-ui", "sans-serif"],
       },
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+      },
     },
   },
   plugins: [require("@tailwindcss/typography")],


### PR DESCRIPTION
## Summary
- add background/foreground tokens to Tailwind config
- ensure dark theme colors for `.therapy-surface`
- wrap chat panel in token-based `therapy-surface` container
- replace black overlays with background token

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6ba8802b4832fbe84f3ffbb463da0