### PR TITLE
Refactor landing layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,54 +1,38 @@
-"use client";
-import { useEffect, useRef } from "react";
-import { useRouter } from "next/navigation";
+import Sidebar from "@/components/Sidebar";
+import ModeBar from "@/components/modes/ModeBar";
 import SearchDock from "@/components/search/SearchDock";
-import ChatPane from "@/components/panels/ChatPane";
-import MedicalProfile from "@/components/panels/MedicalProfile";
-import Timeline from "@/components/panels/Timeline";
-import AlertsPane from "@/components/panels/AlertsPane";
-import SettingsPane from "@/components/panels/SettingsPane";
-import { ResearchFiltersProvider } from "@/store/researchFilters";
+import PanelRouter from "@/components/panels/PanelRouter";
+import { type FC } from "react";
 
-import AiDocPane from "@/components/panels/AiDocPane";
-type Search = { panel?: string };
+interface HomeProps {
+  searchParams?: { panel?: string; query?: string };
+}
 
-export default function Page({ searchParams }: { searchParams: Search }) {
-  const panel = searchParams.panel?.toLowerCase();
-  const chatInputRef = useRef<HTMLInputElement>(null);
-  const router = useRouter();
+const TopBar: FC = () => (
+  <div className="sticky top-0 z-40 bg-background/70 backdrop-blur border-b border-border">
+    <ModeBar />
+  </div>
+);
 
-  useEffect(() => {
-    const handler = () => chatInputRef.current?.focus();
-    window.addEventListener("focus-chat-input", handler);
-    return () => window.removeEventListener("focus-chat-input", handler);
-  }, []);
-
-  const sendQuery = (q: string) => {
-    router.push(`/?panel=chat&query=${encodeURIComponent(q)}`);
-  };
-
-  if (!panel) {
-    return (
-      <div className="min-h-[80vh] flex items-center justify-center">
-        <SearchDock onSubmit={sendQuery} />
-      </div>
-    );
-  }
+export default function Home({ searchParams }: HomeProps) {
+  const hasPanel = !!searchParams?.panel;
 
   return (
-    <main className="flex-1 overflow-y-auto content-layer">
-      {panel === "chat" && (
-        <section className="block h-full">
-          <ResearchFiltersProvider>
-            <ChatPane inputRef={chatInputRef} />
-          </ResearchFiltersProvider>
-        </section>
-      )}
-      {panel === "profile" && <MedicalProfile />}
-      {panel === "timeline" && <Timeline />}
-      {panel === "alerts" && <AlertsPane />}
-      {panel === "settings" && <SettingsPane />}
-      {panel === "ai-doc" && <AiDocPane />}
-    </main>
+    <div className="grid min-h-screen grid-cols-[280px_1fr]">
+      <Sidebar />
+      <main className="relative">
+        <TopBar />
+        {hasPanel ? (
+          <PanelRouter searchParams={searchParams} />
+        ) : (
+          <section
+            className="landing-bg grid min-h-[calc(100svh-56px)] place-items-center px-4"
+          >
+            <SearchDock />
+          </section>
+        )}
+      </main>
+    </div>
   );
 }
+

--- a/components/panels/PanelRouter.tsx
+++ b/components/panels/PanelRouter.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import ChatPane from '@/components/panels/ChatPane';
+import MedicalProfile from '@/components/panels/MedicalProfile';
+import Timeline from '@/components/panels/Timeline';
+import AlertsPane from '@/components/panels/AlertsPane';
+import SettingsPane from '@/components/panels/SettingsPane';
+import AiDocPane from '@/components/panels/AiDocPane';
+import { ResearchFiltersProvider } from '@/store/researchFilters';
+
+interface PanelRouterProps {
+  searchParams?: { panel?: string };
+}
+
+export default function PanelRouter({ searchParams }: PanelRouterProps) {
+  const panel = searchParams?.panel?.toLowerCase();
+  const chatInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handler = () => chatInputRef.current?.focus();
+    window.addEventListener('focus-chat-input', handler);
+    return () => window.removeEventListener('focus-chat-input', handler);
+  }, []);
+
+  if (!panel) return null;
+
+  return (
+    <main className="flex-1 overflow-y-auto content-layer">
+      {panel === 'chat' && (
+        <section className="block h-full">
+          <ResearchFiltersProvider>
+            <ChatPane inputRef={chatInputRef} />
+          </ResearchFiltersProvider>
+        </section>
+      )}
+      {panel === 'profile' && <MedicalProfile />}
+      {panel === 'timeline' && <Timeline />}
+      {panel === 'alerts' && <AlertsPane />}
+      {panel === 'settings' && <SettingsPane />}
+      {panel === 'ai-doc' && <AiDocPane />}
+    </main>
+  );
+}
+

--- a/components/search/SearchDock.tsx
+++ b/components/search/SearchDock.tsx
@@ -1,26 +1,28 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
 
-export default function SearchDock({ onSubmit }: { onSubmit: (q: string)=>void }) {
+export default function SearchDock() {
   const [q, setQ] = useState("");
-  const [docked, setDocked] = useState<boolean>(()=> typeof window !== "undefined" && !!sessionStorage.getItem("search_docked"));
-
-  useEffect(()=> {
-    if (docked) sessionStorage.setItem("search_docked","1");
-  }, [docked]);
+  const router = useRouter();
 
   return (
-    <div
-      className={`fixed left-1/2 -translate-x-1/2 transition-all duration-500 
-    ${docked ? "bottom-4 w-[min(720px,92vw)]" : "top-1/3 w-[min(760px,92vw)]"}`}
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        const v = q.trim();
+        if (!v) return;
+        router.push(`/?panel=chat&query=${encodeURIComponent(v)}`);
+      }}
+      className="w-full max-w-2xl rounded-2xl border border-border bg-card shadow-lg"
     >
-      <form
-        onSubmit={(e)=>{ e.preventDefault(); if (!q.trim()) return; onSubmit(q.trim()); setDocked(true); }}
-        className="rounded-2xl border border-neutral-200 bg-white/90 p-2 shadow-lg backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80"
-      >
-        <input value={q} onChange={e=>setQ(e.target.value)} placeholder="Ask MedX…"
-          className="w-full rounded-xl bg-transparent px-4 py-3 outline-none" />
-      </form>
-    </div>
+      <input
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+        placeholder="Ask MedX…"
+        className="w-full rounded-2xl bg-transparent px-5 py-4 text-base outline-none"
+      />
+    </form>
   );
 }
+


### PR DESCRIPTION
## Summary
- Add always-visible sticky top bar and sidebar grid layout
- Center landing SearchDock and route queries to chat
- Move panel selection into new `PanelRouter` component

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*


------
https://chatgpt.com/codex/tasks/task_e_68c6bc2303ac832fb9af483d846edb57