### PR TITLE
refactor: adopt blue dark surfaces

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,8 +7,15 @@
 
 .btn-secondary{
   @apply inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm transition
-         bg-white text-slate-700 border-slate-200 hover:bg-slate-50
-         dark:bg-gray-800 dark:text-slate-100 dark:border-gray-600 dark:hover:bg-gray-700;
+         bg-white text-slate-700 border-slate-200 hover:bg-slate-50;
+}
+.dark .btn-secondary{
+  @apply text-slate-100;
+  background: var(--medx-panel);
+  border-color: var(--medx-outline);
+}
+.dark .btn-secondary:hover{
+  background: var(--medx-surface);
 }
 
 /* Ensures sidebar sits above content and accepts clicks */
@@ -57,8 +64,11 @@
 
 /* Ensure body/content contrast in dark */
 .dark body { color: rgb(229 231 235); }           /* text-gray-200 */
-.dark .card,.dark .panel { background: #0f172a; } /* slate-900 */
-.dark .border { border-color: rgb(71 85 105); }   /* slate-600 */
+.dark .card,
+.dark .panel {
+  background: var(--medx-panel);
+}
+.dark .border { border-color: var(--medx-outline); }
 .dark .prose-medx :where(li)::marker { color: rgb(148 163 184); }
 
 :root.therapy-mode, .therapy-mode body {
@@ -118,8 +128,8 @@
   --medx-teal:    #2DD4BF;
   --medx-purple:  #A78BFA;
 
-  --medx-surface: rgba(0,0,0,0.35);
-  --medx-panel:   rgba(3,7,18,0.55);
+  --medx-surface: color-mix(in srgb, var(--medx-bg-b) 25%, transparent);
+  --medx-panel:   color-mix(in srgb, var(--medx-bg-a) 40%, transparent);
   --medx-outline: rgba(255,255,255,0.12);
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ const roboto = Roboto({
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={roboto.variable} suppressHydrationWarning>
-      <body className="min-h-screen bg-white dark:bg-slate-950 text-slate-900 dark:text-gray-100 font-sans antialiased">
+      <body className="min-h-screen bg-white dark:bg-[var(--medx-bg-a)] text-slate-900 dark:text-gray-100 font-sans antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <CountryProvider>
             <ContextProvider>

--- a/components/CountryGlobe.tsx
+++ b/components/CountryGlobe.tsx
@@ -25,7 +25,7 @@ export default function CountryGlobe() {
         aria-label="Choose country"
         title={`Country: ${country.name} (${country.code3}) — click to change`}
         onClick={() => setOpen(v => !v)}
-        className="inline-flex items-center gap-1 rounded-full border border-slate-300 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 px-3 py-1.5 text-sm shadow-sm hover:bg-white/80 dark:hover:bg-gray-900"
+        className="inline-flex items-center gap-1 rounded-full border border-slate-300 dark:border-[color:var(--medx-outline)] bg-white/60 dark:bg-[var(--medx-panel)] px-3 py-1.5 text-sm shadow-sm hover:bg-white/80 dark:hover:bg-[var(--medx-panel)]"
       >
         <Globe2 className="h-4 w-4" />
         <span className="font-medium">{country.code3}</span>
@@ -35,7 +35,7 @@ export default function CountryGlobe() {
         <div
           role="dialog"
           aria-label="Select country"
-          className="absolute right-0 mt-2 w-80 rounded-xl border border-slate-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-xl p-3 z-50"
+          className="absolute right-0 mt-2 w-80 rounded-xl border border-slate-200 dark:border-[color:var(--medx-outline)] bg-white dark:bg-[var(--medx-panel)] shadow-xl p-3 z-50"
         >
           <div className="mb-2">
             <input
@@ -43,7 +43,7 @@ export default function CountryGlobe() {
               value={q}
               onChange={e => setQ(e.target.value)}
               placeholder="Search country or code…"
-              className="w-full rounded-lg border border-slate-300 dark:border-gray-700 bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-teal-500/50"
+              className="w-full rounded-lg border border-slate-300 dark:border-[color:var(--medx-outline)] bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-teal-500/50"
             />
           </div>
 
@@ -55,7 +55,7 @@ export default function CountryGlobe() {
                   setCountry(c.code3);
                   setOpen(false);
                 }}
-                className="w-full flex items-center justify-between rounded-lg px-2 py-2 hover:bg-slate-50 dark:hover:bg-gray-800"
+                className="w-full flex items-center justify-between rounded-lg px-2 py-2 hover:bg-slate-50 dark:hover:bg-[var(--medx-surface)]"
               >
                 <span className="flex items-center gap-2">
                   <span className="text-base">{c.flag}</span>

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -21,7 +21,7 @@ export default function Markdown({ text }: { text: string }) {
     const useLabel = (!cleanInner || /^https?:\/\//i.test(cleanInner)) ? sourceLabelFromUrl(safe) : cleanInner;
 
     return `<a href="${safe}" target="_blank" rel="noopener noreferrer"
-    class="inline-flex items-center gap-1 rounded-full border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-xs font-medium text-slate-700 dark:text-slate-200 shadow-sm hover:bg-slate-50 dark:hover:bg-gray-800 transition">
+    class="inline-flex items-center gap-1 rounded-full border border-slate-200 dark:border-[color:var(--medx-outline)] bg-white dark:bg-[var(--medx-panel)] px-2 py-1 text-xs font-medium text-slate-700 dark:text-slate-200 shadow-sm hover:bg-slate-50 dark:hover:bg-[var(--medx-surface)] transition">
       <span>${useLabel}</span><span aria-hidden="true" class="opacity-70">↗</span>
   </a>`;
   });

--- a/components/ResearchFilters.tsx
+++ b/components/ResearchFilters.tsx
@@ -130,7 +130,7 @@ export default function ResearchFilters({ mode, onResults }: Props) {
           onChange={(e)=>setLocal(s=>({ ...s, query: e.target.value }))}
           onKeyDown={(e)=> e.key === 'Enter' && (e.currentTarget as any).form?.requestSubmit()}
           placeholder="Search trials (e.g., condition, gene, topic)…"
-          className="w-full rounded-lg border px-3 py-2 text-sm dark:bg-slate-800 dark:border-slate-700"
+          className="w-full rounded-lg border px-3 py-2 text-sm dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]"
         />
         <button
           type="submit"
@@ -150,7 +150,7 @@ export default function ResearchFilters({ mode, onResults }: Props) {
             onClick={()=>togglePhase(p)}
             className={`px-2 py-1 rounded border text-xs ${
               local.phase === p ? 'bg-blue-600 text-white border-blue-600' :
-              'bg-white dark:bg-slate-800 dark:border-slate-700'
+              'bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]'
             }`}
           >
             Phase {p}
@@ -163,7 +163,7 @@ export default function ResearchFilters({ mode, onResults }: Props) {
         <select
           value={local.status}
           onChange={(e)=>setLocal(s=>({ ...s, status: e.target.value as any }))}
-          className="rounded border px-2 py-1 text-sm dark:bg-slate-800 dark:border-slate-700"
+          className="rounded border px-2 py-1 text-sm dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]"
         >
           {statusLabels.map(o=>(
             <option key={o.key} value={o.key}>{o.label}</option>
@@ -176,7 +176,7 @@ export default function ResearchFilters({ mode, onResults }: Props) {
         <select
           value={source}
           onChange={(e)=>setSource(e.target.value)}
-          className="rounded border px-2 py-1 text-sm dark:bg-slate-800 dark:border-slate-700"
+          className="rounded border px-2 py-1 text-sm dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]"
         >
           <option>All</option>
           <option>CTgov</option>
@@ -195,7 +195,7 @@ export default function ResearchFilters({ mode, onResults }: Props) {
             onClick={()=>toggleCountry(name)}
             className={`px-2 py-1 rounded border text-xs ${
               local.countries.includes(name) ? 'bg-blue-600 text-white border-blue-600' :
-              'bg-white dark:bg-slate-800 dark:border-slate-700'
+              'bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]'
             }`}
           >
             {name}
@@ -209,7 +209,7 @@ export default function ResearchFilters({ mode, onResults }: Props) {
           placeholder="Genes (comma separated)"
           value={local.genes}
           onChange={(e)=>setLocal(s=>({ ...s, genes: e.target.value }))}
-          className="flex-1 rounded border px-2 py-1 text-sm dark:bg-slate-800 dark:border-slate-700"
+          className="flex-1 rounded border px-2 py-1 text-sm dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]"
         />
         <button type="submit" className="px-3 py-1.5 rounded-lg text-sm border bg-blue-600 text-white dark:border-blue-600 disabled:opacity-50" disabled={busy}>
           {busy ? 'Searching…' : 'Apply'}

--- a/components/ResearchToggle.tsx
+++ b/components/ResearchToggle.tsx
@@ -13,7 +13,7 @@ export function ResearchToggle({ defaultOn=false, onChange }:{defaultOn?:boolean
       className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition
         ${on
         ? "bg-emerald-100 text-emerald-900 border-emerald-200/60 dark:bg-emerald-900/30 dark:text-emerald-200 dark:border-emerald-800"
-        : "bg-slate-100 text-slate-800 border-slate-200 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700"}`}>
+        : "bg-slate-100 text-slate-800 border-slate-200 dark:bg-[var(--medx-panel)] dark:text-gray-100 dark:border-[color:var(--medx-outline)]"}`}> 
       <span className={`inline-block h-2.5 w-2.5 rounded-full ${on?"bg-emerald-500":"bg-slate-400"}`} />
       {on ? "Research On" : "Research Off"}
     </button>

--- a/components/SafeLink.tsx
+++ b/components/SafeLink.tsx
@@ -90,9 +90,9 @@ export function LinkBadge(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) 
       target="_blank"
       rel="noopener noreferrer"
       className={
-        "inline-flex items-center gap-1 rounded-full border border-slate-200 dark:border-gray-700 " +
-        "bg-white dark:bg-gray-900 px-2 py-1 text-xs font-medium text-slate-700 dark:text-slate-200 " +
-        "shadow-sm hover:bg-slate-50 dark:hover:bg-gray-800 transition " + className
+        "inline-flex items-center gap-1 rounded-full border border-slate-200 dark:border-[color:var(--medx-outline)] " +
+        "bg-white dark:bg-[var(--medx-panel)] px-2 py-1 text-xs font-medium text-slate-700 dark:text-slate-200 " +
+        "shadow-sm hover:bg-slate-50 dark:hover:bg-[var(--medx-surface)] transition " + className
       }
       {...rest}
     >

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -16,7 +16,7 @@ export default function ThemeToggle() {
       className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm
                  bg-slate-100 text-slate-800 border-slate-200
                  hover:bg-slate-200
-                 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700 dark:hover:bg-gray-700"
+                 dark:bg-[var(--medx-panel)] dark:text-gray-100 dark:border-[color:var(--medx-outline)] dark:hover:bg-[var(--medx-surface)]"
     >
       {theme === "dark" ? "Light" : "Dark"}
     </button>

--- a/components/chat/ThreadKebab.tsx
+++ b/components/chat/ThreadKebab.tsx
@@ -27,7 +27,7 @@ export default function ThreadKebab({ id, title, onRenamed, onDeleted }: {
     <div className="relative" ref={ref}>
       <button
         type="button"
-        className="px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800"
+        className="px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-[var(--medx-surface)]"
         onClick={() => setOpen(s => !s)}
         aria-label="Thread options"
         title="Options"
@@ -36,9 +36,9 @@ export default function ThreadKebab({ id, title, onRenamed, onDeleted }: {
       </button>
 
       {open && (
-        <div className="absolute right-0 mt-1 w-44 rounded-md border bg-white dark:bg-slate-900 dark:border-slate-700 shadow-lg z-20">
+        <div className="absolute right-0 mt-1 w-44 rounded-md border bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)] shadow-lg z-20">
           <button
-            className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
+            className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-[var(--medx-surface)]"
             onClick={() => { setAskRename(true); setOpen(false); }}
           >
             Rename
@@ -70,13 +70,13 @@ export default function ThreadKebab({ id, title, onRenamed, onDeleted }: {
       {askRename && (
         <div className="fixed inset-0 z-30 flex items-center justify-center">
           <div className="absolute inset-0 bg-black/40" onClick={()=>setAskRename(false)} />
-          <div className="relative w-full max-w-sm rounded-lg border bg-white dark:bg-slate-900 dark:border-slate-700 p-4">
+          <div className="relative w-full max-w-sm rounded-lg border bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)] p-4">
             <div className="text-sm font-medium mb-2">Rename chat</div>
             <input
               autoFocus
               value={name}
               onChange={e=>setName(e.target.value)}
-              className="w-full rounded border px-2 py-1 text-sm dark:bg-slate-800 dark:border-slate-700"
+              className="w-full rounded border px-2 py-1 text-sm dark:bg-[var(--medx-surface)] dark:border-[color:var(--medx-outline)]"
             />
             <div className="mt-3 flex justify-end gap-2">
               <button className="px-3 py-1.5 text-sm rounded border"

--- a/components/memory/Snackbar.tsx
+++ b/components/memory/Snackbar.tsx
@@ -38,7 +38,7 @@ export default function MemorySnackbar() {
   })();
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 max-w-sm rounded-xl border bg-white dark:bg-slate-800 shadow-lg p-3 pointer-events-auto">
+    <div className="fixed bottom-4 right-4 z-50 max-w-sm rounded-xl border bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)] shadow-lg p-3 pointer-events-auto">
       <div className="text-sm mb-2">{label}</div>
       <div className="flex gap-2 justify-end">
         <button type="button" onClick={onDismiss} className="px-3 py-1 rounded border text-sm">No</button>

--- a/components/memory/UndoToast.tsx
+++ b/components/memory/UndoToast.tsx
@@ -14,7 +14,7 @@ export default function UndoToast() {
   if (!lastSaved) return null;
 
   return (
-    <div className="fixed bottom-20 right-4 z-50 max-w-sm rounded-xl border bg-white dark:bg-slate-800 shadow-lg p-3 pointer-events-auto">
+    <div className="fixed bottom-20 right-4 z-50 max-w-sm rounded-xl border bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)] shadow-lg p-3 pointer-events-auto">
       <div className="text-sm">Saved: {lastSaved.label}</div>
       <div className="mt-2 text-right">
         <button

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -35,13 +35,13 @@ export default function ModeBar({ onChange }: { onChange?: (s: ModeState) => voi
       <div className="inline-flex rounded-xl border p-1 dark:border-neutral-800">
         <button
           onClick={() => act("ui:set", "patient")}
-          className={`px-3 py-1.5 rounded-lg ${s.ui === "patient" ? "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900" : ""}`}
+          className={`px-3 py-1.5 rounded-lg ${s.ui === "patient" ? "bg-neutral-900 text-white dark:bg-blue-200 dark:text-blue-900" : ""}`}
         >
           Patient
         </button>
         <button
           onClick={() => act("ui:set", "doctor")}
-          className={`px-3 py-1.5 rounded-lg ${s.ui === "doctor" ? "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900" : ""}`}
+          className={`px-3 py-1.5 rounded-lg ${s.ui === "doctor" ? "bg-neutral-900 text-white dark:bg-blue-200 dark:text-blue-900" : ""}`}
         >
           Doctor
         </button>
@@ -50,28 +50,28 @@ export default function ModeBar({ onChange }: { onChange?: (s: ModeState) => voi
       {/* Feature modes */}
       <button
         onClick={() => act("therapy:toggle")}
-        className={`rounded-lg border px-3 py-1.5 ${s.therapy ? "bg-emerald-600 text-white" : "border-neutral-300 dark:border-neutral-700"}`}
+        className={`rounded-lg border px-3 py-1.5 ${s.therapy ? "bg-emerald-600 text-white" : "border-neutral-300 dark:border-[color:var(--medx-outline)]"}`}
       >
         Therapy
       </button>
 
       <button
         onClick={() => act("research:toggle")}
-        className={`rounded-lg border px-3 py-1.5 ${s.research ? "bg-blue-600 text-white" : "border-neutral-300 dark:border-neutral-700"}`}
+        className={`rounded-lg border px-3 py-1.5 ${s.research ? "bg-blue-600 text-white" : "border-neutral-300 dark:border-[color:var(--medx-outline)]"}`}
       >
         Research
       </button>
 
       <button
         onClick={() => router.push('/?panel=chat&threadId=med-profile&context=profile')}
-        className="rounded-lg border px-3 py-1.5 border-neutral-300 dark:border-neutral-700"
+        className="rounded-lg border px-3 py-1.5 border-neutral-300 dark:border-[color:var(--medx-outline)]"
       >
         AI&nbsp;Doc
       </button>
 
       <button
         onClick={toggleTheme}
-        className={`px-3.5 py-1.5 rounded-xl text-sm ${isDark ? "bg-blue-600 text-white" : "border border-neutral-300 bg-white text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100"}`}
+        className={`px-3.5 py-1.5 rounded-xl text-sm ${isDark ? "bg-blue-600 text-white" : "border border-neutral-300 bg-white text-neutral-900 dark:border-[color:var(--medx-outline)] dark:bg-[var(--medx-panel)] dark:text-gray-100"}`}
       >
         {isDark ? "Light" : "Dark"}
       </button>

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -178,7 +178,7 @@ No fabricated IDs. Provide themes, not specific trial numbers unless confident.`
 
 function PendingAnalysisCard({ label }: { label: string }) {
   return (
-    <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl">
+    <div className="rounded-2xl bg-white/90 dark:bg-[var(--medx-panel)] p-4 text-left whitespace-normal max-w-3xl">
       <div className="text-sm text-slate-600 dark:text-slate-300">{label}</div>
     </div>
   );
@@ -186,7 +186,7 @@ function PendingAnalysisCard({ label }: { label: string }) {
 
 function PendingChatCard({ label }: { label: string }) {
   return (
-    <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl">
+    <div className="rounded-2xl bg-white/90 dark:bg-[var(--medx-panel)] p-4 text-left whitespace-normal max-w-3xl">
       <div className="text-sm text-slate-600 dark:text-slate-300">{label}</div>
     </div>
   );
@@ -196,7 +196,7 @@ function AnalysisCard({ m, researchOn, onQuickAction, busy }: { m: Extract<ChatM
   const header = titleForCategory(m.category);
   if (m.pending) return <PendingAnalysisCard label="Analyzing file…" />;
   return (
-    <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl space-y-2">
+    <div className="rounded-2xl bg-white/90 dark:bg-[var(--medx-panel)] p-4 text-left whitespace-normal max-w-3xl space-y-2">
       <header className="flex items-center gap-2">
         <h2 className="text-lg md:text-xl font-semibold">{header}</h2>
         {researchOn && (
@@ -252,7 +252,7 @@ function ChatCard({ m, therapyMode, onFollowUpClick, simple }: { m: Extract<Chat
   if (m.pending) return <PendingChatCard label="Thinking…" />;
   return (
     <div
-      className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl"
+      className="rounded-2xl bg-white/90 dark:bg-[var(--medx-panel)] p-4 text-left whitespace-normal max-w-3xl"
       onClick={() => setFast(true)}
     >
       {m.role === "assistant" ? (
@@ -281,7 +281,7 @@ function ChatCard({ m, therapyMode, onFollowUpClick, simple }: { m: Extract<Chat
             <button
               key={i}
               onClick={() => onFollowUpClick(f)}
-              className="rounded-full border px-3 py-1 text-sm hover:bg-gray-100 dark:hover:bg-gray-700"
+              className="rounded-full border px-3 py-1 text-sm hover:bg-gray-100 dark:hover:bg-[var(--medx-surface)]"
             >
               {f}
             </button>
@@ -1441,7 +1441,7 @@ ${systemCommon}` + baseSys;
             </div>
           )}
           {summary && (
-            <div className="my-2 mx-4 text-sm p-3 rounded border bg-slate-50 dark:bg-slate-800 dark:border-slate-700">
+            <div className="my-2 mx-4 text-sm p-3 rounded border bg-slate-50 dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]">
               <div className="flex items-start gap-2">
                 <div className="mt-0.5 shrink-0">
                   {mode === "doctor" ? <Stethoscope size={16}/> : <Users size={16}/>}
@@ -1459,7 +1459,7 @@ ${systemCommon}` + baseSys;
                   <button
                     type="button"
                     onClick={() => navigator.clipboard.writeText(summary!)}
-                    className="px-2 py-1 text-xs border rounded hover:bg-slate-100 dark:hover:bg-slate-700"
+                    className="px-2 py-1 text-xs border rounded hover:bg-slate-100 dark:hover:bg-[var(--medx-surface)]"
                     title="Copy summary"
                   >
                     <span className="inline-flex items-center gap-1">
@@ -1470,7 +1470,7 @@ ${systemCommon}` + baseSys;
                   <button
                     type="button"
                     onClick={() => setShowDetails(s => !s)}
-                    className="px-2 py-1 text-xs border rounded hover:bg-slate-100 dark:hover:bg-slate-700"
+                    className="px-2 py-1 text-xs border rounded hover:bg-slate-100 dark:hover:bg-[var(--medx-surface)]"
                     title="View details"
                   >
                     <span className="inline-flex items-center gap-1">
@@ -1484,7 +1484,7 @@ ${systemCommon}` + baseSys;
               {showDetails && stats && (
                 <div className="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
                   {/* Phases */}
-                  <div className="rounded border bg-white dark:bg-slate-900 dark:border-slate-700">
+                  <div className="rounded border bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]">
                     <div className="px-3 py-2 font-medium border-b dark:border-slate-700">Phases</div>
                     <ul className="px-3 py-2 space-y-1">
                       {Object.entries(stats.byPhase).sort((a,b)=>b[1]-a[1]).map(([k,v])=>(
@@ -1495,7 +1495,7 @@ ${systemCommon}` + baseSys;
                   </div>
 
                   {/* Statuses */}
-                  <div className="rounded border bg-white dark:bg-slate-900 dark:border-slate-700">
+                  <div className="rounded border bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]">
                     <div className="px-3 py-2 font-medium border-b dark:border-slate-700">Statuses</div>
                     <ul className="px-3 py-2 space-y-1">
                       {Object.entries(stats.byStatus).sort((a,b)=>b[1]-a[1]).map(([k,v])=>(
@@ -1506,7 +1506,7 @@ ${systemCommon}` + baseSys;
                   </div>
 
                   {/* Countries */}
-                  <div className="rounded border bg-white dark:bg-slate-900 dark:border-slate-700">
+                  <div className="rounded border bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]">
                     <div className="px-3 py-2 font-medium border-b dark:border-slate-700">Top countries</div>
                     <ul className="px-3 py-2 space-y-1">
                       {Object.entries(stats.byCountry).sort((a,b)=>b[1]-a[1]).slice(0,5).map(([k,v])=>(
@@ -1517,7 +1517,7 @@ ${systemCommon}` + baseSys;
                   </div>
 
                   {/* Genes */}
-                  <div className="rounded border bg-white dark:bg-slate-900 dark:border-slate-700">
+                  <div className="rounded border bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]">
                     <div className="px-3 py-2 font-medium border-b dark:border-slate-700">Top genes</div>
                     <ul className="px-3 py-2 space-y-1">
                       {stats.genesTop.length ? stats.genesTop.map(([g,c])=>(
@@ -1527,7 +1527,7 @@ ${systemCommon}` + baseSys;
                   </div>
 
                   {/* Conditions */}
-                  <div className="rounded border bg-white dark:bg-slate-900 dark:border-slate-700">
+                  <div className="rounded border bg-white dark:bg-[var(--medx-panel)] dark:border-[color:var(--medx-outline)]">
                     <div className="px-3 py-2 font-medium border-b dark:border-slate-700">Top conditions</div>
                     <ul className="px-3 py-2 space-y-1">
                       {stats.conditionsTop.length ? stats.conditionsTop.map(([k,c])=>(
@@ -1567,7 +1567,7 @@ ${systemCommon}` + baseSys;
       >
         {ui.topic && (
           <div className="mx-auto mb-2 max-w-3xl px-4 sm:px-6">
-            <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs bg-white dark:bg-gray-900 border-slate-200 dark:border-gray-800">
+            <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs bg-white dark:bg-[var(--medx-panel)] border-slate-200 dark:border-[color:var(--medx-outline)]">
               <span className="opacity-70">Topic:</span>
               <strong className="truncate max-w-[16rem]">{ui.topic}</strong>
               <button onClick={() => setUi(prev => ({ ...prev, topic: null }))} className="opacity-60 hover:opacity-100">Clear</button>
@@ -1576,7 +1576,7 @@ ${systemCommon}` + baseSys;
         )}
         {ui.contextFrom && (
           <div className="mx-auto mb-2 max-w-3xl px-4 sm:px-6">
-            <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs bg-white dark:bg-gray-900 border-slate-200 dark:border-gray-800">
+            <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs bg-white dark:bg-[var(--medx-panel)] border-slate-200 dark:border-[color:var(--medx-outline)]">
               <span className="opacity-70">Using context from:</span>
               <strong>{ui.contextFrom}</strong>
               <button onClick={() => { clearContext(); setUi(prev => ({ ...prev, contextFrom: null })); }} className="opacity-60 hover:opacity-100">Clear</button>
@@ -1588,7 +1588,7 @@ ${systemCommon}` + baseSys;
             m.role === 'user' ? (
               <div
                 key={m.id}
-                className="ml-auto max-w-3xl rounded-2xl px-4 py-3 shadow-sm bg-slate-200 text-slate-900 dark:bg-gray-700 dark:text-gray-100 text-left whitespace-normal"
+                className="ml-auto max-w-3xl rounded-2xl px-4 py-3 shadow-sm bg-slate-200 text-slate-900 dark:bg-[var(--medx-panel)] dark:text-gray-100 text-left whitespace-normal"
               >
                 <ChatMarkdown content={m.content} />
               </div>
@@ -1658,7 +1658,7 @@ ${systemCommon}` + baseSys;
       )}
       {pendingCommitIds.length > 0 && (
         <div className="mx-auto my-4 max-w-3xl px-4 sm:px-6">
-          <div className="rounded-lg border p-3 text-sm flex items-center gap-2 bg-white dark:bg-gray-800">
+          <div className="rounded-lg border p-3 text-sm flex items-center gap-2 bg-white dark:bg-[var(--medx-panel)]">
             <span>Add this to your Medical Profile?</span>
             {commitError && <span className="text-xs text-rose-600">{commitError}</span>}
             <button
@@ -1756,7 +1756,7 @@ ${systemCommon}` + baseSys;
               />
             </label>
             {pendingFile && (
-              <div className="flex items-center gap-2 rounded-full bg-white/70 dark:bg-gray-800/70 px-3 py-1 text-xs">
+              <div className="flex items-center gap-2 rounded-full bg-white/70 dark:bg-[var(--medx-panel)] px-3 py-1 text-xs">
                 <span className="truncate max-w-[8rem]">{pendingFile.name}</span>
                 <button
                   type="button"

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -133,8 +133,8 @@ export default function Timeline(){
       {open && active && (
         <>
           <div className="fixed inset-0 bg-black/40 z-40" onClick={() => setOpen(false)} />
-          <aside className="fixed right-0 top-0 bottom-0 z-50 w-full sm:w-[640px] bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 shadow-2xl ring-1 ring-black/5 overflow-y-auto">
-            <header className="sticky top-0 bg-white/90 dark:bg-zinc-900/90 backdrop-blur border-b border-zinc-200/70 dark:border-zinc-800/70 px-4 py-3 flex items-center gap-2">
+          <aside className="fixed right-0 top-0 bottom-0 z-50 w-full sm:w-[640px] bg-white dark:bg-[var(--medx-panel)] text-zinc-900 dark:text-zinc-100 shadow-2xl ring-1 ring-black/5 overflow-y-auto">
+            <header className="sticky top-0 bg-white/90 dark:bg-[var(--medx-panel)] backdrop-blur border-b border-zinc-200/70 dark:border-[color:var(--medx-outline)] px-4 py-3 flex items-center gap-2">
               <h3 className="font-semibold truncate">{active.name || active.meta?.file_name || "Observation"}</h3>
               <div className="ml-auto flex gap-2">
                 {(active.file?.path || active.file?.upload_id) && signedUrl && (

--- a/components/search/SearchDock.tsx
+++ b/components/search/SearchDock.tsx
@@ -16,7 +16,7 @@ export default function SearchDock({ onSubmit }: { onSubmit: (q: string)=>void }
     >
       <form
         onSubmit={(e)=>{ e.preventDefault(); if (!q.trim()) return; onSubmit(q.trim()); setDocked(true); }}
-        className="rounded-2xl border border-neutral-200 bg-white/90 p-2 shadow-lg backdrop-blur dark:border-neutral-800 dark:bg-neutral-900/80"
+        className="rounded-2xl border border-neutral-200 bg-white/90 p-2 shadow-lg backdrop-blur dark:border-[color:var(--medx-outline)] dark:bg-[var(--medx-panel)]"
       >
         <input value={q} onChange={e=>setQ(e.target.value)} placeholder="Ask MedX…"
           className="w-full rounded-xl bg-transparent px-4 py-3 outline-none" />

--- a/components/ui/ScrollToBottom.tsx
+++ b/components/ui/ScrollToBottom.tsx
@@ -54,7 +54,7 @@ export default function ScrollToBottom({ targetRef, threshold = 120, rebindKey }
       onClick={() => {
         (boundEl ?? window).scrollTo({ top: (boundEl?.scrollHeight ?? document.documentElement.scrollHeight), behavior: "smooth" });
       }}
-      className="fixed bottom-5 right-5 z-50 rounded-full bg-neutral-900 px-4 py-2 text-sm text-white shadow-lg transition active:scale-95 dark:bg-neutral-100 dark:text-neutral-900"
+      className="fixed bottom-5 right-5 z-50 rounded-full bg-neutral-900 px-4 py-2 text-sm text-white shadow-lg transition active:scale-95 dark:bg-blue-100 dark:text-blue-900"
       aria-label="Scroll to bottom"
     >
       ↓ New messages

--- a/components/ui/ThinkingTimer.tsx
+++ b/components/ui/ThinkingTimer.tsx
@@ -31,7 +31,7 @@ export default function ThinkingTimer({ label = "Thinking", startedAt, autoStart
   const ss = String(secs % 60).padStart(2, "0");
 
   return (
-    <div className="inline-flex items-center gap-2 rounded-full bg-neutral-100 px-3 py-1 text-sm text-neutral-700 dark:bg-neutral-800 dark:text-neutral-200">
+    <div className="inline-flex items-center gap-2 rounded-full bg-neutral-100 px-3 py-1 text-sm text-neutral-700 dark:bg-[var(--medx-panel)] dark:text-neutral-200">
       <span className="relative flex h-2 w-2">
         <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
         <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-600" />


### PR DESCRIPTION
## Summary
- replace gray/black dark-mode tokens with blue-based `medx` variables
- switch component dark backgrounds to the new surface tokens
- refresh body background to use `medx` blue palette

## Testing
- `npm test` *(fails: drug interaction checker)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6bdd7c9e8832f98d0d411c376184f