### PR TITLE
Allow Patient and Doctor buttons to exit AI Doc mode

### DIFF
--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -43,7 +43,7 @@ export default function ModeBar() {
   return (
     <div className="sticky top-0 z-40 border-b border-border bg-background/70 backdrop-blur">
       <div className="mx-auto flex max-w-screen-xl items-center gap-2 px-4 py-2">
-        <button className={btn(state.base === "patient", aidocOn)} disabled={aidocOn}
+        <button className={btn(state.base === "patient")}
                 onClick={() => apply({ type: "toggle/patient" })}>
           Patient
         </button>
@@ -56,7 +56,7 @@ export default function ModeBar() {
                 onClick={() => apply({ type: "toggle/research" })}>
           Research
         </button>
-        <button className={btn(state.base === "doctor", aidocOn)} disabled={aidocOn}
+        <button className={btn(state.base === "doctor")}
                 onClick={() => apply({ type: "toggle/doctor" })}>
           Doctor
         </button>


### PR DESCRIPTION
## Summary
- Allow switching to Patient or Doctor while AI Doc is active by removing the AI Doc disabled state from those buttons

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6db022b98832f8680c26be11b2b16