### PR TITLE
Preserve query parameters when switching modes

### DIFF
--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -25,6 +25,9 @@ export default function ModeBar() {
     const current = new URLSearchParams(sp.toString());
     // custom exit for aidoc toggle
     if (action.type === "toggle/aidoc" && state.base === "aidoc") {
+      // drop AiDoc-specific params so fromSearchParams doesn't detect AiDoc again
+      current.delete("threadId");
+      current.delete("context");
       const q = toQuery(
         { ...state, base: lastNonAidoc.current, therapy: false, research: false },
         current,

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -22,14 +22,18 @@ export default function ModeBar() {
   }, [state.base]);
 
   const apply = (action: Parameters<typeof reduce>[1]) => {
+    const current = new URLSearchParams(sp.toString());
     // custom exit for aidoc toggle
     if (action.type === "toggle/aidoc" && state.base === "aidoc") {
-      const q = toQuery({ ...state, base: lastNonAidoc.current, therapy: false, research: false });
+      const q = toQuery(
+        { ...state, base: lastNonAidoc.current, therapy: false, research: false },
+        current,
+      );
       router.push(q);
       return;
     }
     const next = reduce(state, action);
-    router.push(toQuery(next));
+    router.push(toQuery(next, current));
   };
 
   const btn = (active: boolean, disabled?: boolean) =>

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -11,8 +11,12 @@ export default function ModeBar() {
   const { theme, setTheme } = useTheme();
 
   const state = useMemo(
-    () => fromSearchParams(sp, (theme as "light"|"dark") ?? "light"),
-    [sp, theme]
+    () =>
+      fromSearchParams(
+        typeof window !== "undefined" ? new URLSearchParams(window.location.search) : sp,
+        (theme as "light" | "dark") ?? "light",
+      ),
+    [sp, theme],
   );
 
   // remember last non-aidoc base to exit aidoc gracefully
@@ -22,7 +26,7 @@ export default function ModeBar() {
   }, [state.base]);
 
   const apply = (action: Parameters<typeof reduce>[1]) => {
-    const current = new URLSearchParams(sp.toString());
+    const current = new URLSearchParams(window.location.search);
     // custom exit for aidoc toggle
     if (action.type === "toggle/aidoc" && state.base === "aidoc") {
       // drop AiDoc-specific params so fromSearchParams doesn't detect AiDoc again

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -369,9 +369,12 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   useEffect(() => {
     if (!threadId && !isProfileThread) {
       const id = createNewThreadId();
-      router.replace(`/?panel=chat&threadId=${id}`);
+      const params = new URLSearchParams(sp.toString());
+      params.set("panel", "chat");
+      params.set("threadId", id);
+      router.replace(`/?${params.toString()}`);
     }
-  }, [threadId, isProfileThread, router]);
+  }, [threadId, isProfileThread, router, sp]);
   const currentMode: 'patient'|'doctor'|'research'|'therapy' = therapyMode ? 'therapy' : (researchMode ? 'research' : mode);
   const [pendingCommitIds, setPendingCommitIds] = useState<string[]>([]);
   const [commitBusy, setCommitBusy] = useState<null | 'save' | 'discard'>(null);

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useRef, useState, useMemo, RefObject, Fragment } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { fromSearchParams } from '@/lib/modes/url';
+import { fromSearchParams, toQuery } from '@/lib/modes/url';
 import Header from '../Header';
 import { useRouter } from 'next/navigation';
 import ChatMarkdown from '@/components/ChatMarkdown';
@@ -369,10 +369,11 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   useEffect(() => {
     if (!threadId && !isProfileThread) {
       const id = createNewThreadId();
-      const params = new URLSearchParams(sp.toString());
+      const params = new URLSearchParams(window.location.search);
       params.set("panel", "chat");
       params.set("threadId", id);
-      router.replace(`/?${params.toString()}`);
+      const state = fromSearchParams(params, 'light');
+      router.replace(toQuery(state, params));
     }
   }, [threadId, isProfileThread, router, sp]);
   const currentMode: 'patient'|'doctor'|'research'|'therapy' = therapyMode ? 'therapy' : (researchMode ? 'research' : mode);

--- a/lib/modes/url.ts
+++ b/lib/modes/url.ts
@@ -1,11 +1,13 @@
 import type { ModeState } from "./types";
 
-export function toQuery(state: ModeState): string {
+export function toQuery(state: ModeState, current?: URLSearchParams): string {
   if (state.base === "aidoc")
     return "/?panel=chat&threadId=med-profile&context=profile";
-  const p = new URLSearchParams({ panel: "chat", mode: state.base });
-  if (state.therapy) p.set("therapy", "1");
-  if (state.research) p.set("research", "1");
+  const p = current ? new URLSearchParams(current) : new URLSearchParams();
+  p.set("panel", "chat");
+  p.set("mode", state.base);
+  if (state.therapy) p.set("therapy", "1"); else p.delete("therapy");
+  if (state.research) p.set("research", "1"); else p.delete("research");
   return `/?${p.toString()}`;
 }
 


### PR DESCRIPTION
## Summary
- keep existing URL query parameters when generating mode URLs so threadId and flags persist
- update ModeBar to pass current search params into mode URL builder
- ensure ChatPane retains mode flags when auto-creating a new thread

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e09931d0832f83fcfc3225ae4d75