### PR TITLE
feat: refine chat suggestions

### DIFF
--- a/components/chat/ComposerFocus.tsx
+++ b/components/chat/ComposerFocus.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import type { Suggestion } from "@/lib/chat/suggestions";
+
+export default function ComposerFocus({ suggestions, composerRef }: { suggestions: Suggestion[]; composerRef: any }) {
+  useEffect(() => {
+    if (suggestions?.some((s) => !s.actionId)) {
+      composerRef.current?.focus?.();
+      composerRef.current?.setPlaceholder?.("Answer here (duration, other symptoms, meds…)");
+    }
+  }, [suggestions, composerRef]);
+  return null;
+}

--- a/components/chat/SuggestionChips.tsx
+++ b/components/chat/SuggestionChips.tsx
@@ -1,0 +1,41 @@
+import { isAction, Suggestion } from "@/lib/chat/suggestions";
+
+type Props = { suggestions: Suggestion[]; onAction: (s: Suggestion) => void };
+
+export default function SuggestionChips({ suggestions, onAction }: Props) {
+  if (!suggestions?.length) return null;
+
+  // Optional hard guard to strip accidental actionIds
+  const safe = suggestions.map((s) => (s.actionId ? s : { ...s, actionId: undefined as never }));
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      {safe.map((s) =>
+        isAction(s) ? (
+          <button
+            key={s.id}
+            type="button"
+            className="px-3 py-1 rounded-2xl text-sm shadow-sm hover:shadow
+                       border border-neutral-300 dark:border-neutral-700
+                       hover:bg-neutral-50 dark:hover:bg-neutral-800"
+            onClick={() => onAction(s)}
+            aria-label={s.label}
+          >
+            {s.label}
+          </button>
+        ) : (
+          <span
+            key={s.id}
+            className="px-3 py-1 rounded-2xl text-sm border border-dashed
+                       text-neutral-500 dark:text-neutral-400
+                       border-neutral-300 dark:border-neutral-700
+                       cursor-default select-text"
+            aria-disabled="true"
+          >
+            {s.label}
+          </span>
+        )
+      )}
+    </div>
+  );
+}

--- a/lib/chat/normalize.ts
+++ b/lib/chat/normalize.ts
@@ -1,0 +1,13 @@
+import { Suggestion } from "./suggestions";
+
+export function normalizeSuggestions(input: unknown): Suggestion[] {
+  if (!input) return [];
+  if (Array.isArray(input)) {
+    return input.map((x, i) =>
+      typeof x === "string"
+        ? ({ id: `s${i}`, label: x } satisfies Suggestion)
+        : (x as Suggestion)
+    );
+  }
+  return [];
+}

--- a/lib/chat/suggestions.ts
+++ b/lib/chat/suggestions.ts
@@ -1,0 +1,9 @@
+export type Suggestion = {
+  id: string;
+  label: string;
+  // If actionId exists → it’s an action button. Otherwise it’s a non-clickable prompt.
+  actionId?: "summarize" | "triage" | "make_timeline" | "pdf" | "share";
+  payload?: unknown;
+};
+
+export const isAction = (s: Suggestion) => !!s.actionId;

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -4,6 +4,7 @@ export type ChatMessage = {
   id: string;
   role: "user" | "assistant" | "system";
   content: string;
-  followUps?: string[];
+  // followUps may be legacy string arrays or Suggestion objects; normalize before use
+  followUps?: unknown;
   citations?: Citation[];
 };


### PR DESCRIPTION
## Summary
- add Suggestion type and normalization helpers
- render chat suggestions as prompts or actionable chips
- focus composer when prompt suggestions appear

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e2ad33ac832fbd54cb8a98926ceb