### PR TITLE
Preserve threadId and mode parameters when switching chat modes

### DIFF
--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -24,12 +24,15 @@ export default function ModeBar() {
   const apply = (action: Parameters<typeof reduce>[1]) => {
     // custom exit for aidoc toggle
     if (action.type === "toggle/aidoc" && state.base === "aidoc") {
-      const q = toQuery({ ...state, base: lastNonAidoc.current, therapy: false, research: false });
+      const q = toQuery(
+        { ...state, base: lastNonAidoc.current, therapy: false, research: false },
+        sp,
+      );
       router.push(q);
       return;
     }
     const next = reduce(state, action);
-    router.push(toQuery(next));
+    router.push(toQuery(next, sp));
   };
 
   const btn = (active: boolean, disabled?: boolean) =>

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -374,9 +374,12 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   useEffect(() => {
     if (!threadId && !isProfileThread) {
       const id = createNewThreadId();
-      router.replace(`/?panel=chat&threadId=${id}`);
+      const params = new URLSearchParams(sp.toString());
+      params.set("panel", "chat");
+      params.set("threadId", id);
+      router.replace(`/?${params.toString()}`);
     }
-  }, [threadId, isProfileThread, router]);
+  }, [threadId, isProfileThread, router, sp]);
   const currentMode: 'patient'|'doctor'|'research'|'therapy' = therapyMode ? 'therapy' : (researchMode ? 'research' : mode);
   const [pendingCommitIds, setPendingCommitIds] = useState<string[]>([]);
   const [commitBusy, setCommitBusy] = useState<null | 'save' | 'discard'>(null);

--- a/lib/modes/url.ts
+++ b/lib/modes/url.ts
@@ -15,6 +15,13 @@ export function toQuery(
   if (state.research && (state.base === "patient" || state.base === "doctor"))
     p.set("research", "1");
   else p.delete("research");
+  if (
+    p.get("threadId") === "med-profile" &&
+    p.get("context") === "profile"
+  ) {
+    p.delete("threadId");
+    p.delete("context");
+  }
   return `/?${p.toString()}`;
 }
 

--- a/lib/modes/url.ts
+++ b/lib/modes/url.ts
@@ -1,11 +1,19 @@
 import type { ModeState } from "./types";
 
-export function toQuery(state: ModeState): string {
+export function toQuery(
+  state: ModeState,
+  current?: URLSearchParams | ReadonlyURLSearchParams,
+): string {
   if (state.base === "aidoc")
     return "/?panel=chat&threadId=med-profile&context=profile";
-  const p = new URLSearchParams({ panel: "chat", mode: state.base });
-  if (state.therapy) p.set("therapy", "1");
-  if (state.research) p.set("research", "1");
+  const p = new URLSearchParams(current ? current.toString() : undefined);
+  p.set("panel", "chat");
+  p.set("mode", state.base);
+  if (state.therapy && state.base === "patient") p.set("therapy", "1");
+  else p.delete("therapy");
+  if (state.research && (state.base === "patient" || state.base === "doctor"))
+    p.set("research", "1");
+  else p.delete("research");
   return `/?${p.toString()}`;
 }
 

--- a/lib/modes/url.ts
+++ b/lib/modes/url.ts
@@ -1,4 +1,5 @@
 import type { ModeState } from "./types";
+import type { ReadonlyURLSearchParams } from "next/navigation";
 
 export function toQuery(
   state: ModeState,


### PR DESCRIPTION
## Summary
- extend `toQuery` to merge existing URL parameters so threadId and flags persist
- pass current search params to `toQuery` from `ModeBar` and keep mode flags when auto-creating chat threads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6ea9e8508832fbe4048d0184565c2