### PR TITLE
feat: enhance markdown rendering and chat tags

### DIFF
--- a/components/chat/Renderer.tsx
+++ b/components/chat/Renderer.tsx
@@ -4,7 +4,19 @@ export const Renderer = {
   h1: ({ children }: { children: ReactNode }) => (
     <h1 className="text-lg font-semibold">{children}</h1>
   ),
+  h2: ({ children }: { children: ReactNode }) => (
+    <h2 className="text-base font-semibold mt-4">{children}</h2>
+  ),
+  ol: ({ children }: { children: ReactNode }) => (
+    <ol className="list-decimal ml-5 space-y-1">{children}</ol>
+  ),
   ul: ({ children }: { children: ReactNode }) => (
     <ul className="list-disc ml-4 space-y-1">{children}</ul>
   ),
+  table: ({ children }: { children: ReactNode }) => (
+    <table className="table-auto border-collapse my-3">{children}</table>
+  ),
+  thead: ({ children }: { children: ReactNode }) => <thead className="bg-muted">{children}</thead>,
+  th: ({ children }: { children: ReactNode }) => <th className="px-2 py-1 font-semibold text-left border">{children}</th>,
+  td: ({ children }: { children: ReactNode }) => <td className="px-2 py-1 align-top border">{children}</td>,
 };


### PR DESCRIPTION
## Summary
- allow Markdown component to accept children or text, enabling GFM parsing with sanitized output and safe external links
- style rendered markdown for headings, lists, tables, blockquotes and more
- extend chat renderer with additional tags (h2, ordered lists, tables)

## Testing
- `npm run lint` *(fails: interactive ESLint prompt)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7047ed98c832fad004776a0155d5e