### PR TITLE
feat: unify markdown rendering

### DIFF
--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -61,6 +61,10 @@ export default function ChatMarkdown({ content, typing = false, onDone, fast }: 
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex]}
         components={{
+          // Explicit emphasis/strong to ensure styling even in minimal containers
+          em: ({ children }) => <em>{children}</em>,
+          strong: ({ children }) => <strong>{children}</strong>,
+
           a: ({ href, children }) => (
             <LinkBadge href={href as string}>
               {typing ? <TypedText childrenNode={children} fast={fast} /> : children}
@@ -69,6 +73,15 @@ export default function ChatMarkdown({ content, typing = false, onDone, fast }: 
           ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
           ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
           hr: () => <hr className="my-3 border-dashed opacity-40" />,
+          table: ({ children }) => (
+            <table className="border-collapse my-3 text-sm">{children}</table>
+          ),
+          thead: ({ children }) => <thead className="bg-slate-50 dark:bg-slate-800/50">{children}</thead>,
+          tbody: ({ children }) => <tbody>{children}</tbody>,
+          tr: ({ children }) => <tr className="align-top">{children}</tr>,
+          th: ({ children }) => <th className="border px-2 py-1 font-semibold text-left">{children}</th>,
+          td: ({ children }) => <td className="border px-2 py-1">{children}</td>,
+
           p: ({ children }) => (
             typing ? (
               <p className="text-left">

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -5,7 +5,7 @@ import { ChatInput } from "@/components/ChatInput";
 import { persistIfTemp } from "@/lib/chat/persist";
 import ThinkingTimer from "@/components/ui/ThinkingTimer";
 import ScrollToBottom from "@/components/ui/ScrollToBottom";
-import Typewriter from "@/components/chat/Typewriter";
+import ChatMarkdown from "@/components/ChatMarkdown";
 import { useTypewriterStore } from "@/lib/state/typewriterStore";
 
 function MessageRow({ m }: { m: { id: string; role: string; content: string } }) {
@@ -16,9 +16,13 @@ function MessageRow({ m }: { m: { id: string; role: string; content: string } })
     <div className="p-2" onClick={() => setFast(true)}>
       <strong>{m.role}:</strong>{" "}
       {m.role === "assistant" ? (
-        <Typewriter text={m.content} fast={fast || isDone} onDone={() => markDone(m.id)} />
+        <ChatMarkdown
+          content={m.content}
+          typing={!fast && !isDone}
+          onDone={() => markDone(m.id)}
+        />
       ) : (
-        m.content
+        <ChatMarkdown content={m.content} />
       )}
     </div>
   );

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,29 +1,21 @@
 'use client';
-import { marked } from 'marked';
-import DOMPurify from 'isomorphic-dompurify';
-import { sourceLabelFromUrl } from "@/lib/url";
-import { normalizeExternalHref } from './SafeLink';
-import { linkify } from './AutoLink';
+import React from 'react';
+import ChatMarkdown from '@/components/ChatMarkdown';
 
-export default function Markdown({ text }: { text: string }) {
-  marked.setOptions({ gfm: true, breaks: true });
-  const raw = linkify(text);
-  const sanitized = DOMPurify.sanitize(marked.parse(raw) as string, {
-    ADD_ATTR: ['target', 'rel'],
-  });
-  const withSafeLinks = sanitized.replace(/<a\s+[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/gi, (_m, href, inner) => {
-    const safe = normalizeExternalHref(href);
-    if (!safe) {
-      return `<span class="inline-flex items-center rounded-full border border-slate-200 dark:border-gray-700 px-2 py-1 text-xs text-slate-400" title="Link unavailable">${inner}</span>`;
-    }
-    // If inner text is empty or a raw URL, swap to source label
-    const cleanInner = String(inner || "").trim();
-    const useLabel = (!cleanInner || /^https?:\/\//i.test(cleanInner)) ? sourceLabelFromUrl(safe) : cleanInner;
+type Props = { text?: string; children?: React.ReactNode };
 
-    return `<a href="${safe}" target="_blank" rel="noopener noreferrer"
-    class="inline-flex items-center gap-1 rounded-full border border-slate-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-2 py-1 text-xs font-medium text-slate-700 dark:text-slate-200 shadow-sm hover:bg-slate-50 dark:hover:bg-gray-800 transition">
-      <span>${useLabel}</span><span aria-hidden="true" class="opacity-70">↗</span>
-  </a>`;
-  });
-  return <div className="markdown" dangerouslySetInnerHTML={{ __html: withSafeLinks }} />;
+function childrenToString(children: React.ReactNode): string {
+  if (children == null) return '';
+  if (typeof children === 'string') return children;
+  if (Array.isArray(children)) return children.map(childrenToString).join('');
+  if (typeof children === 'number' || typeof children === 'boolean') return String(children);
+  // Fallback
+  // @ts-ignore
+  return String(children ?? '');
 }
+
+export default function Markdown({ text, children }: Props) {
+  const content = text ?? childrenToString(children);
+  return <ChatMarkdown content={content} />;
+}
+

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,4 +1,4 @@
-import Markdown from "react-markdown";
+import ChatMarkdown from "@/components/ChatMarkdown";
 import FeedbackControls from "./FeedbackControls";
 
 interface MessageProps {
@@ -8,7 +8,7 @@ interface MessageProps {
 export default function Message({ message }: MessageProps) {
   return (
     <div>
-      <Markdown>{message.text}</Markdown>
+      <ChatMarkdown content={message.text} />
       <div className="mt-2">
         <FeedbackControls messageId={message.id} />
       </div>

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1455,7 +1455,9 @@ ${systemCommon}` + baseSys;
                   {mode === "doctor" ? <Stethoscope size={16}/> : <Users size={16}/>}
                 </div>
 
-                <div className="flex-1 whitespace-pre-wrap">{summary}</div>
+                <div className="flex-1">
+                  <ChatMarkdown content={summary} />
+                </div>
 
                 <div className="flex items-center gap-2">
                   {stats?.recruitingCount ? (


### PR DESCRIPTION
## Summary
- render tables, emphasis, and strong text in ChatMarkdown
- use ChatMarkdown for classic chat message components and summary bubble
- replace legacy Markdown component with ChatMarkdown alias

## Testing
- `npm test` *(fails: drug interaction checker handles api failure gracefully)*

------
https://chatgpt.com/codex/tasks/task_e_68c70e986570832fb860edc98b08fd85