### PR TITLE
feat: unify chat message markdown rendering

### DIFF
--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -61,6 +61,10 @@ export default function ChatMarkdown({ content, typing = false, onDone, fast }: 
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex]}
         components={{
+          // Ensure emphasis and bold always render as expected
+          em: ({ children }) => <em>{children}</em>,
+          strong: ({ children }) => <strong>{children}</strong>,
+
           a: ({ href, children }) => (
             <LinkBadge href={href as string}>
               {typing ? <TypedText childrenNode={children} fast={fast} /> : children}
@@ -69,6 +73,17 @@ export default function ChatMarkdown({ content, typing = false, onDone, fast }: 
           ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
           ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
           hr: () => <hr className="my-3 border-dashed opacity-40" />,
+
+          // Full GFM table support with borders/padding
+          table: ({ children }) => (
+            <table className="border-collapse my-3 text-sm">{children}</table>
+          ),
+          thead: ({ children }) => <thead className="bg-slate-50 dark:bg-slate-800/50">{children}</thead>,
+          tbody: ({ children }) => <tbody>{children}</tbody>,
+          tr:   ({ children }) => <tr className="align-top">{children}</tr>,
+          th:   ({ children }) => <th className="border px-2 py-1 font-semibold text-left">{children}</th>,
+          td:   ({ children }) => <td className="border px-2 py-1">{children}</td>,
+
           p: ({ children }) => (
             typing ? (
               <p className="text-left">

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,4 +1,4 @@
-import Markdown from "react-markdown";
+import ChatMarkdown from "@/components/ChatMarkdown";
 import FeedbackControls from "./FeedbackControls";
 
 interface MessageProps {
@@ -8,7 +8,7 @@ interface MessageProps {
 export default function Message({ message }: MessageProps) {
   return (
     <div>
-      <Markdown>{message.text}</Markdown>
+      <ChatMarkdown content={message.text} />
       <div className="mt-2">
         <FeedbackControls messageId={message.id} />
       </div>


### PR DESCRIPTION
## Summary
- render Message components with shared ChatMarkdown renderer
- ensure ChatMarkdown supports emphasis and GFM tables with consistent styling

## Testing
- `npm test` *(fails: drug interaction checker handles api failure gracefully)*

------
https://chatgpt.com/codex/tasks/task_e_68c714ce21ac832f914380093222c7a0