### PR TITLE
Standardize markdown typography

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,13 @@
 /* smooth theme transitions */
 * { transition: background-color .15s ease, color .15s ease, border-color .15s ease; }
 
+/* Make links readable inside prose */
+.prose a { text-decoration: none; }
+.prose a:hover { text-decoration: underline; }
+
+/* Let code wrap nicely in prose */
+.prose pre { overflow-x: auto; }
+
 .btn-secondary{
   @apply inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm transition
          bg-white text-slate-700 border-slate-200 hover:bg-slate-50
@@ -18,48 +25,11 @@
   pointer-events: auto;
 }
 
-/* Compact typography for AI content */
-.prose-medx {
-  /* narrower line-height than Tailwind Typography defaults */
-  line-height: 1.55; /* roughly Tailwind leading-[1.55] */
-}
-
-/* Tighten paragraph margins */
-.prose-medx :where(p):not(:where([class~="not-prose"] *)) {
-  margin-top: 0.35rem;
-  margin-bottom: 0.35rem;
-}
-
-/* Tighten lists */
-.prose-medx :where(ul):not(:where([class~="not-prose"] *)) {
-  margin-top: 0.4rem;
-  margin-bottom: 0.4rem;
-  padding-left: 1.25rem;
-}
-
-.prose-medx :where(ol):not(:where([class~="not-prose"] *)) {
-  margin-top: 0.4rem;
-  margin-bottom: 0.4rem;
-  padding-left: 1.25rem;
-}
-
-/* Reduce gap between list items */
-.prose-medx :where(li):not(:where([class~="not-prose"] *)) {
-  margin-top: 0.2rem;
-  margin-bottom: 0.2rem;
-}
-
-/* Headings inside cards: smaller margins */
-.prose-medx :where(h2,h3,h4):not(:where([class~="not-prose"] *)) {
-  margin-top: 0.75rem;
-  margin-bottom: 0.4rem;
-}
 
 /* Ensure body/content contrast in dark */
 .dark body { color: rgb(229 231 235); }           /* text-gray-200 */
 .dark .card,.dark .panel { background: #0f172a; } /* slate-900 */
 .dark .border { border-color: rgb(71 85 105); }   /* slate-600 */
-.dark .prose-medx :where(li)::marker { color: rgb(148 163 184); }
 
 :root.therapy-mode, .therapy-mode body {
   /* keep it gentle and readable */

--- a/app/styles.css
+++ b/app/styles.css
@@ -94,8 +94,3 @@ body{
 }
 .iconBtn:disabled{ opacity:.5; cursor:not-allowed }
 
-/* Markdown */
-.markdown h1,.markdown h2,.markdown h3{ margin:12px 0 6px }
-.markdown p{ margin:8px 0 }
-.markdown ul, .markdown ol{ padding-left:22px; margin:8px 0 }
-.markdown code{ background:rgba(255,255,255,.06); padding:2px 6px; border-radius:6px; }

--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -8,6 +8,7 @@ import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 import { LinkBadge } from "./SafeLink";
 import Typewriter from "@/components/chat/Typewriter";
+import { PROSE_CLASS } from "./markdownStyles";
 
 // --- Normalizer ---
 // normalize: unwrap full-message fences, convert ==== to <hr>, bold-lines → headings, list bullets
@@ -48,15 +49,7 @@ export default function ChatMarkdown({ content, typing = false, onDone, fast }: 
   const prepared = normalize(content);
 
   return (
-    <div
-      className="
-        prose prose-slate dark:prose-invert max-w-none
-        prose-headings:font-semibold prose-headings:mb-2 prose-headings:mt-3
-        prose-h3:text-lg prose-h4:text-base
-        prose-p:my-2 prose-li:my-1 prose-strong:font-medium
-        leading-relaxed text-[15px]
-      "
-    >
+    <div className={PROSE_CLASS}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkMath]}
         rehypePlugins={[rehypeKatex]}

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -4,6 +4,7 @@ import DOMPurify from 'isomorphic-dompurify';
 import { sourceLabelFromUrl } from "@/lib/url";
 import { normalizeExternalHref } from './SafeLink';
 import { linkify } from './AutoLink';
+import { PROSE_CLASS } from "./markdownStyles";
 
 export default function Markdown({ text }: { text: string }) {
   marked.setOptions({ gfm: true, breaks: true });
@@ -25,5 +26,5 @@ export default function Markdown({ text }: { text: string }) {
       <span>${useLabel}</span><span aria-hidden="true" class="opacity-70">↗</span>
   </a>`;
   });
-  return <div className="markdown" dangerouslySetInnerHTML={{ __html: withSafeLinks }} />;
+  return <div className={PROSE_CLASS} dangerouslySetInnerHTML={{ __html: withSafeLinks }} />;
 }

--- a/components/markdownStyles.ts
+++ b/components/markdownStyles.ts
@@ -1,0 +1,12 @@
+export const PROSE_CLASS =
+  "prose prose-slate dark:prose-invert max-w-none " +
+  // Headings
+  "prose-headings:font-semibold prose-h1:text-2xl prose-h2:text-xl prose-h3:text-lg " +
+  // Paragraphs & lists
+  "prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-0 " +
+  // Inline code & code blocks
+  "prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md " +
+  "prose-code:bg-slate-100 dark:prose-code:bg-slate-800 " +
+  // HR, tables, blockquotes
+  "prose-hr:my-4 prose-blockquote:italic prose-blockquote:border-l-4 " +
+  "prose-table:my-3";


### PR DESCRIPTION
## Summary
- centralize markdown typography in `PROSE_CLASS`
- apply shared styles to chat and static markdown components
- simplify global CSS and remove legacy markdown rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c71c636914832f9c6853f46facad30