### PR TITLE
Add health answer planner and follow-up chips

### DIFF
--- a/components/FollowUpChips.tsx
+++ b/components/FollowUpChips.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+const LABELS: Record<string,string> = {
+  symptoms: "Symptoms",
+  causes: "Causes",
+  home_care: "Home care",
+  prevention: "Prevention",
+  when_to_seek_help: "When to see a doctor",
+  red_flags: "Red flags",
+  treatment: "Treatment",
+  faq: "FAQs",
+};
+
+export function FollowUpChips({ options, onPick }:{
+  options: string[]; onPick: (opt: string) => void;
+}) {
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      {options.map(opt => (
+        <button
+          key={opt}
+          className="rounded-full border px-3 py-1 text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
+          onClick={() => onPick(opt)}
+        >
+          {LABELS[opt] ?? opt}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,14 +1,21 @@
-import Markdown from "react-markdown";
+'use client';
+
 import FeedbackControls from "./FeedbackControls";
+import ChatMarkdown from "@/components/ChatMarkdown";
+import { FollowUpChips } from "@/components/FollowUpChips";
 
 interface MessageProps {
-  message: { id: string; text: string };
+  message: { id: string; text: string; plan?: { followUps: string[] } };
+  onPick?: (opt: string) => void;
 }
 
-export default function Message({ message }: MessageProps) {
+export default function Message({ message, onPick }: MessageProps) {
   return (
     <div>
-      <Markdown>{message.text}</Markdown>
+      <ChatMarkdown content={message.text} />
+      {message.plan?.followUps?.length ? (
+        <FollowUpChips options={message.plan.followUps} onPick={onPick || (() => {})} />
+      ) : null}
       <div className="mt-2">
         <FeedbackControls messageId={message.id} />
       </div>

--- a/lib/answerPlanner.ts
+++ b/lib/answerPlanner.ts
@@ -1,0 +1,42 @@
+export type DetailLevel = "brief" | "standard" | "expert";
+
+export type HealthTopicSlice =
+  | "definition" | "types" | "symptoms" | "causes"
+  | "home_care" | "treatment" | "prevention"
+  | "red_flags" | "when_to_seek_help" | "faq" | "references";
+
+export interface Plan {
+  topic: string;                // e.g., "back pain"
+  slices: HealthTopicSlice[];   // which sections to include in THIS turn
+  detail: DetailLevel;          // brief by default
+  followUps: HealthTopicSlice[];// buttons to offer next
+  wordCap: number;              // hard cap for the LLM
+}
+
+export function defaultPlan(topic: string): Plan {
+  return {
+    topic,
+    slices: ["definition", "types"],
+    detail: "brief",
+    followUps: ["symptoms","causes","home_care","when_to_seek_help","prevention"],
+    wordCap: 160,
+  };
+}
+
+// On chip click, derive next plan:
+export function nextPlanFromChip(topic: string, chip: HealthTopicSlice, previous?: Plan): Plan {
+  const detail: DetailLevel = previous?.detail ?? "brief";
+  const base = { topic, slices: [chip], detail };
+  switch (chip) {
+    case "symptoms":
+      return { ...base, followUps: ["red_flags","causes","home_care","treatment"], wordCap: 180 };
+    case "causes":
+      return { ...base, followUps: ["symptoms","home_care","prevention"], wordCap: 180 };
+    case "home_care":
+      return { ...base, followUps: ["when_to_seek_help","treatment","prevention"], wordCap: 180 };
+    case "when_to_seek_help":
+      return { ...base, followUps: ["red_flags","treatment"], wordCap: 160 };
+    default:
+      return { ...base, followUps: ["symptoms","causes","home_care","when_to_seek_help"], wordCap: 160 };
+  }
+}

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -1,0 +1,43 @@
+import type { Plan, HealthTopicSlice } from "./answerPlanner";
+
+const SLICE_ORDER: Record<HealthTopicSlice, string> = {
+  definition: "## **What it is**",
+  types: "## **Types**",
+  symptoms: "## **Symptoms**",
+  causes: "## **Common Causes**",
+  home_care: "## **Home Care**",
+  treatment: "## **Treatment Options**",
+  prevention: "## **Prevention**",
+  red_flags: "## **Red Flags**",
+  when_to_seek_help: "## **When to Seek Help**",
+  faq: "## **FAQs**",
+  references: "## **References**",
+};
+
+export function buildHealthPrompt(plan: Plan, userQuestion: string) {
+  const sections = plan.slices.map(s => SLICE_ORDER[s]).join("\n\n");
+  const bulletsHint =
+`- Use bold headers and short bullet points.
+- Keep it under ${plan.wordCap} words total.
+- Avoid repetition.`;
+
+  const followupHint =
+`End with a single line asking if the user wants more, e.g.:
+*Would you like details on symptoms, causes, home care, prevention, or when to seek help?*`;
+
+  return `
+You are a clinical explainer for laypeople. Be accurate, neutral, and concise.
+
+User question: "${userQuestion}"
+Topic: ${plan.topic}
+Detail level: ${plan.detail}
+
+Write ONLY the sections requested, in this order:
+${sections}
+
+Formatting:
+${bulletsHint}
+
+${followupHint}
+`.trim();
+}


### PR DESCRIPTION
## Summary
- introduce a lightweight planning schema for health-topic responses
- build structured health prompt template and wrap LLM call in API route
- add follow-up chip component and render chips in chat messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71d3fc2fc832f98bc8ddc5fef7a44