### PR TITLE
feat: unify typography and font defaults

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -50,9 +50,28 @@
 }
 
 /* Headings inside cards: smaller margins */
-.prose-medx :where(h2,h3,h4):not(:where([class~="not-prose"] *)) {
+.prose-medx :where(h1,h2,h3,h4):not(:where([class~="not-prose"] *)) {
   margin-top: 0.75rem;
   margin-bottom: 0.4rem;
+  @apply font-semibold;
+}
+
+/* Inline code matches body font */
+.prose-medx :where(code):not(:where([class~="not-prose"] *)) {
+  @apply font-sans font-normal px-1 py-0.5 rounded bg-slate-100 dark:bg-slate-800;
+}
+
+/* Gentle rules and separators */
+.prose-medx :where(hr):not(:where([class~="not-prose"] *)) {
+  @apply my-3 border-t border-dashed opacity-40;
+}
+
+/* Emphasis defaults */
+.prose-medx :where(strong):not(:where([class~="not-prose"] *)) {
+  @apply font-semibold;
+}
+.prose-medx :where(em):not(:where([class~="not-prose"] *)) {
+  @apply italic;
 }
 
 /* Ensure body/content contrast in dark */

--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -50,10 +50,7 @@ export default function ChatMarkdown({ content, typing = false, onDone, fast }: 
   return (
     <div
       className="
-        prose prose-slate dark:prose-invert max-w-none
-        prose-headings:font-semibold prose-headings:mb-2 prose-headings:mt-3
-        prose-h3:text-lg prose-h4:text-base
-        prose-p:my-2 prose-li:my-1 prose-strong:font-medium
+        prose prose-slate dark:prose-invert prose-medx max-w-none
         leading-relaxed text-[15px]
       "
     >
@@ -66,9 +63,6 @@ export default function ChatMarkdown({ content, typing = false, onDone, fast }: 
               {typing ? <TypedText childrenNode={children} fast={fast} /> : children}
             </LinkBadge>
           ),
-          ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
-          ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
-          hr: () => <hr className="my-3 border-dashed opacity-40" />,
           p: ({ children }) => (
             typing ? (
               <p className="text-left">

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -25,5 +25,10 @@ export default function Markdown({ text }: { text: string }) {
       <span>${useLabel}</span><span aria-hidden="true" class="opacity-70">↗</span>
   </a>`;
   });
-  return <div className="markdown" dangerouslySetInnerHTML={{ __html: withSafeLinks }} />;
+  return (
+    <div
+      className="prose prose-slate dark:prose-invert prose-medx max-w-none"
+      dangerouslySetInnerHTML={{ __html: withSafeLinks }}
+    />
+  );
 }

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,4 +1,4 @@
-import Markdown from "react-markdown";
+import Markdown from "@/components/Markdown";
 import FeedbackControls from "./FeedbackControls";
 
 interface MessageProps {
@@ -8,7 +8,7 @@ interface MessageProps {
 export default function Message({ message }: MessageProps) {
   return (
     <div>
-      <Markdown>{message.text}</Markdown>
+      <Markdown text={message.text} />
       <div className="mt-2">
         <FeedbackControls messageId={message.id} />
       </div>


### PR DESCRIPTION
## Summary
- ensure consistent typography across markdown elements with new `prose-medx` defaults
- align chat and message markdown rendering on shared font and prose styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c72087d064832f97c76d412ecce711