### PR TITLE
feat: unify markdown rendering across modes

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,7 @@ export const metadata = { title: "MedX", description: "Global medical AI" };
 const roboto = Roboto({
   subsets: ["latin"],
   weight: ["300", "400", "500", "700", "900"],
+  style: ["normal", "italic"],
   variable: "--font-roboto",
   display: "swap",
 });

--- a/app/styles.css
+++ b/app/styles.css
@@ -99,3 +99,6 @@ body{
 .markdown p{ margin:8px 0 }
 .markdown ul, .markdown ol{ padding-left:22px; margin:8px 0 }
 .markdown code{ background:rgba(255,255,255,.06); padding:2px 6px; border-radius:6px; }
+/* Ensure emphasis renders even if prose classes aren't present */
+.markdown strong{ font-weight:700; }
+.markdown em{ font-style:italic; }

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -25,5 +25,5 @@ export default function Markdown({ text }: { text: string }) {
       <span>${useLabel}</span><span aria-hidden="true" class="opacity-70">↗</span>
   </a>`;
   });
-  return <div className="markdown" dangerouslySetInnerHTML={{ __html: withSafeLinks }} />;
+  return <div className="markdown prose prose-slate dark:prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: withSafeLinks }} />;
 }

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,4 +1,4 @@
-import Markdown from "react-markdown";
+import ChatMarkdown from "@/components/ChatMarkdown";
 import FeedbackControls from "./FeedbackControls";
 
 interface MessageProps {
@@ -7,8 +7,8 @@ interface MessageProps {
 
 export default function Message({ message }: MessageProps) {
   return (
-    <div>
-      <Markdown>{message.text}</Markdown>
+    <div className="prose prose-slate dark:prose-invert max-w-none">
+      <ChatMarkdown content={message.text} typing={false} />
       <div className="mt-2">
         <FeedbackControls messageId={message.id} />
       </div>


### PR DESCRIPTION
## Summary
- use shared ChatMarkdown renderer for chat messages
- preserve strong/em tags while animating text
- load Roboto italics and ensure markdown emphasis styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c72609c970832f8139faaa383324ac