### PR TITLE
Refine social intent detection

### DIFF
--- a/lib/social.ts
+++ b/lib/social.ts
@@ -71,11 +71,10 @@ export function detectSocialIntent(text: string): SocialIntent {
   const short = words.length <= 6;
 
   const has = (set: Set<string>) => {
-    if (set.has(s)) return true;
-    if (short) {
-      for (const k of set) {
-        if (s === k || s.startsWith(k)) return true;
-      }
+    if (set.has(s)) return true;              // whole-message exact
+    for (const k of set) {
+      // word-level exact (no prefix matching)
+      if (words.includes(k)) return true;
     }
     return false;
   };


### PR DESCRIPTION
## Summary
- make social intent detector match words individually instead of relying on string prefixes

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c729640da8832fb5c12ed03f584cd8