### PR TITLE
feat: add intent-aware structure and brevity controls

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -52,14 +52,36 @@ export async function POST(req: NextRequest) {
     }
     recentReqs.set(clientRequestId, now);
   }
+  // === Concision controls (SOFT cap, no cutoffs) ===
+  const latestUserMessage =
+    (messages || []).filter((m: any) => m.role === "user").slice(-1)[0]?.content || "";
+  const wordCount = (latestUserMessage || "").trim().split(/\s+/).filter(Boolean).length;
+  const isShortQuery = wordCount <= 6;
+  const briefTopic = /\b(what is|types?|symptoms?|causes?|treatment|home care|prevention|red flags?)\b/i
+    .test(latestUserMessage || "");
+  const targetWordCap = (mode === "doctor")
+    ? (isShortQuery || briefTopic ? 220 : 360)
+    : (isShortQuery || briefTopic ? 180 : 280);
+  const brevitySystem = [
+    "You are MedX chat. Be concise and structured.",
+    `Aim to keep the entire answer under ${targetWordCap} words (SOFT cap).`,
+    "If you are finishing a sentence, you may exceed the cap slightly to complete it (≤ +40 words).",
+    "Never cut a sentence or bullet mid-way; always end with a complete sentence.",
+    "Use bold mini-headers and short bullet points (3–5 bullets).",
+    "Focus strictly on the user question—omit generic boilerplate.",
+    "End with one short follow-up question (≤10 words) that stays on-topic.",
+  ].join("\n");
   const base  = process.env.LLM_BASE_URL!;
   const model = process.env.LLM_MODEL_ID || 'llama-3.1-8b-instant';
   const key   = process.env.LLM_API_KEY!;
   const url = `${base.replace(/\/$/,'')}/chat/completions`;
 
   let finalMessages = messages.filter((m: any) => m.role !== 'system');
+  // Ensure brevity guidance is present even if client didn't send a system prompt
+  if (!finalMessages.length || finalMessages[0]?.role !== 'system') {
+    finalMessages = [{ role: 'system', content: brevitySystem }, ...finalMessages];
+  }
 
-  const latestUserMessage = messages.filter((m: any) => m.role === 'user').slice(-1)[0]?.content || "";
   const userText = (messages || []).map((m: any) => m?.content || '').join('\n');
   const ctx = canonicalizeInputs(extractAll(userText));
   const computed = computeAll(ctx);
@@ -98,7 +120,8 @@ export async function POST(req: NextRequest) {
         profile: p?.profile || p || null,
         packet: pk.text || '',
       });
-      finalMessages = [{ role: 'system', content: sys }, ...finalMessages];
+      // Combine clinical profile with brevity rules (keeps context + concision)
+      finalMessages = [{ role: 'system', content: [sys, brevitySystem].join('\n\n') }, ...finalMessages];
     } catch {}
   }
   // === [MEDX_CALC_PRELUDE_START] ===
@@ -114,12 +137,14 @@ export async function POST(req: NextRequest) {
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
     body: JSON.stringify({
       model,
+      messages: finalMessages,
+      // Token cap with buffer to avoid API truncation while honoring SOFT word cap
+      max_tokens: Math.min(768, Math.max(200, Math.round((targetWordCap + 40) * 1.7))),
       stream: true,
-      temperature: 0,
+      temperature: 0.4,
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,
-      messages: finalMessages,
     })
   });
 

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -933,6 +933,28 @@ ${linkNudge}`;
       const systemCommon = `\nUser country: ${country.code3} (${country.name}). Use generics and note availability varies by region.\nEnd with one short follow-up question (<=10 words) that stays on the current topic.\n`;
       const topicHint = ui.topic ? `ACTIVE TOPIC: ${ui.topic}\nKeep answers scoped to this topic unless the user changes it.\n` : "";
 
+      // Per-mode drafting style (structure only; no provider changes)
+      const PATIENT_DRAFT_STYLE = [
+        "FORMAT: Use 2–3 short sections with bold headers and bullets.",
+        "For 'what is ...' questions, default to these sections:",
+        "## **What it is**",
+        "## **Types**",
+        "Finish with one short follow-up question (≤10 words).",
+      ].join("\n");
+      const DOCTOR_DRAFT_STYLE = [
+        "FORMAT (clinical, concise): Use bold headers + bullets.",
+        "For definition-type asks, prefer this outline:",
+        "## **Definition (clinical)**",
+        "## **Phenotypes**",
+        "## **Red flags** (include only if relevant)",
+        "## **Initial work-up (typical)** (include only if appropriate)",
+        "Finish with one short follow-up question (≤10 words).",
+      ].join("\n");
+
+      // Intent-aware structure (lightweight)
+      const { getIntentStyle } = await import("@/lib/intents");
+      const INTENT_STYLE = getIntentStyle(userText || "", mode);
+
       const sys = topicHint + systemCommon + baseSys;
       const sysWithDomain = DOMAIN_STYLE ? `${sys}\n\n${DOMAIN_STYLE}` : sys;
       let ADV_STYLE = "";
@@ -947,7 +969,8 @@ ${linkNudge}`;
           adv === "preventive"     ? D.PREVENTIVE_STYLE :
           adv === "systems-policy" ? D.SYSTEMS_POLICY_STYLE : "";
       }
-      const systemAll = `${sysWithDomain}${ADV_STYLE ? "\n\n" + ADV_STYLE : ""}`;
+      // Append mode structure and any intent-specific structure
+      const systemAll = `${sysWithDomain}${ADV_STYLE ? "\n\n" + ADV_STYLE : ""}\n\n${mode === "doctor" ? DOCTOR_DRAFT_STYLE : PATIENT_DRAFT_STYLE}${INTENT_STYLE ? "\n\n" + INTENT_STYLE : ""}`;
       let chatMessages: { role: string; content: string }[];
 
       const looksLikeMath = /[0-9\.\s+\-*\/^()]{6,}/.test(userText) || /sin|cos|log|sqrt|derivative|integral|limit/i.test(userText);

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -936,7 +936,7 @@ ${linkNudge}`;
       // Per-mode drafting style (structure only; no provider changes)
       const PATIENT_DRAFT_STYLE = [
         "FORMAT: Use 2–3 short sections with bold headers and bullets.",
-        "For 'what is ...' questions, default to these sections:",
+        "For 'what is' questions, default to these sections:",
         "## **What it is**",
         "## **Types**",
         "Finish with one short follow-up question (≤10 words).",

--- a/lib/intents.ts
+++ b/lib/intents.ts
@@ -8,3 +8,133 @@ export function detectFollowupIntent(text: string): FollowupIntent {
   if (/\b(latest|newest).*(trial|trials|study|studies|research)|\bclinical trial(s)?\b/.test(q)) return "trials";
   return null;
 }
+
+export type Mode = "patient" | "doctor";
+
+/** Simple stem detection → returns an extra structure block for the system prompt. */
+export function getIntentStyle(userText: string, mode: Mode): string {
+  const s = (userText || "").trim().toLowerCase();
+
+  const has = (re: RegExp) => re.test(s);
+
+  // Common stems
+  const isWhatIs   = has(/\b(what\s+is|explain|define)\b/);
+  const isTypes    = has(/\btypes?\b/);
+  const isSymptoms = has(/\bsymptoms?\b/);
+  const isCauses   = has(/\b(why|cause|causes)\b/);
+  const isRedFlags = has(/\b(red\s*flags?|when\s+should\s+i\s+see\s+(a\s+)?doctor|er|emergency)\b/);
+  const isWorkup   = has(/\b(work[\s-]*up|initial\s+(work\s*up|assessment|evaluation)|tests?|diagnos(e|is))\b/);
+  const isTx       = has(/\b(treatment|manage|management|therapy|medication|medications?)\b/);
+  const isHomeCare = has(/\b(home\s*care|self\s*care|at\s*home|remedy|remedies)\b/);
+  const isImaging  = has(/\b(imaging|x-?ray|ct|mri|ultrasound|do\s+i\s+need\s+imaging)\b/);
+
+  if (mode === "patient") {
+    if (isWhatIs || isTypes) {
+      return [
+        "STRUCTURE (intent):",
+        "## **What it is**",
+        "## **Types**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isSymptoms) {
+      return [
+        "STRUCTURE (intent):",
+        "## **Common symptoms**",
+        "## **When to see a doctor (red flags)**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isCauses) {
+      return [
+        "STRUCTURE (intent):",
+        "## **Why it happens (common causes)**",
+        "## **Less common/serious causes**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isHomeCare) {
+      return [
+        "STRUCTURE (intent):",
+        "## **At-home care**",
+        "## **When to stop home care and seek help**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isImaging) {
+      return [
+        "STRUCTURE (intent):",
+        "## **Do I need imaging?**",
+        "## **When imaging is useful vs not needed**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isTx) {
+      return [
+        "STRUCTURE (intent):",
+        "## **First-line options**",
+        "## **If symptoms persist/worsen**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isWorkup || isRedFlags) {
+      return [
+        "STRUCTURE (intent):",
+        "## **What to check** (simple steps/tests)",
+        "## **Red flags — when to seek urgent care**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+  } else {
+    // doctor
+    if (isWhatIs) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **Definition (clinical)**",
+        "## **Phenotypes**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isWorkup) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **Initial work-up** (H&P, labs, imaging)",
+        "## **When to image / stewardship**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isRedFlags) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **Red flags**",
+        "## **Immediate actions / escalation**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isTx) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **First-line management**",
+        "## **Step-up / referral**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isSymptoms) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **Key historical features**",
+        "## **Focused exam maneuvers**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isImaging) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **Imaging choice (indications)**",
+        "## **Avoid imaging when …**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+  }
+  return ""; // no extra structure
+}


### PR DESCRIPTION
## Summary
- add `getIntentStyle` helper for patient/doctor intent outlines
- inject mode + intent drafting styles in ChatPane
- enforce soft word caps and token buffer in chat stream route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c73966630c832f8514873598773753