### PR TITLE
Persist typewriter completion state and skip redundant animation

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -15,11 +15,9 @@ function MessageRow({ m }: { m: { id: string; role: string; content: string } })
   return (
     <div className="p-2" onClick={() => setFast(true)}>
       <strong>{m.role}:</strong>{" "}
-      {m.role === "assistant" ? (
-        <Typewriter text={m.content} fast={fast || isDone} onDone={() => markDone(m.id)} />
-      ) : (
-        m.content
-      )}
+      {m.role === "assistant"
+        ? (isDone ? m.content : <Typewriter text={m.content} fast={fast} onDone={() => markDone(m.id)} />)
+        : m.content}
     </div>
   );
 }

--- a/lib/state/typewriterStore.ts
+++ b/lib/state/typewriterStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 type State = {
   done: Record<string, true>;
@@ -6,8 +7,13 @@ type State = {
   isDone: (k: string) => boolean;
 };
 
-export const useTypewriterStore = create<State>((set, get) => ({
-  done: {},
-  markDone: (k) => set((s) => ({ done: { ...s.done, [k]: true } })),
-  isDone: (k) => !!get().done[k],
-}));
+export const useTypewriterStore = create<State>()(
+  persist(
+    (set, get) => ({
+      done: {},
+      markDone: (k) => set((s) => ({ done: { ...s.done, [k]: true } })),
+      isDone: (k) => !!get().done[k],
+    }),
+    { name: "typewriterDone" }
+  )
+);


### PR DESCRIPTION
## Summary
- persist typewriter completion state via zustand middleware to prevent repeat animations
- avoid mounting Typewriter for completed assistant messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c74cefdc9c832f9d980855113dd4f9