### PR TITLE
feat: add intent-aware outline and soft length cap

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -947,7 +947,7 @@ ${linkNudge}`;
       // Per-mode drafting style (structure only; no provider changes)
       const PATIENT_DRAFT_STYLE = [
         "FORMAT: Use 2–3 short sections with bold headers and bullets.",
-        "For 'what is ...' questions, default to these sections:",
+        "For 'what is' questions, default to these sections:",
         "## **What it is**",
         "## **Types**",
         "Finish with one short follow-up question (≤10 words).",

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -944,6 +944,28 @@ ${linkNudge}`;
       const systemCommon = `\nUser country: ${country.code3} (${country.name}). Use generics and note availability varies by region.\nEnd with one short follow-up question (<=10 words) that stays on the current topic.\n`;
       const topicHint = ui.topic ? `ACTIVE TOPIC: ${ui.topic}\nKeep answers scoped to this topic unless the user changes it.\n` : "";
 
+      // Per-mode drafting style (structure only; no provider changes)
+      const PATIENT_DRAFT_STYLE = [
+        "FORMAT: Use 2–3 short sections with bold headers and bullets.",
+        "For 'what is ...' questions, default to these sections:",
+        "## **What it is**",
+        "## **Types**",
+        "Finish with one short follow-up question (≤10 words).",
+      ].join("\n");
+      const DOCTOR_DRAFT_STYLE = [
+        "FORMAT (clinical, concise): Use bold headers + bullets.",
+        "For definition-type asks, prefer this outline:",
+        "## **Definition (clinical)**",
+        "## **Phenotypes**",
+        "## **Red flags** (include only if relevant)",
+        "## **Initial work-up (typical)** (include only if appropriate)",
+        "Finish with one short follow-up question (≤10 words).",
+      ].join("\n");
+
+      // Intent-aware structure (lightweight)
+      const { getIntentStyle } = await import("@/lib/intents");
+      const INTENT_STYLE = getIntentStyle(userText || "", mode);
+
       const sys = topicHint + systemCommon + baseSys;
       const sysWithDomain = DOMAIN_STYLE ? `${sys}\n\n${DOMAIN_STYLE}` : sys;
       let ADV_STYLE = "";
@@ -958,7 +980,8 @@ ${linkNudge}`;
           adv === "preventive"     ? D.PREVENTIVE_STYLE :
           adv === "systems-policy" ? D.SYSTEMS_POLICY_STYLE : "";
       }
-      const systemAll = `${sysWithDomain}${ADV_STYLE ? "\n\n" + ADV_STYLE : ""}`;
+      // Append mode structure and any intent-specific structure
+      const systemAll = `${sysWithDomain}${ADV_STYLE ? "\n\n" + ADV_STYLE : ""}\n\n${mode === "doctor" ? DOCTOR_DRAFT_STYLE : PATIENT_DRAFT_STYLE}${INTENT_STYLE ? "\n\n" + INTENT_STYLE : ""}`;
       let chatMessages: { role: string; content: string }[];
 
       const looksLikeMath = /[0-9\.\s+\-*\/^()]{6,}/.test(userText) || /sin|cos|log|sqrt|derivative|integral|limit/i.test(userText);

--- a/lib/intents.ts
+++ b/lib/intents.ts
@@ -8,3 +8,133 @@ export function detectFollowupIntent(text: string): FollowupIntent {
   if (/\b(latest|newest).*(trial|trials|study|studies|research)|\bclinical trial(s)?\b/.test(q)) return "trials";
   return null;
 }
+
+export type Mode = "patient" | "doctor";
+
+/** Simple stem detection → returns an extra structure block for the system prompt. */
+export function getIntentStyle(userText: string, mode: Mode): string {
+  const s = (userText || "").trim().toLowerCase();
+
+  const has = (re: RegExp) => re.test(s);
+
+  // Common stems
+  const isWhatIs   = has(/\b(what\s+is|explain|define)\b/);
+  const isTypes    = has(/\btypes?\b/);
+  const isSymptoms = has(/\bsymptoms?\b/);
+  const isCauses   = has(/\b(why|cause|causes)\b/);
+  const isRedFlags = has(/\b(red\s*flags?|when\s+should\s+i\s+see\s+(a\s+)?doctor|er|emergency)\b/);
+  const isWorkup   = has(/\b(work[\s-]*up|initial\s+(work\s*up|assessment|evaluation)|tests?|diagnos(e|is))\b/);
+  const isTx       = has(/\b(treatment|manage|management|therapy|medication|medications?)\b/);
+  const isHomeCare = has(/\b(home\s*care|self\s*care|at\s*home|remedy|remedies)\b/);
+  const isImaging  = has(/\b(imaging|x-?ray|ct|mri|ultrasound|do\s+i\s+need\s+imaging)\b/);
+
+  if (mode === "patient") {
+    if (isWhatIs || isTypes) {
+      return [
+        "STRUCTURE (intent):",
+        "## **What it is**",
+        "## **Types**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isSymptoms) {
+      return [
+        "STRUCTURE (intent):",
+        "## **Common symptoms**",
+        "## **When to see a doctor (red flags)**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isCauses) {
+      return [
+        "STRUCTURE (intent):",
+        "## **Why it happens (common causes)**",
+        "## **Less common/serious causes**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isHomeCare) {
+      return [
+        "STRUCTURE (intent):",
+        "## **At-home care**",
+        "## **When to stop home care and seek help**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isImaging) {
+      return [
+        "STRUCTURE (intent):",
+        "## **Do I need imaging?**",
+        "## **When imaging is useful vs not needed**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isTx) {
+      return [
+        "STRUCTURE (intent):",
+        "## **First-line options**",
+        "## **If symptoms persist/worsen**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isWorkup || isRedFlags) {
+      return [
+        "STRUCTURE (intent):",
+        "## **What to check** (simple steps/tests)",
+        "## **Red flags — when to seek urgent care**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+  } else {
+    // doctor
+    if (isWhatIs) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **Definition (clinical)**",
+        "## **Phenotypes**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isWorkup) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **Initial work-up** (H&P, labs, imaging)",
+        "## **When to image / stewardship**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isRedFlags) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **Red flags**",
+        "## **Immediate actions / escalation**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isTx) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **First-line management**",
+        "## **Step-up / referral**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isSymptoms) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **Key historical features**",
+        "## **Focused exam maneuvers**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+    if (isImaging) {
+      return [
+        "STRUCTURE (intent, clinical):",
+        "## **Imaging choice (indications)**",
+        "## **Avoid imaging when …**",
+        "Finish with one short follow-up question (≤10 words)."
+      ].join("\n");
+    }
+  }
+  return ""; // no extra structure
+}


### PR DESCRIPTION
## Summary
- add stem-based intent detector that outputs patient/doctor-specific outline
- include per-mode and intent-aware drafting structure in ChatPane system prompt
- enforce soft word cap with token buffer and concise response rules in chat API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c74dfc0350832f84fd970e8287ef71