### PR TITLE
chore: remove ellipsis placeholder from intents library

### DIFF
--- a/lib/intents.ts
+++ b/lib/intents.ts
@@ -10,7 +10,7 @@
 // - Utilities: classifyIntent, listIntents, defaultDraftStyle
 //
 // Design notes
-// - Strings never contain ASCII three-dots `...`
+// - Strings never contain ASCII three consecutive dots
 // - Spread operators in code are fine; UI copy uses full words
 // - All outlines finish with one short follow-up question instruction
 //


### PR DESCRIPTION
## Summary
- remove stray ASCII ellipsis from intents comment to satisfy placeholder check

## Testing
- `rg -n -e "'[^']*\.\.\.[^']*'" -e "\"[^\"]*\.\.\.[^\"]*\"" components app lib`
- `node tools/check-placeholders.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68c7b915896c832fbefe6bce96fad85c