### PR TITLE
feat: add websearch proxy route

### DIFF
--- a/app/api/websearch/route.ts
+++ b/app/api/websearch/route.ts
@@ -1,0 +1,25 @@
+export const runtime = 'nodejs';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const q = new URL(req.url).searchParams.get('q') || '';
+  if (!q) return NextResponse.json({ results: [] });
+
+  const key = process.env.GOOGLE_CSE_KEY!;
+  const cx  = process.env.GOOGLE_CSE_CX!;
+  const r = await fetch(
+    `https://www.googleapis.com/customsearch/v1?key=${key}&cx=${cx}&q=${encodeURIComponent(q)}`,
+    { cache: 'no-store' }
+  );
+  if (!r.ok) return NextResponse.json({ results: [] });
+
+  const j = await r.json();
+  const results = (j.items || []).map((it: any) => ({
+    title: it.title || '',
+    snippet: it.snippet || it.htmlSnippet || '',
+    url: it.link || '',
+    source: 'web'
+  })).filter((x: any) => x.title && x.url);
+
+  return NextResponse.json({ results });
+}


### PR DESCRIPTION
## Summary
- add websearch API route that proxies Google CSE queries and returns formatted results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7e98a1878832f8e141222c92eb33b