### PR TITLE
Add research brief style and client rendering

### DIFF
--- a/lib/styles.ts
+++ b/lib/styles.ts
@@ -1,0 +1,8 @@
+export const RESEARCH_BRIEF_STYLE = `
+Be crisp.
+- One-line TL;DR (<=20 words).
+- Up to 3 bullets (<=18 words each).
+- Use concrete numbers/dates when known.
+- Cite provided sources as [1], [2], etc.
+Return JSON exactly: {"tldr":"","bullets":["..."],"citations":[{"title":"","url":""}]}
+`;


### PR DESCRIPTION
## Summary
- add RESEARCH_BRIEF_STYLE for concise research answers
- support brief research mode in chat stream endpoint
- render brief JSON with TL;DR, bullets, and citations on client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c809e53c70832fa36af811bee7795c