### PR TITLE
feat: add stop button for chat

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -40,6 +40,7 @@ import { detectDomain } from "@/lib/intents/domains";
 import * as DomainStyles from "@/lib/prompts/domains";
 import ThinkingTimer from "@/components/ui/ThinkingTimer";
 import ScrollToBottom from "@/components/ui/ScrollToBottom";
+import { StopButton } from "@/components/ui/StopButton";
 import { useTypewriterStore } from "@/lib/state/typewriterStore";
 
 const AIDOC_UI = process.env.NEXT_PUBLIC_AIDOC_UI === '1';
@@ -1857,31 +1858,34 @@ ${systemCommon}` + baseSys;
                 </button>
               </div>
             )}
-            {/* REPLACE the single-line <input> with this <textarea> */}
-            <textarea
-              ref={inputRef as unknown as RefObject<HTMLTextAreaElement>}
-              rows={1}
-              className="flex-1 resize-none bg-transparent outline-none text-sm md:text-base leading-6 placeholder:text-slate-500 dark:placeholder:text-slate-400 px-2 text-medx"
-              placeholder={
-                pendingFile
-                  ? 'Add a note or question for this document (optional)'
-                  : 'Send a message'
-              }
-              value={note}
-              onChange={(e) => setNote(e.target.value)}
-              onKeyDown={(e) => {
-                // Send on Enter (no Shift), allow newline on Shift+Enter.
-                // Respect IME composition (don’t send while composing).
-                // NOTE: keep behavior identical to ChatGPT.
-                const isComposing = (e.nativeEvent as any).isComposing;
-                if (e.key === 'Enter' && !e.shiftKey && !isComposing) {
-                  e.preventDefault();
-                  onSubmit();
+            <div className="relative flex-1">
+              <textarea
+                ref={inputRef as unknown as RefObject<HTMLTextAreaElement>}
+                rows={1}
+                className="flex-1 resize-none bg-transparent outline-none text-sm md:text-base leading-6 placeholder:text-slate-500 dark:placeholder:text-slate-400 px-2 pr-12 text-medx"
+                placeholder={
+                  pendingFile
+                    ? 'Add a note or question for this document (optional)'
+                    : 'Send a message'
                 }
-              }}
-              disabled={busy}
-            />
-            {!busy ? (
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                onKeyDown={(e) => {
+                  // Send on Enter (no Shift), allow newline on Shift+Enter.
+                  // Respect IME composition (don't send while composing).
+                  // NOTE: keep behavior identical to ChatGPT.
+                  const isComposing = (e.nativeEvent as any).isComposing;
+                  if (e.key === 'Enter' && !e.shiftKey && !isComposing) {
+                    e.preventDefault();
+                    onSubmit();
+                  }
+                }}
+              />
+              {busy && (
+                <StopButton onClick={onStop} className="absolute bottom-2 right-2" />
+              )}
+            </div>
+            {!busy && (
               <button
                 className="w-10 h-10 rounded-full flex items-center justify-center text-lg medx-btn-accent disabled:opacity-50"
                 type="submit"
@@ -1889,15 +1893,6 @@ ${systemCommon}` + baseSys;
                 aria-label="Send"
               >
                 <Send size={16} />
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={onStop}
-                className="w-10 h-10 rounded-full flex items-center justify-center text-lg bg-red-600 text-white"
-                aria-label="Stop"
-              >
-                Stop
               </button>
             )}
           </form>

--- a/components/ui/StopButton.tsx
+++ b/components/ui/StopButton.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { motion } from "framer-motion";
+import { Square } from "lucide-react";
+
+type Props = {
+  onClick: () => void;
+  className?: string;
+  title?: string;
+};
+
+export function StopButton({ onClick, className, title = "Stop generating (Esc)" }: Props) {
+  return (
+    <motion.button
+      type="button"
+      onClick={onClick}
+      aria-label="Stop generating"
+      title={title}
+      initial={{ scale: 0.9, opacity: 0 }}
+      animate={{ scale: 1, opacity: 1 }}
+      whileTap={{ scale: 0.92 }}
+      className={[
+        "h-9 w-9 rounded-full",
+        "bg-white/80 dark:bg-zinc-900/70 backdrop-blur",
+        "ring-1 ring-zinc-300 hover:ring-red-400 dark:ring-zinc-700 shadow-sm",
+        "flex items-center justify-center",
+        "transition-colors hover:bg-white dark:hover:bg-zinc-900",
+        "focus:outline-none focus:ring-2 focus:ring-blue-500",
+        className || ""
+      ].join(" ")}
+    >
+      <Square className="h-4 w-4 text-zinc-700 dark:text-zinc-200" strokeWidth={2.25} />
+      <span className="sr-only">Stop</span>
+    </motion.button>
+  );
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.57.0",
+        "framer-motion": "^12.23.12",
         "isomorphic-dompurify": "2.13.0",
         "katex": "^0.16.22",
         "lucide-react": "0.441.0",
@@ -3586,6 +3587,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "dev": true,
@@ -5911,6 +5939,21 @@
     "node_modules/mlly/node_modules/pathe": {
       "version": "2.0.3",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.57.0",
+    "framer-motion": "^12.23.12",
     "isomorphic-dompurify": "2.13.0",
     "katex": "^0.16.22",
     "lucide-react": "0.441.0",


### PR DESCRIPTION
## Summary
- add reusable StopButton component with motion and lucide square icon
- overlay StopButton in chat composer and hide Send while streaming
- keep textarea editable and add framer-motion dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8167b8fdc832f86c6fc2e4425db53