### PR TITLE
Buffer chat stream before rendering

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -777,11 +777,11 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
               const delta = payload?.choices?.[0]?.delta?.content;
               if (delta) {
                 acc += delta;
-                setMessages(prev => prev.map(m => (m.id === pendingId ? { ...m, content: acc } : m)));
               }
             } catch {}
           }
         }
+        acc += decoder.decode();
         const { main, followUps } = splitFollowUps(acc);
         setMessages(prev =>
           prev.map(m =>
@@ -1133,13 +1133,11 @@ ${systemCommon}` + baseSys;
             const delta = payload?.choices?.[0]?.delta?.content;
             if (delta) {
               acc += delta;
-              setMessages(prev =>
-                prev.map(m => (m.id === pendingId ? { ...m, content: acc } : m))
-              );
             }
           } catch {}
         }
       }
+      acc += decoder.decode();
       const { main, followUps } = splitFollowUps(acc);
       setMessages(prev =>
         prev.map(m =>


### PR DESCRIPTION
## Summary
- buffer streaming chat response in client and update UI only once final text is received
- flush decoder after streaming to capture remaining bytes

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c81e3a8fa4832f92e9dd7485e530aa