### PR TITLE
feat(ai-doc): add longitudinal cardiovascular risk scoring

### DIFF
--- a/app/api/predict/route.ts
+++ b/app/api/predict/route.ts
@@ -1,0 +1,111 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+import { buildTimeSeriesFeatures, scoreRisk } from "@/lib/ai/predict";
+import type { FeatureBuilderInput, PatientDemographics } from "@/types/prediction";
+
+const errorResponse = (message: string, status = 400) =>
+  NextResponse.json({ error: message }, { status });
+
+const computeAge = (dob: unknown): number | null => {
+  if (!dob) return null;
+  const date = new Date(dob as any);
+  if (Number.isNaN(date.getTime())) return null;
+  const diff = Date.now() - date.getTime();
+  if (diff <= 0) return null;
+  return Math.floor(diff / (365.25 * 24 * 60 * 60 * 1000));
+};
+
+const normaliseSex = (value: unknown): string | null => {
+  if (!value) return null;
+  const str = String(value).trim().toLowerCase();
+  if (!str) return null;
+  if (["f", "female", "woman", "female_sex"].includes(str)) return "female";
+  if (["m", "male", "man", "male_sex"].includes(str)) return "male";
+  if (["nonbinary", "non-binary", "nb"].includes(str)) return "non-binary";
+  return str;
+};
+
+const pickDemographics = (row: any): PatientDemographics | undefined => {
+  if (!row) return undefined;
+  const age = computeAge(row.dob ?? row.date_of_birth ?? row.birth_date ?? row.birthdate);
+  const sex = normaliseSex(row.sex ?? row.gender ?? row.gender_identity);
+  if (age == null && !sex) return undefined;
+  return { age: age ?? undefined, sex: sex ?? undefined };
+};
+
+export async function POST(req: NextRequest) {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseServiceKey) {
+    return errorResponse("Supabase credentials are not configured", 500);
+  }
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("Invalid JSON payload", 400);
+  }
+
+  const patientId = body?.patientId ?? body?.patientID ?? body?.id;
+  if (!patientId || typeof patientId !== "string") {
+    return errorResponse("patientId is required", 400);
+  }
+
+  const sb = createClient(supabaseUrl, supabaseServiceKey);
+
+  const [profileRes, vitalsRes, labsRes, medsRes, notesRes, encountersRes] = await Promise.all([
+    sb.from("profiles").select("id, dob, sex, gender, gender_identity").eq("id", patientId).maybeSingle(),
+    sb.from("vitals").select("*").eq("patient_id", patientId).order("taken_at", { ascending: true }),
+    sb.from("labs").select("*").eq("patient_id", patientId).order("taken_at", { ascending: true }),
+    sb.from("medications").select("*").eq("patient_id", patientId).order("start_at", { ascending: true }),
+    sb.from("notes").select("*").eq("patient_id", patientId).order("created_at", { ascending: true }),
+    sb.from("encounters").select("*").eq("patient_id", patientId).order("start_at", { ascending: true }),
+  ]);
+
+  const queryErrors = [vitalsRes.error, labsRes.error, medsRes.error, notesRes.error, encountersRes.error].filter(Boolean);
+  if (queryErrors.length) {
+    const err = queryErrors[0]!;
+    return errorResponse(`Failed to fetch longitudinal data: ${err.message}`, 500);
+  }
+  if (profileRes.error && profileRes.error.message && profileRes.error.code !== "PGRST116") {
+    return errorResponse(`Failed to fetch demographics: ${profileRes.error.message}`, 500);
+  }
+
+  const demographics = profileRes.data ? pickDemographics(profileRes.data) : undefined;
+
+  const featureInput: FeatureBuilderInput = {
+    vitals: vitalsRes.data ?? [],
+    labs: labsRes.data ?? [],
+    meds: medsRes.data ?? [],
+    notes: notesRes.data ?? [],
+    encounters: encountersRes.data ?? [],
+    demographics,
+  };
+
+  const features = buildTimeSeriesFeatures(featureInput);
+  const result = await scoreRisk(features);
+
+  const persistRes = await sb.from("predictions").insert({
+    patient_id: patientId,
+    condition: result.condition,
+    risk_score: result.riskScore,
+    risk_label: result.riskLabel,
+    features: result.windows,
+    top_factors: result.topFactors,
+    context: result.context ?? null,
+    generated_at: result.generatedAt,
+  });
+
+  if (persistRes.error) {
+    return errorResponse(`Failed to persist prediction: ${persistRes.error.message}`, 500);
+  }
+
+  return NextResponse.json(result);
+}

--- a/lib/ai/features.ts
+++ b/lib/ai/features.ts
@@ -1,0 +1,80 @@
+import type { MetricWindowStats, WindowKey, WindowSnapshot, WindowStatOptions } from "@/types/prediction";
+
+export type Point = { t: number; v: number };
+export const DAY = 86_400_000;
+
+const NOW = () => Date.now();
+
+export function windowStats(points: Point[], days: number, options: WindowStatOptions = {}): MetricWindowStats | null {
+  if (!Array.isArray(points) || points.length === 0) return null;
+  const cutoff = NOW() - days * DAY;
+  const windowPoints = points.filter((p) => typeof p?.t === "number" && p.t >= cutoff).sort((a, b) => a.t - b.t);
+  if (!windowPoints.length) return null;
+
+  const values = windowPoints.map((p) => p.v).filter((v) => Number.isFinite(v));
+  if (!values.length) return null;
+
+  const n = values.length;
+  const mean = values.reduce((acc, val) => acc + val, 0) / n;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const variance = values.reduce((acc, val) => acc + (val - mean) ** 2, 0) / n;
+  const std = Math.sqrt(variance);
+
+  const firstPoint = windowPoints[0];
+  const lastPoint = windowPoints[windowPoints.length - 1];
+  const denomDays = Math.max(1, (lastPoint.t - firstPoint.t) / DAY);
+  const slope = windowPoints.length > 1 ? (lastPoint.v - firstPoint.v) / denomDays : 0;
+  const timeSinceLast = Math.max(0, (NOW() - lastPoint.t) / DAY);
+
+  let percentOutOfRange: number | undefined;
+  let timeSinceLastNormal: number | undefined;
+
+  if (options.normalRange) {
+    const [low, high] = options.normalRange;
+    let normalCount = 0;
+    let lastNormalTs: number | null = null;
+    for (const point of windowPoints) {
+      const isAboveLow = low == null || point.v >= low;
+      const isBelowHigh = high == null || point.v <= high;
+      if (isAboveLow && isBelowHigh) {
+        normalCount += 1;
+        lastNormalTs = point.t;
+      }
+    }
+    percentOutOfRange = ((n - normalCount) / n) * 100;
+    if (lastNormalTs != null) {
+      timeSinceLastNormal = Math.max(0, (NOW() - lastNormalTs) / DAY);
+    }
+  }
+
+  return {
+    n,
+    count: n,
+    mean,
+    min,
+    max,
+    std,
+    slope,
+    first: firstPoint.v,
+    last: lastPoint.v,
+    firstObservedAt: new Date(firstPoint.t).toISOString(),
+    lastObservedAt: new Date(lastPoint.t).toISOString(),
+    timeSinceLast,
+    percentOutOfRange,
+    timeSinceLastNormal,
+  };
+}
+
+export function cloneWindowSnapshots(source: Record<WindowKey, WindowSnapshot>): Record<WindowKey, WindowSnapshot> {
+  const entries = Object.entries(source).map(([winKey, metrics]) => [
+    winKey,
+    Object.fromEntries(
+      Object.entries(metrics).map(([metric, stat]) => [
+        metric,
+        { ...stat },
+      ])
+    ),
+  ]);
+  return Object.fromEntries(entries) as Record<WindowKey, WindowSnapshot>;
+}

--- a/lib/ai/predict.ts
+++ b/lib/ai/predict.ts
@@ -1,0 +1,477 @@
+import { Point, windowStats } from "@/lib/ai/features";
+import { evaluateCardiovascularRisk } from "@/lib/ai/rulesets/cardiovascular";
+import type {
+  EngineeredFeatures,
+  FeatureBuilderInput,
+  MetricWindowStats,
+  PredictionResult,
+  WindowKey,
+  WindowSnapshot,
+} from "@/types/prediction";
+
+const WINDOW_SPECS: { key: WindowKey; days: number }[] = [
+  { key: "days7", days: 7 },
+  { key: "days30", days: 30 },
+  { key: "days90", days: 90 },
+  { key: "days365", days: 365 },
+];
+
+const TRACKED_NORMALS: Partial<Record<string, [number | null, number | null]>> = {
+  ldl: [0, 130],
+  triglycerides: [0, 175],
+  hba1c: [0, 6.4],
+  sbp: [90, 129],
+  dbp: [60, 79],
+  bmi: [18.5, 24.9],
+  hr: [55, 100],
+  temp: [36.1, 37.5],
+  spo2: [95, 100],
+};
+
+const RISK_CORE_METRICS = ["ldl", "triglycerides", "hba1c", "sbp", "bmi"];
+
+const TIMESTAMP_KEYS = [
+  "taken_at",
+  "observed_at",
+  "recorded_at",
+  "measured_at",
+  "measuredAt",
+  "collected_at",
+  "collectedAt",
+  "sampled_at",
+  "resulted_at",
+  "reported_at",
+  "start_at",
+  "started_at",
+  "startAt",
+  "encountered_at",
+  "occurred_at",
+  "created_at",
+  "createdAt",
+  "timestamp",
+  "time",
+  "date",
+  "datetime",
+  "effective_at",
+  "effective_time",
+];
+
+const METRIC_ALIASES: Record<string, string> = {
+  ldl: "ldl",
+  ldl_c: "ldl",
+  ldl_cholesterol: "ldl",
+  low_density_lipoprotein: "ldl",
+  triglyceride: "triglycerides",
+  triglycerides: "triglycerides",
+  triacylglycerol: "triglycerides",
+  tg: "triglycerides",
+  hba1c: "hba1c",
+  hb_a1c: "hba1c",
+  hemoglobin_a1c: "hba1c",
+  glycated_hemoglobin: "hba1c",
+  glycosylated_hemoglobin: "hba1c",
+  glycohemoglobin: "hba1c",
+  sbp: "sbp",
+  systolic: "sbp",
+  systolic_bp: "sbp",
+  systolic_blood_pressure: "sbp",
+  systolic_pressure: "sbp",
+  bp_systolic: "sbp",
+  systolic_reading: "sbp",
+  dbp: "dbp",
+  diastolic: "dbp",
+  diastolic_bp: "dbp",
+  diastolic_blood_pressure: "dbp",
+  bp_diastolic: "dbp",
+  bmi: "bmi",
+  body_mass_index: "bmi",
+  heart_rate: "hr",
+  hr: "hr",
+  pulse: "hr",
+  bpm: "hr",
+  temperature: "temp",
+  temp: "temp",
+  body_temperature: "temp",
+  spo2: "spo2",
+  oxygen_saturation: "spo2",
+  o2_saturation: "spo2",
+  weight: "weight",
+  weight_kg: "weight",
+  body_weight: "weight",
+  mass: "weight",
+  height: "height",
+  body_height: "height",
+  stature: "height",
+  visits: "visits",
+  encounter: "visits",
+  encounters: "visits",
+  visit: "visits",
+};
+
+const TRACKED_METRICS = new Set([
+  "ldl",
+  "triglycerides",
+  "hba1c",
+  "sbp",
+  "dbp",
+  "bmi",
+  "hr",
+  "temp",
+  "spo2",
+  "weight",
+  "height",
+  "visits",
+]);
+
+const SNAPSHOT_FIELDS: (keyof MetricWindowStats)[] = [
+  "n",
+  "count",
+  "mean",
+  "min",
+  "max",
+  "std",
+  "slope",
+  "first",
+  "firstObservedAt",
+  "last",
+  "lastObservedAt",
+  "timeSinceLast",
+  "percentOutOfRange",
+  "timeSinceLastNormal",
+];
+
+const asNumber = (value: unknown): number | null => {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const match = value.match(/-?\d+(?:\.\d+)?/);
+    return match ? Number(match[0]) : null;
+  }
+  if (typeof value === "object") {
+    const candidate = (value as Record<string, unknown>).value ?? (value as Record<string, unknown>).amount;
+    return asNumber(candidate);
+  }
+  return null;
+};
+
+const toTimestamp = (value: unknown): number | null => {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return null;
+    return value > 3_000_000_000 ? value : value * 1000;
+  }
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) return parsed.getTime();
+  }
+  return null;
+};
+
+const extractTimestamp = (...rows: any[]): number | null => {
+  for (const row of rows) {
+    if (!row || typeof row !== "object") continue;
+    for (const key of TIMESTAMP_KEYS) {
+      const ts = toTimestamp((row as Record<string, unknown>)[key]);
+      if (ts != null) return ts;
+    }
+  }
+  return null;
+};
+
+const normaliseMetric = (raw: unknown): string | null => {
+  if (typeof raw !== "string") return null;
+  const cleaned = raw.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  if (!cleaned) return null;
+  if (METRIC_ALIASES[cleaned]) return METRIC_ALIASES[cleaned];
+  if (cleaned.includes("ldl")) return "ldl";
+  if (cleaned.includes("triglycer")) return "triglycerides";
+  if (cleaned.includes("a1c")) return "hba1c";
+  if (cleaned.includes("glyc")) return "hba1c";
+  if (cleaned.includes("systolic")) return "sbp";
+  if (cleaned.includes("diastolic")) return "dbp";
+  if (cleaned.includes("bmi")) return "bmi";
+  if (cleaned.includes("heart_rate") || cleaned.endsWith("bpm")) return "hr";
+  if (cleaned.includes("pulse")) return "hr";
+  if (cleaned.includes("temp")) return "temp";
+  if (cleaned.includes("oxygen") || cleaned.includes("spo2")) return "spo2";
+  if (cleaned.includes("weight")) return "weight";
+  if (cleaned.includes("height")) return "height";
+  if (cleaned.includes("encounter") || cleaned.includes("visit")) return "visits";
+  return TRACKED_METRICS.has(cleaned) ? cleaned : null;
+};
+
+const mergeRow = (row: any) => {
+  if (!row || typeof row !== "object") return {} as Record<string, unknown>;
+  const merged: Record<string, unknown> = { ...row };
+  const nestedKeys = ["meta", "details", "data", "payload", "extra"];
+  for (const key of nestedKeys) {
+    const nested = row?.[key];
+    if (nested && typeof nested === "object") {
+      Object.assign(merged, nested);
+    }
+  }
+  return merged;
+};
+
+const addPoint = (series: Record<string, Point[]>, metric: string, timestamp: number, value: number) => {
+  if (!TRACKED_METRICS.has(metric)) return;
+  if (!Number.isFinite(value)) return;
+  if (!series[metric]) series[metric] = [];
+  series[metric].push({ t: timestamp, v: value });
+};
+
+const parseBpString = (value: string): { systolic?: number; diastolic?: number } => {
+  const match = value.match(/(\d{2,3})\s*[^0-9]+\s*(\d{2,3})/);
+  if (!match) return {};
+  const systolic = Number(match[1]);
+  const diastolic = Number(match[2]);
+  return {
+    systolic: Number.isFinite(systolic) ? systolic : undefined,
+    diastolic: Number.isFinite(diastolic) ? diastolic : undefined,
+  };
+};
+
+const ensureSortedSeries = (series: Record<string, Point[]>) => {
+  for (const key of Object.keys(series)) {
+    series[key].sort((a, b) => a.t - b.t);
+  }
+};
+
+const computeMissingMetrics = (windows: Record<WindowKey, WindowSnapshot>): string[] => {
+  const missing: string[] = [];
+  for (const metric of RISK_CORE_METRICS) {
+    const hasData = WINDOW_SPECS.some(({ key }) => windows[key][metric]);
+    if (!hasData) missing.push(metric);
+  }
+  return missing;
+};
+
+export function buildTimeSeriesFeatures(input: FeatureBuilderInput): EngineeredFeatures {
+  const vitals = Array.isArray(input.vitals) ? input.vitals : [];
+  const labs = Array.isArray(input.labs) ? input.labs : [];
+  const encounters = Array.isArray(input.encounters) ? input.encounters : [];
+
+  const series: Record<string, Point[]> = {};
+  const eventSeries: Record<string, number[]> = { visits: [] };
+
+  for (const row of vitals) {
+    const merged = mergeRow(row);
+    const ts = extractTimestamp(row, merged);
+    if (ts == null) continue;
+    const seen = new Set<string>();
+
+    const directNumericFields: Array<[string, string]> = [
+      ["sbp", "sbp"],
+      ["systolic", "sbp"],
+      ["systolic_bp", "sbp"],
+      ["systolic_blood_pressure", "sbp"],
+      ["dbp", "dbp"],
+      ["diastolic", "dbp"],
+      ["diastolic_bp", "dbp"],
+      ["diastolic_blood_pressure", "dbp"],
+      ["bmi", "bmi"],
+      ["body_mass_index", "bmi"],
+      ["weight", "weight"],
+      ["weight_kg", "weight"],
+      ["body_weight", "weight"],
+      ["height", "height"],
+      ["body_height", "height"],
+      ["heart_rate", "hr"],
+      ["hr", "hr"],
+      ["pulse", "hr"],
+      ["temperature", "temp"],
+      ["temp", "temp"],
+      ["spo2", "spo2"],
+      ["oxygen_saturation", "spo2"],
+    ];
+
+    for (const [field, metric] of directNumericFields) {
+      if (seen.has(metric)) continue;
+      const val = asNumber(merged[field]);
+      if (val != null) {
+        addPoint(series, metric, ts, val);
+        seen.add(metric);
+      }
+    }
+
+    if (typeof merged.bp === "string" && !seen.has("sbp")) {
+      const parsed = parseBpString(merged.bp);
+      if (parsed.systolic != null) {
+        addPoint(series, "sbp", ts, parsed.systolic);
+        seen.add("sbp");
+      }
+      if (parsed.diastolic != null) {
+        addPoint(series, "dbp", ts, parsed.diastolic);
+        seen.add("dbp");
+      }
+    }
+
+    const metricName =
+      normaliseMetric(merged.metric as string) ??
+      normaliseMetric(merged.type as string) ??
+      normaliseMetric(merged.kind as string) ??
+      normaliseMetric(merged.name as string) ??
+      normaliseMetric(merged.label as string);
+    if (metricName && !seen.has(metricName)) {
+      const value = asNumber(merged.value ?? merged.result ?? merged.reading ?? merged.measurement ?? merged.amount);
+      if (value != null) {
+        addPoint(series, metricName, ts, value);
+        seen.add(metricName);
+      }
+    }
+  }
+
+  for (const row of labs) {
+    const merged = mergeRow(row);
+    const ts = extractTimestamp(row, merged);
+    if (ts == null) continue;
+    const metricName =
+      normaliseMetric(merged.metric as string) ??
+      normaliseMetric(merged.test as string) ??
+      normaliseMetric(merged.name as string) ??
+      normaliseMetric(merged.code as string) ??
+      normaliseMetric(merged.analyte as string) ??
+      normaliseMetric(merged.label as string);
+    if (!metricName) continue;
+    const value = asNumber(merged.value ?? merged.result ?? merged.measurement ?? merged.amount ?? merged.numeric_value);
+    if (value == null) continue;
+    addPoint(series, metricName, ts, value);
+  }
+
+  for (const row of encounters) {
+    const merged = mergeRow(row);
+    const ts = extractTimestamp(row, merged);
+    if (ts == null) continue;
+    eventSeries.visits.push(ts);
+  }
+
+  if (eventSeries.visits.length) {
+    eventSeries.visits.sort((a, b) => a - b);
+    series.visits = eventSeries.visits.map((t) => ({ t, v: 1 }));
+  }
+
+  ensureSortedSeries(series);
+
+  const windows: Record<WindowKey, WindowSnapshot> = {
+    days7: {},
+    days30: {},
+    days90: {},
+    days365: {},
+  };
+
+  const flatFeatures: Record<string, MetricWindowStats> = {};
+
+  for (const [metric, points] of Object.entries(series)) {
+    for (const spec of WINDOW_SPECS) {
+      const normalRange = TRACKED_NORMALS[metric] ?? undefined;
+      const stats = windowStats(points, spec.days, normalRange ? { normalRange } : {});
+      if (!stats) continue;
+      windows[spec.key][metric] = stats;
+      flatFeatures[`${metric}_${spec.key}`] = stats;
+    }
+  }
+
+  const missing = computeMissingMetrics(windows);
+
+  const features: EngineeredFeatures = {
+    windows,
+    demographics: input.demographics,
+    counts: {},
+  } as EngineeredFeatures;
+
+  Object.assign(features, flatFeatures);
+
+  const counts: Record<string, number> = {};
+  for (const spec of WINDOW_SPECS) {
+    const visitStats = windows[spec.key].visits;
+    if (visitStats) {
+      counts[`visits_${spec.key}`] = visitStats.count ?? visitStats.n;
+    }
+  }
+  if (Object.keys(counts).length) {
+    features.counts = counts;
+  } else {
+    delete features.counts;
+  }
+
+  if (missing.length) {
+    features.missing = missing;
+  }
+
+  return features;
+}
+
+const labelForScore = (score: number): PredictionResult["riskLabel"] => {
+  if (score < 0.33) return "Low";
+  if (score < 0.66) return "Moderate";
+  return "High";
+};
+
+const buildWindowsSnapshot = (windows: Record<WindowKey, WindowSnapshot>) => {
+  const snapshot: Record<WindowKey, WindowSnapshot> = {
+    days7: {},
+    days30: {},
+    days90: {},
+    days365: {},
+  };
+
+  for (const [winKey, metrics] of Object.entries(windows) as [WindowKey, WindowSnapshot][]) {
+    const metricEntries = Object.entries(metrics).map(([metric, stat]) => {
+      const filtered: Partial<MetricWindowStats> = {};
+      for (const field of SNAPSHOT_FIELDS) {
+        const value = stat[field];
+        if (value != null) {
+          filtered[field] = value;
+        }
+      }
+      return [metric, filtered] as [string, MetricWindowStats];
+    });
+    snapshot[winKey] = Object.fromEntries(metricEntries);
+  }
+
+  return snapshot;
+};
+
+export async function scoreRisk(features: EngineeredFeatures): Promise<PredictionResult> {
+  const evaluation = evaluateCardiovascularRisk(features);
+  const normalised = evaluation.maxScore > 0 ? Math.min(1, Math.max(0, evaluation.score / evaluation.maxScore)) : 0;
+  const riskLabel = labelForScore(normalised);
+
+  const metricSet = new Set<string>();
+  for (const win of Object.values(features.windows)) {
+    for (const metric of Object.keys(win)) {
+      metricSet.add(metric);
+    }
+  }
+
+  const context = {
+    featureCount: metricSet.size,
+    missing: features.missing,
+    demographicSummary: buildDemographicSummary(features.demographics),
+  };
+
+  const result: PredictionResult = {
+    condition: "Cardiovascular",
+    riskScore: normalised,
+    riskLabel,
+    topFactors: evaluation.factors,
+    windows: buildWindowsSnapshot(features.windows),
+    generatedAt: new Date().toISOString(),
+    context,
+  };
+
+  return result;
+}
+
+const buildDemographicSummary = (demographics: EngineeredFeatures["demographics"]): string | undefined => {
+  if (!demographics) return undefined;
+  const parts: string[] = [];
+  if (demographics.sex) parts.push(String(demographics.sex));
+  if (typeof demographics.age === "number" && Number.isFinite(demographics.age)) {
+    parts.push(`${Math.round(demographics.age)} yrs`);
+  }
+  return parts.length ? parts.join(", ") : undefined;
+};

--- a/lib/ai/rulesets/cardiovascular.ts
+++ b/lib/ai/rulesets/cardiovascular.ts
@@ -1,0 +1,158 @@
+import type {
+  EngineeredFeatures,
+  MetricWindowStats,
+  RiskFactor,
+  RuleEvaluation,
+  WindowKey,
+} from "@/types/prediction";
+
+const WINDOW_KEYS: WindowKey[] = ["days7", "days30", "days90", "days365"];
+
+type RuleDirection = "positive" | "negative";
+
+interface CardiovascularRule {
+  id: string;
+  label: string;
+  weight: number;
+  direction?: RuleDirection;
+  when: (features: EngineeredFeatures) => boolean;
+  detail?: (features: EngineeredFeatures) => string | null | undefined;
+}
+
+const normaliseImpactDirection = (weight: number, direction?: RuleDirection): RuleDirection => {
+  if (direction) return direction;
+  return weight >= 0 ? "positive" : "negative";
+};
+
+const getStat = (features: EngineeredFeatures, metric: string, windowKey: WindowKey): MetricWindowStats | undefined => {
+  const windows = features.windows ?? {};
+  if (windows[windowKey]?.[metric]) {
+    return windows[windowKey][metric];
+  }
+  const flatKey = `${metric}_${windowKey}`;
+  const candidate = features[flatKey];
+  if (candidate && typeof candidate === "object") {
+    return candidate as MetricWindowStats;
+  }
+  return undefined;
+};
+
+const cardiovascularRules: CardiovascularRule[] = [
+  {
+    id: "ldl_high_mean_90d",
+    label: "LDL ↑ (90d mean)",
+    weight: 0.22,
+    when: (features) => {
+      const stat = getStat(features, "ldl", "days90");
+      return !!stat && Number.isFinite(stat.mean) && stat.mean > 130;
+    },
+    detail: (features) => {
+      const stat = getStat(features, "ldl", "days90");
+      return stat?.mean ? `${Math.round(stat.mean)} mg/dL` : null;
+    },
+  },
+  {
+    id: "triglycerides_high_mean_90d",
+    label: "Triglycerides ↑",
+    weight: 0.16,
+    when: (features) => {
+      const stat = getStat(features, "triglycerides", "days90");
+      return !!stat && Number.isFinite(stat.mean) && stat.mean > 175;
+    },
+    detail: (features) => {
+      const stat = getStat(features, "triglycerides", "days90");
+      return stat?.mean ? `${Math.round(stat.mean)} mg/dL` : null;
+    },
+  },
+  {
+    id: "hba1c_elevated_chronic",
+    label: "HbA1c ↑ (chronic)",
+    weight: 0.18,
+    when: (features) => {
+      const stat = getStat(features, "hba1c", "days365");
+      return !!stat && Number.isFinite(stat.mean) && stat.mean >= 6.5;
+    },
+    detail: (features) => {
+      const stat = getStat(features, "hba1c", "days365");
+      return stat?.mean ? `${stat.mean.toFixed(1)}%` : null;
+    },
+  },
+  {
+    id: "sbp_high_mean_90d",
+    label: "SBP ↑",
+    weight: 0.18,
+    when: (features) => {
+      const stat = getStat(features, "sbp", "days90");
+      return !!stat && Number.isFinite(stat.mean) && stat.mean >= 140;
+    },
+    detail: (features) => {
+      const stat = getStat(features, "sbp", "days90");
+      return stat?.mean ? `${Math.round(stat.mean)} mmHg` : null;
+    },
+  },
+  {
+    id: "bmi_obesity_mean_365d",
+    label: "BMI obesity range",
+    weight: 0.10,
+    when: (features) => {
+      const stat = getStat(features, "bmi", "days365");
+      return !!stat && Number.isFinite(stat.mean) && stat.mean >= 30;
+    },
+    detail: (features) => {
+      const stat = getStat(features, "bmi", "days365");
+      return stat?.mean ? `${Math.round(stat.mean)}` : null;
+    },
+  },
+  {
+    id: "age_elderly",
+    label: "Age ≥ 65",
+    weight: 0.10,
+    when: (features) => {
+      const age = features.demographics?.age;
+      return typeof age === "number" && age >= 65;
+    },
+    detail: (features) => {
+      const age = features.demographics?.age;
+      return typeof age === "number" ? `${Math.round(age)} yrs` : null;
+    },
+  },
+  {
+    id: "encounter_frequent_recent",
+    label: "Recurrent acute visits",
+    weight: 0.06,
+    when: (features) => {
+      const stat = getStat(features, "visits", "days90");
+      return !!stat && Number.isFinite(stat.count) && stat.count >= 2;
+    },
+    detail: (features) => {
+      const stat = getStat(features, "visits", "days90");
+      return stat?.count ? `${stat.count} visits/90d` : null;
+    },
+  },
+];
+
+export function evaluateCardiovascularRisk(features: EngineeredFeatures): RuleEvaluation {
+  let score = 0;
+  let maxScore = 0;
+  const factors: RiskFactor[] = [];
+
+  for (const rule of cardiovascularRules) {
+    if (rule.weight > 0) {
+      maxScore += rule.weight;
+    }
+    const triggered = rule.when(features);
+    if (triggered) {
+      score += rule.weight;
+      factors.push({
+        name: rule.label,
+        impact: rule.weight,
+        detail: rule.detail?.(features) ?? null,
+        direction: normaliseImpactDirection(rule.weight, rule.direction),
+      });
+    }
+  }
+
+  return { score, factors: factors.sort((a, b) => b.impact - a.impact), maxScore };
+}
+
+export { getStat, WINDOW_KEYS };

--- a/types/prediction.ts
+++ b/types/prediction.ts
@@ -1,0 +1,83 @@
+export type RiskLabel = "Low" | "Moderate" | "High";
+
+export type WindowKey = "days7" | "days30" | "days90" | "days365";
+
+export interface WindowStatOptions {
+  normalRange?: [number | null, number | null];
+}
+
+export interface MetricWindowStats {
+  n: number;
+  count: number;
+  mean: number;
+  min: number;
+  max: number;
+  std: number;
+  slope: number;
+  first?: number;
+  last?: number;
+  firstObservedAt?: string;
+  lastObservedAt?: string;
+  timeSinceLast?: number;
+  percentOutOfRange?: number;
+  timeSinceLastNormal?: number;
+}
+
+export type WindowSnapshot = Record<string, MetricWindowStats>;
+
+export interface PatientDemographics {
+  age?: number | null;
+  sex?: string | null;
+}
+
+export interface FeatureBuilderInput {
+  vitals: any[];
+  labs: any[];
+  meds: any[];
+  notes: any[];
+  encounters: any[];
+  demographics?: PatientDemographics;
+}
+
+export interface EngineeredFeatures {
+  windows: Record<WindowKey, WindowSnapshot>;
+  demographics?: PatientDemographics;
+  counts?: Record<string, number>;
+  missing?: string[];
+  [key: string]:
+    | MetricWindowStats
+    | WindowSnapshot
+    | PatientDemographics
+    | Record<string, number>
+    | string[]
+    | undefined;
+}
+
+export interface RiskFactor {
+  name: string;
+  impact: number;
+  detail?: string | null;
+  direction?: "positive" | "negative";
+}
+
+export interface PredictionContext {
+  featureCount: number;
+  missing?: string[];
+  demographicSummary?: string;
+}
+
+export interface PredictionResult {
+  condition: string;
+  riskScore: number;
+  riskLabel: RiskLabel;
+  topFactors: RiskFactor[];
+  windows: Record<WindowKey, WindowSnapshot>;
+  generatedAt: string;
+  context?: PredictionContext;
+}
+
+export interface RuleEvaluation {
+  score: number;
+  factors: RiskFactor[];
+  maxScore: number;
+}


### PR DESCRIPTION
## Summary
- add a POST /api/predict route that pulls longitudinal patient data from Supabase, computes features, scores risk, and stores the prediction payload
- implement reusable time-window feature engineering utilities and cardiovascular risk scoring orchestration for interpretable outputs
- codify cardiovascular rule weights and shared prediction types to enable future model swaps and UI consumption

## Testing
- `npx tsc --noEmit` *(fails: existing placeholder test fixtures contain invalid TypeScript syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68c91478aef0832f8e1d0e90344433ea