### PR TITLE
Fix timeline observation panel blank state

### DIFF
--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -75,6 +75,9 @@ export default function Timeline(){
   const long = active?.meta?.summary_long;
   const short = active?.meta?.summary;
   const text = active?.meta?.text;
+  const hasSummary = Boolean(long || short);
+  const hasText = Boolean(text);
+  const hasContent = hasSummary || hasText;
 
   return (
     <div className="p-4">
@@ -158,26 +161,30 @@ export default function Timeline(){
                   <div className="text-sm text-muted-foreground text-center">Preview unavailable. Use <b>Open</b> or <b>Download</b>.</div>
                 )
               ) : (
-                <Tabs defaultValue={long ? 'summary' : (short ? 'summary' : 'text')}>
-                  {(long || short) && (
-                    <TabsList className="mb-3">
-                      <TabsTrigger value="summary">Summary</TabsTrigger>
-                      {text && <TabsTrigger value="text">Full text</TabsTrigger>}
-                    </TabsList>
-                  )}
-                  {(long || short) && (
-                    <TabsContent value="summary">
-                      <article className="prose prose-zinc dark:prose-invert max-w-none whitespace-pre-wrap select-text">
-                        {(long || short) as string}
-                      </article>
-                    </TabsContent>
-                  )}
-                  {text && (
-                    <TabsContent value="text">
-                      <pre className="whitespace-pre-wrap break-words text-sm leading-6 select-text">{text}</pre>
-                    </TabsContent>
-                  )}
-                </Tabs>
+                hasContent ? (
+                  <Tabs key={active.id} defaultValue={hasSummary ? 'summary' : 'text'}>
+                    {hasSummary && (
+                      <TabsList className="mb-3">
+                        <TabsTrigger value="summary">Summary</TabsTrigger>
+                        {hasText && <TabsTrigger value="text">Full text</TabsTrigger>}
+                      </TabsList>
+                    )}
+                    {hasSummary && (
+                      <TabsContent value="summary">
+                        <article className="prose prose-zinc dark:prose-invert max-w-none whitespace-pre-wrap select-text">
+                          {(long || short) as string}
+                        </article>
+                      </TabsContent>
+                    )}
+                    {hasText && (
+                      <TabsContent value="text">
+                        <pre className="whitespace-pre-wrap break-words text-sm leading-6 select-text">{text}</pre>
+                      </TabsContent>
+                    )}
+                  </Tabs>
+                ) : (
+                  <div className="text-sm text-muted-foreground text-center">No summary available for this observation.</div>
+                )
               )}
             </div>
           </aside>

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -57,6 +57,7 @@ export default function Timeline(){
   const [signedUrl, setSignedUrl] = useState<string|null>(null);
   useEffect(()=>{
     if (!open || !active?.file) { setSignedUrl(null); return; }
+    setSignedUrl(null);
     const f = active.file;
     const qs = f.upload_id
       ? `?uploadId=${encodeURIComponent(f.upload_id)}`
@@ -78,6 +79,15 @@ export default function Timeline(){
   const hasSummary = Boolean(long || short);
   const hasText = Boolean(text);
   const hasContent = hasSummary || hasText;
+  const defaultTab = hasSummary ? "summary" : "text";
+  const tabResetKey = active
+    ? active.id ??
+      active.meta?.file_name ??
+      active.name ??
+      active.observed_at ??
+      active.uploaded_at ??
+      ""
+    : "";
 
   return (
     <div className="p-4">
@@ -162,7 +172,7 @@ export default function Timeline(){
                 )
               ) : (
                 hasContent ? (
-                  <Tabs key={active.id} defaultValue={hasSummary ? 'summary' : 'text'}>
+                  <Tabs defaultValue={defaultTab} resetKey={tabResetKey}>
                     {hasSummary && (
                       <TabsList className="mb-3">
                         <TabsTrigger value="summary">Summary</TabsTrigger>

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -4,8 +4,19 @@ import * as React from "react";
 type Ctx = { value: string; setValue: (v: string) => void };
 const TabsContext = React.createContext<Ctx | null>(null);
 
-export function Tabs({ defaultValue, children }: { defaultValue: string; children: React.ReactNode }) {
+type TabsProps = {
+  defaultValue: string;
+  resetKey?: React.Key;
+  children: React.ReactNode;
+};
+
+export function Tabs({ defaultValue, resetKey, children }: TabsProps) {
   const [value, setValue] = React.useState(defaultValue);
+
+  React.useEffect(() => {
+    setValue(defaultValue);
+  }, [defaultValue, resetKey]);
+
   return <TabsContext.Provider value={{ value, setValue }}>{children}</TabsContext.Provider>;
 }
 


### PR DESCRIPTION
## Summary
- reset the timeline observation tabs when switching observations so matching content renders
- show a friendly placeholder when an observation has no summary or text content

## Testing
- npm run lint *(fails: prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68c97fefa778832f9785009978648d99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observation panel now shows dynamic tabs (Summary and Full text) only when content exists, defaulting to Summary when available.
  * Tabs reset their default selection when content changes, ensuring predictable behavior when switching items.
  * Added a clear fallback message when no summary or text is available.

* **Bug Fixes**
  * Prevents stale file preview URLs from appearing while new content loads, avoiding brief incorrect displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->