### PR TITLE
Guard trial summary notice updates

### DIFF
--- a/app/api/trials/fetch/route.ts
+++ b/app/api/trials/fetch/route.ts
@@ -1,0 +1,369 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { TrialFacts, TrialIntervention, TrialOutcome } from "@/types/trialSummaries";
+
+export const runtime = "nodejs";
+
+const ID_REGEX = /\bNCT\d{8}\b/gi;
+const TTL_MS = 60 * 60 * 1000;
+const MAX_CACHE = 100;
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124 Safari/537.36";
+
+interface CacheEntry {
+  data: TrialFacts;
+  expiresAt: number;
+  touchedAt: number;
+}
+
+const globalScope = globalThis as unknown as { __trialFetchCache?: Map<string, CacheEntry> };
+const memCache: Map<string, CacheEntry> = globalScope.__trialFetchCache || new Map();
+if (!globalScope.__trialFetchCache) {
+  globalScope.__trialFetchCache = memCache;
+}
+
+class RateLimitError extends Error {
+  status = 429;
+  constructor(message: string) {
+    super(message);
+    this.name = "RateLimitError";
+  }
+}
+
+function normalizeId(raw: string) {
+  const match = raw.toUpperCase().match(/NCT\d{8}/);
+  return match ? match[0] : null;
+}
+
+function fromCache(nctId: string): TrialFacts | null {
+  const entry = memCache.get(nctId);
+  if (!entry) return null;
+  const now = Date.now();
+  if (entry.expiresAt < now) {
+    memCache.delete(nctId);
+    return null;
+  }
+  entry.touchedAt = now;
+  return entry.data;
+}
+
+function pruneCache() {
+  if (memCache.size <= MAX_CACHE) return;
+  const entries = Array.from(memCache.entries());
+  entries.sort((a, b) => a[1].touchedAt - b[1].touchedAt);
+  while (memCache.size > MAX_CACHE && entries.length) {
+    const [id] = entries.shift()!;
+    memCache.delete(id);
+  }
+}
+
+function toCache(nctId: string, data: TrialFacts) {
+  memCache.set(nctId, { data, expiresAt: Date.now() + TTL_MS, touchedAt: Date.now() });
+  pruneCache();
+}
+
+function safeString(value?: any) {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length ? trimmed : null;
+  }
+  return null;
+}
+
+function formatAgeRange(minAge?: string | null, maxAge?: string | null) {
+  const min = safeString(minAge);
+  const max = safeString(maxAge);
+  if (min && max) return `${min} to ${max}`;
+  if (min) return `${min} and older`;
+  if (max) return `${max} and younger`;
+  return null;
+}
+
+function formatDateStruct(struct?: { StartDate?: string; PrimaryCompletionDate?: string; CompletionDate?: string }) {
+  if (!struct) return null;
+  const keys = ["StartDate", "PrimaryCompletionDate", "CompletionDate"] as const;
+  for (const key of keys) {
+    const value = (struct as any)[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function parseEligibility(raw?: string | null) {
+  const keyInclusion: string[] = [];
+  const keyExclusion: string[] = [];
+  if (!raw) return { keyInclusion, keyExclusion };
+  const lines = raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  let section: "none" | "inclusion" | "exclusion" = "none";
+  for (const line of lines) {
+    if (/^inclusion criteria[:]?$/i.test(line)) {
+      section = "inclusion";
+      continue;
+    }
+    if (/^exclusion criteria[:]?$/i.test(line)) {
+      section = "exclusion";
+      continue;
+    }
+    const normalized = line
+      .replace(/^[\-•*\u2022\u2023\u25E6\u2043\u2219\s]+/, "")
+      .replace(/^\d+[\).\s]+/, "")
+      .trim();
+    if (!normalized) continue;
+    if (section === "inclusion") keyInclusion.push(normalized);
+    else if (section === "exclusion") keyExclusion.push(normalized);
+  }
+  if (!keyInclusion.length && !keyExclusion.length) {
+    const bullets = lines
+      .map((line) =>
+        line
+          .replace(/^[\-•*\u2022\u2023\u25E6\u2043\u2219\s]+/, "")
+          .replace(/^\d+[\).\s]+/, "")
+          .trim()
+      )
+      .filter(Boolean)
+      .slice(0, 6);
+    keyInclusion.push(...bullets);
+  }
+  return {
+    keyInclusion: keyInclusion.slice(0, 6),
+    keyExclusion: keyExclusion.slice(0, 6),
+  };
+}
+
+function uniqueStrings(values: Array<string | null | undefined>) {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    if (!value) continue;
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function mapTrial(study: any, nctId: string): TrialFacts {
+  const protocol = study?.ProtocolSection ?? {};
+  const identification = protocol.IdentificationModule ?? {};
+  const status = protocol.StatusModule ?? {};
+  const design = protocol.DesignModule ?? {};
+  const outcomes = protocol.OutcomesModule ?? {};
+  const eligibilityModule = protocol.EligibilityModule ?? {};
+  const arms = protocol.ArmsInterventionsModule ?? {};
+  const contacts = protocol.ContactsLocationsModule ?? {};
+  const sponsors = protocol.SponsorCollaboratorsModule ?? {};
+  const conditionsModule = protocol.ConditionsModule ?? {};
+
+  const interventionList: TrialIntervention[] = Array.isArray(arms?.InterventionList?.Intervention)
+    ? arms.InterventionList.Intervention.map((item: any) => ({
+        type: safeString(item?.InterventionType),
+        name: safeString(item?.InterventionName),
+      }))
+    : [];
+
+  const primaryOutcomes: TrialOutcome[] = Array.isArray(outcomes?.PrimaryOutcomeList?.PrimaryOutcome)
+    ? outcomes.PrimaryOutcomeList.PrimaryOutcome.map((item: any) => ({
+        title: safeString(item?.PrimaryOutcomeMeasure) || "",
+        timeFrame: safeString(item?.PrimaryOutcomeTimeFrame),
+      }))
+        .filter((item: TrialOutcome) => Boolean(item.title))
+    : [];
+
+  const countries = Array.isArray(contacts?.LocationList?.Location)
+    ? uniqueStrings(
+        contacts.LocationList.Location.map((loc: any) => safeString(loc?.LocationCountry)).filter(Boolean) as string[]
+      ).slice(0, 12)
+    : [];
+
+  const enrollmentCount = Number(design?.EnrollmentInfo?.EnrollmentCount);
+
+  return {
+    nctId,
+    title: safeString(identification?.OfficialTitle) || safeString(identification?.BriefTitle) || null,
+    status: safeString(status?.OverallStatus),
+    phase: Array.isArray(design?.PhaseList?.Phase)
+      ? uniqueStrings(design.PhaseList.Phase.map((p: any) => (typeof p === "string" ? p : null))).join(", ") || null
+      : safeString(design?.Phase) || null,
+    studyType: safeString(design?.StudyType),
+    conditions: Array.isArray(conditionsModule?.ConditionList?.Condition)
+      ? uniqueStrings(
+          conditionsModule.ConditionList.Condition.map((condition: any) =>
+            typeof condition === "string" ? condition : null
+          )
+        )
+      : [],
+    design: {
+      masking: safeString(design?.MaskingInfo?.Masking),
+      allocation: safeString(design?.Allocation),
+      model: safeString(design?.InterventionModel) || safeString(design?.ObservationalModel),
+      arms:
+        typeof design?.NumberOfArms === "number"
+          ? design.NumberOfArms
+          : Array.isArray(arms?.ArmList?.Arm)
+          ? arms.ArmList.Arm.length
+          : null,
+    },
+    population: {
+      age: formatAgeRange(eligibilityModule?.MinimumAge, eligibilityModule?.MaximumAge),
+      sex: safeString(eligibilityModule?.Gender),
+      targetEnrollment: Number.isFinite(enrollmentCount) ? enrollmentCount : null,
+      countries,
+    },
+    interventions: interventionList,
+    outcomes: {
+      primary: primaryOutcomes,
+    },
+    eligibility: parseEligibility(eligibilityModule?.EligibilityCriteria),
+    contacts: {
+      sponsor: safeString(sponsors?.LeadSponsor?.LeadSponsorName),
+      locationsCount: Array.isArray(contacts?.LocationList?.Location)
+        ? contacts.LocationList.Location.length
+        : null,
+    },
+    dates: {
+      start:
+        safeString(status?.StartDateStruct?.StartDate) ||
+        safeString((status?.StartDateStruct as any)?.StartDate) ||
+        formatDateStruct(status?.StartDateStruct) ||
+        safeString((status as any)?.StartDate),
+      primaryCompletion:
+        safeString(status?.PrimaryCompletionDateStruct?.PrimaryCompletionDate) ||
+        formatDateStruct(status?.PrimaryCompletionDateStruct),
+      completion:
+        safeString(status?.CompletionDateStruct?.CompletionDate) ||
+        formatDateStruct(status?.CompletionDateStruct),
+    },
+    sources: [
+      {
+        label: "ClinicalTrials.gov",
+        url: `https://clinicaltrials.gov/study/${nctId}`,
+      },
+    ],
+  };
+}
+
+async function fetchTrial(nctId: string): Promise<TrialFacts | null> {
+  const cached = fromCache(nctId);
+  if (cached) return cached;
+  const url = `https://clinicaltrials.gov/api/query/full_studies?expr=${encodeURIComponent(
+    nctId
+  )}&min_rnk=1&max_rnk=1&fmt=json`;
+
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8000);
+    try {
+      const res = await fetch(url, {
+        method: "GET",
+        headers: {
+          accept: "application/json",
+          "user-agent": USER_AGENT,
+        },
+        signal: controller.signal,
+      });
+      if (res.status === 404) return null;
+      if (res.status === 429) throw new RateLimitError("clinicaltrials.gov rate limited");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json();
+      const study = json?.FullStudiesResponse?.FullStudies?.[0]?.Study;
+      if (!study) return null;
+      const mapped = mapTrial(study, nctId);
+      toCache(nctId, mapped);
+      return mapped;
+    } catch (err: any) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (err instanceof RateLimitError) throw err;
+      if (err?.name === "AbortError") {
+        if (attempt === 2) throw new Error("clinicaltrials.gov timeout");
+      } else if (attempt === 2) {
+        throw lastError;
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+  if (lastError) throw lastError;
+  return null;
+}
+
+function extractIds(param: string | null) {
+  if (!param) return [];
+  const set = new Set<string>();
+  const matches = param.match(ID_REGEX);
+  if (!matches) return [];
+  for (const m of matches) {
+    const normalized = normalizeId(m);
+    if (normalized) set.add(normalized);
+    if (set.size >= 5) break;
+  }
+  return Array.from(set);
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const idsParam = searchParams.get("ids");
+  const ids = extractIds(idsParam);
+  if (!ids.length) {
+    return NextResponse.json({ trials: [], error: "No valid NCT IDs provided" }, { status: 400 });
+  }
+
+  const trials: TrialFacts[] = [];
+  try {
+    for (const id of ids) {
+      try {
+        const data = await fetchTrial(id);
+        if (data) {
+          trials.push(data);
+        } else {
+          trials.push({
+            nctId: id,
+            conditions: [],
+            design: {},
+            population: { countries: [] },
+            interventions: [],
+            outcomes: { primary: [] },
+            eligibility: { keyInclusion: [], keyExclusion: [] },
+            contacts: {},
+            dates: {},
+            sources: [
+              {
+                label: "ClinicalTrials.gov",
+                url: `https://clinicaltrials.gov/study/${id}`,
+              },
+            ],
+            error: "Not found on ClinicalTrials.gov",
+          });
+        }
+      } catch (err: any) {
+        if (err instanceof RateLimitError) {
+          return NextResponse.json(
+            {
+              trials,
+              error: "Please try again in a minute—source rate limited.",
+            },
+            { status: 429 }
+          );
+        }
+        throw err;
+      }
+    }
+    return NextResponse.json(
+      { trials },
+      {
+        status: 200,
+        headers: {
+          "Cache-Control": "public, max-age=0, s-maxage=3600",
+        },
+      }
+    );
+  } catch (err: any) {
+    const message = typeof err?.message === "string" ? err.message : "Failed to fetch trials";
+    return NextResponse.json({ trials, error: message }, { status: 502 });
+  }
+}

--- a/app/api/trials/summary/route.ts
+++ b/app/api/trials/summary/route.ts
@@ -1,0 +1,320 @@
+import { NextResponse } from "next/server";
+import type { TrialFacts, TrialSummaryMarkdown, TrialIntervention, TrialOutcome, TrialSource } from "@/types/trialSummaries";
+import { callGroq } from "@/lib/llm/groq";
+import type { ChatCompletionMessageParam } from "@/lib/llm/types";
+
+export const runtime = "nodejs";
+
+function coerceString(value: any) {
+  return typeof value === "string" && value.trim().length ? value.trim() : null;
+}
+
+function coerceNumber(value: any) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function coerceArray<T>(value: any, mapper: (item: any) => T | null): T[] {
+  if (!Array.isArray(value)) return [];
+  const out: T[] = [];
+  for (const item of value) {
+    const mapped = mapper(item);
+    if (mapped !== null) out.push(mapped);
+  }
+  return out;
+}
+
+function coerceTrial(input: any): TrialFacts | null {
+  if (!input || typeof input !== "object") return null;
+  const nctId = coerceString((input as any).nctId)?.toUpperCase();
+  if (!nctId || !/^NCT\d{8}$/.test(nctId)) return null;
+  const design = (input as any).design ?? {};
+  const population = (input as any).population ?? {};
+  const outcomes = (input as any).outcomes ?? {};
+  const eligibility = (input as any).eligibility ?? {};
+  const contacts = (input as any).contacts ?? {};
+  const dates = (input as any).dates ?? {};
+  const sources = (input as any).sources ?? [];
+  return {
+    nctId,
+    title: coerceString((input as any).title),
+    status: coerceString((input as any).status),
+    phase: coerceString((input as any).phase),
+    studyType: coerceString((input as any).studyType),
+    conditions: coerceArray((input as any).conditions, (v) => coerceString(v)),
+    design: {
+      masking: coerceString(design?.masking),
+      allocation: coerceString(design?.allocation),
+      model: coerceString(design?.model),
+      arms: coerceNumber(design?.arms),
+    },
+    population: {
+      age: coerceString(population?.age),
+      sex: coerceString(population?.sex),
+      targetEnrollment: coerceNumber(population?.targetEnrollment),
+      countries: coerceArray(population?.countries, (v) => coerceString(v)),
+    },
+    interventions: coerceArray((input as any).interventions, (item) => {
+      if (!item || typeof item !== "object") return null;
+      const type = coerceString(item.type);
+      const name = coerceString(item.name);
+      if (!type && !name) return null;
+      return {
+        type,
+        name,
+      } as TrialIntervention;
+    }),
+    outcomes: {
+      primary: coerceArray(outcomes?.primary, (item) => {
+        if (!item || typeof item !== "object") return null;
+        const title = coerceString(item.title);
+        if (!title) return null;
+        return {
+          title,
+          timeFrame: coerceString(item.timeFrame),
+        } as TrialOutcome;
+      }),
+    },
+    eligibility: {
+      keyInclusion: coerceArray(eligibility?.keyInclusion, (v) => coerceString(v)).slice(0, 8),
+      keyExclusion: coerceArray(eligibility?.keyExclusion, (v) => coerceString(v)).slice(0, 8),
+    },
+    contacts: {
+      sponsor: coerceString(contacts?.sponsor),
+      locationsCount: coerceNumber(contacts?.locationsCount),
+    },
+    dates: {
+      start: coerceString(dates?.start),
+      primaryCompletion: coerceString(dates?.primaryCompletion),
+      completion: coerceString(dates?.completion),
+    },
+    sources: coerceArray(sources, (item) => {
+      if (!item || typeof item !== "object") return null;
+      const label = coerceString(item.label) || "ClinicalTrials.gov";
+      const url = coerceString(item.url);
+      if (!url) return null;
+      return { label, url } as TrialSource;
+    }),
+    error: coerceString((input as any).error),
+  };
+}
+
+function chunkTrials<T>(list: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < list.length; i += size) {
+    out.push(list.slice(i, i + size));
+  }
+  return out;
+}
+
+function joinParts(parts: Array<string | null | undefined>, fallback = "Not reported") {
+  const filtered = parts.map((p) => (typeof p === "string" ? p.trim() : "")).filter(Boolean);
+  return filtered.length ? filtered.join(" · ") : fallback;
+}
+
+function formatInterventions(trial: TrialFacts) {
+  const parts = trial.interventions
+    .map((i) => [i.type, i.name].filter(Boolean).join(": ").trim())
+    .filter(Boolean);
+  return parts.length ? parts.join("; ") : "Not reported";
+}
+
+function formatOutcomes(trial: TrialFacts) {
+  const parts = trial.outcomes.primary
+    .map((o) => (o.timeFrame ? `${o.title} (${o.timeFrame})` : o.title))
+    .filter(Boolean);
+  return parts.length ? parts.join("; ") : "Not reported";
+}
+
+function formatEligibilitySection(title: string, values: string[]) {
+  if (!values.length) return [] as string[];
+  const lines = [`- ${title}:`];
+  for (const value of values.slice(0, 4)) {
+    lines.push(`  - ${value}`);
+  }
+  return lines;
+}
+
+function formatPopulation(trial: TrialFacts) {
+  const parts: string[] = [];
+  if (trial.population.age) parts.push(`Age: ${trial.population.age}`);
+  if (trial.population.sex) parts.push(`Sex: ${trial.population.sex}`);
+  if (typeof trial.population.targetEnrollment === "number")
+    parts.push(`Target enrollment: ${trial.population.targetEnrollment}`);
+  if (trial.population.countries?.length)
+    parts.push(`Countries: ${trial.population.countries.slice(0, 5).join(", ")}`);
+  return parts.length ? parts.join(" · ") : "Not reported";
+}
+
+function formatDesign(trial: TrialFacts) {
+  const parts: string[] = [];
+  if (trial.design.model) parts.push(trial.design.model);
+  if (trial.design.allocation) parts.push(trial.design.allocation);
+  if (trial.design.masking) parts.push(`Masking: ${trial.design.masking}`);
+  if (typeof trial.design.arms === "number") parts.push(`${trial.design.arms} arm${trial.design.arms === 1 ? "" : "s"}`);
+  return parts.length ? parts.join(" · ") : "Not reported";
+}
+
+function formatStatus(trial: TrialFacts) {
+  const parts: string[] = [];
+  if (trial.status) parts.push(trial.status);
+  if (trial.dates.start) parts.push(`Start: ${trial.dates.start}`);
+  if (trial.dates.primaryCompletion) parts.push(`Primary completion: ${trial.dates.primaryCompletion}`);
+  if (trial.dates.completion) parts.push(`Completion: ${trial.dates.completion}`);
+  return parts.length ? parts.join(" · ") : "Not reported";
+}
+
+function formatSources(trial: TrialFacts) {
+  if (!trial.sources?.length) return "ClinicalTrials.gov";
+  return trial.sources
+    .map((s) => `[${s.label || "ClinicalTrials.gov"}](${s.url})`)
+    .join(", ");
+}
+
+function buildTldr(trial: TrialFacts) {
+  const parts: string[] = [];
+  if (trial.title) parts.push(trial.title);
+  if (trial.status) parts.push(trial.status);
+  if (trial.phase) parts.push(trial.phase);
+  if (trial.interventions.find((i) => i.name)) {
+    const first = trial.interventions.find((i) => i.name)?.name;
+    if (first) parts.push(first);
+  } else if (trial.conditions.length) {
+    parts.push(trial.conditions[0]);
+  }
+  return parts.slice(0, 3).join(" · ") || "See details below.";
+}
+
+function formatPlainTrial(trial: TrialFacts): string {
+  const lines: string[] = [];
+  lines.push(`### ${trial.nctId} — Doctor Brief`);
+  lines.push(`**TL;DR:** ${buildTldr(trial)}`);
+  lines.push(`**Phase / Type:** ${joinParts([trial.phase, trial.studyType])}`);
+  lines.push(`**Population:** ${formatPopulation(trial)}`);
+  lines.push(`**Design:** ${formatDesign(trial)}`);
+  lines.push(`**Interventions:** ${formatInterventions(trial)}`);
+  lines.push(`**Primary outcomes:** ${formatOutcomes(trial)}`);
+  lines.push(`**Status / Dates:** ${formatStatus(trial)}`);
+  lines.push(`**Key eligibility (short):**`);
+  const eligibilityLines = [
+    ...formatEligibilitySection("Inclusion", trial.eligibility.keyInclusion),
+    ...formatEligibilitySection("Exclusion", trial.eligibility.keyExclusion),
+  ];
+  if (eligibilityLines.length === 0) {
+    lines.push("- Not specified.");
+  } else {
+    lines.push(...eligibilityLines);
+  }
+  lines.push(`**Sources:** ${formatSources(trial)}`);
+  return lines.join("\n");
+}
+
+function parseGroqMarkdown(raw: string, expected: TrialFacts[]): TrialSummaryMarkdown[] | null {
+  const trimmed = (raw || "").trim();
+  if (!trimmed) return null;
+  const sections = trimmed.split(/(?=^###\s+NCT\d{8})/m).map((s) => s.trim()).filter(Boolean);
+  if (!sections.length) return null;
+  const summaries: TrialSummaryMarkdown[] = [];
+  for (const section of sections) {
+    const header = section.match(/^###\s+(NCT\d{8})/m);
+    const nctId = header?.[1];
+    if (nctId) {
+      summaries.push({ nctId, markdown: section });
+    }
+  }
+  if (!summaries.length) return null;
+  const ordered: TrialSummaryMarkdown[] = [];
+  for (const trial of expected) {
+    const match = summaries.find((s) => s.nctId === trial.nctId);
+    if (!match) return null;
+    ordered.push(match);
+  }
+  return ordered;
+}
+
+export async function POST(req: Request) {
+  let payload: any;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ summaries: [], error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const style = payload?.style === "plain" ? "plain" : "doctor-brief";
+  const rawTrials = Array.isArray(payload?.trials) ? payload.trials : [];
+  const trials = rawTrials
+    .map((item: any) => coerceTrial(item))
+    .filter((item: TrialFacts | null): item is TrialFacts => !!item)
+    .slice(0, 5);
+
+  if (!trials.length) {
+    return NextResponse.json({ summaries: [] });
+  }
+
+  let notice: string | undefined;
+  const validTrials = trials.filter((trial): trial is TrialFacts => !trial.error);
+  const needGroq = style === "doctor-brief" && process.env.GROQ_API_KEY && validTrials.length > 0;
+  let summaries: TrialSummaryMarkdown[] | null = null;
+
+  if (needGroq) {
+    try {
+      const chunks = chunkTrials<TrialFacts>(validTrials, 2);
+      const collected: TrialSummaryMarkdown[] = [];
+      for (const chunk of chunks) {
+        const system = "You are a medical summarizer. Only use provided JSON; do not invent facts; units and names must match source.";
+        const content = JSON.stringify(chunk, null, 2);
+        const messages: ChatCompletionMessageParam[] = [
+          { role: "system", content: system },
+          { role: "user", content },
+        ];
+        const response = await callGroq(messages, {
+          temperature: 0,
+          max_tokens: 900,
+          metadata: { source: "trial-summary" },
+        });
+        const parsed = parseGroqMarkdown(response, chunk);
+        if (!parsed) {
+          throw new Error("Groq output malformed");
+        }
+        collected.push(...parsed);
+      }
+      const combined: TrialSummaryMarkdown[] = [];
+      for (const trial of validTrials) {
+        const match = collected.find((item) => item.nctId === trial.nctId);
+        if (!match) {
+          throw new Error("Missing Groq summary");
+        }
+        combined.push(match);
+      }
+      const merged: TrialSummaryMarkdown[] = [];
+      for (const trial of trials) {
+        if (trial.error) {
+          merged.push({
+            nctId: trial.nctId,
+            markdown: `> ${trial.error}`,
+          });
+        } else {
+          const summary = combined.find((item) => item.nctId === trial.nctId);
+          merged.push(summary!);
+        }
+      }
+      summaries = merged;
+    } catch (err) {
+      console.error("Groq trial summary fallback", err);
+      notice = "Showing factual summary without TL;DR.";
+    }
+  }
+
+  if (!summaries) {
+    if (style === "doctor-brief" && !notice) {
+      notice = "Showing factual summary without TL;DR.";
+    }
+    summaries = trials.map((trial) => ({
+      nctId: trial.nctId,
+      markdown: trial.error ? `> ${trial.error}` : formatPlainTrial(trial),
+    }));
+  }
+
+  return NextResponse.json({ summaries, notice });
+}

--- a/components/trials/TrialCard.tsx
+++ b/components/trials/TrialCard.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import { Clipboard, ExternalLink, Check } from 'lucide-react';
+import ChatMarkdown from '@/components/ChatMarkdown';
+
+type TrialCardProps = {
+  nctId: string;
+  title?: string | null;
+  status?: string | null;
+  phase?: string | null;
+  url?: string | null;
+  markdown?: string;
+  pending?: boolean;
+  error?: string | null;
+};
+
+export default function TrialCard({
+  nctId,
+  title,
+  status,
+  phase,
+  url,
+  markdown,
+  pending,
+  error,
+}: TrialCardProps) {
+  const [copied, setCopied] = useState<'idle' | 'copied' | 'error'>('idle');
+
+  if (pending) {
+    return (
+      <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 space-y-3 animate-pulse">
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-32 rounded bg-slate-200 dark:bg-slate-700" />
+          <div className="flex gap-2">
+            <div className="h-4 w-16 rounded bg-slate-200 dark:bg-slate-700" />
+            <div className="h-4 w-16 rounded bg-slate-200 dark:bg-slate-700" />
+          </div>
+        </div>
+        <div className="h-4 w-3/4 rounded bg-slate-200 dark:bg-slate-700" />
+        <div className="h-4 w-full rounded bg-slate-200 dark:bg-slate-700" />
+        <div className="h-4 w-5/6 rounded bg-slate-200 dark:bg-slate-700" />
+      </div>
+    );
+  }
+
+  const handleCopy = async () => {
+    if (!markdown) return;
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopied('copied');
+      setTimeout(() => setCopied('idle'), 2000);
+    } catch (err) {
+      console.error('copy_failed', err);
+      setCopied('error');
+      setTimeout(() => setCopied('idle'), 2000);
+    }
+  };
+
+  return (
+    <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 space-y-3">
+      <header className="flex flex-wrap items-center gap-2">
+        <h3 className="text-base font-semibold tracking-tight">{nctId}</h3>
+        {status && (
+          <span className="ml-1 inline-flex items-center rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200 px-2 py-0.5 text-xs">
+            {status}
+          </span>
+        )}
+        {phase && (
+          <span className="inline-flex items-center rounded-full bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200 px-2 py-0.5 text-xs">
+            {phase}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-2 text-xs">
+          {markdown && (
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1 rounded border border-slate-200 dark:border-slate-700 px-2 py-1 hover:bg-slate-100 dark:hover:bg-slate-800 transition"
+            >
+              {copied === 'copied' ? <Check size={14} /> : <Clipboard size={14} />}
+              {copied === 'copied' ? 'Copied' : 'Copy'}
+            </button>
+          )}
+          {url && (
+            <a
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 rounded border border-slate-200 dark:border-slate-700 px-2 py-1 hover:bg-slate-100 dark:hover:bg-slate-800 transition"
+            >
+              <ExternalLink size={14} /> Open
+            </a>
+          )}
+        </div>
+      </header>
+      {title && <p className="text-sm font-medium text-slate-700 dark:text-slate-300">{title}</p>}
+      {error ? (
+        <div className="text-sm text-rose-600 dark:text-rose-300">{error}</div>
+      ) : (
+        markdown && <ChatMarkdown content={markdown} />
+      )}
+    </div>
+  );
+}

--- a/types/trialSummaries.ts
+++ b/types/trialSummaries.ts
@@ -1,0 +1,69 @@
+export type TrialDesign = {
+  masking?: string | null;
+  allocation?: string | null;
+  model?: string | null;
+  arms?: number | null;
+};
+
+export type TrialPopulation = {
+  age?: string | null;
+  sex?: string | null;
+  targetEnrollment?: number | null;
+  countries: string[];
+};
+
+export type TrialIntervention = {
+  type?: string | null;
+  name?: string | null;
+};
+
+export type TrialOutcome = {
+  title: string;
+  timeFrame?: string | null;
+};
+
+export type TrialEligibility = {
+  keyInclusion: string[];
+  keyExclusion: string[];
+};
+
+export type TrialContacts = {
+  sponsor?: string | null;
+  locationsCount?: number | null;
+};
+
+export type TrialDates = {
+  start?: string | null;
+  primaryCompletion?: string | null;
+  completion?: string | null;
+};
+
+export type TrialSource = {
+  label: string;
+  url: string;
+};
+
+export type TrialFacts = {
+  nctId: string;
+  title?: string | null;
+  status?: string | null;
+  phase?: string | null;
+  studyType?: string | null;
+  conditions: string[];
+  design: TrialDesign;
+  population: TrialPopulation;
+  interventions: TrialIntervention[];
+  outcomes: {
+    primary: TrialOutcome[];
+  };
+  eligibility: TrialEligibility;
+  contacts: TrialContacts;
+  dates: TrialDates;
+  sources: TrialSource[];
+  error?: string | null;
+};
+
+export type TrialSummaryMarkdown = {
+  nctId: string;
+  markdown: string;
+};


### PR DESCRIPTION
## Summary
- add a ClinicalTrials.gov fetch API that caches structured trial facts and surfaces friendly error messages
- add a summary formatter API that builds markdown cards with a Groq-backed doctor brief and plain fallback
- update the chat UI to detect NCT IDs, render trial cards with skeletons, and skip research brief styling when trials are summarized
- fix the trial summary Groq chunk typing so the handler passes typed TrialFacts arrays into Groq parsing
- guard chat trial-summary state updates so TypeScript only reads `notice` from the appropriate message kind

## Testing
- `npm run build` *(fails: Next.js attempts to patch the lockfile by downloading SWC binaries, which is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c96fc698bc832f9d29d9abdff4ff24