### PR TITLE
Normalize hemodynamic calculator input units

### DIFF
--- a/lib/medical/engine/calculators/abc_mtp.ts
+++ b/lib/medical/engine/calculators/abc_mtp.ts
@@ -15,6 +15,6 @@ export function runABC({Penetrating, PositiveFAST, SBP, HR}: ABCInputs) {
 register({
   id: "abc_mtp",
   label: "ABC Score (Massive Transfusion Trigger)",
-  inputs: [{key:"Penetrating",required:true},{key:"PositiveFAST",required:true},{key:"SBP",required:true},{key:"HR",required:true}],
+  inputs: [{key:"Penetrating",required:true},{key:"PositiveFAST",required:true},{key:"SBP",unit:"mmHg",required:true},{key:"HR",unit:"bpm",required:true}],
   run: runABC as any,
 });

--- a/lib/medical/engine/calculators/composite_engines.ts
+++ b/lib/medical/engine/calculators/composite_engines.ts
@@ -48,6 +48,6 @@ export function runShockIndexBands({ HR, SBP }: ShockInputs) {
 }
 
 register({ id:"dka_severity", label:"DKA severity", inputs:[{key:"pH",required:true},{key:"HCO3",required:true},{key:"mental_status"}], run: runDKASeverity as any });
-register({ id:"sepsis_bundle_flag", label:"Sepsis bundle flag", inputs:[{key:"SBP"},{key:"MAP"},{key:"Lactate"}], run: runSepsisBundleFlag as any });
+register({ id:"sepsis_bundle_flag", label:"Sepsis bundle flag", inputs:[{key:"SBP",unit:"mmHg"},{key:"MAP",unit:"mmHg"},{key:"Lactate",unit:"mmol/L"}], run: runSepsisBundleFlag as any });
 register({ id:"ards_severity", label:"ARDS severity (Berlin)", inputs:[{key:"PaO2",required:true},{key:"FiO2",required:true},{key:"ventilatory_support"},{key:"PEEP_cmH2O"}], run: runARDSSeverity as any });
-register({ id:"shock_index_bands", label:"Shock index bands", inputs:[{key:"HR",required:true},{key:"SBP",required:true}], run: runShockIndexBands as any });
+register({ id:"shock_index_bands", label:"Shock index bands", inputs:[{key:"HR",unit:"bpm",required:true},{key:"SBP",unit:"mmHg",required:true}], run: runShockIndexBands as any });

--- a/lib/medical/engine/calculators/icu_helpers.ts
+++ b/lib/medical/engine/calculators/icu_helpers.ts
@@ -4,7 +4,7 @@ import { register } from "../registry";
 register({
   id: "map",
   label: "Mean arterial pressure",
-  inputs: [{ key: "SBP", required: true }, { key: "DBP", required: true }],
+  inputs: [{ key: "SBP", unit: "mmHg", required: true }, { key: "DBP", unit: "mmHg", required: true }],
   run: ({ SBP, DBP }) => {
     if (SBP == null || DBP == null) return null;
     const val = (SBP + 2 * DBP) / 3;
@@ -18,7 +18,7 @@ register({
 register({
   id: "shock_index",
   label: "Shock index",
-  inputs: [{ key: "HR", required: true }, { key: "SBP", required: true }],
+  inputs: [{ key: "HR", unit: "bpm", required: true }, { key: "SBP", unit: "mmHg", required: true }],
   run: ({ HR, SBP }) => {
     if (HR == null || SBP == null || SBP === 0) return null;
     const val = HR / SBP;

--- a/lib/medical/engine/calculators/lab_interpretation.ts
+++ b/lib/medical/engine/calculators/lab_interpretation.ts
@@ -338,7 +338,7 @@ register({
 register({
   id: "circulation_summary",
   label: "Circulation",
-  inputs: [{ key: "SBP" }, { key: "DBP" }, { key: "HR" }],
+  inputs: [{ key: "SBP", unit: "mmHg" }, { key: "DBP", unit: "mmHg" }, { key: "HR", unit: "bpm" }],
   run: ({ SBP, DBP, HR }) => {
     if (SBP == null || DBP == null || HR == null) return null;
     const map = (SBP + 2 * DBP) / 3;
@@ -5344,8 +5344,8 @@ register({
   tags: ["pulmonary", "icu_scores"],
   inputs: [
     { key: "FiO2", required: true },
-    { key: "MAP", required: true },
-    { key: "PaO2", required: true },
+    { key: "MAP", unit: "mmHg", required: true },
+    { key: "PaO2", unit: "mmHg", required: true },
   ],
   run: ({ FiO2, MAP, PaO2 }) => {
     const oi = (FiO2 * MAP * 100) / PaO2;
@@ -6787,7 +6787,7 @@ register({
   label: "SOFA cardiovascular subscore",
   tags: ["icu_scores","sepsis"],
   inputs: [
-    { key:"MAP", required:true },
+    { key:"MAP", unit:"mmHg", required:true },
     { key:"on_vasopressors", required:true }
   ],
   run: ({MAP,on_vasopressors})=>{
@@ -7471,8 +7471,8 @@ register({
   label: "QTc (Hodges)",
   tags: ["cardiology","ecg"],
   inputs: [
-    { key:"QT_ms", required:true },
-    { key:"HR", required:true }
+    { key:"QT_ms", unit:"ms", required:true },
+    { key:"HR", unit:"bpm", required:true }
   ],
   run: ({QT_ms,HR})=>{
     const val=QT_ms+1.75*(HR-60);
@@ -9496,8 +9496,8 @@ register({
   label: "QTc (Bazett)",
   tags: ["cardiology","ecg"],
   inputs: [
-    { key:"QT_ms", required:true },
-    { key:"HR", required:true }
+    { key:"QT_ms", unit:"ms", required:true },
+    { key:"HR", unit:"bpm", required:true }
   ],
   run: ({QT_ms,HR})=>{
     if (HR<=0) return null;
@@ -9513,8 +9513,8 @@ register({
   label: "QTc (Fridericia)",
   tags: ["cardiology","ecg"],
   inputs: [
-    { key:"QT_ms", required:true },
-    { key:"HR", required:true }
+    { key:"QT_ms", unit:"ms", required:true },
+    { key:"HR", unit:"bpm", required:true }
   ],
   run: ({QT_ms,HR})=>{
     if (HR<=0) return null;
@@ -9531,8 +9531,8 @@ register({
   label: "Rate–pressure product (RPP)",
   tags: ["cardiology","hemodynamics"],
   inputs: [
-    { key:"HR", required:true },
-    { key:"SBP", required:true }
+    { key:"HR", unit:"bpm", required:true },
+    { key:"SBP", unit:"mmHg", required:true }
   ],
   run: ({HR,SBP})=>{
     const val=HR*SBP;
@@ -9546,8 +9546,8 @@ register({
   label: "Pulse pressure band",
   tags: ["cardiology","hemodynamics"],
   inputs: [
-    { key:"SBP", required:true },
-    { key:"DBP", required:true }
+    { key:"SBP", unit:"mmHg", required:true },
+    { key:"DBP", unit:"mmHg", required:true }
   ],
   run: ({SBP,DBP})=>{
     const pp=SBP-DBP;
@@ -9561,8 +9561,8 @@ register({
   label: "Cardiac output from SV & HR",
   tags: ["cardiology","hemodynamics"],
   inputs: [
-    { key:"SV_ml", required:true },
-    { key:"HR", required:true }
+    { key:"SV_ml", unit:"mL", required:true },
+    { key:"HR", unit:"bpm", required:true }
   ],
   run: ({SV_ml,HR})=>{
     const co = (SV_ml*HR)/1000; // L/min
@@ -9575,8 +9575,8 @@ register({
   label: "Cardiac index from CO & BSA",
   tags: ["cardiology","hemodynamics"],
   inputs: [
-    { key:"CO_L_min", required:true },
-    { key:"BSA_m2", required:true }
+    { key:"CO_L_min", unit:"L/min", required:true },
+    { key:"BSA_m2", unit:"m²", required:true }
   ],
   run: ({CO_L_min,BSA_m2})=>{
     if (BSA_m2<=0) return null;
@@ -9591,8 +9591,8 @@ register({
   label: "Stroke volume from LVOT (SV = VTI×area)",
   tags: ["cardiology","echo"],
   inputs: [
-    { key:"lvot_diam_cm", required:true },
-    { key:"lvot_vti_cm", required:true }
+    { key:"lvot_diam_cm", unit:"cm", required:true },
+    { key:"lvot_vti_cm", unit:"cm", required:true }
   ],
   run: ({lvot_diam_cm,lvot_vti_cm})=>{
     const radius=lvot_diam_cm/2;
@@ -9607,8 +9607,8 @@ register({
   label: "Stroke volume index (SVI) from SV & BSA",
   tags: ["cardiology","echo"],
   inputs: [
-    { key:"SV_ml", required:true },
-    { key:"BSA_m2", required:true }
+    { key:"SV_ml", unit:"mL", required:true },
+    { key:"BSA_m2", unit:"m²", required:true }
   ],
   run: ({SV_ml,BSA_m2})=>{
     if (BSA_m2<=0) return null;
@@ -9846,8 +9846,8 @@ register({
   label: "Pregnancy-induced hypertension flag",
   tags: ["obstetrics"],
   inputs: [
-    { key:"SBP", required:true },
-    { key:"DBP", required:true }
+    { key:"SBP", unit:"mmHg", required:true },
+    { key:"DBP", unit:"mmHg", required:true }
   ],
   run: ({SBP,DBP})=>{
     const pos = SBP>=140 || DBP>=90;
@@ -10353,7 +10353,7 @@ register({
   id: "shock_index",
   label: "Shock index (HR/SBP)",
   tags: ["icu","hemodynamics"],
-  inputs: [{ key:"HR", required:true }, { key:"SBP", required:true }],
+  inputs: [{ key:"HR", unit:"bpm", required:true }, { key:"SBP", unit:"mmHg", required:true }],
   run: ({HR,SBP})=>{
     if (SBP<=0) return null;
     const val=HR/SBP;
@@ -10366,7 +10366,7 @@ register({
   id: "modified_shock_index",
   label: "Modified shock index (HR/MAP)",
   tags: ["icu","hemodynamics"],
-  inputs: [{ key:"HR", required:true }, { key:"MAP", required:true }],
+  inputs: [{ key:"HR", unit:"bpm", required:true }, { key:"MAP", unit:"mmHg", required:true }],
   run: ({HR,MAP})=>{
     if (MAP<=0) return null;
     const val=HR/MAP;
@@ -10379,7 +10379,7 @@ register({
   id: "map_calc",
   label: "Mean arterial pressure (MAP)",
   tags: ["hemodynamics"],
-  inputs: [{ key:"SBP", required:true }, { key:"DBP", required:true }],
+  inputs: [{ key:"SBP", unit:"mmHg", required:true }, { key:"DBP", unit:"mmHg", required:true }],
   run: ({SBP,DBP})=>{
     const val = (SBP + 2*DBP)/3;
     const notes=[val<65?"low MAP":"ok"];
@@ -10392,9 +10392,9 @@ register({
   label: "Systemic vascular resistance (SVR)",
   tags: ["hemodynamics","cardiology","icu"],
   inputs: [
-    { key:"MAP", required:true },
-    { key:"RAP", required:true },     // right atrial pressure
-    { key:"CO_L_min", required:true }
+    { key:"MAP", unit:"mmHg", required:true },
+    { key:"RAP", unit:"mmHg", required:true },     // right atrial pressure
+    { key:"CO_L_min", unit:"L/min", required:true }
   ],
   run: ({MAP,RAP,CO_L_min})=>{
     if (CO_L_min<=0) return null;
@@ -10409,9 +10409,9 @@ register({
   label: "Pulmonary vascular resistance (PVR)",
   tags: ["hemodynamics","pulmonary","icu"],
   inputs: [
-    { key:"mPAP", required:true },
-    { key:"PAWP", required:true },
-    { key:"CO_L_min", required:true }
+    { key:"mPAP", unit:"mmHg", required:true },
+    { key:"PAWP", unit:"mmHg", required:true },
+    { key:"CO_L_min", unit:"L/min", required:true }
   ],
   run: ({mPAP,PAWP,CO_L_min})=>{
     if (CO_L_min<=0) return null;
@@ -10440,7 +10440,7 @@ register({
   id: "oxygenation_index",
   label: "Oxygenation Index (OI)",
   tags: ["pulmonary","icu"],
-  inputs: [{ key:"FiO2", required:true }, { key:"MAP", required:true }, { key:"PaO2", required:true }],
+  inputs: [{ key:"FiO2", required:true }, { key:"MAP", unit:"mmHg", required:true }, { key:"PaO2", unit:"mmHg", required:true }],
   run: ({FiO2,MAP,PaO2})=>{
     if (PaO2<=0) return null;
     const val = (FiO2*MAP*100)/PaO2;
@@ -10453,7 +10453,7 @@ register({
   id: "oxygen_saturation_index",
   label: "Oxygen Saturation Index (OSI)",
   tags: ["pulmonary","icu"],
-  inputs: [{ key:"FiO2", required:true }, { key:"MAP", required:true }, { key:"SpO2", required:true }],
+  inputs: [{ key:"FiO2", required:true }, { key:"MAP", unit:"mmHg", required:true }, { key:"SpO2", unit:"%", required:true }],
   run: ({FiO2,MAP,SpO2})=>{
     if (SpO2<=0) return null;
     const val = (FiO2*MAP*100)/SpO2;

--- a/lib/medical/engine/calculators/metabolic_syndrome.ts
+++ b/lib/medical/engine/calculators/metabolic_syndrome.ts
@@ -32,6 +32,9 @@ export function runMetabolicSyndrome(i: MetSynInputs) {
 register({
   id: "metabolic_syndrome_gate",
   label: "Metabolic Syndrome (ATP III gate)",
-  inputs: [{key:"Waist_cm"},{key:"Sex"},{key:"Triglycerides_mg_dL"},{key:"HDL_mg_dL"},{key:"SBP"},{key:"DBP"},{key:"On_BP_Tx"},{key:"FastingGlucose_mg_dL"},{key:"Diabetes"}],
+  inputs: [
+    {key:"Waist_cm",unit:"cm"},{key:"Sex"},{key:"Triglycerides_mg_dL",unit:"mg/dL"},{key:"HDL_mg_dL",unit:"mg/dL"},
+    {key:"SBP",unit:"mmHg"},{key:"DBP",unit:"mmHg"},{key:"On_BP_Tx"},{key:"FastingGlucose_mg_dL",unit:"mg/dL"},{key:"Diabetes"}
+  ],
   run: runMetabolicSyndrome as any,
 });

--- a/lib/medical/engine/calculators/sofa_surrogate.ts
+++ b/lib/medical/engine/calculators/sofa_surrogate.ts
@@ -105,7 +105,7 @@ register({
   inputs: [
     {key:"PaO2"},{key:"FiO2"},{key:"ventilatory_support"},
     {key:"Platelets_k"},{key:"Bilirubin_mg_dL"},
-    {key:"MAP"},{key:"dopamine_ug_kg_min"},{key:"dobutamine"},{key:"norepi_ug_kg_min"},{key:"epi_ug_kg_min"},
+    {key:"MAP",unit:"mmHg"},{key:"dopamine_ug_kg_min"},{key:"dobutamine"},{key:"norepi_ug_kg_min"},{key:"epi_ug_kg_min"},
     {key:"GCS"},
     {key:"Creatinine_mg_dL"},{key:"Urine_mL_day"}
   ],


### PR DESCRIPTION
## Summary
- add explicit units for SBP/DBP/HR/MAP and related hemodynamic measurements across calculator registries, including composite engines, ICU helpers, and lab interpretation helpers
- extend metabolic syndrome and SOFA surrogate inputs with measurement units for clarity

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9b14dad90832fb4ecb46f8bbdefe3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Inputs across multiple medical calculators now display standardized units (e.g., SBP mmHg, DBP mmHg, HR bpm, MAP mmHg, Lactate mmol/L, QT ms, PaO2 mmHg, SV mL, CO L/min, BSA m², LVOT cm, lipids mg/dL, glucose mg/dL, waist circumference cm).
  - Enhances clarity, consistency, and validation in the UI without changing calculation results or workflows.
  - Applies to ABC/MTP, sepsis and shock index tools, ICU helpers (MAP, Shock Index), lab interpretation suites, metabolic syndrome, and SOFA-surrogate inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->