### PR TITLE
Add AI Doc recompute endpoint with Groq/OpenAI adapter

### DIFF
--- a/app/api/ai-doc/recompute/route.ts
+++ b/app/api/ai-doc/recompute/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import LLM from "@/lib/LLM";
+
+// minimal snapshot helper (adjust codes if yours differ)
+function buildSnapshot(profile: any, observations: any[] = []) {
+  const by = (code: string) =>
+    observations.find(o => (o.code||"").toLowerCase() === code.toLowerCase());
+  const hb    = by("hb") || by("hemoglobin");
+  const tsh   = by("tsh");
+  const creat = by("creatinine");
+  return {
+    demographics: { age: profile?.age, sex: profile?.sex },
+    labs: {
+      hb:    hb    ? { value: hb.value, unit: hb.unit, ts: hb.observed_at } : undefined,
+      tsh:   tsh   ? { value: tsh.value, unit: tsh.unit, ts: tsh.observed_at } : undefined,
+      creat: creat ? { value: creat.value, unit: creat.unit, ts: creat.observed_at } : undefined
+    }
+  };
+}
+
+export async function POST(_req: NextRequest) {
+  try {
+    const sb = supabaseAdmin();
+
+    // test phase: use first user as default
+    const { data: users } = await sb.auth.admin.listUsers({ page:1, perPage:1 });
+    const userId = users?.users?.[0]?.id as string | undefined;
+    if (!userId) {
+      return NextResponse.json({ ok:false, error:"No users available" }, { status: 400 });
+    }
+
+    // get existing Ai Doc thread (no new panel)
+    const { data: thread } = await sb
+      .from("chat_threads").select("id").eq("user_id", userId).eq("type","aidoc")
+      .limit(1).maybeSingle();
+    if (!thread?.id) {
+      return NextResponse.json({ ok:false, error:"No AI Doc thread" }, { status: 400 });
+    }
+
+    // load data
+    const [{ data: profile }, { data: obs }] = await Promise.all([
+      sb.from("profiles").select("*").eq("user_id", userId).maybeSingle(),
+      sb.from("observations").select("*").eq("user_id", userId).order("observed_at",{ascending:false}).limit(500)
+    ]);
+
+    const snapshot = buildSnapshot(profile, obs || []);
+
+    // Step A: OpenAI GPT-5 strict JSON validation
+    const verified = await LLM.validateJson(
+      "You are a clinical QA engine. Validate and correct the structured health state. Return strict JSON (schema provided).",
+      "Down-weight stale data (>90d). If conflicts exist, propose corrections in 'save'. Provide short and long observations.",
+      JSON.stringify({ profile, snapshot }).slice(0, 180000)
+    );
+
+    // (optional) persist conservative corrections (labs example)
+    if (Array.isArray(verified?.save?.labs)) {
+      for (const l of verified.save.labs) {
+        await sb.from("observations").insert({ user_id:userId, kind:"lab", ...l });
+      }
+    }
+
+    // Step B: Groq final summary (post into EXISTING Ai Doc chat)
+    const summary = await LLM.finalize([
+      { role: "system", content: "You are an expert clinical summarizer. Be concise, safe, and actionable." },
+      { role: "user", content:
+        `OBS_SHORT:${verified?.observations?.short||""}\nOBS_LONG:${verified?.observations?.long||""}\nDOCTOR:${verified?.reply_doctor||""}\nPATIENT:${verified?.reply_patient||""}`
+      }
+    ]);
+
+    // save prediction + timeline + chat message
+    await sb.from("predictions").insert({ user_id:userId, summary, raw_verified: verified });
+    await sb.from("timeline").insert({
+      user_id:userId, kind:"ai", title:"AI health assessment updated",
+      summary: verified?.observations?.short || "AI updated assessment",
+      detail: verified?.observations?.long || summary
+    });
+    await sb.from("chat_messages").insert({
+      thread_id: thread.id, role:"assistant", content: summary, kind:"aidoc_summary"
+    });
+
+    return NextResponse.json({ ok:true });
+  } catch (e:any) {
+    console.error("aidoc recompute error:", e);
+    return NextResponse.json({ ok:false, error:String(e?.message||e) }, { status: 500 });
+  }
+}

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -420,7 +420,7 @@ export default function MedicalProfile() {
             >Discuss & Correct in Chat</button>
             <button
               onClick={async () => {
-                await fetch("/api/alerts/recompute", { method: "POST" });
+                await fetch("/api/ai-doc/recompute", { method: "POST" });
                 await loadSummary();
               }}
               className="text-xs px-2 py-1 rounded-md border"

--- a/lib/LLM/index.ts
+++ b/lib/LLM/index.ts
@@ -1,0 +1,70 @@
+import OpenAI from "openai";
+import Groq from "groq-sdk";
+
+export type Msg = { role: "system" | "user" | "assistant"; content: string };
+
+export const AiDocJsonSchema = {
+  name: "AiDocOut",
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      reply_patient: { type: "string" },
+      reply_doctor:  { type: "string" },
+      observations: {
+        type: "object",
+        additionalProperties: false,
+        properties: { short: { type: "string" }, long: { type: "string" } },
+        required: ["short","long"]
+      },
+      save: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          medications: { type: "array", items: { type: "object" } },
+          conditions:  { type: "array", items: { type: "object" } },
+          labs:        { type: "array", items: { type: "object" } },
+        },
+        required: ["medications","conditions","labs"]
+      }
+    },
+    required: ["observations","save"]
+  }
+};
+
+export const LLM = {
+  // Strict JSON validation / corrections -> OpenAI (GPT-5)
+  async validateJson(system: string, instruction: string, user: string): Promise<any> {
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+    const model = process.env.OPENAI_MODEL_GPT5 || "gpt-5";
+    const r = await openai.chat.completions.create({
+      model,
+      messages: [
+        { role: "system", content: system },
+        { role: "system", content: instruction },
+        { role: "user", content: user }
+      ],
+      response_format: { type: "json_schema", json_schema: AiDocJsonSchema },
+      temperature: 0.2
+    });
+    const raw = r.choices?.[0]?.message?.content ?? "{}";
+    try { return JSON.parse(raw); }
+    catch {
+      return {
+        reply_patient:"", reply_doctor:"",
+        observations:{ short:"", long:"" },
+        save:{ medications:[], conditions:[], labs:[] }
+      };
+    }
+  },
+
+  // Final narrative / summary -> Groq
+  async finalize(messages: Msg[]): Promise<string> {
+    const groq = new Groq({ apiKey: process.env.GROQ_API_KEY! });
+    const model = process.env.GROQ_MODEL || "llama-3.1-70b";
+    const r = await groq.chat.completions.create({ model, temperature: 0.1, messages });
+    return r.choices?.[0]?.message?.content?.trim() || "";
+  }
+};
+
+export default LLM;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.57.0",
         "framer-motion": "^12.23.12",
+        "groq-sdk": "^0.5.0",
         "isomorphic-dompurify": "2.13.0",
         "katex": "^0.16.22",
         "lucide-react": "0.441.0",
@@ -3852,6 +3853,40 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/groq-sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-0.5.0.tgz",
+      "integrity": "sha512-RVmhW7qZ+XZoy5fIuSdx/LGQJONpL8MHgZEW7dFwTdgkzStub2XQx6OKv28CHogijdwH41J+Npj/z2jBPu3vmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/groq-sdk/node_modules/@types/node": {
+      "version": "18.19.125",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.125.tgz",
+      "integrity": "sha512-4TWNu0IxTQcszliYdW2mxrVvhHeERUeDCUwVuvQFn9JCU02kxrUDs8v52yOazPo7wLHKgqEd2FKxlSN6m8Deqg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/groq-sdk/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next": "14.2.4",
     "next-auth": "^4.24.11",
     "next-themes": "0.3.0",
+    "groq-sdk": "^0.5.0",
     "openai": "^4.56.0",
     "pdf-lib": "^1.17.1",
     "pdf-parse": "^1.1.1",


### PR DESCRIPTION
## Summary
- add a shared LLM adapter backed by OpenAI GPT-5 JSON responses and Groq summaries
- create an /api/ai-doc/recompute route that validates Supabase data, persists corrections, and posts a refreshed summary
- retarget the Medical Profile "Recompute Risk" button to the new endpoint and install the Groq SDK dependency

## Testing
- npm run lint *(fails: interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c9bb889974832f855b590ec01a701d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Recompute Risk” action that now refreshes your AI health summary using the latest profile and observations.
  - The recomputed result updates your timeline and chat with a new AI summary entry.
  - Improved validation of health data during recomputation for more consistent summaries.

- Bug Fixes
  - Button now targets the correct recompute endpoint to ensure the summary updates as expected.

- Chores
  - Added a new AI provider dependency to support summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->