### PR TITLE
Add AI Doc recompute endpoint and wire risk button

### DIFF
--- a/app/api/ai-doc/recompute/route.ts
+++ b/app/api/ai-doc/recompute/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import LLM from "@/lib/LLM";
+
+export const runtime = "nodejs"; // ensure server runtime
+
+type SupabaseClient = ReturnType<typeof supabaseAdmin>;
+
+type Observation = {
+  code?: string | null;
+  value?: any;
+  unit?: string | null;
+  observed_at?: string | null;
+};
+
+type ProfileRow = {
+  age?: number | null;
+  sex?: string | null;
+};
+
+function buildSnapshot(profile: ProfileRow | null, observations: Observation[] = []) {
+  const by = (code: string) =>
+    observations.find(o => (o?.code || "").toLowerCase() === code.toLowerCase());
+  const hb    = by("hb") || by("hemoglobin");
+  const tsh   = by("tsh");
+  const creat = by("creatinine");
+  return {
+    demographics: { age: profile?.age ?? null, sex: profile?.sex ?? null },
+    labs: {
+      hb:    hb    ? { value: hb.value, unit: hb.unit, ts: hb.observed_at } : undefined,
+      tsh:   tsh   ? { value: tsh.value, unit: tsh.unit, ts: tsh.observed_at } : undefined,
+      creat: creat ? { value: creat.value, unit: creat.unit, ts: creat.observed_at } : undefined
+    }
+  };
+}
+
+async function defaultUserId(sb: SupabaseClient) {
+  const list = await sb.auth.admin.listUsers({ page: 1, perPage: 1 });
+  const uid = list?.data?.users?.[0]?.id;
+  if (!uid) throw new Error("No test user found in auth.");
+  return uid;
+}
+
+async function getOrCreateAidocThread(sb: SupabaseClient, userId: string) {
+  const found = await sb
+    .from("chat_threads")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("type", "aidoc")
+    .limit(1)
+    .maybeSingle();
+  if (found.error && found.error.code !== "PGRST116") throw found.error;
+  if (found.data?.id) return found.data.id as string;
+
+  const created = await sb
+    .from("chat_threads")
+    .insert({ user_id: userId, type: "aidoc", title: "AI Doc" })
+    .select("id")
+    .single();
+  if (created.error) throw created.error;
+  return created.data?.id as string;
+}
+
+export async function runAidocRecompute() {
+  const sb = supabaseAdmin();
+  const userId = await defaultUserId(sb);
+  const threadId = await getOrCreateAidocThread(sb, userId);
+
+  const [profileRes, obsRes] = await Promise.all([
+    sb.from("profiles").select("*").eq("id", userId).maybeSingle(),
+    sb
+      .from("observations")
+      .select("*")
+      .eq("user_id", userId)
+      .order("observed_at", { ascending: false })
+      .limit(500),
+  ]);
+
+  if (profileRes.error) throw profileRes.error;
+  if (obsRes.error) throw obsRes.error;
+
+  const profile = profileRes.data as ProfileRow | null;
+  const observations = Array.isArray(obsRes.data) ? (obsRes.data as Observation[]) : [];
+  const snapshot = buildSnapshot(profile, observations);
+
+  // Step A: GPT-5 strict JSON validation/corrections
+  const verified = await LLM.validateJson(
+    "You are a clinical QA engine. Validate and correct the structured health state. Return strict JSON (schema provided).",
+    "Down-weight stale data (>90d). If conflicts exist, propose corrections in 'save'. Provide short and long observations.",
+    JSON.stringify({ profile, snapshot }).slice(0, 180000)
+  );
+
+  // (optional) persist conservative corrections (labs only)
+  if (Array.isArray(verified?.save?.labs)) {
+    for (const rawLab of verified.save.labs) {
+      const lab: Record<string, any> = {
+        user_id: userId,
+        kind: "lab",
+        ...rawLab,
+      };
+      if (!lab.observed_at) lab.observed_at = new Date().toISOString();
+      const { error } = await sb.from("observations").insert(lab);
+      if (error) throw error;
+    }
+  }
+
+  // Step B: Groq final summary → post to existing Ai Doc chat
+  const summary = await LLM.finalize([
+    { role: "system", content: "You are an expert clinical summarizer. Be concise, safe, and actionable." },
+    {
+      role: "user",
+      content:
+        `OBS_SHORT:${verified?.observations?.short || ""}\n` +
+        `OBS_LONG:${verified?.observations?.long || ""}\n` +
+        `DOCTOR:${verified?.reply_doctor || ""}\n` +
+        `PATIENT:${verified?.reply_patient || ""}`,
+    },
+  ]);
+
+  const { error: predErr } = await sb.from("predictions").insert({
+    user_id: userId,
+    thread_id: threadId,
+    summary,
+    raw_verified: verified,
+  });
+  if (predErr) throw predErr;
+
+  const { error: timelineErr } = await sb.from("timeline").insert({
+    user_id: userId,
+    kind: "ai",
+    title: "AI health assessment updated",
+    summary: verified?.observations?.short || "AI updated assessment",
+    detail: verified?.observations?.long || summary,
+  });
+  if (timelineErr) throw timelineErr;
+
+  const { error: chatErr } = await sb.from("chat_messages").insert({
+    thread_id: threadId,
+    role: "assistant",
+    content: summary,
+    kind: "aidoc_summary",
+  });
+  if (chatErr) throw chatErr;
+}
+
+export async function POST(_req: NextRequest) {
+  try {
+    await runAidocRecompute();
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    console.error("[aidoc-recompute] ERROR:", e?.message || e);
+    return NextResponse.json({ ok: false, error: e?.message || String(e) }, { status: 500 });
+  }
+}

--- a/app/api/alerts/recompute/route.ts
+++ b/app/api/alerts/recompute/route.ts
@@ -1,19 +1,15 @@
-export const dynamic = "force-dynamic";
-export const revalidate = 0;
-
+export const runtime = "nodejs";
 import { NextResponse } from "next/server";
-import { supabaseAdmin } from "@/lib/supabase/admin";
-import { getUserId } from "@/lib/getUserId";
+import { runAidocRecompute } from "@/app/api/ai-doc/recompute/route";
 
 export async function POST() {
-  const userId = await getUserId();
-  if (!userId) return new NextResponse("Unauthorized", { status: 401 });
-  const supa = supabaseAdmin();
-  const [p,o] = await Promise.all([
-    supa.from("predictions").select("id",{count:"exact", head:true}).eq("user_id",userId),
-    supa.from("observations").select("id",{count:"exact", head:true}).eq("user_id",userId),
-  ]);
-  if (p.error) return NextResponse.json({ error:p.error.message }, { status:500 });
-  if (o.error) return NextResponse.json({ error:o.error.message }, { status:500 });
-  return NextResponse.json({ ok:true, inspected:{predictions:p.count||0, observations:o.count||0} }, { headers: { "Cache-Control":"no-store" }});
+  try {
+    await runAidocRecompute();
+    return NextResponse.json({ ok: true, forwarded: true });
+  } catch (e: any) {
+    return NextResponse.json(
+      { ok: false, error: e?.message || String(e) },
+      { status: 500 }
+    );
+  }
 }

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -69,6 +69,25 @@ export default function MedicalProfile() {
   };
   useEffect(() => { loadSummary(); }, []);
 
+  async function onRecomputeRisk() {
+    const btn = document.getElementById("recompute-risk-btn") as HTMLButtonElement | null;
+    if (btn) btn.disabled = true;
+    try {
+      const res = await fetch("/api/ai-doc/recompute", { method: "POST" });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok || body?.ok === false) {
+        throw new Error(body?.error || `HTTP ${res.status}`);
+      }
+      await loadSummary();
+      // optional: toast.success("Risk recomputed");
+    } catch (err: any) {
+      console.error("Recompute failed:", err?.message || err);
+      alert(`Recompute failed: ${err?.message || String(err)}`);
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  }
+
   const prof = data?.profile ?? null;
   const [bootstrapped, setBootstrapped] = useState(false);
   const [fullName, setFullName] = useState("");
@@ -419,11 +438,9 @@ export default function MedicalProfile() {
               className="text-xs px-2 py-1 rounded-md border"
             >Discuss & Correct in Chat</button>
             <button
-              onClick={async () => {
-                await fetch("/api/alerts/recompute", { method: "POST" });
-                await loadSummary();
-              }}
-              className="text-xs px-2 py-1 rounded-md border"
+              id="recompute-risk-btn"
+              onClick={onRecomputeRisk}
+              className="text-xs px-2 py-1 rounded-md border disabled:opacity-50"
             >Recompute Risk</button>
           </div>
         </div>

--- a/lib/LLM/index.ts
+++ b/lib/LLM/index.ts
@@ -1,0 +1,70 @@
+import OpenAI from "openai";
+import Groq from "groq-sdk";
+
+export type Msg = { role: "system" | "user" | "assistant"; content: string };
+
+export const AiDocJsonSchema = {
+  name: "AiDocOut",
+  schema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      reply_patient: { type: "string" },
+      reply_doctor:  { type: "string" },
+      observations: {
+        type: "object",
+        additionalProperties: false,
+        properties: { short: { type: "string" }, long: { type: "string" } },
+        required: ["short","long"]
+      },
+      save: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          medications: { type: "array", items: { type: "object" } },
+          conditions:  { type: "array", items: { type: "object" } },
+          labs:        { type: "array", items: { type: "object" } },
+        },
+        required: ["medications","conditions","labs"]
+      }
+    },
+    required: ["observations","save"]
+  }
+};
+
+export const LLM = {
+  // Strict JSON validation/corrections → OpenAI (GPT-5)
+  async validateJson(system: string, instruction: string, user: string): Promise<any> {
+    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+    const model = process.env.OPENAI_MODEL_GPT5 || "gpt-5";
+    const r = await openai.chat.completions.create({
+      model,
+      messages: [
+        { role: "system", content: system },
+        { role: "system", content: instruction },
+        { role: "user", content: user }
+      ],
+      response_format: { type: "json_schema", json_schema: AiDocJsonSchema },
+      temperature: 0.2
+    });
+    const raw = r.choices?.[0]?.message?.content ?? "{}";
+    try { return JSON.parse(raw); }
+    catch {
+      return {
+        reply_patient:"", reply_doctor:"",
+        observations:{ short:"", long:"" },
+        save:{ medications:[], conditions:[], labs:[] }
+      };
+    }
+  },
+
+  // Final narrative/summary → Groq
+  async finalize(messages: Msg[]): Promise<string> {
+    const groq = new Groq({ apiKey: process.env.GROQ_API_KEY! });
+    const model = process.env.GROQ_MODEL || "llama-3.1-70b";
+    const r = await groq.chat.completions.create({ model, temperature: 0.1, messages });
+    return r.choices?.[0]?.message?.content?.trim() || "";
+  }
+};
+
+export default LLM;


### PR DESCRIPTION
## Summary
- add a shared Groq/OpenAI LLM adapter with the AiDoc validation schema
- implement the /api/ai-doc/recompute endpoint to refresh summaries, store corrections, and reuse from the legacy alerts route
- update the medical profile "Recompute Risk" button to call the new endpoint with error handling

## Testing
- npm run lint *(aborted: command prompted for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c20046fc832fafbdd8dc4d753549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “Recompute Risk” now triggers an AI summary recomputation and auto-refreshes the summary on success.
  * Button shows a disabled state during processing to prevent duplicate actions.

* **Bug Fixes**
  * More robust error handling: detects server errors, surfaces clear alerts to users, and reliably re-enables the button.

* **Refactor**
  * Consolidated recompute logic behind a dedicated endpoint for consistency.

* **Chores**
  * Server runtime standardized to Node.js for relevant API routes to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->