### PR TITLE
Add background prediction workflow

### DIFF
--- a/app/api/aidoc/predict/route.ts
+++ b/app/api/aidoc/predict/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { assembleBundle } from "@/lib/predict/assemble";
+import { runOpenAI } from "@/lib/predict/openai";
+import { formatWithLLM } from "@/lib/predict/llm";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    if (process.env.SECOND_OPINION_PREDICT !== "on") {
+      return NextResponse.json({ ok: false, error: "disabled" }, { status: 503 });
+    }
+    const { userId, threadId, dryRun } = await req.json();
+    if (!userId || !threadId) {
+      return NextResponse.json({ ok: false, error: "bad_request" }, { status: 400 });
+    }
+
+    const DRY = String(dryRun ?? process.env.SECOND_OPINION_DRYRUN) === "1";
+
+    const bundle = await assembleBundle({ userId });
+
+    if (DRY) {
+      console.log("[PREDICT][DRYRUN]", {
+        userId,
+        threadId,
+        counts: {
+          obs: bundle.observations.length,
+          labs: bundle.labs.length,
+          meds: bundle.meds.length,
+          chunks: bundle.chunks.length,
+        },
+      });
+      return NextResponse.json({ ok: true, dryRun: true });
+    }
+
+    const pr = await runOpenAI(bundle);
+    const text = await formatWithLLM(pr);
+
+    (globalThis as any).__AIDOC_MESSAGES__ ||= new Map();
+    const arr = (globalThis as any).__AIDOC_MESSAGES__.get(threadId) || [];
+    arr.push({ role: "assistant", content: text, ts: Date.now() });
+    (globalThis as any).__AIDOC_MESSAGES__.set(threadId, arr);
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.error("[PREDICT][ERROR]", e);
+    return NextResponse.json({ ok: false, error: "server_error" }, { status: 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { Suspense } from "react";
 import MemorySnackbar from "@/components/memory/Snackbar";
 import UndoToast from "@/components/memory/UndoToast";
 import { Roboto } from "next/font/google";
+import dynamic from "next/dynamic";
 
 export const metadata = { title: BRAND_NAME, description: "Global medical AI" };
 
@@ -18,6 +19,11 @@ const roboto = Roboto({
   variable: "--font-roboto",
   display: "swap",
 });
+
+const PredictionHeartbeat = dynamic(
+  () => import("@/components/bg/PredictionHeartbeat"),
+  { ssr: false }
+);
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -41,6 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </ContextProvider>
           </CountryProvider>
         </ThemeProvider>
+        {process.env.NEXT_PUBLIC_SECOND_OPINION_BG_PREDICT !== "off" ? <PredictionHeartbeat /> : null}
       </body>
     </html>
   );

--- a/components/bg/PredictionHeartbeat.tsx
+++ b/components/bg/PredictionHeartbeat.tsx
@@ -23,13 +23,15 @@ async function maybeRun() {
   const now = Date.now();
   if (now - last < MIN_GAP_MS) return;
 
-  const userId = sessionStorage.getItem("user_id") || "default_user";
   const threadId = sessionStorage.getItem("aidoc_thread") || "default_thread";
 
   try {
     await fetch("/api/aidoc/predict", {
       method: "POST",
-      body: JSON.stringify({ userId, threadId }),
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      keepalive: true,
+      body: JSON.stringify({ threadId }),
     });
     localStorage.setItem(LAST_KEY, String(now));
   } catch {}

--- a/components/bg/PredictionHeartbeat.tsx
+++ b/components/bg/PredictionHeartbeat.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+const LOCK_KEY = "so-bg-leader-lock";
+const LAST_KEY = "so-last-predict-at";
+const INTERVAL_MS = 60_000;
+const MIN_GAP_MS = 30 * 60_000;
+
+function isLeader() {
+  const now = Date.now();
+  const n = Number(localStorage.getItem(LOCK_KEY) || 0);
+  if (!n || now - n > 120000) {
+    localStorage.setItem(LOCK_KEY, String(now));
+    return true;
+  }
+  return false;
+}
+
+async function maybeRun() {
+  if (process.env.NEXT_PUBLIC_SECOND_OPINION_BG_PREDICT === "off") return;
+  if (!isLeader()) return;
+
+  const last = Number(localStorage.getItem(LAST_KEY) || 0);
+  const now = Date.now();
+  if (now - last < MIN_GAP_MS) return;
+
+  const userId = sessionStorage.getItem("user_id") || "default_user";
+  const threadId = sessionStorage.getItem("aidoc_thread") || "default_thread";
+
+  try {
+    await fetch("/api/aidoc/predict", {
+      method: "POST",
+      body: JSON.stringify({ userId, threadId }),
+    });
+    localStorage.setItem(LAST_KEY, String(now));
+  } catch {}
+}
+
+export default function PredictionHeartbeat() {
+  if (typeof window === "undefined") return null;
+  setTimeout(maybeRun, 1500);
+  setInterval(maybeRun, INTERVAL_MS);
+  return null;
+}

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -422,6 +422,15 @@ export default function MedicalProfile() {
               onClick={async () => {
                 await fetch("/api/alerts/recompute", { method: "POST" });
                 await loadSummary();
+                // fire-and-forget background prediction (keeps existing logic untouched)
+                try {
+                  const userId = sessionStorage.getItem("user_id") || "default_user";
+                  const threadId = sessionStorage.getItem("aidoc_thread") || "default_thread";
+                  fetch("/api/aidoc/predict", {
+                    method: "POST",
+                    body: JSON.stringify({ userId, threadId }),
+                  });
+                } catch {}
               }}
               className="text-xs px-2 py-1 rounded-md border"
             >Recompute Risk</button>

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -424,11 +424,13 @@ export default function MedicalProfile() {
                 await loadSummary();
                 // fire-and-forget background prediction (keeps existing logic untouched)
                 try {
-                  const userId = sessionStorage.getItem("user_id") || "default_user";
                   const threadId = sessionStorage.getItem("aidoc_thread") || "default_thread";
                   fetch("/api/aidoc/predict", {
                     method: "POST",
-                    body: JSON.stringify({ userId, threadId }),
+                    headers: { "Content-Type": "application/json" },
+                    credentials: "include",
+                    keepalive: true,
+                    body: JSON.stringify({ threadId }),
                   });
                 } catch {}
               }}

--- a/lib/predict/assemble.ts
+++ b/lib/predict/assemble.ts
@@ -1,0 +1,31 @@
+import { createClient } from "@supabase/supabase-js";
+
+const sb = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+type Opts = { userId: string };
+
+export async function assembleBundle({ userId }: Opts) {
+  const [profile, observations, labs, meds, chunks] = await Promise.all([
+    sb.from("profile").select("*").eq("user_id", userId).maybeSingle(),
+    sb.from("observations").select("*").eq("user_id", userId).order("observed_at", { ascending: true }),
+    sb.from("labs_values").select("*").eq("user_id", userId).order("observed_at", { ascending: true }),
+    sb.from("medications").select("*").eq("user_id", userId).order("start_date", { ascending: true }),
+    sb
+      .from("text_chunks")
+      .select("file_id,page,chunk_index,content,created_at")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false })
+      .limit(800),
+  ]);
+
+  return {
+    profile: profile.data || null,
+    observations: observations.data || [],
+    labs: labs.data || [],
+    meds: meds.data || [],
+    chunks: (chunks.data || []).slice(0, 600),
+  };
+}

--- a/lib/predict/llm.ts
+++ b/lib/predict/llm.ts
@@ -1,0 +1,29 @@
+import type { PredictionReport } from "./openai";
+
+const BASE = process.env.LLM_BASE_URL || "https://api.groq.com/openai/v1";
+const MODEL = process.env.LLM_MODEL_ID || "llama-3.1-8b-instant";
+const KEY = process.env.LLM_API_KEY!;
+
+export async function formatWithLLM(pr: PredictionReport): Promise<string> {
+  const body = {
+    model: MODEL,
+    temperature: 0.3,
+    messages: [
+      { role: "system", content: "Reformat the given PredictionReport into ≤10 crisp bullet lines. No chit-chat, no disclaimers." },
+      { role: "user", content: JSON.stringify(pr) },
+    ],
+  };
+
+  const res = await fetch(`${BASE}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) return "Prediction ready.";
+  const json = await res.json();
+  return json?.choices?.[0]?.message?.content?.trim() || "Prediction ready.";
+}

--- a/lib/predict/openai.ts
+++ b/lib/predict/openai.ts
@@ -1,0 +1,52 @@
+import OpenAI from "openai";
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+type Bundle = Awaited<ReturnType<typeof import("./assemble").assembleBundle>>;
+export type PredictionReport = {
+  risks: Array<{ condition: string; band: "Low" | "Moderate" | "High"; prob?: string }>;
+  drivers: Array<{ metric: string; pattern: string; cites: string[] }>;
+  next_steps: string[];
+  uncertainties: string[];
+  citations: string[];
+};
+
+export async function runOpenAI(bundle: Bundle): Promise<PredictionReport> {
+  const sys = [
+    "You are Second Opinion (clinical).",
+    "Input: structured (profile, observations, labs, meds) + unstructured (report text chunks).",
+    "Normalize units/dates, de-duplicate, compute derived metrics, run calculators when inputs exist.",
+    "Resolve contradictions; keep unknowns explicit. Output ONLY JSON in this schema:",
+    "{ risks:[], drivers:[], next_steps:[], uncertainties:[], citations:[] }",
+  ].join("\n");
+
+  const user = JSON.stringify({
+    structured: {
+      profile: bundle.profile,
+      observations: bundle.observations,
+      labs: bundle.labs,
+      meds: bundle.meds,
+    },
+    unstructured_chunks: bundle.chunks.map((c: any) => ({
+      ref: `${c.file_id}:${c.page}:${c.chunk_index}`,
+      text: c.content,
+    })),
+  });
+
+  const model = process.env.OPENAI_TEXT_MODEL || "gpt-5";
+  const r = await client.chat.completions.create({
+    model,
+    temperature: 0.2,
+    response_format: { type: "json_object" },
+    messages: [
+      { role: "system", content: sys },
+      { role: "user", content: user },
+    ],
+  });
+
+  const content = r.choices[0]?.message?.content || "{}";
+  try {
+    return JSON.parse(content);
+  } catch {
+    return { risks: [], drivers: [], next_steps: [], uncertainties: ["parse_error"], citations: [] };
+  }
+}

--- a/lib/predict/openai.ts
+++ b/lib/predict/openai.ts
@@ -1,5 +1,17 @@
 import OpenAI from "openai";
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+let cachedClient: OpenAI | null = null;
+
+function getClient() {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is required for predictions");
+  }
+  if (!cachedClient) {
+    cachedClient = new OpenAI({ apiKey });
+  }
+  return cachedClient;
+}
 
 type Bundle = Awaited<ReturnType<typeof import("./assemble").assembleBundle>>;
 export type PredictionReport = {
@@ -32,8 +44,8 @@ export async function runOpenAI(bundle: Bundle): Promise<PredictionReport> {
     })),
   });
 
-  const model = process.env.OPENAI_TEXT_MODEL || "gpt-5";
-  const r = await client.chat.completions.create({
+  const model = process.env.OPENAI_TEXT_MODEL || "gpt-3.5-turbo";
+  const r = await getClient().chat.completions.create({
     model,
     temperature: 0.2,
     response_format: { type: "json_object" },


### PR DESCRIPTION
## Summary
- add a fire-and-forget /api/aidoc/predict route that assembles Supabase data, calls OpenAI for predictions, formats with Groq, and stores assistant messages in-memory
- introduce reusable helpers for bundle assembly, OpenAI predictions, and Groq-based formatting
- mount a background heartbeat client (including Recompute Risk trigger) so eligible tabs kick off predictions when allowed

## Testing
- Not run (Next.js `next lint` prompts for interactive config in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68c9e5b664d0832fa6d19a1ad6352fea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a server prediction endpoint that produces concise second-opinion summaries (supports dry-run and requires authentication).
  * Introduces client-only background heartbeat to optionally trigger periodic predictions, coordinated across tabs.
  * Triggers a non-blocking background prediction when recomputing risk in the Medical Profile.
  * Adds server-side bundle assembly and LLM/OpenAI-powered formatting to generate short, user-facing summary text.
* **Chores**
  * Behavior controlled via environment flags for enabling, dry-run, and background activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->