### PR TITLE
Guard analyze ingest in doctor mode

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -111,7 +111,7 @@ export async function POST(req: Request) {
 
     if (mime === "application/pdf" || name.toLowerCase().endsWith(".pdf")) {
       text = await extractTextFromPDF(buf);
-      if (text) {
+      if (!doctorMode && text) {
         const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
         const cookie = req.headers.get("cookie") || undefined;
         try {
@@ -238,7 +238,7 @@ export async function POST(req: Request) {
       category,
       report,
       disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
-      obsIds,
+      obsIds: doctorMode ? [] : obsIds,
     });
   } catch (e: any) {
     return NextResponse.json({ error: e.message || "analyze failed" }, { status: 500 });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint || true",
-    "test": "vitest run test/extract.noFalsePositives.test.ts test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts test/engine.nanFilter.test.ts && tsx --test test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/drugInteractions.test.ts test/mentalHealthResources.test.ts test/womensHealthBasics.test.ts test/pediatricGrowthInfo.test.ts test/conditionCarePack.test.ts test/labExplainers.test.ts test/vaccineReminders.test.ts test/allergyChecker.test.ts test/newFeatures.test.ts test/emergencyNumbers.test.ts test/symptomTracker.test.ts"
+    "test": "vitest run test/extract.noFalsePositives.test.ts test/aidoc.vendor.test.ts test/aidoc.redflags.test.ts test/engine.nanFilter.test.ts && tsx --test test/analyze.doctorMode.test.ts test/medx.test.ts test/selfLearning.test.ts test/pediatricFlow.test.ts test/clarifyMinimal.test.ts test/vaccineIntent.test.ts test/seniorSafety.test.ts test/firstAidCards.test.ts test/symptomTriage.test.ts test/drugInteractions.test.ts test/mentalHealthResources.test.ts test/womensHealthBasics.test.ts test/pediatricGrowthInfo.test.ts test/conditionCarePack.test.ts test/labExplainers.test.ts test/vaccineReminders.test.ts test/allergyChecker.test.ts test/newFeatures.test.ts test/emergencyNumbers.test.ts test/symptomTracker.test.ts"
   },
   "dependencies": {
     "@napi-rs/canvas": "^0.1.78",

--- a/test/analyze.doctorMode.test.ts
+++ b/test/analyze.doctorMode.test.ts
@@ -1,0 +1,125 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+
+import { POST } from '../app/api/analyze/route';
+
+process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || 'test-key';
+process.env.NEXT_PUBLIC_BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://test.local';
+
+async function buildPdfFile(text: string) {
+  const pdf = await PDFDocument.create();
+  const page = pdf.addPage();
+  const font = await pdf.embedFont(StandardFonts.Helvetica);
+  const fontSize = 12;
+  const { width, height } = page.getSize();
+  page.drawText(text, {
+    x: 40,
+    y: height - 60,
+    size: fontSize,
+    font,
+    maxWidth: width - 80,
+    lineHeight: fontSize + 2,
+  });
+  const pdfBytes = await pdf.save();
+  return new File([pdfBytes], 'report.pdf', { type: 'application/pdf' });
+}
+
+function createRequest(doctorMode: boolean, file: File) {
+  const fd = new FormData();
+  fd.append('file', file);
+  fd.append('doctorMode', String(doctorMode));
+  return new Request('http://test.local/api/analyze', {
+    method: 'POST',
+    body: fd,
+  });
+}
+
+function urlFromInput(input: RequestInfo | URL) {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  return (input as Request).url;
+}
+
+const LONG_TEXT = Array(10)
+  .fill(
+    'Comprehensive metabolic panel shows mild transaminitis with ALT slightly above reference range. '
+  )
+  .join(' ');
+
+test('doctor mode uploads skip ingest and return empty obsIds', async () => {
+  const file = await buildPdfFile(LONG_TEXT);
+  const req = createRequest(true, file);
+  const originalFetch = globalThis.fetch;
+  let ingestCalls = 0;
+
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = urlFromInput(input);
+    if (url.includes('/api/ingest/from-text')) {
+      ingestCalls += 1;
+      return new Response(JSON.stringify({ ids: ['obs-test'] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('api.openai.com')) {
+      const content = 'Doctor oriented summary';
+      return new Response(JSON.stringify({ choices: [{ message: { content } }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response('{}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  try {
+    const res = (await POST(req as any)) as Response;
+    const body = await res.json();
+    assert.equal(ingestCalls, 0);
+    assert.deepEqual(body.obsIds, []);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('patient mode uploads call ingest and return obsIds', async () => {
+  const file = await buildPdfFile(LONG_TEXT);
+  const req = createRequest(false, file);
+  const originalFetch = globalThis.fetch;
+  let ingestCalls = 0;
+
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = urlFromInput(input);
+    if (url.includes('/api/ingest/from-text')) {
+      ingestCalls += 1;
+      return new Response(JSON.stringify({ ids: ['obs-123'] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('api.openai.com')) {
+      const content = 'Patient friendly summary';
+      return new Response(JSON.stringify({ choices: [{ message: { content } }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response('{}', {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  try {
+    const res = (await POST(req as any)) as Response;
+    const body = await res.json();
+    assert.equal(ingestCalls, 1);
+    assert.deepEqual(body.obsIds, ['obs-123']);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+


### PR DESCRIPTION
## Summary
- skip ingesting observations during /api/analyze when Doctor Mode uploads are processed and always return an empty obsIds array in that mode
- add Doctor Mode upload coverage verifying observations are not persisted while Patient Mode still ingests
- wire the new test into the npm test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca61b7c75c832f830862291e9f1164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Doctor Mode now processes PDFs without ingesting data, preventing creation of observation IDs. Responses in Doctor Mode return an empty obsIds array; Patient Mode behavior is unchanged.

* **Tests**
  * Added automated tests covering Doctor vs Patient Mode flows, including PDF upload scenarios and response validation.
  * Updated test script to include the new Doctor Mode analysis test file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->