### PR TITLE
Polish chat rendering and suggestions

### DIFF
--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -6,6 +6,7 @@ import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 import { LinkBadge } from "./SafeLink";
+import type { CodeProps } from "react-markdown/lib/ast-to-react";
 
 // --- Normalizer ---
 // normalize: unwrap full-message fences, convert ==== to <hr>, bold-lines → headings, list bullets
@@ -134,17 +135,25 @@ export default function ChatMarkdown({ content }: { content: string }) {
                 <table {...props}>{children}</table>
               </div>
             ),
-            code: ({ inline, children, ...props }) =>
-              inline ? (
-                <code
-                  {...props}
-                  className="rounded bg-black/5 px-1 py-0.5 dark:bg-white/10"
-                >
-                  {children}
-                </code>
-              ) : (
-                <CodeBlock>{String(children)}</CodeBlock>
-              ),
+            code: (props: CodeProps) => {
+              const { inline, children, ...rest } = props;
+              if (inline) {
+                return (
+                  <code
+                    {...rest}
+                    className="rounded bg-black/5 px-1 py-0.5 dark:bg-white/10"
+                  >
+                    {children}
+                  </code>
+                );
+              }
+
+              const text = Array.isArray(children)
+                ? children.join("")
+                : String(children ?? "");
+
+              return <CodeBlock>{text}</CodeBlock>;
+            },
           }}
         >
           {prepared}

--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -19,53 +20,136 @@ function normalize(raw: string){
   return s + "\n";
 }
 
+function AutoCollapse({ children, maxHeight = 600 }: { children: React.ReactNode; maxHeight?: number }) {
+  const [expanded, setExpanded] = React.useState(false);
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [collapse, setCollapse] = React.useState(false);
+  React.useEffect(() => {
+    if (!ref.current) return;
+    const shouldCollapse = ref.current.scrollHeight > maxHeight && !expanded;
+    setCollapse(shouldCollapse);
+    if (expanded && ref.current) {
+      ref.current.style.maxHeight = "none";
+    }
+  }, [expanded, maxHeight, children]);
+  return (
+    <div>
+      <div
+        ref={ref}
+        className={collapse ? "max-h-[600px] overflow-hidden" : ""}
+      >
+        {children}
+      </div>
+      {collapse && (
+        <button
+          type="button"
+          className="mt-3 text-sm underline opacity-80 transition hover:opacity-100"
+          onClick={() => setExpanded(true)}
+        >
+          Show more
+        </button>
+      )}
+    </div>
+  );
+}
+
+function CodeBlock({ children }: { children: string }) {
+  const [copied, setCopied] = React.useState(false);
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => {
+          void navigator.clipboard.writeText(children);
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1200);
+        }}
+        className="absolute right-2 top-2 rounded bg-black/10 px-2 py-1 text-xs text-black/80 transition hover:bg-black/20 dark:bg-white/10 dark:text-white/80 dark:hover:bg-white/20"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+      <pre className="overflow-auto rounded-lg bg-black/5 p-3 dark:bg-white/10">
+        <code>{children}</code>
+      </pre>
+    </div>
+  );
+}
+
+function normalizeLLM(s: string) {
+  return (s || "")
+    .replace(/\bHere:\s*/gi, "")
+    .replace(/^\s*Detail:\s*-\s*/gim, "")
+    .replace(/^\s*-\s*-\s*/gm, "- ")
+    .replace(/^\s*-\s*$/gm, "")
+    .replace(/\s+:/g, ":")
+    .trim();
+}
+
 export default function ChatMarkdown({ content }: { content: string }) {
-  const prepared = normalize(content);
+  const prepared = normalizeLLM(normalize(content));
 
   return (
     <div
       className="
-        prose prose-slate dark:prose-invert max-w-none
+        prose prose-slate dark:prose-invert max-w-[72ch]
         prose-headings:font-semibold prose-headings:mb-2 prose-headings:mt-3
         prose-h3:text-lg prose-h4:text-base
         prose-p:my-2 prose-li:my-1 prose-strong:font-medium
-        leading-relaxed text-[15px]
+        leading-7 text-[15px]
       "
     >
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkMath]}
-        rehypePlugins={[rehypeKatex]}
-        components={{
-          a: ({ href, children }) => (
-            <LinkBadge href={href as string}>
-              {children}
-            </LinkBadge>
-          ),
-          ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
-          ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
-          hr: () => <hr className="my-3 border-dashed opacity-40" />,
-          p: ({ children }) => (
-            <p className="text-left">{children}</p>
-          ),
-          li: ({ children }) => (
-            <li>{children}</li>
-          ),
-          h1: ({ children }) => (
-            <h1>{children}</h1>
-          ),
-          h2: ({ children }) => (
-            <h2>{children}</h2>
-          ),
-          h3: ({ children }) => (
-            <h3>{children}</h3>
-          ),
-          h4: ({ children }) => (
-            <h4>{children}</h4>
-          ),
-        }}
-      >
-        {prepared}
-      </ReactMarkdown>
+      <AutoCollapse>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm, remarkMath]}
+          rehypePlugins={[rehypeKatex]}
+          components={{
+            a: ({ href, children }) => (
+              <LinkBadge href={href as string}>
+                {children}
+              </LinkBadge>
+            ),
+            ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
+            ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
+            hr: () => <hr className="my-3 border-dashed opacity-40" />,
+            p: ({ children }) => (
+              <p className="text-left">{children}</p>
+            ),
+            li: ({ children }) => (
+              <li>{children}</li>
+            ),
+            h1: ({ children }) => (
+              <h1>{children}</h1>
+            ),
+            h2: ({ children }) => (
+              <h2>{children}</h2>
+            ),
+            h3: ({ children }) => (
+              <h3>{children}</h3>
+            ),
+            h4: ({ children }) => (
+              <h4>{children}</h4>
+            ),
+            table: ({ children, ...props }) => (
+              <div className="overflow-x-auto">
+                <table {...props}>{children}</table>
+              </div>
+            ),
+            code: ({ inline, children, ...props }) =>
+              inline ? (
+                <code
+                  {...props}
+                  className="rounded bg-black/5 px-1 py-0.5 dark:bg-white/10"
+                >
+                  {children}
+                </code>
+              ) : (
+                <CodeBlock>{String(children)}</CodeBlock>
+              ),
+          }}
+        >
+          {prepared}
+        </ReactMarkdown>
+      </AutoCollapse>
     </div>
   );
 }

--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -6,7 +6,6 @@ import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 import { LinkBadge } from "./SafeLink";
-import type { CodeProps } from "react-markdown/lib/ast-to-react";
 
 // --- Normalizer ---
 // normalize: unwrap full-message fences, convert ==== to <hr>, bold-lines → headings, list bullets
@@ -54,7 +53,12 @@ function AutoCollapse({ children, maxHeight = 600 }: { children: React.ReactNode
   );
 }
 
-function CodeBlock({ children }: { children: string }) {
+type MarkdownCodeProps = React.ComponentPropsWithoutRef<"code"> & {
+  inline?: boolean;
+  node?: unknown;
+};
+
+function CodeBlock({ children, className }: { children: string; className?: string }) {
   const [copied, setCopied] = React.useState(false);
   return (
     <div className="relative">
@@ -70,7 +74,7 @@ function CodeBlock({ children }: { children: string }) {
         {copied ? "Copied" : "Copy"}
       </button>
       <pre className="overflow-auto rounded-lg bg-black/5 p-3 dark:bg-white/10">
-        <code>{children}</code>
+        <code className={className}>{children}</code>
       </pre>
     </div>
   );
@@ -135,13 +139,19 @@ export default function ChatMarkdown({ content }: { content: string }) {
                 <table {...props}>{children}</table>
               </div>
             ),
-            code: (props: CodeProps) => {
-              const { inline, children, ...rest } = props;
+            code: (props: MarkdownCodeProps) => {
+              const { inline, children, className, ...rest } = props;
               if (inline) {
+                const combined = [
+                  "rounded bg-black/5 px-1 py-0.5 dark:bg-white/10",
+                  className || "",
+                ]
+                  .filter(Boolean)
+                  .join(" ");
                 return (
                   <code
                     {...rest}
-                    className="rounded bg-black/5 px-1 py-0.5 dark:bg-white/10"
+                    className={combined}
                   >
                     {children}
                   </code>
@@ -152,7 +162,7 @@ export default function ChatMarkdown({ content }: { content: string }) {
                 ? children.join("")
                 : String(children ?? "");
 
-              return <CodeBlock>{text}</CodeBlock>;
+              return <CodeBlock className={typeof className === "string" ? className : undefined}>{text}</CodeBlock>;
             },
           }}
         >

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -321,7 +321,10 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   const therapyMode = modeState.therapy;
   const defaultSuggestions = useMemo(() => getDefaultSuggestions(modeState), [modeState]);
   const liveSuggestions = useMemo(() => getInlineSuggestions(userText, modeState), [userText, modeState]);
-  const visibleMessages = useMemo(() => messages.filter(m => m.role !== 'system'), [messages]);
+  const visibleMessages = useMemo(
+    () => messages.filter(m => m.role === 'user' || m.role === 'assistant'),
+    [messages]
+  );
   const trimmedInput = userText.trim();
   const showDefaultSuggestions = visibleMessages.length === 0 && trimmedInput.length === 0;
   const showLiveSuggestions = trimmedInput.length > 0 && liveSuggestions.length > 0;

--- a/components/suggest/SuggestBar.tsx
+++ b/components/suggest/SuggestBar.tsx
@@ -1,0 +1,34 @@
+"use client";
+import React from "react";
+
+export default function SuggestBar({
+  suggestions,
+  onPick,
+  title = "Try asking:",
+  className = "",
+}: {
+  suggestions: string[];
+  onPick: (text: string) => void;
+  title?: string;
+  className?: string;
+}) {
+  if (!suggestions?.length) return null;
+  return (
+    <div className={`mb-3 ${className}`}>
+      <div className="mb-2 text-sm opacity-70">{title}</div>
+      <div className="flex flex-wrap gap-2">
+        {suggestions.map((s, i) => (
+          <button
+            key={`${s}-${i}`}
+            type="button"
+            onClick={() => onPick(s)}
+            className="rounded-full border border-zinc-300 px-3 py-1.5 text-sm transition hover:bg-zinc-100 dark:border-zinc-700 dark:hover:bg-zinc-800"
+            title={s}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/data/suggestions.ts
+++ b/data/suggestions.ts
@@ -1,0 +1,67 @@
+export type Suggestion = { text: string; modes?: Array<"patient" | "doctor" | "aidoc"> };
+
+export const DEFAULT_PATIENT: string[] = [
+  "What is dandruff?",
+  "How to get rid of dandruff at home?",
+  "Why is my hair falling?",
+  "Medication for acne?",
+  "Side effects of metformin?",
+  "Diet for high blood pressure?",
+  "When should I see a doctor for back pain?",
+  "Tests for anemia (first line)?",
+];
+
+export const DEFAULT_DOCTOR: string[] = [
+  "Workup for chest pain (ACS/PE/dissection)",
+  "Initial management of sepsis (ED bundle)",
+  "Calculate HEART score for chest pain",
+  "Empiric antibiotics for CAP (adult)",
+  "Disposition criteria for pneumonia (CURB-65/PSI)",
+  "Stroke code: imaging + thrombolysis window",
+  "Interpret ECG: wide-complex tachycardia",
+  "Hyponatremia algorithm (hypo/eu/hypervolemic)",
+];
+
+export const DEFAULT_AIDOC: string[] = [
+  "Summarize this lab report in simple terms",
+  "Explain my CBC (what’s high/low and why)",
+  "Interpret my lipid profile and give targets",
+  "Compare this ECG with the previous one",
+  "Flag red flags in this discharge summary",
+  "Extract ICD-10 codes from this report",
+  "Suggest follow-up tests with reasoning",
+];
+
+export const TRIGGER_WHAT_IS: string[] = [
+  "What is dandruff?",
+  "What is hair fall (alopecia)?",
+  "What is diabetes?",
+  "What is PCOS?",
+  "What is GERD?",
+  "What is migraine?",
+];
+
+export const TRIGGER_MED_FOR: string[] = [
+  "What is the medication for acne?",
+  "What is the medication for back pain?",
+  "What is the medication for migraine?",
+  "What is the medication for anxiety?",
+];
+
+export const TRIGGER_SIDE_EFFECTS: string[] = [
+  "Side effects of metformin?",
+  "Side effects of isotretinoin?",
+  "Side effects of omeprazole?",
+];
+
+export const TRIGGER_TEST_FOR: string[] = [
+  "Which test for anemia?",
+  "Which test for thyroid problems?",
+  "Which test for chest pain?",
+];
+
+export const TRIGGER_DOC_WORKUP: string[] = [
+  "Workup for syncope (San Francisco rule)",
+  "Workup for headache (SAH rule-out)",
+  "Workup for abdominal pain (RUQ/RLQ/epigastric)",
+];

--- a/lib/suggestions/engine.ts
+++ b/lib/suggestions/engine.ts
@@ -1,0 +1,34 @@
+import type { ModeState } from "@/lib/modes/types";
+import {
+  DEFAULT_PATIENT,
+  DEFAULT_DOCTOR,
+  DEFAULT_AIDOC,
+  TRIGGER_WHAT_IS,
+  TRIGGER_MED_FOR,
+  TRIGGER_SIDE_EFFECTS,
+  TRIGGER_TEST_FOR,
+  TRIGGER_DOC_WORKUP,
+} from "@/data/suggestions";
+
+export function getDefaultSuggestions(mode: ModeState): string[] {
+  if (mode.base === "doctor") return DEFAULT_DOCTOR;
+  if (mode.base === "aidoc") return DEFAULT_AIDOC;
+  return DEFAULT_PATIENT;
+}
+
+export function getInlineSuggestions(query: string, mode: ModeState): string[] {
+  const q = (query || "").trim().toLowerCase();
+  if (!q) return [];
+
+  if (mode.base === "doctor") {
+    if (q.startsWith("workup") || q.includes("rule out")) return TRIGGER_DOC_WORKUP;
+  }
+
+  if (q.startsWith("what is")) return TRIGGER_WHAT_IS;
+  if (q.startsWith("what is the medication for") || q.startsWith("medication for")) return TRIGGER_MED_FOR;
+  if (q.includes("side effect")) return TRIGGER_SIDE_EFFECTS;
+  if (q.startsWith("which test") || q.includes("test for")) return TRIGGER_TEST_FOR;
+
+  const pool = getDefaultSuggestions(mode);
+  return pool.filter(t => t.toLowerCase().includes(q)).slice(0, 8);
+}


### PR DESCRIPTION
## Summary
- refactor the chat markdown renderer to enforce a ChatGPT-like layout with auto-collapse, copy buttons, and table overflow handling
- ensure patient/doctor drafting templates persist while research hints are appended via a shared system prompt builder
- introduce a suggestion engine, data set, and SuggestBar UI to surface default and inline question chips, and render AI Doc observations through the unified markdown view

## Testing
- npm run lint *(prompts for ESLint configuration and cannot complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7b9ae614832f94b3f0b2c0e04ebf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suggestion bar shows default and live inline suggestions as you type; click to populate the input.
  * Copy button for code blocks.

* **Enhancements**
  * Math formulas render correctly in chat.
  * Long messages auto-collapse with a Show more toggle.
  * Tables scroll horizontally; inline and block code are styled distinctly.
  * Improved list/link styling, text width/spacing, and richer markdown for short observations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->