### PR TITLE
Add observation deletion controls to timeline

### DIFF
--- a/lib/utils/readResponseError.ts
+++ b/lib/utils/readResponseError.ts
@@ -1,0 +1,33 @@
+export async function readResponseError(res: Response, fallback: string): Promise<string> {
+  const base = res.statusText?.trim() || fallback;
+  const contentType = res.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    try {
+      const data = await res.clone().json() as { error?: unknown; message?: unknown };
+      const message =
+        typeof data?.error === "string"
+          ? data.error
+          : typeof data?.message === "string"
+          ? data.message
+          : null;
+      if (message?.trim()) {
+        return message.trim();
+      }
+    } catch (error) {
+      // ignore JSON parsing issues and fall back to the next strategy
+    }
+  }
+
+  try {
+    const text = await res.clone().text();
+    const trimmed = text.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  } catch (error) {
+    // ignore text parsing issues and fall back to the base message
+  }
+
+  return base;
+}


### PR DESCRIPTION
## Summary
- track a shared action error and deletion state for timeline actions
- add delete controls for observation entries and guard against drawer interactions
- call the discard API, handle error responses, close the preview drawer, and refresh the timeline after deletion

## Testing
- npm run lint *(fails: command prompts for configuration and cannot be automated in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caafcc1e7c832fb5dac13e4b3d025b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Per-observation Delete with confirmation, per-item progress state (“Deleting…”), disabled button while deleting, prevents accidental opens, refreshes timeline and closes detail pane if needed.
  - Reset action now shows progress (“Resetting…”), is disabled while running, and provides clearer feedback on success/failure.

- Refactor
  - Header layout updated to fit action controls.
  - Consolidated error handling and user-friendly error messages (including prompts to sign in when required).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->