### PR TITLE
Fix ChatPane drafting helper duplication and set AI Doc runtime

### DIFF
--- a/app/api/ai-doc/route.ts
+++ b/app/api/ai-doc/route.ts
@@ -4,7 +4,6 @@ export const revalidate = 0;
 
 import { NextRequest, NextResponse } from "next/server";
 import { getUserId } from "@/lib/getUserId";
-import { prisma } from "@/lib/prisma";
 import { callOpenAIJson } from "@/lib/aidoc/vendor";
 import { getMemByThread, upsertMem } from "@/lib/aidoc/memory";
 import { runRules } from "@/lib/aidoc/rules";
@@ -14,6 +13,12 @@ import { buildAiDocPrompt } from "@/lib/ai/prompts/aidoc";
 import { supabaseAdmin } from "@/lib/supabase/admin";
 import { extractAll, canonicalizeInputs } from "@/lib/medical/engine/extract";
 import { computeAll } from "@/lib/medical/engine/computeAll";
+import {
+  buildClinicalState,
+  mergeProfileConditions,
+  normalizeIso,
+  parseNumber,
+} from "@/lib/aidoc/clinicalState";
 // === [MEDX_CALC_ROUTE_IMPORTS_START] ===
 // === [MEDX_CALC_ROUTE_IMPORTS_END] ===
 
@@ -33,88 +38,360 @@ async function getFeedbackSummary(conversationId: string) {
   }
 }
 
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function asStringArray(input: any): string[] {
+  if (Array.isArray(input)) {
+    return input
+      .map((item) => (typeof item === "string" ? item.trim() : String(item ?? "").trim()))
+      .filter(Boolean);
+  }
+  if (typeof input === "string") {
+    try {
+      const parsed = JSON.parse(input);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map((item) => (typeof item === "string" ? item.trim() : String(item ?? "").trim()))
+          .filter(Boolean);
+      }
+    } catch {
+      // fall back to comma/newline separation for plain strings
+      return input
+        .split(/[,\n;]/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+    }
+  }
+  return [];
+}
+
+function normalizePregnancy(input: any): "yes" | "no" | "unsure" | null {
+  if (input == null) return null;
+  if (typeof input === "boolean") return input ? "yes" : "no";
+  const text = String(input).trim().toLowerCase();
+  if (!text) return null;
+  if (["yes", "y", "true", "pregnant", "positive"].includes(text)) return "yes";
+  if (["no", "n", "false", "not pregnant", "negative"].includes(text)) return "no";
+  if (["not sure", "unsure", "unknown", "maybe"].includes(text)) return "unsure";
+  return null;
+}
+
+function clampAgeYears(input: any): number | null {
+  const num = parseNumber(input);
+  if (num == null) return null;
+  if (num < 0 || num > 130) return null;
+  return Math.round(num);
+}
+
+function computeAgeFromDob(dob?: string | null): number | null {
+  if (!dob) return null;
+  const birth = new Date(dob);
+  if (!Number.isFinite(birth.getTime())) return null;
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const m = today.getMonth() - birth.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) age--;
+  return age >= 0 && age < 130 ? age : null;
+}
+
+function buildPromptProfile(row: any, overrides?: any) {
+  const name = (overrides?.name || row?.full_name || row?.name || "New Patient").toString();
+  const dobAge = computeAgeFromDob(row?.dob ?? null);
+  const ageRaw = overrides?.age ?? row?.age ?? dobAge;
+  const age = ageRaw == null ? null : Number(ageRaw);
+  const sex = overrides?.sex ?? row?.sex ?? null;
+  let pregnant: any = overrides?.pregnant ?? row?.pregnant ?? null;
+  if (typeof pregnant === "string") {
+    const p = pregnant.toLowerCase();
+    if (["yes", "true", "y"].includes(p)) pregnant = "yes";
+    else if (["no", "false", "n"].includes(p)) pregnant = "no";
+  }
+  return {
+    name,
+    age: Number.isFinite(age) ? Number(age) : null,
+    sex: sex ?? null,
+    pregnant: pregnant ?? null,
+  };
+}
+
+function safeSummary(text: string, max = 120) {
+  const t = text.trim();
+  if (t.length <= max) return t;
+  return t.slice(0, max - 1).trimEnd() + "…";
+}
+
+function pushObservationRow(
+  collection: any[],
+  userId: string,
+  threadId: string | null,
+  row: {
+    kind: string;
+    value_num?: number | null;
+    value_text?: string | null;
+    unit?: string | null;
+    observed_at?: string | null;
+    meta?: Record<string, any>;
+  }
+) {
+  collection.push({
+    user_id: userId,
+    thread_id: threadId,
+    kind: row.kind,
+    value_num: row.value_num ?? null,
+    value_text: row.value_text ?? null,
+    unit: row.unit ?? null,
+    observed_at: normalizeIso(row.observed_at),
+    meta: { source_type: "ai_doc", ...(row.meta ?? {}) },
+  });
+}
+
+function latestObservationByKind(obsRows: any[], kind: string) {
+  let latest: any = null;
+  let latestTs = -Infinity;
+  for (const row of Array.isArray(obsRows) ? obsRows : []) {
+    if (!row || row.kind !== kind) continue;
+    const ts = new Date(row.observed_at ?? row.created_at ?? 0).getTime();
+    if (ts > latestTs) {
+      latest = row;
+      latestTs = ts;
+    }
+  }
+  return latest;
+}
+
+function hydrateProfileDemographics(
+  profileRow: any,
+  obsRows: any[],
+  mem: Awaited<ReturnType<typeof getMemByThread>>
+) {
+  if (!profileRow) return;
+
+  const ageFromMem = mem.facts.find((f) => f.key === "demographics.age_years");
+  if (profileRow.age == null && ageFromMem?.value != null) {
+    const parsed = clampAgeYears(ageFromMem.value);
+    if (parsed != null) profileRow.age = parsed;
+  }
+
+  const pregFromMem = mem.facts.find(
+    (f) => f.key === "demographics.pregnancy_status"
+  );
+  if (profileRow.pregnant == null && pregFromMem?.value != null) {
+    const norm = normalizePregnancy(pregFromMem.value);
+    if (norm) profileRow.pregnant = norm;
+  }
+
+  const ageObs = latestObservationByKind(obsRows, "demographics.age_years");
+  if (profileRow.age == null && ageObs) {
+    const val =
+      ageObs.value_num ??
+      clampAgeYears(ageObs.value_text) ??
+      clampAgeYears(ageObs.meta?.value);
+    if (val != null) profileRow.age = val;
+  }
+
+  const pregObs = latestObservationByKind(
+    obsRows,
+    "demographics.pregnancy_status"
+  );
+  if (profileRow.pregnant == null && pregObs) {
+    const val =
+      normalizePregnancy(pregObs.value_text) ??
+      normalizePregnancy(pregObs.meta?.value);
+    if (val) profileRow.pregnant = val;
+  }
+}
+
 export async function POST(req: NextRequest) {
   const userId = await getUserId(req);
   if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 
-  const { threadId, message, profileIntent, newProfile } = await req.json();
-  if (!message) return NextResponse.json({ error: "no message" }, { status: 400 });
+  const payload = await req.json().catch(() => ({} as any));
+  const rawMessage = payload?.message;
+  const message = typeof rawMessage === "string" ? rawMessage : String(rawMessage ?? "");
+  if (!message.trim()) return NextResponse.json({ error: "no message" }, { status: 400 });
 
-  // Ensure profile & load clinical state + memory
-  let profile = await prisma.patientProfile.findFirst({ where: { userId } });
+  const threadId =
+    typeof payload?.threadId === "string" && payload.threadId.trim()
+      ? payload.threadId.trim()
+      : null;
+  const profileIntent = payload?.profileIntent;
+  const newProfile = payload?.newProfile ?? null;
 
-  // New patient quick-create (only for this call)
+  const supa = supabaseAdmin();
+  let profileRow: any = null;
+
   if (profileIntent === "new") {
-    const p = await prisma.patientProfile.create({
-      data: {
-        userId,
-        name: (newProfile?.name || "New Patient").slice(0, 80),
-        age: newProfile?.age ? Number(newProfile.age) : null,
-        sex: newProfile?.sex || null,
-        pregnant:
-          newProfile?.pregnant === "yes"
-            ? true
-            : newProfile?.pregnant === "no"
-            ? false
-            : null,
-      } as any,
-    });
-    profile = p;
+    const patch: Record<string, any> = {
+      id: userId,
+      full_name: (newProfile?.name || "New Patient").toString().slice(0, 80),
+    };
+    if (newProfile?.sex) patch.sex = newProfile.sex;
 
-    // seed basic notes/meds from intake if provided
-    const ops: any[] = [];
-    if (newProfile?.symptoms)
-      ops.push(
-        prisma.note.create({
-          data: { profileId: p.id, body: `Symptoms: ${newProfile.symptoms}` },
-        }),
+    const { data: upserted, error: upsertErr } = await supa
+      .from("profiles")
+      .upsert(patch, { onConflict: "id" })
+      .select("*")
+      .single();
+    if (upsertErr) {
+      return NextResponse.json({ error: upsertErr.message }, { status: 500 });
+    }
+    profileRow = upserted;
+
+    const seeds: any[] = [];
+    const ageYears = clampAgeYears(newProfile?.age);
+    if (ageYears != null) {
+      profileRow.age = ageYears;
+      await upsertMem(userId, null, "aidoc.fact", "demographics.age_years", ageYears);
+      pushObservationRow(seeds, userId, threadId, {
+        kind: "demographics.age_years",
+        value_num: ageYears,
+        observed_at: new Date().toISOString(),
+        meta: {
+          category: "demographic",
+          summary: `Age ${ageYears}`,
+          value: ageYears,
+        },
+      });
+    }
+    const pregStatus = normalizePregnancy(newProfile?.pregnant);
+    if (pregStatus) {
+      profileRow.pregnant = pregStatus;
+      await upsertMem(
+        userId,
+        null,
+        "aidoc.fact",
+        "demographics.pregnancy_status",
+        pregStatus
       );
-    if (newProfile?.allergies)
-      ops.push(
-        prisma.note.create({
-          data: { profileId: p.id, body: `Allergies: ${newProfile.allergies}` },
-        }),
-      );
+      pushObservationRow(seeds, userId, threadId, {
+        kind: "demographics.pregnancy_status",
+        value_text: pregStatus,
+        observed_at: new Date().toISOString(),
+        meta: {
+          category: "demographic",
+          summary: `Pregnancy: ${pregStatus}`,
+          value: pregStatus,
+        },
+      });
+    }
+    if (newProfile?.symptoms) {
+      const text = String(newProfile.symptoms);
+      pushObservationRow(seeds, userId, threadId, {
+        kind: "note.intake_symptoms",
+        value_text: `Symptoms: ${text}`,
+        meta: { category: "note", summary: safeSummary(`Symptoms: ${text}`) },
+      });
+    }
+    if (newProfile?.allergies) {
+      const text = String(newProfile.allergies);
+      pushObservationRow(seeds, userId, threadId, {
+        kind: "note.intake_allergies",
+        value_text: `Allergies: ${text}`,
+        meta: { category: "note", summary: safeSummary(`Allergies: ${text}`) },
+      });
+    }
     if (newProfile?.meds) {
       const meds = String(newProfile.meds)
         .split(/[,;\n]/)
         .map((s) => s.trim())
         .filter(Boolean);
-      for (const m of meds)
-        ops.push(prisma.medication.create({ data: { profileId: p.id, name: m } }));
+      for (const med of meds) {
+        pushObservationRow(seeds, userId, threadId, {
+          kind: `medication.intake_${slugify(med)}`,
+          value_text: med,
+          meta: { category: "medication", summary: med },
+        });
+      }
     }
-    if (ops.length) await prisma.$transaction(ops);
+    if (seeds.length) {
+      const { error: seedErr } = await supa.from("observations").insert(seeds);
+      if (seedErr) {
+        return NextResponse.json({ error: seedErr.message }, { status: 500 });
+      }
+    }
   }
 
-  if (!profile) {
-    const p = await prisma.patientProfile.create({
-      data: { userId, name: "New Patient" } as any,
-    });
-    profile = p;
+  if (!profileRow) {
+    const { data, error } = await supa
+      .from("profiles")
+      .select("*")
+      .eq("id", userId)
+      .maybeSingle();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    profileRow = data ?? null;
+  }
+  if (!profileRow) {
+    const { data, error } = await supa
+      .from("profiles")
+      .upsert({ id: userId, full_name: "New Patient" }, { onConflict: "id" })
+      .select("*")
+      .single();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    profileRow = data;
   }
 
-  const [labs, meds, conditions, mem] = await Promise.all([
-    prisma.labResult.findMany({ where: { profileId: profile.id } }),
-    prisma.medication.findMany({ where: { profileId: profile.id } }),
-    prisma.condition.findMany({ where: { profileId: profile.id } }),
-    getMemByThread(threadId || ""),
-  ]);
+  if (profileRow) {
+    profileRow.chronic_conditions = asStringArray(profileRow.chronic_conditions);
+    profileRow.conditions_predisposition = asStringArray(
+      profileRow.conditions_predisposition
+    );
+  }
 
-  // Opportunistically capture preferences from user's message
-  for (const p of extractPrefsFromUser(message)) {
-    await upsertMem(threadId, "aidoc.pref", p.key, p.value);
-    await prisma.timelineEvent.create({
-      data: {
-        profileId: profile.id,
-        at: new Date(),
-        type: "preference",
-        summary: `Saved preference: ${p.key} = ${p.value}`,
-      },
+  let memBefore: Awaited<ReturnType<typeof getMemByThread>>;
+  try {
+    memBefore = await getMemByThread(userId, threadId);
+  } catch (err: any) {
+    console.error("[ai-doc] memory preload error", err?.message || err);
+    memBefore = { prefs: [], facts: [], redflags: [], goals: [] };
+  }
+
+  const obsRes = await supa
+    .from("observations")
+    .select("id, kind, value_num, value_text, unit, observed_at, created_at, meta")
+    .eq("user_id", userId);
+  if (obsRes.error) return NextResponse.json({ error: obsRes.error.message }, { status: 500 });
+
+  const predRes = await supa
+    .from("predictions")
+    .select("id, name, label, type, probability, created_at, details")
+    .eq("user_id", userId);
+  if (predRes.error) {
+    console.warn("[ai-doc] predictions load error", predRes.error.message);
+  }
+
+  const obsRows = Array.isArray(obsRes.data) ? obsRes.data : [];
+  const predRows = Array.isArray(predRes.data) ? predRes.data : [];
+  if (profileRow) {
+    hydrateProfileDemographics(profileRow, obsRows, memBefore);
+  }
+  const clinical = buildClinicalState(obsRows, predRows);
+  if (profileRow) {
+    mergeProfileConditions(
+      clinical,
+      profileRow.chronic_conditions ?? [],
+      profileRow.conditions_predisposition ?? []
+    );
+  }
+  const profile = buildPromptProfile(profileRow, newProfile);
+
+  const pendingObservations: any[] = [];
+  for (const pref of extractPrefsFromUser(message)) {
+    const val = pref?.value ?? "";
+    await upsertMem(userId, threadId, "aidoc.pref", pref.key, val);
+    pushObservationRow(pendingObservations, userId, threadId, {
+      kind: `preference.${slugify(pref.key)}`,
+      value_text: `Saved preference: ${pref.key} = ${val}`,
+      meta: { category: "note", summary: safeSummary(`Saved preference: ${pref.key} = ${val}`), raw: pref },
     });
   }
 
   // System prompt with guardrails
-  let system = buildAiDocPrompt({ profile, labs, meds, conditions });
+  let system = buildAiDocPrompt({ profile, labs: clinical.labs, meds: clinical.meds, conditions: clinical.conditions });
 
   const userText = String(message || "");
   const ctx = canonicalizeInputs(extractAll(userText));
@@ -228,7 +505,7 @@ export async function POST(req: NextRequest) {
     user: message,
     instruction: "Return JSON with {reply, save:{medications,conditions,labs,notes,prefs}, observations:{short,long}}",
     metadata: {
-      conversationId: threadId,
+      conversationId: threadId ?? undefined,
       lastMessageId: null,
       feedback_summary,
       app: "medx",
@@ -236,145 +513,114 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  // Persist structured saves + timeline
-  for (const p of out?.save?.prefs ?? []) {
-    await upsertMem(threadId, "aidoc.pref", p.key, String(p.value));
-    await prisma.timelineEvent.create({
-      data: {
-        profileId: profile.id,
-        at: new Date(),
-        type: "preference",
-        summary: `Saved preference: ${p.key} = ${p.value}`,
+  const save = out?.save || {};
+
+  for (const p of save.prefs ?? []) {
+    const val = p?.value ?? "";
+    await upsertMem(userId, threadId, "aidoc.pref", p.key, val);
+    pushObservationRow(pendingObservations, userId, threadId, {
+      kind: `preference.${slugify(p.key)}`,
+      value_text: `Saved preference: ${p.key} = ${val}`,
+      meta: { category: "note", summary: safeSummary(`Saved preference: ${p.key} = ${val}`), raw: p },
+    });
+  }
+
+  for (const c of save.conditions ?? []) {
+    if (!c?.label) continue;
+    const label = String(c.label).trim();
+    if (!label) continue;
+    const status = typeof c.status === "string" ? c.status : "active";
+    const since = normalizeIso(c.since ?? null);
+    clinical.conditions.push({ label, status, code: c.code ?? null, since });
+    pushObservationRow(pendingObservations, userId, threadId, {
+      kind: `condition.${slugify(label)}`,
+      value_text: label,
+      observed_at: since,
+      meta: { category: "diagnosis", status, code: c.code ?? null, summary: label, raw: c },
+    });
+  }
+
+  for (const m of save.medications ?? []) {
+    if (!m?.name) continue;
+    const name = String(m.name).trim();
+    if (!name) continue;
+    const dose = m.dose ? String(m.dose) : null;
+    const since = normalizeIso(m.since ?? null);
+    const stoppedAt = m.stoppedAt ? normalizeIso(m.stoppedAt) : null;
+    clinical.meds.push({ name, dose, since, stoppedAt });
+    pushObservationRow(pendingObservations, userId, threadId, {
+      kind: `medication.${slugify(name)}`,
+      value_text: dose ? `${name} ${dose}` : name,
+      observed_at: since,
+      meta: {
+        category: "medication",
+        name,
+        dose,
+        since,
+        stopped_at: stoppedAt,
+        summary: dose ? `${name} ${dose}` : name,
+        raw: m,
       },
     });
   }
 
-  const save = out?.save || {};
-  await prisma.$transaction(async (tx) => {
-    // CONDITIONS
-    for (const c of save.conditions ?? []) {
-      const existing = await tx.condition.findFirst({
-        where: { profileId: profile.id, label: c.label, status: (c.status as any) ?? "active" },
-      });
-      if (existing) {
-        await tx.condition.update({
-          where: { id: existing.id },
-          data: { code: c.code ?? existing.code, since: c.since ?? existing.since },
-        });
-      } else {
-        const row = await tx.condition.create({
-          data: {
-            profileId: profile.id,
-            label: c.label,
-            status: (c.status as any) ?? "active",
-            code: c.code ?? null,
-            since: c.since ?? null,
-          },
-        });
-        await tx.timelineEvent.create({
-          data: { profileId: profile.id, at: new Date(), type: "diagnosis", refId: row.id, summary: c.label },
-        });
-      }
-    }
+  for (const l of save.labs ?? []) {
+    if (!l?.name) continue;
+    const name = String(l.name).trim();
+    if (!name) continue;
+    const valueNum = parseNumber((l as any).value ?? (l as any).value_num ?? null);
+    const rawValue =
+      valueNum == null
+        ? ((l as any).value_text ?? l.value ?? null)
+        : null;
+    const valueText = rawValue != null ? String(rawValue) : null;
+    const takenAt = normalizeIso(l.takenAt ?? null);
+    clinical.labs.push({
+      name,
+      value: valueNum ?? valueText,
+      unit: l.unit ?? null,
+      takenAt,
+      panel: l.panel ?? null,
+      abnormal: (l as any).abnormal ?? null,
+    });
+    pushObservationRow(pendingObservations, userId, threadId, {
+      kind: `lab.${slugify(name)}`,
+      value_num: valueNum,
+      value_text: valueNum == null ? valueText : null,
+      unit: l.unit ?? null,
+      observed_at: takenAt,
+      meta: {
+        category: "lab",
+        label: name,
+        panel: l.panel ?? null,
+        abnormal: (l as any).abnormal ?? null,
+        summary: safeSummary(`${name}: ${valueText ?? valueNum ?? ""}${l.unit ? ` ${l.unit}` : ""}`),
+        raw: l,
+      },
+    });
+  }
 
-    // MEDICATIONS
-    for (const m of save.medications ?? []) {
-      const existing = await tx.medication.findFirst({
-        where: { profileId: profile.id, name: m.name, dose: m.dose ?? null, stoppedAt: null },
-      });
-      if (existing) {
-        await tx.medication.update({
-          where: { id: existing.id },
-          data: { since: m.since ?? existing.since },
-        });
-      } else {
-        const row = await tx.medication.create({
-          data: {
-            profileId: profile.id,
-            name: m.name,
-            dose: m.dose ?? null,
-            since: m.since ?? null,
-            stoppedAt: m.stoppedAt ?? null,
-          },
-        });
-        await tx.timelineEvent.create({
-          data: {
-            profileId: profile.id,
-            at: new Date(),
-            type: "med_start",
-            refId: row.id,
-            summary: (`Started ${m.name} ${m.dose || ""}`).trim(),
-          },
-        });
-      }
-    }
+  for (const note of save.notes ?? []) {
+    if (!note) continue;
+    const text = String(note).trim();
+    if (!text) continue;
+    pushObservationRow(pendingObservations, userId, threadId, {
+      kind: "note.ai_doc",
+      value_text: text,
+      meta: { category: "note", summary: safeSummary(text) },
+    });
+  }
 
-    // LABS
-    for (const l of save.labs ?? []) {
-      const takenAt = l.takenAt ? new Date(l.takenAt) : null;
-      const existing = await tx.labResult.findFirst({
-        where: { profileId: profile.id, name: l.name, takenAt },
-      });
-      if (existing) {
-        await tx.labResult.update({
-          where: { id: existing.id },
-          data: {
-            value: (l as any).value ?? existing.value,
-            unit: l.unit ?? existing.unit,
-            refLow: (l as any).normalLow ?? existing.refLow,
-            refHigh: (l as any).normalHigh ?? existing.refHigh,
-            abnormal: (l as any).abnormal ?? existing.abnormal,
-          },
-        });
-      } else {
-        const row = await tx.labResult.create({
-          data: {
-            profileId: profile.id,
-            panel: l.panel ?? null,
-            name: l.name,
-            value: (l as any).value ?? null,
-            unit: l.unit ?? null,
-            refLow: (l as any).normalLow ?? null,
-            refHigh: (l as any).normalHigh ?? null,
-            takenAt,
-            abnormal: (l as any).abnormal ?? null,
-          },
-        });
-        await tx.timelineEvent.create({
-          data: {
-            profileId: profile.id,
-            at: new Date(),
-            type: "lab",
-            refId: row.id,
-            summary: (`${l.name}: ${l.value ?? ""}${l.unit ?? ""}`).trim(),
-          },
-        });
-      }
-    }
+  let memAfter;
+  try {
+    memAfter = await getMemByThread(userId, threadId);
+  } catch (err: any) {
+    console.error("[ai-doc] memory load error", err?.message || err);
+    memAfter = { prefs: [], facts: [], redflags: [], goals: [] };
+  }
 
-    // NOTES
-    for (const note of save.notes ?? []) {
-      const row = await tx.note.create({ data: { profileId: profile.id, body: note } });
-      await tx.timelineEvent.create({
-        data: { profileId: profile.id, at: new Date(), type: "note", refId: row.id, summary: note },
-      });
-    }
-
-    // PREFS
-    for (const p of save.prefs ?? []) {
-      const existing = await tx.preference.findFirst({ where: { profileId: profile.id, key: p.key } });
-      if (existing) {
-        await tx.preference.update({ where: { id: existing.id }, data: { value: p.value } });
-      } else {
-        await tx.preference.create({ data: { profileId: profile.id, key: p.key, value: p.value } });
-      }
-    }
-  });
-
-  // Personalization via rule engine
-  const memAfter = await getMemByThread(threadId || "");
-  const ruled = runRules({ labs, meds, conditions, mem: memAfter });
-  const plan = buildPersonalPlan(ruled, memAfter, { symptomsText: message });
+  const ruled = runRules({ labs: clinical.labs, meds: clinical.meds, conditions: clinical.conditions, mem: memAfter });
+  const plan = buildPersonalPlan(ruled, memAfter, { vitals: clinical.vitals, symptomsText: message });
 
   // Keep core alerts fresh (stale/abnormal)
   await fetch(new URL("/api/alerts/recompute", req.url), {
@@ -382,16 +628,20 @@ export async function POST(req: NextRequest) {
     headers: { cookie: req.headers.get("cookie") || "" },
   }).catch(() => {});
 
-  // Log which rules fired
-  await prisma.timelineEvent.create({
-    data: {
-      profileId: profile.id,
-      at: new Date(),
-      type: "ai_reason",
+  pushObservationRow(pendingObservations, userId, threadId, {
+    kind: "ai_doc.rules_fired",
+    value_text: `Rules: ${plan.rulesFired.join(", ")}`,
+    meta: {
+      category: "note",
       summary: `Rules: ${plan.rulesFired.join(", ")}`,
-      details: JSON.stringify({ rules: plan.rulesFired }),
+      details: { rules: plan.rulesFired },
     },
   });
+
+  if (pendingObservations.length) {
+    const { error: insertErr } = await supa.from("observations").insert(pendingObservations);
+    if (insertErr) return NextResponse.json({ error: insertErr.message }, { status: 500 });
+  }
 
   return NextResponse.json({
     reply: out.reply,

--- a/app/api/aidoc/chat/route.ts
+++ b/app/api/aidoc/chat/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 // [AIDOC_TRIAGE_IMPORT] add triage imports
 import { handleDocAITriage, detectExperientialIntent } from "@/lib/aidoc/triage";
-import { POST as streamPOST, runtime } from "../../chat/stream/route";
+import { POST as streamPOST } from "../../chat/stream/route";
 
-export { runtime };
+export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
   const cloned = req.clone();

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -5,23 +5,19 @@ export const revalidate = 0;
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase/admin";
 import { getUserId } from "@/lib/getUserId";
+import {
+  OBSERVATION_LABELS as LABELS,
+  ObservationGroupKey as GroupKey,
+  classifyObservation,
+  normalizeObservationKind,
+  startCaseObservation,
+} from "@/lib/supabase/observationGroups";
 
 function noStoreHeaders() {
   return { "Cache-Control": "no-store, max-age=0" };
 }
 
 // Group types for the UI
-type GroupKey =
-  | "vitals"
-  | "labs"
-  | "imaging"
-  | "medications"
-  | "diagnoses"
-  | "procedures"
-  | "immunizations"
-  | "notes"
-  | "other";
-
 type Item = {
   key: string;                 // observation kind (e.g., "alt", "mri_report")
   label: string;               // human-friendly label
@@ -30,152 +26,7 @@ type Item = {
   observedAt: string;
   source?: string | null;      // modality/source (e.g., "MRI", "PDF", "Rx")
 };
-
 type Groups = Record<GroupKey, Item[]>;
-
-// --- labels (extendable) ---
-const LABELS: Record<string, string> = {
-  bp: "BP",
-  hr: "HR",
-  bmi: "BMI",
-  hba1c: "HbA1c",
-  fasting_glucose: "Fasting Glucose",
-  egfr: "eGFR",
-  alt: "ALT",
-  ast: "AST",
-  alp: "ALP",
-  ggt: "GGT",
-  total_bilirubin: "Bilirubin Total",
-  direct_bilirubin: "Bilirubin Direct",
-  indirect_bilirubin: "Bilirubin Indirect",
-  hemoglobin: "Hemoglobin",
-  wbc: "WBC",
-  platelets: "Platelets",
-  esr: "ESR",
-  uibc: "UIBC",
-  tibc: "TIBC",
-  transferrin_saturation: "Transferrin Saturation",
-  total_cholesterol: "Total Cholesterol",
-  triglycerides: "Triglycerides",
-  ldl: "LDL",
-  hdl: "HDL",
-  vitamin_d: "Vitamin D",
-  vitamin_b12: "Vitamin B12",
-  creatinine: "Serum Creatinine",
-  lipase: "Serum Lipase",
-  amylase: "Serum Amylase",
-  fsh: "FSH",
-  lh: "LH",
-  rheumatoid_factor: "Rheumatoid Factor",
-  rbc_count: "Erythrocyte Count",
-};
-
-// --- normalization for common synonyms/kinds ---
-function normalizeKind(raw: string) {
-  const k = String(raw || "").trim().toLowerCase().replace(/\s+/g, "_");
-  // exact matches or common synonyms
-  if (["erythrocyte_count", "rbc", "rbc_count"].includes(k)) return "rbc_count";
-  if (["total_chol", "cholesterol", "cholesterol_total"].includes(k)) return "total_cholesterol";
-  if (["bilirubin", "tbil", "tbil_total"].includes(k)) return "total_bilirubin";
-  if (["vit_b12", "b12"].includes(k)) return "vitamin_b12";
-  if (["vitamin_d3", "25_oh_vitamin_d", "25-oh-vitamin-d"].includes(k)) return "vitamin_d";
-  if (["serum_creatinine"].includes(k)) return "creatinine";
-  if (["rf", "ra_factor"].includes(k)) return "rheumatoid_factor";
-  return k;
-}
-
-// --- deterministic overrides (canonical kind -> group) ---
-const KIND_CATEGORY_OVERRIDES: Record<string, GroupKey> = {
-  // always labs:
-  rbc_count: "labs",
-  hemoglobin: "labs",
-  wbc: "labs",
-  platelets: "labs",
-  esr: "labs",
-  uibc: "labs",
-  tibc: "labs",
-  transferrin_saturation: "labs",
-  egfr: "labs",
-  creatinine: "labs",
-  fasting_glucose: "labs",
-  hba1c: "labs",
-  total_cholesterol: "labs",
-  triglycerides: "labs",
-  ldl: "labs",
-  hdl: "labs",
-  total_bilirubin: "labs",
-  direct_bilirubin: "labs",
-  indirect_bilirubin: "labs",
-  alt: "labs",
-  ast: "labs",
-  alp: "labs",
-  ggt: "labs",
-  vitamin_d: "labs",
-  vitamin_b12: "labs",
-  lipase: "labs",
-  amylase: "labs",
-  fsh: "labs",
-  lh: "labs",
-  rheumatoid_factor: "labs",
-
-  // real vitals:
-  bp: "vitals",
-  hr: "vitals",
-  bmi: "vitals",
-  height: "vitals",
-  weight: "vitals",
-  spo2: "vitals",
-  pulse: "vitals",
-};
-
-// imaging trigger words, but require 'report' or meta.imaging to avoid false positives
-const IMG_WORDS = ["xray", "xr", "cxr", "ct", "mri", "usg", "ultrasound", "echo"];
-const RX_WORDS  = ["med", "rx", "drug", "dose", "tablet", "capsule", "syrup"];
-
-// broader lab hints
-const LAB_HINT = [
-  "glucose","cholesterol","triglycer","hba1c","egfr","creatinine","bun",
-  "bilirubin","ast","alt","alp","ggt","hb","hemoglobin","wbc","platelet","esr",
-  "ferritin","tibc","uibc","transferrin","sodium","potassium","ldl","hdl",
-  "vitamin","lipase","amylase","fsh","lh","rheumatoid"
-];
-
-function startCase(s: string) {
-  return s.replaceAll("_", " ").replace(/(^|\s)\S/g, c => c.toUpperCase());
-}
-
-function classify(kindRaw: string, meta: any): GroupKey {
-  const kind = normalizeKind(kindRaw);
-  // 1) explicit override
-  if (KIND_CATEGORY_OVERRIDES[kind]) return KIND_CATEGORY_OVERRIDES[kind];
-
-  const k = kind;
-  const cat = (meta?.category as string | undefined)?.toLowerCase();
-  const modality = (meta?.modality as string | undefined)?.toLowerCase();
-  const src = (meta?.source_type as string | undefined)?.toLowerCase();
-  const textHas = (arr: string[]) => arr.some(w => k.includes(w));
-
-  // 2) explicit meta from parser
-  if (cat === "vital") return "vitals";
-  if (cat === "lab") return "labs";
-  if (cat === "imaging") return "imaging";
-  if (cat === "medication" || cat === "prescription") return "medications";
-  if (cat === "diagnosis" || cat === "problem") return "diagnoses";
-  if (cat === "procedure") return "procedures";
-  if (cat === "immunization" || cat === "vaccine") return "immunizations";
-  if (cat === "note" || cat === "symptom") return "notes";
-
-  // 3) heuristics (tightened)
-  const looksImaging = textHas(IMG_WORDS) || (modality && IMG_WORDS.some(w => modality.includes(w)));
-  if (looksImaging && (k.includes("report") || cat === "imaging")) return "imaging";
-
-  if (textHas(RX_WORDS)) return "medications";
-  if (textHas(["bp","hr","pulse","temp","spo2","bmi","height","weight"])) return "vitals";
-  if (textHas(LAB_HINT)) return "labs";
-  if (src === "note" || src === "text" || k.includes("note") || k.includes("symptom")) return "notes";
-
-  return "other";
-}
 
 export async function GET(_req: NextRequest) {
   const userId = await getUserId();
@@ -256,9 +107,9 @@ export async function GET(_req: NextRequest) {
   };
 
   for (const [rawKind, info] of latestByKind.entries()) {
-    const kind = normalizeKind(rawKind);
-    const group = classify(kind, info.meta);
-    const label = LABELS[kind] ?? startCase(kind);
+    const kind = normalizeObservationKind(rawKind);
+    const group = classifyObservation(rawKind, info.meta);
+    const label = LABELS[kind] ?? startCaseObservation(kind);
 
     let val: string | number | null = info.value;
     if (typeof val === "string" && val.length > 160) {

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -977,7 +977,9 @@ ${linkNudge}`;
 
       // ---- Unified drafting helpers (define ONCE) --------------------------
       const { getIntentStyle } = await import("@/lib/intents");
-      const baseMode = (modeState?.base ?? mode) as "doctor" | "patient" | string;
+      // Ensure baseMode is a proper Mode union (no plain string)
+      type Mode = "doctor" | "patient" | "aidoc";
+      const baseMode = (modeState?.base ?? mode) as Mode;
       const INTENT_STYLE = getIntentStyle(userText || "", baseMode);
       const DRAFT_STYLE =
         baseMode === "doctor" ? DOCTOR_DRAFT_STYLE : PATIENT_DRAFT_STYLE;

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -975,16 +975,17 @@ ${linkNudge}`;
         "Finish with one short follow-up question (≤10 words).",
       ].join("\n");
 
-      // Intent-aware structure (lightweight)
+      // ---- Unified drafting helpers (define ONCE) --------------------------
       const { getIntentStyle } = await import("@/lib/intents");
-      const INTENT_STYLE = getIntentStyle(userText || "", mode);
-
-      // Build drafting structure exactly once from the base mode
-      const DRAFT_STYLE = modeState.base === "doctor" ? DOCTOR_DRAFT_STYLE : PATIENT_DRAFT_STYLE;
-      const STRUCTURE_STYLE = [DRAFT_STYLE, INTENT_STYLE || ""].filter(Boolean).join("\n\n");
-
-      // Keep research as an additive hint, never a new template
-      const RESEARCH_STITCH = modeState.research
+      const baseMode = (modeState?.base ?? mode) as "doctor" | "patient" | string;
+      const INTENT_STYLE = getIntentStyle(userText || "", baseMode);
+      const DRAFT_STYLE =
+        baseMode === "doctor" ? DOCTOR_DRAFT_STYLE : PATIENT_DRAFT_STYLE;
+      const STRUCTURE_STYLE = [DRAFT_STYLE, INTENT_STYLE || ""]
+        .filter(Boolean)
+        .join("\n\n");
+      const researchEnabled = (modeState?.research ?? researchMode) === true;
+      const RESEARCH_STITCH = researchEnabled
         ? [
             "RESEARCH INTEGRATION:",
             "- Keep the above section headings exactly as-is.",
@@ -992,11 +993,11 @@ ${linkNudge}`;
             "- Cite inline as [1], [2] and include linked references at the end."
           ].join("\n")
         : "";
-
       const buildSystemAll = (base: string, domain?: string, adv?: string) =>
         [base, domain || "", adv || "", STRUCTURE_STYLE, RESEARCH_STITCH]
           .filter(Boolean)
           .join("\n\n");
+      // ----------------------------------------------------------------------
 
       const sys = topicHint + systemCommon + baseSys;
       const sysWithDomain = sys;

--- a/lib/aidoc/clinicalState.ts
+++ b/lib/aidoc/clinicalState.ts
@@ -1,0 +1,250 @@
+import { classifyObservation, normalizeObservationKind } from "../supabase/observationGroups";
+
+export type ClinicalState = {
+  labs: any[];
+  meds: any[];
+  conditions: any[];
+  vitals: { sbp?: number; hr?: number; spo2?: number; temp?: number };
+};
+
+export function normalizeIso(input?: any): string {
+  if (!input) return new Date().toISOString();
+  const d = new Date(input);
+  return Number.isFinite(d.getTime()) ? d.toISOString() : new Date().toISOString();
+}
+
+export function parseNumber(value: any): number | null {
+  if (value == null || value === "") return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+export function buildClinicalState(obsRows: any[], predRows: any[]): ClinicalState {
+  const labs = new Map<string, any>();
+  const meds = new Map<string, any>();
+  const conditions = new Map<string, any>();
+  const vitals: ClinicalState["vitals"] = {};
+
+  for (const row of Array.isArray(obsRows) ? obsRows : []) {
+    const meta = (row?.meta as Record<string, any>) || {};
+    const canonicalKind = normalizeObservationKind(row?.kind ?? "");
+    const group = classifyObservation(row?.kind ?? "", meta);
+    const labelRaw =
+      meta?.label ??
+      meta?.name ??
+      meta?.analyte ??
+      meta?.test_name ??
+      row?.kind ??
+      "Observation";
+    const label = String(labelRaw).trim();
+    const observedAt = normalizeIso(row?.observed_at ?? meta?.observed_at ?? row?.created_at ?? null);
+    if (group === "labs") {
+      const numeric =
+        row?.value_num != null
+          ? parseNumber(row.value_num)
+          : parseNumber((row as any)?.value ?? meta?.value ?? meta?.result);
+      const textVal =
+        row?.value_text ??
+        meta?.value ??
+        meta?.result ??
+        (numeric == null ? null : undefined);
+      const entry = {
+        name: label,
+        value: numeric ?? (textVal != null ? textVal : null),
+        unit: row?.unit ?? meta?.unit ?? null,
+        takenAt: observedAt,
+        panel: meta?.panel ?? null,
+        abnormal: meta?.abnormal ?? null,
+      };
+      const key = `${label.toLowerCase()}|${entry.unit ?? ""}`;
+      const prev = labs.get(key);
+      if (!prev || new Date(observedAt).getTime() > new Date(prev.takenAt).getTime()) {
+        labs.set(key, entry);
+      }
+    }
+
+    if (group === "medications") {
+      const dose =
+        meta?.dose ??
+        meta?.dosage ??
+        meta?.sig ??
+        (typeof row?.value_text === "string" ? row.value_text : null);
+      const entry = {
+        name: label,
+        dose: dose ? String(dose) : null,
+        since: normalizeIso(meta?.started_at ?? meta?.start_date ?? observedAt),
+        stoppedAt: meta?.stopped_at || meta?.stop_date ? normalizeIso(meta?.stopped_at ?? meta?.stop_date) : null,
+      };
+      const key = label.toLowerCase();
+      const prev = meds.get(key);
+      if (!prev || new Date(entry.since || 0).getTime() > new Date(prev.since || 0).getTime()) {
+        meds.set(key, entry);
+      }
+    }
+
+    if (group === "diagnoses") {
+      const entry = {
+        label,
+        status: meta?.status ?? (meta?.active === false ? "resolved" : "active"),
+        code: meta?.code ?? meta?.icd10 ?? meta?.icd ?? null,
+        since: normalizeIso(meta?.since ?? meta?.start_date ?? observedAt),
+      };
+      const key = label.toLowerCase();
+      const prev = conditions.get(key);
+      if (!prev || new Date(entry.since || 0).getTime() > new Date(prev.since || 0).getTime()) {
+        conditions.set(key, entry);
+      }
+    }
+
+    const kindForVitals = `${canonicalKind} ${(meta?.label ?? "")} ${(meta?.name ?? "")} ${(meta?.summary ?? "")}`
+      .toLowerCase();
+    if (
+      group === "vitals" ||
+      canonicalKind.startsWith("vitals.") ||
+      canonicalKind.includes("bp") ||
+      canonicalKind.includes("heart") ||
+      canonicalKind.includes("spo2") ||
+      canonicalKind.includes("temperature")
+    ) {
+      if (kindForVitals.includes("bp") || kindForVitals.includes("blood pressure")) {
+        const sbp = parseNumber(meta?.sbp ?? (Array.isArray(meta?.values) ? meta.values?.[0] : null));
+        if (sbp != null) vitals.sbp = sbp;
+        else if (typeof row?.value_text === "string" && row.value_text.includes("/")) {
+          const parts = row.value_text.split(/[\/\s]+/).filter(Boolean);
+          const parsed = parseNumber(parts?.[0]);
+          if (parsed != null) vitals.sbp = parsed;
+        }
+      }
+      if (
+        kindForVitals.includes("hr") ||
+        kindForVitals.includes("heart") ||
+        kindForVitals.includes("heart rate")
+      ) {
+        const hr =
+          row?.value_num != null
+            ? parseNumber(row.value_num)
+            : parseNumber(meta?.value ?? row?.value_text);
+        if (hr != null) vitals.hr = hr;
+      }
+      if (
+        kindForVitals.includes("spo2") ||
+        kindForVitals.includes("oxygen")
+      ) {
+        const spo2 =
+          row?.value_num != null
+            ? parseNumber(row.value_num)
+            : parseNumber(meta?.value ?? row?.value_text);
+        if (spo2 != null) vitals.spo2 = spo2;
+      }
+      if (kindForVitals.includes("temp") || kindForVitals.includes("temperature")) {
+        const temp =
+          row?.value_num != null
+            ? parseNumber(row.value_num)
+            : parseNumber(meta?.value ?? row?.value_text);
+        if (temp != null) vitals.temp = temp;
+      }
+    }
+  }
+
+  for (const pred of Array.isArray(predRows) ? predRows : []) {
+    const details = (pred?.details as Record<string, any>) || {};
+    const label =
+      pred?.label ??
+      pred?.name ??
+      details?.label ??
+      details?.name ??
+      null;
+    if (!label) continue;
+    const cat = String(details?.category ?? pred?.type ?? "").toLowerCase();
+    if (
+      cat &&
+      !["diagnosis", "condition", "problem", "history"].some((k) => cat.includes(k))
+    ) {
+      continue;
+    }
+    const probability =
+      typeof pred?.probability === "number"
+        ? pred.probability
+        : typeof details?.probability === "number"
+        ? details.probability
+        : null;
+    if (probability != null && probability < 0.5) continue;
+    const entry = {
+      label: String(label),
+      status: details?.status ?? (probability != null && probability < 0.7 ? "review" : "active"),
+      code: details?.code ?? details?.icd10 ?? details?.icd ?? null,
+      since: normalizeIso(details?.since ?? details?.start_date ?? pred?.created_at ?? null),
+    };
+    const key = entry.label.toLowerCase();
+    const prev = conditions.get(key);
+    if (!prev || new Date(entry.since || 0).getTime() > new Date(prev.since || 0).getTime()) {
+      conditions.set(key, entry);
+    }
+  }
+
+  return {
+    labs: Array.from(labs.values()).sort(
+      (a, b) => new Date(b.takenAt).getTime() - new Date(a.takenAt).getTime()
+    ),
+    meds: Array.from(meds.values()).sort(
+      (a, b) => new Date(b.since || 0).getTime() - new Date(a.since || 0).getTime()
+    ),
+    conditions: Array.from(conditions.values()).sort(
+      (a, b) => new Date(b.since || 0).getTime() - new Date(a.since || 0).getTime()
+    ),
+    vitals,
+  };
+}
+
+export function mergeProfileConditions(
+  clinical: ClinicalState,
+  chronic: string[],
+  predisposition: string[]
+) {
+  const map = new Map<string, any>();
+  for (const c of clinical.conditions) {
+    if (!c?.label) continue;
+    map.set(String(c.label).toLowerCase(), c);
+  }
+
+  for (const label of chronic) {
+    const trimmed = label.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    const existing = map.get(key);
+    const entry = {
+      label: trimmed,
+      status: "active",
+      code: existing?.code ?? null,
+      since: existing?.since ?? null,
+      source: existing?.source ?? "profile",
+    };
+    map.set(key, { ...existing, ...entry });
+  }
+
+  for (const label of predisposition) {
+    const trimmed = label.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (map.has(key)) {
+      const existing = map.get(key);
+      map.set(key, {
+        ...existing,
+        source: existing?.source ?? "profile",
+        status: existing?.status || "family",
+      });
+      continue;
+    }
+    map.set(key, {
+      label: trimmed,
+      status: "family",
+      code: null,
+      since: null,
+      source: "profile",
+    });
+  }
+
+  clinical.conditions = Array.from(map.values()).sort(
+    (a, b) => new Date(b.since || 0).getTime() - new Date(a.since || 0).getTime()
+  );
+}

--- a/lib/aidoc/memory.ts
+++ b/lib/aidoc/memory.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@/lib/prisma";
+import { supabaseAdmin } from "@/lib/supabase/admin";
 
 export type MemScope =
   | "aidoc.pref"    // preferences (pref_test_time, pref_med_form, diet_type, budget, etc.)
@@ -6,36 +6,177 @@ export type MemScope =
   | "aidoc.redflag"   // safety notes (e.g., chest pain at rest -> ER)
   | "aidoc.goal";     // longitudinal goals (e.g., LDL < 100 by 12 weeks)
 
+const SESSION_SCOPE = "aidoc.session";
+
+type ScopeBucket = {
+  prefs: Array<{ key: string; value: any }>;
+  facts: Array<{ key: string; value: any }>;
+  redflags: Array<{ key: string; value: any }>;
+  goals: Array<{ key: string; value: any }>;
+};
+
+function baseBuckets(): ScopeBucket {
+  return { prefs: [], facts: [], redflags: [], goals: [] };
+}
+
+function encodeValue(scope: string, key: string, value: any) {
+  return { mem_scope: scope, key, value };
+}
+
+async function findMemoryRow(params: {
+  userId: string;
+  scope: "global" | "thread";
+  threadId?: string | null;
+  key: string;
+  memScope?: string;
+}) {
+  const db = supabaseAdmin();
+  let builder = db
+    .from("medx_memory")
+    .select("id, value")
+    .eq("user_id", params.userId)
+    .eq("scope", params.scope)
+    .eq("key", params.key)
+    .limit(1);
+
+  if (params.scope === "thread") {
+    builder = builder.eq("thread_id", params.threadId ?? null);
+  } else {
+    builder = builder.is("thread_id", null);
+  }
+
+  if (params.memScope) {
+    builder = builder.eq("value->>mem_scope", params.memScope);
+  }
+
+  const { data, error } = await builder.maybeSingle();
+  if (error && error.code !== "PGRST116") throw error;
+  return data ?? null;
+}
+
 export async function wasAskedOnce(userId: string, threadId: string, key: string) {
-  return !!(await prisma.sessionFlag.findFirst({ where: { userId, threadId, key } }));
+  if (!userId || !threadId || !key) return false;
+  const row = await findMemoryRow({
+    userId,
+    scope: "thread",
+    threadId,
+    key,
+    memScope: SESSION_SCOPE,
+  });
+  return !!row;
 }
 
 export async function markAsked(userId: string, threadId: string, key: string) {
-  await prisma.sessionFlag.upsert({
-    where: { userId_threadId_key: { userId, threadId, key } },
-    create: { userId, threadId, key, value: "1" },
-    update: { value: "1" },
-  });
-}
-
-export async function getMemByThread(threadId: string) {
-  if (!threadId) return { prefs:[], facts:[], redflags:[], goals:[] };
-  const rows = await prisma.memory.findMany({ where: { threadId } });
-  const pick = (scope: MemScope) => rows.filter(r => r.scope === scope).map(r => ({ key: r.key, value: r.value }));
-  return {
-    prefs: pick("aidoc.pref"),
-    facts: pick("aidoc.fact"),
-    redflags: pick("aidoc.redflag"),
-    goals: pick("aidoc.goal"),
+  if (!userId || !threadId || !key) return;
+  const db = supabaseAdmin();
+  const scope = "thread" as const;
+  const existing = await findMemoryRow({ userId, scope, threadId, key, memScope: SESSION_SCOPE });
+  const payload = {
+    user_id: userId,
+    scope,
+    thread_id: threadId,
+    key,
+    value: encodeValue(SESSION_SCOPE, key, "1"),
+    source: "aidoc",
+    confidence: 1,
+    updated_at: new Date().toISOString(),
   };
+  if (existing?.id) {
+    await db
+      .from("medx_memory")
+      .update(payload)
+      .eq("id", existing.id)
+      .eq("user_id", userId);
+  } else {
+    await db.from("medx_memory").insert({ ...payload, created_at: new Date().toISOString() });
+  }
 }
 
-export async function upsertMem(threadId: string, scope: MemScope, key: string, value: string) {
-  await prisma.memory.upsert({
-    where: { threadId_scope_key: { threadId, scope, key } },
-    update: { value },
-    create: { threadId, scope, key, value },
+export async function getMemByThread(userId: string, threadId?: string | null) {
+  if (!userId) return baseBuckets();
+  const db = supabaseAdmin();
+
+  const [globalRes, threadRes] = await Promise.all([
+    db
+      .from("medx_memory")
+      .select("key, value")
+      .eq("user_id", userId)
+      .eq("scope", "global")
+      .is("thread_id", null)
+      .order("updated_at", { ascending: false })
+      .limit(200),
+    threadId
+      ? db
+          .from("medx_memory")
+          .select("key, value")
+          .eq("user_id", userId)
+          .eq("scope", "thread")
+          .eq("thread_id", threadId)
+          .order("updated_at", { ascending: false })
+          .limit(200)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  const buckets = baseBuckets();
+  const rows = [
+    ...(Array.isArray(globalRes.data) ? globalRes.data : []),
+    ...(Array.isArray((threadRes as any).data) ? (threadRes as any).data : []),
+  ];
+
+  for (const row of rows) {
+    const val: any = row?.value ?? {};
+    const memScope = typeof val?.mem_scope === "string" ? (val.mem_scope as MemScope) : null;
+    const memKey = (val && typeof val.key === "string") ? val.key : row.key;
+    const memVal = val?.value ?? val;
+    if (!memScope || !memKey) continue;
+    if (memScope === "aidoc.pref") buckets.prefs.push({ key: memKey, value: memVal });
+    else if (memScope === "aidoc.fact") buckets.facts.push({ key: memKey, value: memVal });
+    else if (memScope === "aidoc.redflag") buckets.redflags.push({ key: memKey, value: memVal });
+    else if (memScope === "aidoc.goal") buckets.goals.push({ key: memKey, value: memVal });
+  }
+
+  return buckets;
+}
+
+export async function upsertMem(
+  userId: string,
+  threadId: string | null | undefined,
+  scope: MemScope,
+  key: string,
+  value: any
+) {
+  if (!userId || !key) return;
+  const db = supabaseAdmin();
+  const isThread = Boolean(threadId);
+  const sbScope: "thread" | "global" = isThread ? "thread" : "global";
+  const existing = await findMemoryRow({
+    userId,
+    scope: sbScope,
+    threadId: isThread ? threadId : null,
+    key,
+    memScope: scope,
   });
+  const payload = {
+    user_id: userId,
+    scope: sbScope,
+    thread_id: isThread ? threadId : null,
+    key,
+    value: encodeValue(scope, key, value),
+    source: "aidoc",
+    confidence: 0.9,
+    updated_at: new Date().toISOString(),
+  };
+  if (existing?.id) {
+    await db
+      .from("medx_memory")
+      .update(payload)
+      .eq("id", existing.id)
+      .eq("user_id", userId);
+  } else {
+    await db
+      .from("medx_memory")
+      .insert({ ...payload, created_at: new Date().toISOString() });
+  }
 }
 
 export function memLookup(mem: {prefs:any[]}, key: string) {

--- a/lib/supabase/observationGroups.ts
+++ b/lib/supabase/observationGroups.ts
@@ -1,0 +1,291 @@
+export type ObservationGroupKey =
+  | "vitals"
+  | "labs"
+  | "imaging"
+  | "medications"
+  | "diagnoses"
+  | "procedures"
+  | "immunizations"
+  | "notes"
+  | "other";
+
+export const OBSERVATION_LABELS: Record<string, string> = {
+  bp: "BP",
+  hr: "HR",
+  bmi: "BMI",
+  hba1c: "HbA1c",
+  fasting_glucose: "Fasting Glucose",
+  egfr: "eGFR",
+  alt: "ALT",
+  ast: "AST",
+  alp: "ALP",
+  ggt: "GGT",
+  total_bilirubin: "Bilirubin Total",
+  direct_bilirubin: "Bilirubin Direct",
+  indirect_bilirubin: "Bilirubin Indirect",
+  hemoglobin: "Hemoglobin",
+  wbc: "WBC",
+  platelets: "Platelets",
+  esr: "ESR",
+  uibc: "UIBC",
+  tibc: "TIBC",
+  transferrin_saturation: "Transferrin Saturation",
+  total_cholesterol: "Total Cholesterol",
+  triglycerides: "Triglycerides",
+  ldl: "LDL",
+  hdl: "HDL",
+  vitamin_d: "Vitamin D",
+  vitamin_b12: "Vitamin B12",
+  creatinine: "Serum Creatinine",
+  lipase: "Serum Lipase",
+  amylase: "Serum Amylase",
+  fsh: "FSH",
+  lh: "LH",
+  rheumatoid_factor: "Rheumatoid Factor",
+  rbc_count: "Erythrocyte Count",
+};
+
+const KIND_CATEGORY_OVERRIDES: Record<string, ObservationGroupKey> = {
+  rbc_count: "labs",
+  hemoglobin: "labs",
+  wbc: "labs",
+  platelets: "labs",
+  esr: "labs",
+  uibc: "labs",
+  tibc: "labs",
+  transferrin_saturation: "labs",
+  egfr: "labs",
+  creatinine: "labs",
+  fasting_glucose: "labs",
+  hba1c: "labs",
+  total_cholesterol: "labs",
+  triglycerides: "labs",
+  ldl: "labs",
+  hdl: "labs",
+  total_bilirubin: "labs",
+  direct_bilirubin: "labs",
+  indirect_bilirubin: "labs",
+  alt: "labs",
+  ast: "labs",
+  alp: "labs",
+  ggt: "labs",
+  vitamin_d: "labs",
+  vitamin_b12: "labs",
+  lipase: "labs",
+  amylase: "labs",
+  fsh: "labs",
+  lh: "labs",
+  rheumatoid_factor: "labs",
+  bp: "vitals",
+  hr: "vitals",
+  bmi: "vitals",
+  height: "vitals",
+  weight: "vitals",
+  spo2: "vitals",
+  pulse: "vitals",
+};
+
+const IMG_WORDS = [
+  "xray",
+  "xr",
+  "cxr",
+  "ct",
+  "mri",
+  "usg",
+  "ultrasound",
+  "echo",
+  "imaging",
+];
+
+const RX_WORDS = [
+  "med",
+  "rx",
+  "drug",
+  "dose",
+  "tablet",
+  "capsule",
+  "syrup",
+  "injection",
+  "prescription",
+  "therapy",
+  "medication",
+];
+
+const LAB_HINTS = [
+  "glucose",
+  "cholesterol",
+  "triglycer",
+  "hba1c",
+  "egfr",
+  "creatinine",
+  "bun",
+  "bilirubin",
+  "ast",
+  "alt",
+  "alp",
+  "ggt",
+  "hb",
+  "hemoglobin",
+  "wbc",
+  "platelet",
+  "esr",
+  "ferritin",
+  "tibc",
+  "uibc",
+  "transferrin",
+  "sodium",
+  "potassium",
+  "vitamin",
+  "lipase",
+  "amylase",
+  "fsh",
+  "lh",
+  "rheumatoid",
+];
+
+const CONDITION_HINTS = [
+  "diagnosis",
+  "diagnoses",
+  "condition",
+  "conditions",
+  "problem",
+  "problems",
+  "disease",
+  "hx",
+  "fhx",
+  "family history",
+  "family_history",
+  "history",
+  "chronic",
+];
+
+const VITAL_HINTS = [
+  "bp",
+  "blood_pressure",
+  "heart_rate",
+  "hr",
+  "pulse",
+  "spo2",
+  "oxygen",
+  "resp",
+  "rr",
+  "temperature",
+  "temp",
+  "vital",
+];
+
+const NOTE_HINTS = ["note", "notes", "symptom", "symptoms", "observation"];
+
+const IMMUNIZATION_HINTS = ["vaccine", "immunization", "immunisations", "booster"];
+
+const PROCEDURE_HINTS = ["procedure", "surgery", "operation"];
+
+function lower(value: any) {
+  return typeof value === "string" ? value.toLowerCase() : String(value ?? "").toLowerCase();
+}
+
+export function normalizeObservationKind(raw: string) {
+  const base = String(raw || "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "_");
+
+  if (["erythrocyte_count", "rbc", "rbc_count"].includes(base)) return "rbc_count";
+  if (["total_chol", "cholesterol", "cholesterol_total"].includes(base)) {
+    return "total_cholesterol";
+  }
+  if (["bilirubin", "tbil", "tbil_total"].includes(base)) return "total_bilirubin";
+  if (["vit_b12", "b12"].includes(base)) return "vitamin_b12";
+  if (["vitamin_d3", "25_oh_vitamin_d", "25-oh-vitamin-d"].includes(base)) {
+    return "vitamin_d";
+  }
+  if (["serum_creatinine"].includes(base)) return "creatinine";
+  if (["rf", "ra_factor"].includes(base)) return "rheumatoid_factor";
+  return base;
+}
+
+export function startCaseObservation(value: string) {
+  return value.replaceAll("_", " ").replace(/(^|\s)\S/g, (c) => c.toUpperCase());
+}
+
+export function classifyObservation(
+  rawKind: string,
+  meta: Record<string, any> | null | undefined
+): ObservationGroupKey {
+  const kind = normalizeObservationKind(rawKind);
+  const metaObj = meta ?? {};
+  if (KIND_CATEGORY_OVERRIDES[kind]) return KIND_CATEGORY_OVERRIDES[kind];
+
+  const catParts = [
+    metaObj.category,
+    metaObj.type,
+    metaObj.group,
+    metaObj.source_type,
+  ]
+    .filter((v) => v != null)
+    .map(lower);
+
+  const text = [
+    kind,
+    metaObj.category,
+    metaObj.type,
+    metaObj.group,
+    metaObj.label,
+    metaObj.name,
+    metaObj.summary,
+    metaObj.notes,
+  ]
+    .filter((v) => v != null)
+    .map(lower)
+    .join(" ");
+
+  const modality = lower(metaObj.modality);
+
+  const catHas = (...needles: string[]) =>
+    catParts.some((c) => needles.some((needle) => c.includes(needle)));
+
+  const textHas = (needles: string[]) =>
+    needles.some((needle) => text.includes(needle));
+
+  if (catHas("vital")) return "vitals";
+  if (catHas("lab")) return "labs";
+  if (catHas("imaging") || catHas("radiology")) return "imaging";
+  if (catHas("medication", "medications", "prescription", "rx", "meds", "drug")) {
+    return "medications";
+  }
+  if (
+    catHas(
+      "diagnosis",
+      "diagnoses",
+      "condition",
+      "conditions",
+      "problem",
+      "problems",
+      "history",
+      "family_history",
+      "fhx",
+      "chronic"
+    )
+  ) {
+    return "diagnoses";
+  }
+  if (catHas("procedure")) return "procedures";
+  if (catHas("immunization", "vaccine")) return "immunizations";
+  if (catHas("note", "symptom")) return "notes";
+
+  const looksImaging =
+    IMG_WORDS.some((word) => text.includes(word) || modality.includes(word)) &&
+    (kind.includes("report") || text.includes("report"));
+  if (looksImaging) return "imaging";
+
+  if (textHas(RX_WORDS)) return "medications";
+  if (textHas(VITAL_HINTS)) return "vitals";
+  if (textHas(LAB_HINTS)) return "labs";
+  if (textHas(CONDITION_HINTS)) return "diagnoses";
+  if (textHas(IMMUNIZATION_HINTS)) return "immunizations";
+  if (textHas(PROCEDURE_HINTS)) return "procedures";
+  if (textHas(NOTE_HINTS)) return "notes";
+
+  return "other";
+}
+

--- a/test/aidoc.clinicalState.test.ts
+++ b/test/aidoc.clinicalState.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { buildClinicalState, mergeProfileConditions } from "../lib/aidoc/clinicalState";
+import { buildAiDocPrompt } from "../lib/ai/prompts/aidoc";
+
+describe("AI Doc clinical state helpers", () => {
+  it("extracts labs, medications, and conditions from timeline observations", () => {
+    const observations = [
+      {
+        kind: "labs.hba1c",
+        observed_at: "2024-05-01T10:00:00.000Z",
+        value_num: null,
+        value_text: "8.2",
+        unit: "%",
+        meta: { category: "labs", label: "HbA1c" },
+      },
+      {
+        kind: "rx.metformin",
+        observed_at: "2024-04-15T09:00:00.000Z",
+        meta: { category: "meds", label: "Metformin", dose: "500 mg BID" },
+      },
+      {
+        kind: "dx.hypertension",
+        observed_at: "2024-03-20T08:00:00.000Z",
+        meta: { category: "diagnoses", label: "Hypertension" },
+      },
+    ];
+
+    const state = buildClinicalState(observations as any, []);
+
+    expect(state.labs.map((l) => l.name)).toContain("HbA1c");
+    expect(state.meds[0]).toMatchObject({ name: "Metformin", dose: "500 mg BID" });
+    expect(state.conditions.map((c) => c.label)).toContain("Hypertension");
+  });
+
+  it("recognizes condition rows saved with supabase profile categories", () => {
+    const observations = [
+      {
+        kind: "condition.chronic_kidney_disease",
+        observed_at: "2023-12-01T00:00:00.000Z",
+        meta: { category: "conditions", label: "Chronic Kidney Disease", status: "active" },
+      },
+      {
+        kind: "history.fhx_breast_cancer",
+        observed_at: "2023-12-01T00:00:00.000Z",
+        meta: {
+          category: "family_history",
+          label: "Breast cancer",
+          status: "family",
+          group: "fhx",
+        },
+      },
+    ];
+
+    const state = buildClinicalState(observations as any, []);
+
+    expect(state.conditions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Chronic Kidney Disease", status: "active" }),
+        expect.objectContaining({ label: "Breast cancer", status: "family" }),
+      ])
+    );
+  });
+
+  it("merges chronic and family history conditions", () => {
+    const state = {
+      labs: [],
+      meds: [],
+      conditions: [
+        {
+          label: "Type 2 Diabetes",
+          status: "active",
+          code: null,
+          since: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      vitals: {},
+    };
+
+    mergeProfileConditions(state as any, ["Hypertension"], ["Breast cancer"]);
+
+    expect(state.conditions.find((c: any) => c.label === "Hypertension")?.status).toBe(
+      "active",
+    );
+    expect(state.conditions.find((c: any) => c.label === "Breast cancer")?.status).toBe(
+      "family",
+    );
+  });
+
+  it("includes family history in the AI Doc prompt", () => {
+    const prompt = buildAiDocPrompt({
+      profile: { name: "Test", age: 55, sex: "female", pregnant: "no" },
+      labs: [],
+      meds: [],
+      conditions: [
+        { label: "Hypertension", status: "active" },
+        { label: "Breast cancer", status: "family" },
+      ],
+    });
+
+    expect(prompt).toContain("Active Conditions: Hypertension");
+    expect(prompt).toContain("Family History: Breast cancer");
+  });
+});


### PR DESCRIPTION
## Summary
- unify the ChatPane drafting helper logic so intent, structure, and research hints are computed once from the resolved mode state
- export a literal Next.js runtime value for the AI Doc chat route to avoid build-time warnings

## Testing
- `npm run build` *(fails: Next.js cannot patch swc dependencies without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8a841204832fbabd5ab274a548b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - AI Doc now includes a clear plan, soft alerts, and triggered rules in chat responses.
  - Patient Snapshot shows Active Conditions and a new Family History section.
  - Improved patient initialization: auto-hydrates demographics, symptoms, allergies, and meds.
  - Research hints in prompts are now opt-in based on settings.

- Refactor
  - Migrated data and memory storage to Supabase for more consistent, batched saves.
  - Centralized observation normalization and grouping for consistent labels and categories.
  - Unified drafting logic for system prompts across modes.

- Tests
  - Added coverage for clinical state extraction, condition merging, and prompt output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->