### PR TITLE
Integrate LLM predictions pipeline

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,7 @@
 OPENPASS_API_KEY=your_key_here
+OPENAI_API_KEY=sk-...
+OPENAI_TEXT_MODEL=gpt-5
+LLM_API_KEY=groq-...
+LLM_MODEL_ID=llama-3.1-70b
+LLM_BASE_URL=https://api.groq.com/openai/v1
+NEXT_PUBLIC_BASE_URL=https://your-domain.vercel.app

--- a/app/api/predictions/compute/route.ts
+++ b/app/api/predictions/compute/route.ts
@@ -2,64 +2,406 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase/admin";
-import { deriveInputs } from "@/lib/predict/derive";
-import { scoreRisk } from "@/lib/predict/score";
 import { getUserId } from "@/lib/getUserId";
+import LLM, { type Msg } from "@/lib/LLM";
+
+const MODEL_NAME = process.env.LLM_MODEL_ID || "llama-3.1-70b";
 
 export async function POST(req: NextRequest) {
   try {
     const userId = await getUserId();
     if (!userId) return new NextResponse("Unauthorized", { status: 401 });
 
-    const { threadId } = await req.json().catch(() => ({} as any));
-    if (!threadId) return NextResponse.json({ error: "threadId required" }, { status: 400 });
-
-    // 1) derive inputs from latest observations (snake_case fields)
-    const inputs = await deriveInputs(userId, threadId);
-
-    // 2) score
-    const result = scoreRisk(inputs);
-
-    // 3) save prediction
-    const sb = supabaseAdmin();
-    const { data: pred, error: perr } = await sb
-      .from("predictions")
-      .insert({
-        user_id: userId,
-        thread_id: threadId,
-        model: "medx-heuristic-v1",
-        risk_score: result.riskScore,
-        band: result.band,
-        factors: result.factors,
-        recommendations: result.recommendations,
-        inputs_snapshot: inputs,
-      })
-      .select("id, created_at, risk_score, band")
-      .single();
-    if (perr) throw new Error(perr.message);
-
-    // 4) alert on thresholds
-    if (result.band === "Red" || (result.band === "Yellow" && result.riskScore >= 50)) {
-      await sb.from("alerts").insert({
-        user_id: userId,
-        thread_id: threadId,
-        severity: result.band === "Red" ? "high" : "medium",
-        title: result.band === "Red" ? "High Risk Alert" : "Moderate Risk Alert",
-        body: `Latest risk score ${result.riskScore} (${result.band}). Review timeline.`,
-        meta: { factors: result.factors },
-      });
+    const { threadId = "" } = (await req.json().catch(() => ({}))) as { threadId?: string };
+    if (!threadId) {
+      return NextResponse.json({ ok: false, error: "threadId required" }, { status: 400 });
     }
 
-    // Map to UI shape on response (optional)
-    const out = {
-      id: pred.id,
-      createdAt: pred.created_at,
-      riskScore: pred.risk_score,
-      band: pred.band,
-    };
+    const snapshot = await loadSnapshot(userId);
+    if (!snapshot) {
+      throw new Error("No patient data available to compute risk summary.");
+    }
 
-    return NextResponse.json({ ok: true, prediction: out, inputs, result });
-  } catch (e: any) {
-    return NextResponse.json({ error: e?.message || "compute failed" }, { status: 500 });
+    const { systemPrompt, instruction, userBlock } = buildPrompts(snapshot);
+    const structured = await LLM.validateJson(systemPrompt, instruction, userBlock);
+
+    const summary = await generateSummary({ snapshot, structured });
+
+    const supa = supabaseAdmin();
+    const inserted = await savePrediction({
+      supa,
+      userId,
+      threadId,
+      snapshot,
+      structured,
+      summary,
+    });
+
+    await recordTimelineEvent({ supa, userId, threadId, summary, structured });
+
+    return NextResponse.json({
+      ok: true,
+      prediction: inserted,
+      structured,
+      summary,
+      snapshot,
+    });
+  } catch (err: any) {
+    console.error("[predictions/compute]", err);
+    const message = err?.message || "compute failed";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+type SupaClient = ReturnType<typeof supabaseAdmin>;
+
+type Snapshot = {
+  profile: PatientProfile;
+  observations: ObservationLine[];
+  highlights: string[];
+};
+
+type PatientProfile = {
+  name: string | null;
+  dob: string | null;
+  age: number | null;
+  sex: string | null;
+  blood_group: string | null;
+  chronic_conditions: string[];
+  conditions_predisposition: string[];
+};
+
+type ObservationLine = {
+  label: string;
+  value: string;
+  observedAt: string;
+  category: string;
+};
+
+async function loadSnapshot(userId: string): Promise<Snapshot | null> {
+  const supa = supabaseAdmin();
+  const [{ data: profileRow, error: profileErr }, { data: obsRows, error: obsErr }] = await Promise.all([
+    supa
+      .from("profiles")
+      .select("full_name,dob,sex,blood_group,conditions_predisposition,chronic_conditions")
+      .eq("id", userId)
+      .maybeSingle(),
+    supa
+      .from("observations")
+      .select("kind,name,value_num,value_text,unit,meta,details,observed_at,created_at")
+      .eq("user_id", userId)
+      .order("observed_at", { ascending: false })
+      .limit(120),
+  ]);
+
+  if (profileErr) throw new Error(profileErr.message);
+  if (obsErr) throw new Error(obsErr.message);
+
+  if (!profileRow && !obsRows?.length) return null;
+
+  const profile = normalizeProfile(profileRow || {});
+  const observations = buildObservationLines(obsRows || []);
+  const highlights = buildHighlights(obsRows || []);
+
+  return { profile, observations, highlights };
+}
+
+function normalizeProfile(row: any): PatientProfile {
+  const chronic = toArray(row?.chronic_conditions);
+  const predis = toArray(row?.conditions_predisposition);
+  const dob = typeof row?.dob === "string" ? row.dob : null;
+  const age = dob ? calcAge(dob) : null;
+  return {
+    name: typeof row?.full_name === "string" ? row.full_name : null,
+    dob,
+    age,
+    sex: typeof row?.sex === "string" ? row.sex : null,
+    blood_group: typeof row?.blood_group === "string" ? row.blood_group : null,
+    chronic_conditions: chronic,
+    conditions_predisposition: predis,
+  };
+}
+
+function toArray(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String).filter(Boolean);
+  if (typeof value === "string" && value.trim()) {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) return parsed.map(String).filter(Boolean);
+    } catch {
+      return value.split(/[,\n]/).map(s => s.trim()).filter(Boolean);
+    }
+  }
+  return [];
+}
+
+function calcAge(dob: string): number | null {
+  const d = new Date(dob);
+  if (Number.isNaN(d.getTime())) return null;
+  const diff = Date.now() - d.getTime();
+  return Math.max(0, Math.floor(diff / (365.25 * 24 * 3600 * 1000)));
+}
+
+type RawObservation = {
+  kind?: string | null;
+  name?: string | null;
+  value_num?: number | null;
+  value_text?: string | null;
+  unit?: string | null;
+  meta?: any;
+  details?: any;
+  observed_at?: string | null;
+  created_at?: string | null;
+};
+
+function buildObservationLines(rows: RawObservation[]): ObservationLine[] {
+  const sorted = [...rows].sort((a, b) =>
+    new Date(b?.observed_at || b?.created_at || 0).getTime() -
+    new Date(a?.observed_at || a?.created_at || 0).getTime()
+  );
+
+  const MAX = 60;
+  const lines: ObservationLine[] = [];
+  for (const row of sorted) {
+    if (lines.length >= MAX) break;
+    const label = labelFor(row);
+    const value = valueFor(row);
+    const observedAt = row?.observed_at || row?.created_at || new Date().toISOString();
+    const category = inferCategory(row);
+    if (!label || !value) continue;
+    lines.push({ label, value, observedAt, category });
+  }
+  return lines;
+}
+
+function labelFor(row: RawObservation): string | null {
+  const meta = row?.meta || row?.details || {};
+  return (
+    row?.name ||
+    row?.kind ||
+    meta?.label ||
+    meta?.name ||
+    meta?.analyte ||
+    meta?.test_name ||
+    meta?.title ||
+    null
+  );
+}
+
+function valueFor(row: RawObservation): string | null {
+  const meta = row?.meta || row?.details || {};
+  const raw =
+    row?.value_num ??
+    row?.value_text ??
+    meta?.value_num ??
+    meta?.value ??
+    meta?.summary ??
+    meta?.text ??
+    null;
+  const unit = row?.unit || meta?.unit || "";
+  if (raw == null) return null;
+  if (typeof raw === "number") return `${raw}${unit ? ` ${unit}` : ""}`;
+  const txt = String(raw).trim();
+  return txt ? `${txt}${unit ? ` ${unit}` : ""}` : null;
+}
+
+function inferCategory(row: RawObservation): string {
+  const meta = row?.meta || row?.details || {};
+  const cat = typeof meta?.category === "string" ? meta.category.toLowerCase() : "";
+  if (cat) return cat;
+  const kind = `${row?.kind || ""}`.toLowerCase();
+  if (/(lab|glucose|chol|hba1c|egfr|bilirubin|ldl|hdl|vitamin)/.test(kind)) return "lab";
+  if (/(note|symptom|complaint)/.test(kind)) return "note";
+  if (/(med|rx|drug|tablet|capsule)/.test(kind)) return "medication";
+  if (/(imaging|ct|mri|xray|ultrasound|echo)/.test(kind)) return "imaging";
+  return cat || "observation";
+}
+
+function buildHighlights(rows: RawObservation[]): string[] {
+  const pick = (rx: RegExp) =>
+    [...rows]
+      .filter(r => {
+        const text = `${r?.kind || ""} ${r?.name || ""} ${JSON.stringify(r?.meta || {})}`.toLowerCase();
+        return rx.test(text);
+      })
+      .sort((a, b) =>
+        new Date(b?.observed_at || b?.created_at || 0).getTime() -
+        new Date(a?.observed_at || a?.created_at || 0).getTime()
+      )[0];
+
+  const line = (label: string, row: RawObservation | undefined) => {
+    if (!row) return null;
+    const val = valueFor(row);
+    if (!val) return null;
+    const when = row?.observed_at || row?.created_at || "";
+    const date = when ? new Date(when).toISOString().slice(0, 10) : "";
+    return `${label}: ${val}${date ? ` (${date})` : ""}`;
+  };
+
+  const highlights = [
+    line("HbA1c", pick(/\bhba1c\b/)),
+    line("Fasting glucose", pick(/fasting|fpg|fbs|glucose/)),
+    line("LDL", pick(/\bldl\b/)),
+    line("eGFR", pick(/\begfr\b/)),
+    line("Vitamin D", pick(/vitamin\s*d/)),
+  ].filter(Boolean) as string[];
+
+  return highlights.slice(0, 5);
+}
+
+function buildPrompts(snapshot: Snapshot) {
+  const { profile, observations, highlights } = snapshot;
+
+  const profileLines = [
+    profileLine(profile),
+    profile.chronic_conditions.length
+      ? `Chronic conditions: ${profile.chronic_conditions.join(", ")}`
+      : "Chronic conditions: none recorded",
+    profile.conditions_predisposition.length
+      ? `Family history / predisposition: ${profile.conditions_predisposition.join(", ")}`
+      : "Family history / predisposition: none recorded",
+  ];
+
+  const highlightLines = highlights.length
+    ? [`Key recent labs:`, ...highlights.map(h => `- ${h}`)]
+    : [];
+
+  const obsLines = observations.map(o => `- [${o.category}] ${o.label}: ${o.value} (${o.observedAt})`);
+
+  const userBlock = [
+    profileLines.join("\n"),
+    highlightLines.join("\n"),
+    obsLines.length ? "Observations:" : "",
+    ...obsLines,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const systemPrompt = [
+    "You are a clinical reasoning assistant. Analyze the patient snapshot and produce a structured overview.",
+    "Use only the provided data. If data is missing or stale, acknowledge the gap.",
+    "Return JSON that matches the AiDocOut schema with patient and doctor replies plus observations.",
+    "Ensure medications/conditions/labs saved arrays are concise and deduplicated.",
+  ].join("\n");
+
+  const instruction =
+    "Return AiDocOut JSON with {reply_patient, reply_doctor, observations:{short,long}, save:{medications,conditions,labs}}.";
+
+  return { systemPrompt, instruction, userBlock };
+}
+
+function profileLine(profile: PatientProfile) {
+  const parts = [] as string[];
+  if (profile.name) parts.push(`Name: ${profile.name}`);
+  if (profile.age != null) parts.push(`Age: ${profile.age}`);
+  if (profile.sex) parts.push(`Sex: ${profile.sex}`);
+  if (profile.blood_group) parts.push(`Blood group: ${profile.blood_group}`);
+  return parts.length ? parts.join(", ") : "Demographics: not recorded";
+}
+
+async function generateSummary({
+  snapshot,
+  structured,
+}: {
+  snapshot: Snapshot;
+  structured: any;
+}): Promise<string> {
+  const profile = profileLine(snapshot.profile);
+  const highlightLines = snapshot.highlights.length
+    ? snapshot.highlights.map(h => `• ${h}`).join("\n")
+    : "• No recent labs captured.";
+
+  const messages: Msg[] = [
+    {
+      role: "system",
+      content: "You are a clinical summarizer. Produce a concise 4–6 sentence risk overview using the structured JSON provided.",
+    },
+    {
+      role: "user",
+      content: [
+        `Patient profile: ${profile}`,
+        "Structured JSON:",
+        JSON.stringify(structured, null, 2),
+        "Key labs:",
+        highlightLines,
+      ].join("\n\n"),
+    },
+  ];
+
+  const text = await LLM.finalize(messages);
+  return text || "AI summary unavailable.";
+}
+
+async function savePrediction({
+  supa,
+  userId,
+  threadId,
+  snapshot,
+  structured,
+  summary,
+}: {
+  supa: SupaClient;
+  userId: string;
+  threadId: string;
+  snapshot: Snapshot;
+  structured: any;
+  summary: string;
+}) {
+  const payload: any = {
+    user_id: userId,
+    thread_id: threadId,
+    model: MODEL_NAME,
+    name: "AI Risk Summary",
+    risk_score: null,
+    band: null,
+    factors: null,
+    recommendations: null,
+    probability: null,
+    inputs_snapshot: snapshot,
+    details: {
+      structured,
+      summary,
+    },
+    summary,
+  };
+
+  const { data, error } = await supa
+    .from("predictions")
+    .insert(payload)
+    .select("id, created_at, summary, details")
+    .single();
+
+  if (error) throw new Error(error.message);
+  return data;
+}
+
+async function recordTimelineEvent({
+  supa,
+  userId,
+  threadId,
+  summary,
+  structured,
+}: {
+  supa: SupaClient;
+  userId: string;
+  threadId: string;
+  summary: string;
+  structured: any;
+}) {
+  try {
+    await supa.from("observations").insert({
+      user_id: userId,
+      thread_id: threadId,
+      kind: "ai_summary",
+      name: "AI Risk Summary",
+      value_text: summary,
+      observed_at: new Date().toISOString(),
+      meta: {
+        source: "predictions.compute",
+        structured,
+      },
+    });
+  } catch (err) {
+    console.warn("[predictions/compute] timeline insert failed", err);
   }
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -993,32 +993,12 @@ ${linkNudge}`;
 
       // Intent-aware structure (lightweight)
       const { getIntentStyle } = await import("@/lib/intents");
-      const INTENT_STYLE = getIntentStyle(messageText || "", mode);
 
-      // Build drafting structure exactly once from the base mode
-      const DRAFT_STYLE = mode === "doctor" ? DOCTOR_DRAFT_STYLE : PATIENT_DRAFT_STYLE;
-      const STRUCTURE_STYLE = [DRAFT_STYLE, INTENT_STYLE || ""].filter(Boolean).join("\n\n");
-
-      // Keep research as an additive hint, never a new template
-      const RESEARCH_STITCH = researchMode
-        ? [
-            "RESEARCH INTEGRATION:",
-            "- Keep the above section headings exactly as-is.",
-            "- Add 1–2 bullets labeled **Research says:** where relevant.",
-            "- Cite inline as [1], [2] and include linked references at the end."
-          ].join("\n")
-        : "";
-
-      const buildSystemAll = (base: string, domain?: string, adv?: string) =>
-        [base, domain || "", adv || "", STRUCTURE_STYLE, RESEARCH_STITCH]
-          .filter(Boolean)
-          .join("\n\n");
-
-      // Build drafting structure exactly once from the base mode
+      // Build drafting structure once from the base mode
       const DRAFT_STYLE = modeState.base === "doctor" ? DOCTOR_DRAFT_STYLE : PATIENT_DRAFT_STYLE;
+      const INTENT_STYLE = getIntentStyle(messageText || "", mode);
       const STRUCTURE_STYLE = [DRAFT_STYLE, INTENT_STYLE || ""].filter(Boolean).join("\n\n");
 
-      // Keep research as an additive hint, never a new template
       const RESEARCH_STITCH = modeState.research
         ? [
             "RESEARCH INTEGRATION:",

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -69,6 +69,28 @@ export default function MedicalProfile() {
   };
   useEffect(() => { loadSummary(); }, []);
 
+  const onRecomputeRisk = async () => {
+    const btn = document.getElementById("recompute-risk-btn") as HTMLButtonElement | null;
+    if (btn) btn.disabled = true;
+    try {
+      const res = await fetch("/api/predictions/compute", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ threadId: "med-profile" })
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok || body?.ok === false) {
+        throw new Error(body?.error || `HTTP ${res.status}`);
+      }
+      await loadSummary();
+    } catch (err: any) {
+      console.error("Recompute failed:", err?.message || err);
+      alert(`Recompute failed: ${err?.message || String(err)}`);
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  };
+
   const prof = data?.profile ?? null;
   const [bootstrapped, setBootstrapped] = useState(false);
   const [fullName, setFullName] = useState("");
@@ -419,10 +441,8 @@ export default function MedicalProfile() {
               className="text-xs px-2 py-1 rounded-md border"
             >Discuss & Correct in Chat</button>
             <button
-              onClick={async () => {
-                await fetch("/api/alerts/recompute", { method: "POST" });
-                await loadSummary();
-              }}
+              id="recompute-risk-btn"
+              onClick={onRecomputeRisk}
               className="text-xs px-2 py-1 rounded-md border"
             >Recompute Risk</button>
           </div>

--- a/lib/LLM/index.ts
+++ b/lib/LLM/index.ts
@@ -1,0 +1,72 @@
+import OpenAI from "openai";
+
+export type Msg = { role: "system" | "user" | "assistant"; content: string };
+
+function openaiClient() {
+  return new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+}
+function groqClient() {
+  return new OpenAI({
+    apiKey: process.env.LLM_API_KEY!,
+    baseURL: process.env.LLM_BASE_URL || "https://api.groq.com/openai/v1"
+  });
+}
+
+export const AiDocJsonSchema = {
+  name: "AiDocOut",
+  schema: {
+    type: "object",
+    properties: {
+      reply_patient: { type: "string" },
+      reply_doctor: { type: "string" },
+      observations: {
+        type: "object",
+        properties: {
+          short: { type: "string" },
+          long: { type: "string" }
+        },
+        required: ["short", "long"]
+      },
+      save: {
+        type: "object",
+        properties: {
+          medications: { type: "array", items: { type: "object" } },
+          conditions: { type: "array", items: { type: "object" } },
+          labs: { type: "array", items: { type: "object" } }
+        },
+        required: ["medications", "conditions", "labs"]
+      }
+    },
+    required: ["observations", "save"]
+  }
+};
+
+export async function validateJson(system: string, instruction: string, user: string): Promise<any> {
+  const client = openaiClient();
+  const model = process.env.OPENAI_TEXT_MODEL || "gpt-5";
+  const r = await client.chat.completions.create({
+    model,
+    temperature: 0.2,
+    messages: [
+      { role: "system", content: system },
+      { role: "system", content: instruction },
+      { role: "user", content: user }
+    ],
+    response_format: { type: "json_schema", json_schema: AiDocJsonSchema }
+  });
+  try {
+    return JSON.parse(r.choices?.[0]?.message?.content ?? "{}");
+  } catch {
+    return { reply_patient: "", reply_doctor: "", observations: { short: "", long: "" }, save: { medications: [], conditions: [], labs: [] } };
+  }
+}
+
+export async function finalize(messages: Msg[]): Promise<string> {
+  const client = groqClient();
+  const model = process.env.LLM_MODEL_ID || "llama-3.1-70b";
+  const r = await client.chat.completions.create({ model, temperature: 0.1, messages });
+  return r.choices?.[0]?.message?.content?.trim() || "";
+}
+
+const LLM = { validateJson, finalize };
+export default LLM;


### PR DESCRIPTION
## Summary
- clean up duplicate drafting prompt logic in ChatPane and use mode state consistently
- add reusable OpenAI/Groq adapter for schema validation and finalization
- rebuild predictions compute route to assemble patient snapshot, call LLMs, and persist summaries
- wire medical profile recompute button to new endpoint and document required env vars

## Testing
- `npm run build` *(fails: Next.js lockfile patch requires network access in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cb5232a254832f9dce65eb39c880e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - AI-powered patient snapshot analysis generates structured insights and a readable summary in predictions.
  - “Recompute Risk” in Medical Profile now triggers end-to-end AI analysis and refreshes the summary.
  - Timeline entries are recorded for each AI summary.

- Improvements
  - Clearer, standardized success/error responses with better in-app feedback.
  - Refined chat prompting for more role-aware, coherent drafts.
  - Enhanced loading/disabled states and error handling during recompute.

- Chores
  - Added configuration for AI providers and public base URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->