### PR TITLE
Fix recompute risk workflow and ensure prediction results emit

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -156,7 +156,11 @@ export async function POST(req: Request) {
             assumeAdultIfUnknown: FLAGS.ASSUME_ADULT,
             maxReviewPasses: FLAGS.MAX_REVIEW,
           });
-          return NextResponse.json(result, { status: 200 });
+          const payload =
+            result && typeof result === "object"
+              ? { ...result, obsIds: doctorMode ? [] : obsIds }
+              : { result, obsIds: doctorMode ? [] : obsIds };
+          return NextResponse.json(payload, { status: 200 });
         }
 
         if (FLAGS.DUAL && FLAGS.LLM && FLAGS.USE_CALC && category !== "lab_report") {
@@ -170,7 +174,11 @@ export async function POST(req: Request) {
             assumeAdultIfUnknown: FLAGS.ASSUME_ADULT,
             maxReviewPasses: FLAGS.MAX_REVIEW,
           });
-          return NextResponse.json(result, { status: 200 });
+          const payload =
+            result && typeof result === "object"
+              ? { ...result, obsIds: doctorMode ? [] : obsIds }
+              : { result, obsIds: doctorMode ? [] : obsIds };
+          return NextResponse.json(payload, { status: 200 });
         }
 
         const basePrompt = promptForCategory(category, doctorMode);


### PR DESCRIPTION
## Summary
- rework the medical profile "Recompute Risk" button to queue the chat thread, dispatch an event-driven recompute, and manage disabled state/timeouts
- teach the chat pane to listen for the recompute event, run the prediction API, post the user/assistant messages, and notify listeners when the run completes or fails
- ensure dual-engine analyze responses always carry obsIds so downstream expectations remain satisfied

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb8647f15c832fb3a38d65a09e4ce0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Recompute Risk now runs through a guided workflow that persists across page reloads and navigates you to Chat for progress.
  * Chat shows a pending assistant message during recompute and updates automatically on completion.
  * Medical Profile refreshes summaries after recompute completes.
* Bug Fixes
  * Clearer status and error feedback during recompute, with automatic cleanup on timeout.
  * Analyze responses consistently include observation IDs; hidden when Doctor Mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->