### PR TITLE
Add Overpass-powered nearby search route and helper

### DIFF
--- a/app/api/nearby/route.ts
+++ b/app/api/nearby/route.ts
@@ -1,64 +1,117 @@
-export const runtime = "nodejs";
+import { NextResponse } from "next/server";
 
-import { NextRequest, NextResponse } from "next/server";
-import { buildOverpassQuery, callOverpass } from "@/lib/nearby/overpass";
-import { mapOverpassElements } from "@/lib/nearby/normalize";
-import type { NearbyType, NearbyResponse } from "@/lib/nearby/types";
+const OVERPASS_URL = process.env.OVERPASS_URL || "https://overpass-api.de/api/interpreter";
+const TYPE_TAGS: Record<string, string[]> = {
+  pharmacy: [
+    `node["amenity"="pharmacy"]`,
+    `way["amenity"="pharmacy"]`,
+    `relation["amenity"="pharmacy"]`,
+  ],
+  doctor: [
+    `node["amenity"="doctors"]`,
+    `way["amenity"="doctors"]`,
+    `relation["amenity"="doctors"]`,
+  ],
+  clinic: [
+    `node["amenity"="clinic"]`,
+    `way["amenity"="clinic"]`,
+    `relation["amenity"="clinic"]`,
+  ],
+  hospital: [
+    `node["amenity"="hospital"]`,
+    `way["amenity"="hospital"]`,
+    `relation["amenity"="hospital"]`,
+  ],
+  lab: [
+    `node["healthcare"="laboratory"]`,
+    `way["healthcare"="laboratory"]`,
+    `relation["healthcare"="laboratory"]`,
+    `node["amenity"="laboratory"]`,
+    `way["amenity"="laboratory"]`,
+    `relation["amenity"="laboratory"]`,
+  ],
+};
 
-const ON = (k: string) => (process.env[k] || "").toLowerCase() === "true";
-const FEATURE = ON("FEATURE_NEARBY");
-
-const DEF_RADIUS = Number(process.env.NEARBY_DEFAULT_RADIUS_KM || 5);
-const MAX_RESULTS = Number(process.env.NEARBY_MAX_RESULTS || 40);
-const TTL = Number(process.env.NEARBY_CACHE_TTL_SEC || 300);
-
-function clamp(n: number, min: number, max: number) {
-  return isNaN(n) ? min : Math.max(min, Math.min(max, n));
+const toRad = (d: number) => (d * Math.PI) / 180;
+function distM(a: { lat: number; lon: number }, b: { lat: number; lon: number }) {
+  const R = 6371000;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lon - a.lon);
+  const c = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(a.lat)) * Math.cos(toRad(b.lat)) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(c));
 }
 
-export async function GET(req: NextRequest) {
-  if (!FEATURE) return NextResponse.json({ error: "disabled" }, { status: 404 });
-
+export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
-  const type = (searchParams.get("type") || "doctor") as NearbyType;
-  const specialty = (searchParams.get("specialty") || "").trim();
+  const type = (searchParams.get("type") || "pharmacy").toLowerCase();
   const lat = Number(searchParams.get("lat"));
-  const lng = Number(searchParams.get("lng"));
-  const radiusKm = clamp(Number(searchParams.get("radius_km") || DEF_RADIUS), 1, 20);
-  const limit = clamp(Number(searchParams.get("limit") || MAX_RESULTS), 1, MAX_RESULTS);
-
-  if (!isFinite(lat) || !isFinite(lng)) {
-    return NextResponse.json({ error: "coords_required" }, { status: 400 });
+  const lon = Number(searchParams.get("lon"));
+  const radius = Math.min(Number(searchParams.get("radius") || 2000), 10000);
+  if (!lat || !lon || Number.isNaN(lat) || Number.isNaN(lon)) {
+    return NextResponse.json({ error: "missing_lat_lon" }, { status: 400 });
   }
 
-  const key = `nearby:${type}:${specialty}:${lat.toFixed(3)}:${lng.toFixed(3)}:${radiusKm}`;
-  // const cached = await kv.get<NearbyResponse>(key);
-  // if (cached) return NextResponse.json({ ...cached, meta: { ...cached.meta, cached: true } });
+  const selectors = TYPE_TAGS[type] || TYPE_TAGS.pharmacy;
+  const query = `
+    [out:json][timeout:30];
+    (
+      ${selectors.map((s) => `${s}(around:${radius},${lat},${lon});`).join("\n")}
+    );
+    out center tags 60;
+  `.trim();
 
-  const q = buildOverpassQuery(lat, lng, radiusKm * 1000, type, specialty);
-  let data;
-  try {
-    data = await callOverpass(q);
-  } catch (e: any) {
-    return NextResponse.json({ error: e?.message || "overpass_error" }, { status: 502 });
+  let attempt = 0,
+    json: any = null,
+    ok = false;
+  while (attempt < 2) {
+    const r = await fetch(OVERPASS_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "user-agent": "SecondOpinion-Nearby/1.0",
+      },
+      body: new URLSearchParams({ data: query }).toString(),
+      cache: "no-store",
+    });
+    ok = r.ok;
+    json = await r.json().catch(() => null);
+    if (ok && json) break;
+    await new Promise((res) => setTimeout(res, 800));
+    attempt++;
   }
 
-  const elements = Array.isArray(data?.elements) ? data.elements : [];
-  let items = mapOverpassElements(elements, { lat, lng }, type);
+  const elements = Array.isArray(json?.elements) ? json.elements : [];
+  const origin = { lat, lon };
 
-  if (type === "specialist" && specialty) {
-    const rx = new RegExp(`(^|;)\\s*${specialty}\\s*($|;)`, "i");
-    items = items.filter((i) => rx.test(i.specialty || ""));
-  }
+  const results = elements
+    .map((el: any) => {
+      const plat = el.lat ?? el.center?.lat;
+      const plon = el.lon ?? el.center?.lon;
+      const name = el.tags?.name || el.tags?.["name:en"] || "(Unnamed)";
+      const address = [
+        el.tags?.["addr:housenumber"],
+        el.tags?.["addr:street"],
+        el.tags?.["addr:suburb"],
+        el.tags?.["addr:city"],
+      ]
+        .filter(Boolean)
+        .join(", ");
+      return {
+        id: `${el.type}/${el.id}`,
+        kind: type,
+        name,
+        lat: plat,
+        lon: plon,
+        address: address || undefined,
+        phone: el.tags?.phone || el.tags?.["contact:phone"],
+        website: el.tags?.website || el.tags?.["contact:website"],
+        osm_url: `https://www.openstreetmap.org/${el.type}/${el.id}`,
+        distance_m: plat && plon ? Math.round(distM(origin, { lat: plat, lon: plon })) : undefined,
+      };
+    })
+    .filter((p: any) => p.lat && p.lon)
+    .sort((a: any, b: any) => (a.distance_m ?? 1e12) - (b.distance_m ?? 1e12))
+    .slice(0, 25);
 
-  items.sort((a, b) => a.distance_km - b.distance_km);
-  items = items.slice(0, limit);
-
-  const payload: NearbyResponse = {
-    meta: { provider: "overpass", radius_km: radiusKm, total: items.length, cached: false },
-    items,
-  };
-
-  // await kv.set(key, payload, { ex: TTL });
-  return NextResponse.json(payload, { status: 200 });
+  return NextResponse.json({ results, attribution: "© OpenStreetMap contributors" });
 }

--- a/lib/nearby.ts
+++ b/lib/nearby.ts
@@ -1,0 +1,16 @@
+export async function getUserPosition() {
+  if (!("geolocation" in navigator)) return null;
+  return new Promise<{ lat: number; lon: number }>((res) => {
+    navigator.geolocation.getCurrentPosition(
+      (p) => res({ lat: p.coords.latitude, lon: p.coords.longitude }),
+      () => res(null),
+      { enableHighAccuracy: true, timeout: 8000, maximumAge: 120000 }
+    );
+  });
+}
+
+export async function fetchNearby(kind: string, lat: number, lon: number, radius = 2000) {
+  const qs = new URLSearchParams({ type: kind, lat: String(lat), lon: String(lon), radius: String(radius) });
+  const r = await fetch(`/api/nearby?${qs.toString()}`);
+  return await r.json();
+}


### PR DESCRIPTION
## Summary
- replace the nearby API route with a direct Overpass query that supports multiple provider types
- add a browser helper for obtaining the user position and calling the nearby API

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd748f7c4832fbd1e9a69e35ad2cc