### PR TITLE
Wire AI Doc triage to profile data and med profile chat

### DIFF
--- a/app/api/aidoc/chat/route.ts
+++ b/app/api/aidoc/chat/route.ts
@@ -8,24 +8,45 @@ import { supabaseAdmin } from "@/lib/supabase/admin";
 export { runtime };
 
 export async function POST(req: NextRequest) {
-  const cloned = req.clone();
   const body = await req.json().catch(() => ({} as any));
   const message = (body?.message ?? body?.text ?? "").toString();
   const answers = (body?.answers && typeof body.answers === "object") ? body.answers : null;
   const incomingProfile = (body?.profile && typeof body.profile === "object") ? body.profile : null;
+  const messages: Array<{ role: string; content: string }> = Array.isArray(body?.messages)
+    ? [...body.messages]
+    : [];
+  const context = typeof body?.context === "string" ? body.context : undefined;
+  const needsContextPacket = !!context && ["profile", "timeline", "ai-doc-med-profile"].includes(context);
 
   // ensure you have resolved the `profile` object here
   // profile = { name, age, sex, pregnant }
   let profile: any = null;
+  let contextPacket: any = null;
+  let observations: Array<{
+    id: string;
+    observed_at: string;
+    kind: string;
+    title: string | null;
+    payload: unknown;
+  }> = [];
   try {
     const userId = await getUserId(req);
     if (userId) {
       const sb = supabaseAdmin();
-      const { data: prof } = await sb
+      const profilePromise = sb
         .from("profiles")
         .select("full_name,dob,sex,blood_group,conditions_predisposition,chronic_conditions")
         .eq("id", userId)
         .maybeSingle();
+      const observationsPromise: Promise<{ data: typeof observations | null }> = needsContextPacket
+        ? sb
+            .from("observations")
+            .select("id, observed_at, kind, title, payload")
+            .eq("user_id", userId)
+            .order("observed_at", { ascending: false })
+            .limit(50)
+        : Promise.resolve({ data: null });
+      const [{ data: prof }, { data: obs }] = await Promise.all([profilePromise, observationsPromise]);
       const dob = prof?.dob ? new Date(prof.dob) : null;
       const age = dob && !Number.isNaN(dob.getTime())
         ? Math.max(0, Math.floor((Date.now() - dob.getTime()) / (365.25 * 24 * 3600 * 1000)))
@@ -35,9 +56,31 @@ export async function POST(req: NextRequest) {
         age,
         sex: prof?.sex || undefined,
       };
+      observations = Array.isArray(obs) ? obs : [];
+      if (needsContextPacket) {
+        const briefObs = observations.map((o) => ({
+          id: o.id,
+          when: o.observed_at,
+          kind: o.kind,
+          title: o.title,
+          summary: typeof o.payload === "string" ? o.payload.slice(0, 800) : o.payload,
+        }));
+        contextPacket = {
+          profile: {
+            name: prof?.full_name,
+            age,
+            sex: prof?.sex,
+            blood_group: prof?.blood_group,
+            chronic_conditions: prof?.chronic_conditions,
+            risk_predisposition: prof?.conditions_predisposition,
+          },
+          observations: briefObs,
+        };
+      }
     }
   } catch (err) {
     console.error("Failed to load profile for triage:", err);
+    observations = [];
   }
 
   const demoFromAnswers = (answers && typeof (answers as any).demographics === "object") ? (answers as any).demographics : null;
@@ -85,6 +128,43 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // -------- Context Packet: profile + observations --------
+  if (!contextPacket && needsContextPacket && profile) {
+    const briefObs = observations.map((o) => ({
+      id: o.id,
+      when: o.observed_at,
+      kind: o.kind,
+      title: o.title,
+      summary: typeof o.payload === "string" ? o.payload.slice(0, 800) : o.payload,
+    }));
+    contextPacket = {
+      profile: {
+        name: profile?.name,
+        age: profile?.age,
+        sex: profile?.sex,
+      },
+      observations: briefObs,
+    };
+  }
+
+  const systemPreamble = {
+    role: "system",
+    content:
+      "You are AI Doc. If a context packet is present, USE IT for clinical reasoning before asking for clarifications."
+      + (contextPacket ? `\n\n<CONTEXT_PACKET>${JSON.stringify(contextPacket)}</CONTEXT_PACKET>` : ""),
+  };
+  const finalMessages = [systemPreamble, ...messages];
+  const forwardBody = { ...body, messages: finalMessages };
+
+  const headers = new Headers(req.headers);
+  headers.delete("content-length");
+  headers.set("content-type", "application/json");
+  const forwardReq = new NextRequest(req.url, {
+    method: req.method,
+    headers,
+    body: JSON.stringify(forwardBody),
+  });
+
   // existing streaming setup continues here
-  return streamPOST(cloned as any);
+  return streamPOST(forwardReq);
 }

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -77,6 +77,7 @@ export default function MedicalProfile() {
       const url = new URL(window.location.href);
       url.searchParams.set("panel", "ai-doc");
       url.searchParams.set("threadId", threadId);
+      url.searchParams.set("context", "ai-doc-med-profile");
       history.replaceState(null, "", url.toString());
 
       const res = await fetch("/api/predictions/compute", {

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -73,16 +73,40 @@ export default function MedicalProfile() {
     const btn = document.getElementById("recompute-risk-btn") as HTMLButtonElement | null;
     if (btn) btn.disabled = true;
     try {
+      const threadId = "med-profile";
+      const url = new URL(window.location.href);
+      url.searchParams.set("panel", "ai-doc");
+      url.searchParams.set("threadId", threadId);
+      history.replaceState(null, "", url.toString());
+
       const res = await fetch("/api/predictions/compute", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ threadId: "med-profile" })
+        body: JSON.stringify({ threadId })
       });
       const body = await res.json().catch(() => ({}));
       if (!res.ok || body?.ok === false) {
         throw new Error(body?.error || `HTTP ${res.status}`);
       }
       await loadSummary();
+
+      fetch("/api/aidoc/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode: "doctor",
+          threadId,
+          messages: [
+            {
+              role: "user",
+              content:
+                "Recompute risk based on my latest profile and timeline. Summarize key risks & next steps.",
+            },
+          ],
+          context: "ai-doc-med-profile",
+          clientRequestId: `recompute-${Date.now()}`,
+        }),
+      }).catch(() => {});
     } catch (err: any) {
       console.error("Recompute failed:", err?.message || err);
       alert(`Recompute failed: ${err?.message || String(err)}`);

--- a/lib/getUserId.ts
+++ b/lib/getUserId.ts
@@ -4,11 +4,18 @@ import { NextRequest } from "next/server";
 
 /** Returns NextAuth user id, or MEDX_TEST_USER_ID if not logged in. */
 export async function getUserId(_req?: NextRequest): Promise<string | null> {
+  const fallback = () =>
+    process.env.MEDX_TEST_USER_ID
+    ?? process.env.NEXT_PUBLIC_MEDX_TEST_USER_ID
+    ?? null;
+
   try {
     const session = await getServerSession(authOptions);
     const id = (session?.user as { id?: string } | undefined)?.id ?? null;
-    return id ?? process.env.MEDX_TEST_USER_ID ?? null;
+    if (id) return id;
   } catch {
-    return process.env.MEDX_TEST_USER_ID ?? null;
+    // Ignore auth errors; rely on fallback below.
   }
+
+  return fallback();
 }


### PR DESCRIPTION
## Summary
- load the authenticated user's profile from Supabase when handling AI Doc chat and message routes
- derive a simple age from stored DOB and pass the demographics into triage fallbacks
- update the Medical Profile panel so recompute risk opens the doctor chat thread and fires a kickoff message after recomputing predictions

## Testing
- not run (next lint prompts for setup in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cc0a45e174832f9af71ef39073b44f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Personalized triage now uses your saved profile (name, age, sex) and recent health observations for more relevant guidance.
  - Enhanced clinical reasoning with an automatic context packet built from your profile and timeline.
  - After “Recompute Risk” in Medical Profile, a background doctor chat summarizes key risks and next steps.
  - More reliable user detection with environment-based fallback for consistent sessions and threads.

- Bug Fixes
  - Improved error handling when loading profile/observations to avoid blocking chats and maintain smooth triage flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->