### PR TITLE
Rename Patient mode UI to Wellness

### DIFF
--- a/components/UnifiedUpload.tsx
+++ b/components/UnifiedUpload.tsx
@@ -74,7 +74,7 @@ export default function UnifiedUpload() {
           {out.type === "pdf" && (
             <>
               <section className="p-3 border rounded">
-                <h3 className="font-semibold mb-1">Patient Summary</h3>
+                <h3 className="font-semibold mb-1">Wellness Summary</h3>
                 <p className="whitespace-pre-wrap text-sm">{out.patient}</p>
               </section>
               {out.doctor && (

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -48,7 +48,7 @@ export default function ModeBar() {
       <div className="mx-auto flex max-w-screen-xl items-center gap-2 px-4 py-2">
         <button className={btn(state.base === "patient")}
                 onClick={() => apply({ type: "toggle/patient" })}>
-          Patient
+          Wellness
         </button>
         <button className={btn(state.therapy, aidocOn || state.base !== "patient")}
                 disabled={aidocOn || state.base !== "patient"}

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -143,7 +143,7 @@ export default function MedicalProfile() {
     <div className="p-4 space-y-4 relative z-0">
       <section className="rounded-xl border p-4">
         <div className="flex items-center justify-between">
-          <h2 className="font-semibold">Patient Info</h2>
+          <h2 className="font-semibold">Wellness Info</h2>
           <div className="flex items-center gap-2">
             {/* Reset (sidebar-safe) */}
             <button

--- a/components/panels/TrialsPane.tsx
+++ b/components/panels/TrialsPane.tsx
@@ -87,7 +87,7 @@ export default function TrialsPane() {
 
       <div className="flex gap-2">
         <button className="px-3 py-2 rounded bg-black text-white" onClick={onSearch} disabled={loading}>Search trials</button>
-        <button className="px-3 py-2 rounded border" onClick={()=>summarize("patient")} disabled={!rows.length}>Summarize (Patient)</button>
+        <button className="px-3 py-2 rounded border" onClick={()=>summarize("patient")} disabled={!rows.length}>Summarize (Wellness)</button>
         <button className="px-3 py-2 rounded border" onClick={()=>summarize("doctor")} disabled={!rows.length}>Summarize (Doctor)</button>
       </div>
 

--- a/lib/welcomeMessages.ts
+++ b/lib/welcomeMessages.ts
@@ -3,17 +3,17 @@ export const WELCOME_MESSAGES = [
   `Get a Second Opinion—first.
 You can upload tests, prescriptions, or scans for AI-driven explanations.
 Ask about conditions, treatments, or local health resources, and get answers tailored to your country.
-Choose Patient Mode for easy summaries or Doctor Mode for detailed analysis.`,
+Choose Wellness Mode for easy summaries or Doctor Mode for detailed analysis.`,
 
   `Because one opinion isn’t always enough.
 You can upload tests, prescriptions, or scans for AI-driven explanations.
 Ask about conditions, treatments, or local health resources, and get answers tailored to your country.
-Choose Patient Mode for easy summaries or Doctor Mode for detailed analysis.`,
+Choose Wellness Mode for easy summaries or Doctor Mode for detailed analysis.`,
 
   `Your first stop for a Second Opinion.
 You can upload tests, prescriptions, or scans for AI-driven explanations.
 Ask about conditions, treatments, or local health resources, and get answers tailored to your country.
-Choose Patient Mode for easy summaries or Doctor Mode for detailed analysis.`,
+Choose Wellness Mode for easy summaries or Doctor Mode for detailed analysis.`,
 ];
 
 export const getRandomWelcome = () =>


### PR DESCRIPTION
## Summary
- rename the mode toggle button label from Patient to Wellness and adjust related UI copy
- update wellness-related panels and upload summaries to use the new Wellness wording
- refresh welcome messages so they mention Wellness Mode instead of Patient Mode

## Testing
- npm run lint *(fails: next lint prompts for interactive configuration and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68cc104bae2c832fbda43d0ed5e57869