### PR TITLE
Refine sidebar and mode bar styling

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -40,68 +40,84 @@ export default function Sidebar() {
   };
   const filtered = threads.filter(t => t.title.toLowerCase().includes(q.toLowerCase()));
   return (
-    <aside className="sidebar-click-guard hidden md:flex md:flex-col justify-between !fixed inset-y-0 left-0 w-64 h-full medx-glass text-medx">
-      <button type="button" onClick={handleNew} className="w-full text-left px-4 py-3 rounded-xl mb-4 font-medium medx-btn-accent">
-        + New Chat
-      </button>
+    <aside className="sidebar-click-guard hidden md:flex !fixed inset-y-0 left-0 w-64 h-full medx-glass text-medx px-4 pt-5 pb-4">
+      <div className="flex h-full w-full flex-col">
+        <button
+          type="button"
+          onClick={handleNew}
+          className="w-full text-left py-3 rounded-xl font-medium medx-btn-accent"
+        >
+          + New Chat
+        </button>
 
-      <div className="px-3">
-        <div className="relative">
-          <input className="w-full h-10 rounded-lg pl-3 pr-8 text-sm medx-surface text-medx placeholder:text-slate-500 dark:placeholder:text-slate-400" placeholder="Search chats" onChange={e => handleSearch(e.target.value)} />
-          <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500" />
-        </div>
-        <Tabs />
-      </div>
-
-      <div className="mt-3 space-y-1 px-2 flex-1 overflow-y-auto">
-        {filtered.map(t => (
-          <div
-            key={t.id}
-            className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm mb-1.5 medx-surface text-medx"
-          >
-            <button
-              onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
-              className="flex-1 text-left truncate text-sm"
-              title={t.title}
-            >
-              {t.title}
-            </button>
-            <ThreadKebab
-              id={t.id}
-              title={t.title}
-              onRenamed={nt => {
-                setThreads(prev =>
-                  prev.map(x => (x.id === t.id ? { ...x, title: nt, updatedAt: Date.now() } : x))
-                );
-              }}
-              onDeleted={() => {
-                setThreads(prev => prev.filter(x => x.id !== t.id));
-              }}
-            />
+        <div className="mt-5 flex flex-1 flex-col gap-4 overflow-hidden">
+          <div className="space-y-3">
+            <div className="relative">
+              <input
+                className="w-full h-10 rounded-lg pl-3 pr-8 text-sm medx-surface text-medx placeholder:text-slate-500 dark:placeholder:text-slate-400"
+                placeholder="Search chats"
+                onChange={e => handleSearch(e.target.value)}
+              />
+              <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500" />
+            </div>
+            <Tabs />
           </div>
-        ))}
 
-        {aidocThreads.length > 0 && (
-          <div className="mt-4">
-            <div className="px-4 text-xs font-semibold opacity-60 mb-1">AI Doc</div>
-            {aidocThreads.map(t => (
-              <div key={t.id} className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm mb-1.5 medx-surface text-medx">
+          <div className="flex-1 space-y-1 overflow-y-auto pr-1">
+            {filtered.map(t => (
+              <div
+                key={t.id}
+                className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm mb-1.5 medx-surface text-medx"
+              >
                 <button
-                  onClick={() => router.push(`/?panel=ai-doc&threadId=${t.id}&context=profile`)}
+                  onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
                   className="flex-1 text-left truncate text-sm"
-                  title={t.title ?? ''}
+                  title={t.title}
                 >
-                  {t.title ?? 'AI Doc — New Case'}
+                  {t.title}
                 </button>
+                <ThreadKebab
+                  id={t.id}
+                  title={t.title}
+                  onRenamed={nt => {
+                    setThreads(prev =>
+                      prev.map(x => (x.id === t.id ? { ...x, title: nt, updatedAt: Date.now() } : x))
+                    );
+                  }}
+                  onDeleted={() => {
+                    setThreads(prev => prev.filter(x => x.id !== t.id));
+                  }}
+                />
               </div>
             ))}
-          </div>
-        )}
-      </div>
 
-      <button type="button" className="mx-3 mt-auto mb-3 h-10 rounded-lg px-3 text-left flex items-center gap-2 medx-surface text-medx">
-        <Settings size={16} /> Preferences
-      </button>
+            {aidocThreads.length > 0 && (
+              <div className="pt-3">
+                <div className="px-4 text-xs font-semibold opacity-60 mb-1">AI Doc</div>
+                {aidocThreads.map(t => (
+                  <div key={t.id} className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm mb-1.5 medx-surface text-medx">
+                    <button
+                      onClick={() => router.push(`/?panel=ai-doc&threadId=${t.id}&context=profile`)}
+                      className="flex-1 text-left truncate text-sm"
+                      title={t.title ?? ''}
+                    >
+                      {t.title ?? 'AI Doc — New Case'}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => router.push('/?panel=settings')}
+          className="mt-6 flex h-10 items-center gap-2 rounded-lg px-3 text-left medx-surface text-medx"
+        >
+          <Settings size={16} /> Preferences
+        </button>
+      </div>
     </aside>
   );
 }

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -35,11 +35,22 @@ export default function ModeBar() {
     router.push(toQuery(next, sp));
   };
 
-  const btn = (active: boolean, disabled?: boolean) =>
-    `h-9 px-3 rounded-lg border text-sm transition
-     ${active ? "bg-[var(--medx-accent)] text-white border-[var(--medx-accent)]"
-              : "bg-card text-foreground border-border hover:bg-muted"}
-     ${disabled ? "opacity-50 cursor-not-allowed" : ""}`;
+  const btn = (active: boolean, disabled?: boolean) => {
+    const classes = [
+      "h-9 px-3 rounded-full text-sm transition-[filter,color] duration-150",
+      "border border-transparent",
+    ];
+
+    classes.push(active ? "medx-btn-accent shadow-sm" : "medx-surface text-medx");
+
+    if (disabled) {
+      classes.push("opacity-60 cursor-not-allowed");
+    } else {
+      classes.push("hover:brightness-[1.05]");
+    }
+
+    return classes.join(" ");
+  };
 
   const aidocOn = state.base === "aidoc";
 

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -2326,7 +2326,7 @@ ${systemCommon}` + baseSys;
         return m.role === 'user' ? (
           <div
             key={derivedKey}
-            className="ml-auto max-w-3xl rounded-2xl px-4 py-3 shadow-sm bg-slate-200 text-slate-900 dark:bg-gray-700 dark:text-gray-100 text-left whitespace-normal"
+            className="ml-auto max-w-3xl rounded-2xl px-4 py-3 shadow-sm bg-[var(--medx-accent)] text-white text-left whitespace-normal dark:bg-[var(--medx-accent)]/90"
           >
             <ChatMarkdown content={m.content} />
           </div>


### PR DESCRIPTION
## Summary
- restyle mode bar toggles to use MedX glass and accent treatments with consistent disabled behavior
- pad the sidebar glass panel, organize its layout, and wire the Preferences shortcut to the settings panel
- recolor user chat bubbles with the MedX accent palette for clearer sender contrast

## Testing
- npm run lint *(fails: prompts for ESLint configuration in non-interactive mode)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd2231afc832f867fdbbb1be56cab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Inline thread actions (rename/delete) available directly in the chat list.
  - Unified scrollable list showing Chats and AI Docs with a clear section header.
  - Preferences and New Chat controls repositioned for quicker access.

- Style
  - Refreshed ModeBar buttons (rounded, accent styling, smoother transitions).
  - New Chat button styling updated.
  - User chat bubbles now use the site accent color for improved contrast.

- Refactor
  - Sidebar reorganized into a single vertical layout with consolidated content.
  - Navigation behavior preserved while streamlining layout and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->