### PR TITLE
Enforce OpenAI provider and structured lab handling for AI Doc

### DIFF
--- a/app/api/aidoc/chat/route.ts
+++ b/app/api/aidoc/chat/route.ts
@@ -171,7 +171,13 @@ export async function POST(req: NextRequest) {
       + (contextPacket ? `\n\n<CONTEXT_PACKET>${JSON.stringify(contextPacket)}</CONTEXT_PACKET>` : ""),
   };
   const finalMessages = [systemPreamble, ...messages];
-  const forwardBody = { ...body, messages: finalMessages };
+  const inferredPanel =
+    typeof body?.panel === "string"
+      ? body.panel
+      : context === "ai-doc-med-profile"
+      ? "med-profile"
+      : "ai-doc";
+  const forwardBody = { ...body, panel: inferredPanel, messages: finalMessages };
 
   const headers = new Headers(req.headers);
   headers.delete("content-length");

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -156,7 +156,10 @@ export async function POST(req: Request) {
             assumeAdultIfUnknown: FLAGS.ASSUME_ADULT,
             maxReviewPasses: FLAGS.MAX_REVIEW,
           });
-          return NextResponse.json(result, { status: 200 });
+          return NextResponse.json(
+            { ...result, obsIds: doctorMode ? [] : obsIds },
+            { status: 200 }
+          );
         }
 
         if (FLAGS.DUAL && FLAGS.LLM && FLAGS.USE_CALC && category !== "lab_report") {
@@ -170,7 +173,10 @@ export async function POST(req: Request) {
             assumeAdultIfUnknown: FLAGS.ASSUME_ADULT,
             maxReviewPasses: FLAGS.MAX_REVIEW,
           });
-          return NextResponse.json(result, { status: 200 });
+          return NextResponse.json(
+            { ...result, obsIds: doctorMode ? [] : obsIds },
+            { status: 200 }
+          );
         }
 
         const basePrompt = promptForCategory(category, doctorMode);

--- a/app/api/chat/final/route.ts
+++ b/app/api/chat/final/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { ensureMinDelay } from "@/lib/utils/ensureMinDelay";
 import { callGroqChat, callOpenAIChat } from "@/lib/medx/providers";
+import { pickProvider } from "@/lib/provider";
 
 // Optional calculator prelude (safe if absent)
 let composeCalcPrelude: any, extractAll: any, canonicalizeInputs: any, computeAll: any;
@@ -11,14 +12,9 @@ try {
   ({ computeAll } = require("@/lib/medical/engine/computeAll"));
 } catch {}
 
-function pickProvider(mode?: string) {
-  const m = (mode || "").toLowerCase();
-  return (m === "basic" || m === "casual") ? "groq" : "openai";
-}
-
 export async function POST(req: Request) {
   const { messages = [], mode } = await req.json();
-  const provider = pickProvider(mode);
+  const provider = pickProvider({ panel: 'chat', intent: mode });
 
   if (provider === "groq") {
     const reply = await ensureMinDelay(callGroqChat(messages, { temperature: 0.2, max_tokens: 1200 }));

--- a/lib/aidoc/vendor.ts
+++ b/lib/aidoc/vendor.ts
@@ -1,4 +1,4 @@
-import OpenAI from "openai";
+import { getLLM } from "../llm";
 
 export const AiDocJsonSchema = {
   name: "AiDocOut",
@@ -114,7 +114,8 @@ function tryParseJson(s: string) {
 }
 
 export async function callOpenAIJson({ system, user, instruction, metadata }: CallIn): Promise<any> {
-  const oai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const oai = getLLM('openai');
+  if (!oai) throw new Error('OpenAI client unavailable');
   const model = process.env.AIDOC_MODEL || "gpt-5";
   const backoff = [250, 750, 1500];
   let lastErr: any;

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -1,4 +1,15 @@
+import OpenAI from 'openai';
+
 export type ChatMsg = { role: 'system'|'user'|'assistant'; content: string };
+
+export type Provider = 'openai' | 'none';
+
+export function getLLM(provider: Provider = 'openai') {
+  if (provider === 'openai') {
+    return new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+  }
+  return null;
+}
 
 const GROQ_URL   = process.env.LLM_BASE_URL || 'https://api.groq.com/openai/v1';
 const GROQ_KEY   = process.env.LLM_API_KEY!;

--- a/lib/provider.ts
+++ b/lib/provider.ts
@@ -1,0 +1,17 @@
+export type ChatProvider = 'openai' | 'groq' | 'none';
+
+export function pickProvider(opts: { panel: string; intent?: string }): ChatProvider {
+  const panel = (opts.panel || '').toLowerCase();
+  if (panel === 'ai-doc' || panel === 'med-profile') {
+    return 'openai';
+  }
+
+  const intent = (opts.intent || '').toLowerCase();
+  if (intent === 'basic' || intent === 'casual') {
+    return 'groq';
+  }
+
+  const env = (process.env.NEXT_PUBLIC_CHAT_PROVIDER as ChatProvider | undefined) || 'openai';
+  if (env === 'groq' || env === 'none') return env;
+  return 'openai';
+}


### PR DESCRIPTION
## Summary
- add a provider picker that forces AI Doc/med-profile traffic onto OpenAI and honor it inside chat streaming and final routes
- extend the AI Doc chat panel to route lab/report intents through the structured labs API with new renderers and raw-text guardrails
- reuse a shared OpenAI client for AI Doc JSON calls and propagate obsIds through analyze dual-engine responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd75a785d0832f8c1a272f90326924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Richer lab insights in AI Doc/Medical Profile: date-wise views, latest values, auto-compare, series, trends, and gap detection.
  - Context-aware provider selection for chat and AI Doc, supporting multiple providers.
  - Unified handling of raw lab text within AI Doc.

- Improvements
  - Smarter panel inference in requests; less manual configuration needed.
  - Enhanced streaming chat with research vs. standard modes and better token handling.
  - Lab summaries fetched with no-store caching to avoid staleness.
  - Analyze responses now include observation IDs when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->