### PR TITLE
Enforce OpenAI provider for Ai Doc flows

### DIFF
--- a/app/api/chat/final/route.ts
+++ b/app/api/chat/final/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { ensureMinDelay } from "@/lib/utils/ensureMinDelay";
-import { callGroqChat, callOpenAIChat } from "@/lib/medx/providers";
+import { callGroqChat, callOpenAIChat, providerFromRequest, FORCE_OPENAI_HEADER, FORCE_OPENAI_VALUE } from "@/lib/medx/providers";
 
 // Optional calculator prelude (safe if absent)
 let composeCalcPrelude: any, extractAll: any, canonicalizeInputs: any, computeAll: any;
@@ -18,11 +18,14 @@ function pickProvider(mode?: string) {
 
 export async function POST(req: Request) {
   const { messages = [], mode } = await req.json();
-  const provider = pickProvider(mode);
+  const provider = providerFromRequest(req, pickProvider(mode));
+  const isAiDoc = req.headers.get(FORCE_OPENAI_HEADER)?.toLowerCase() === FORCE_OPENAI_VALUE;
 
   if (provider === "groq") {
     const reply = await ensureMinDelay(callGroqChat(messages, { temperature: 0.2, max_tokens: 1200 }));
-    return NextResponse.json({ ok: true, provider, reply });
+    const headers = new Headers({ "content-type": "application/json" });
+    if (isAiDoc) headers.set(FORCE_OPENAI_HEADER, FORCE_OPENAI_VALUE);
+    return new NextResponse(JSON.stringify({ ok: true, provider, reply }), { headers });
   }
 
   // OpenAI final-say path with calculator prelude (if available)
@@ -39,11 +42,13 @@ export async function POST(req: Request) {
   }
 
   const reply = await ensureMinDelay(callOpenAIChat([{ role: "system", content: system }, ...messages]));
-  return new Response(JSON.stringify({ ok: true, provider: "openai", reply }), {
-    headers: {
-      "content-type": "application/json",
-      "x-medx-provider": "openai",
-      "x-medx-model": process.env.OPENAI_TEXT_MODEL || "gpt-5",
-    },
+  const headers = new Headers({
+    "content-type": "application/json",
+    "x-medx-provider": "openai",
+    "x-medx-model": process.env.OPENAI_TEXT_MODEL || "gpt-5",
+  });
+  if (isAiDoc) headers.set(FORCE_OPENAI_HEADER, FORCE_OPENAI_VALUE);
+  return new NextResponse(JSON.stringify({ ok: true, provider: "openai", reply }), {
+    headers,
   });
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1633,7 +1633,7 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
         const endpoint = '/api/aidoc/chat';
         const res = await fetch(endpoint, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', 'x-medx-context': 'aidoc' },
           body: JSON.stringify({
             mode: mode === 'doctor' ? 'doctor' : 'patient',
             messages: thread,
@@ -2142,7 +2142,11 @@ ${systemCommon}` + baseSys;
       const sourceHash = `${file?.name ?? 'doc'}:${file?.size ?? ''}:${(file as any)?.lastModified ?? ''}`;
       fd.append('sourceHash', sourceHash);
       const data = await safeJson(
-        fetch('/api/analyze', { method: 'POST', body: fd })
+        fetch('/api/analyze', {
+          method: 'POST',
+          headers: isProfileThread ? { 'x-medx-context': 'aidoc' } : undefined,
+          body: fd,
+        })
       );
       setMessages(prev =>
         prev.map(m =>

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -82,7 +82,7 @@ export default function MedicalProfile() {
 
       const res = await fetch("/api/predictions/compute", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-medx-context": "aidoc" },
         body: JSON.stringify({ threadId })
       });
       const body = await res.json().catch(() => ({}));
@@ -93,7 +93,7 @@ export default function MedicalProfile() {
 
       fetch("/api/aidoc/chat", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "x-medx-context": "aidoc" },
         body: JSON.stringify({
           mode: "doctor",
           threadId,


### PR DESCRIPTION
## Summary
- add provider gating helpers for Ai Doc and expose OpenAI JSON chat helper
- force /api/aidoc/chat, predictions, and analyze routes down OpenAI-only code paths and forward the context header to downstream calls
- ensure Ai Doc clients mark requests with `x-medx-context: aidoc` so chat, analyze, and predictions APIs pick the OpenAI provider

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ce280cfbac832fac386264143468a9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds per-request deduplication to prevent duplicate chat processing within 60 seconds.
  - Enables an “AI Doc” context for chat, analysis, and predictions via request headers.
  - Introduces structured JSON generation for prediction summaries.

- Improvements
  - Direct, resilient streaming from the AI provider for faster, more stable responses.
  - Consistent response headers and content types across chat, analysis, and predictions.
  - More robust PDF first-page rendering with graceful fallback on errors.

- Bug Fixes
  - Clearer error responses for missing inputs and unsupported files.
  - Prevents duplicate processing and preserves context headers on errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->