### PR TITLE
Add OpenAI-first fallback for Ai Doc APIs

### DIFF
--- a/app/api/predictions/compute/route.ts
+++ b/app/api/predictions/compute/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase/admin";
 import { getUserId } from "@/lib/getUserId";
 import LLM, { type Msg } from "@/lib/LLM";
+import { callAiDocWithFallback } from "@/lib/llm/aidocFailover";
 
 const MODEL_NAME = process.env.LLM_MODEL_ID || "llama-3.1-70b";
 
@@ -328,7 +329,8 @@ async function generateSummary({
     },
   ];
 
-  const text = await LLM.finalize(messages);
+  const { reply } = await callAiDocWithFallback({ messages, temperature: 0.1 });
+  const text = reply?.trim();
   return text || "AI summary unavailable.";
 }
 

--- a/lib/llm/aidocFailover.ts
+++ b/lib/llm/aidocFailover.ts
@@ -1,0 +1,26 @@
+import { callOpenAIChat } from "@/lib/llm/openai";
+import { callGroqChat } from "@/lib/llm/groq";
+import type { ChatCompletionMessageParam } from "@/lib/llm/types";
+
+export async function callAiDocWithFallback(params: {
+  messages: ChatCompletionMessageParam[];
+  model?: string;
+  temperature?: number;
+}) {
+  const temperature = params.temperature ?? 0.2;
+  try {
+    const reply = await callOpenAIChat({
+      messages: params.messages,
+      model: params.model || process.env.OPENAI_TEXT_MODEL || "gpt-5",
+      temperature,
+    });
+    return { reply, provider: "openai" as const };
+  } catch (err: any) {
+    console.error("OpenAI failed, falling back to Groq:", err?.message || err);
+    const reply = await callGroqChat({
+      messages: params.messages,
+      temperature,
+    });
+    return { reply, provider: "groq" as const };
+  }
+}

--- a/lib/llm/groq.ts
+++ b/lib/llm/groq.ts
@@ -35,3 +35,11 @@ export async function callGroq(messages: ChatCompletionMessageParam[], {
   const content = data?.choices?.[0]?.message?.content ?? "";
   return content as string;
 }
+
+export async function callGroqChat(params: {
+  messages: ChatCompletionMessageParam[];
+  temperature?: number;
+}) {
+  const { messages, temperature } = params;
+  return callGroq(messages, { temperature });
+}

--- a/lib/llm/openai.ts
+++ b/lib/llm/openai.ts
@@ -1,0 +1,25 @@
+import OpenAI from "openai";
+import type { ChatCompletionMessageParam } from "./types";
+
+export async function callOpenAIChat({
+  messages,
+  model,
+  temperature,
+}: {
+  messages: ChatCompletionMessageParam[];
+  model?: string;
+  temperature?: number;
+}) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) throw new Error("OPENAI_API_KEY missing");
+
+  const client = new OpenAI({ apiKey: key });
+  const resolvedModel = model || process.env.OPENAI_TEXT_MODEL || "gpt-5";
+  const response = await client.chat.completions.create({
+    model: resolvedModel,
+    messages,
+    temperature: temperature ?? 0.2,
+  });
+
+  return response?.choices?.[0]?.message?.content ?? "";
+}


### PR DESCRIPTION
## Summary
- add an Ai Doc LLM failover helper that prefers OpenAI and falls back to Groq
- update the Ai Doc chat, predictions, and analyze endpoints to route through the failover helper and preserve existing response shapes
- expose lightweight OpenAI and Groq chat callers to support the new flow

## Testing
- npm run lint *(blocked by interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ce32e0c17c832f8bbdba9641f6c89a