### PR TITLE
Fix header logo container

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -153,6 +153,33 @@
 .medx-surface:hover { filter: brightness(1.03); }
 
 
+/* Top panel logo handling */
+.top-panel-logo {
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0;
+  background: transparent;
+}
+
+.logo-img {
+  height: 50px;
+  max-width: 200px;
+  object-fit: contain;
+  display: block;
+  background: transparent;
+  image-rendering: -webkit-optimize-contrast;
+}
+
+.logo-img:not([src]) {
+  background: transparent;
+  height: 50px;
+  width: 200px;
+}
+
+
 @keyframes caret {
   0%, 49% { opacity: 1; }
   50%, 100% { opacity: 0; }

--- a/components/brand/Logo.tsx
+++ b/components/brand/Logo.tsx
@@ -13,8 +13,8 @@ import { BRAND_NAME, LOGO_SRC, LOGO_FALLBACKS } from "@/lib/brand";
  * - If all fail, shows brand name text (so you never see a broken image)
  */
 export default function Logo({
-  width = 160,
-  height = 48,
+  width = 200,
+  height = 50,
   className = "",
 }: {
   width?: number;
@@ -45,16 +45,18 @@ export default function Logo({
       {showText || !src ? (
         <span className="font-semibold tracking-tight">{BRAND_NAME}</span>
       ) : (
-        <Image
-          key={src} // force re-render on src change
-          src={src}
-          alt={BRAND_NAME}
-          width={width}
-          height={height}
-          priority
-          className="block select-none"
-          onError={handleError}
-        />
+        <div className="top-panel-logo">
+          <Image
+            key={src} // force re-render on src change
+            src={src}
+            alt={BRAND_NAME}
+            width={width}
+            height={height}
+            priority
+            className="logo-img select-none"
+            onError={handleError}
+          />
+        </div>
       )}
     </Link>
   );


### PR DESCRIPTION
## Summary
- wrap the header logo image in a fixed-height container to prevent layout shifts
- add global logo styles to crop transparent padding and keep the logo aligned with the top bar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce3749bce8832f98e131bfc7aaef73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added top-panel logo support with a dedicated, centered container.
  * Improved fallback behavior when no logo source is provided.

* **Style**
  * Increased default logo size to 200×50 for better visibility.
  * Optimized image rendering and ensured transparent backgrounds.
  * Standardized alignment and layout for consistent logo display across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->