### PR TITLE
Implement centralized assistant renderer with source chips

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+@import "../styles/citations.css";
+
 /* smooth theme transitions */
 * { transition: background-color .15s ease, color .15s ease, border-color .15s ease; }
 

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -6,12 +6,21 @@ import { persistIfTemp } from "@/lib/chat/persist";
 import ThinkingTimer from "@/components/ui/ThinkingTimer";
 import ScrollToBottom from "@/components/ui/ScrollToBottom";
 import { getResearchFlagFromUrl } from "@/utils/researchFlag";
+import { AssistantContent } from "@/components/citations/AssistantContent";
+import { normalizeCitations } from "@/lib/normalizeCitations";
 
-function MessageRow({ m }: { m: { id: string; role: string; content: string } }) {
+function MessageRow({ m }: { m: { id: string; role: string; content: string; citations?: any } }) {
+  const isAssistant = m.role === "assistant";
   return (
     <div className="p-2">
-      <strong>{m.role}:</strong>{" "}
-      {m.content}
+      <strong>{m.role}:</strong>
+      <div className="mt-1">
+        {isAssistant ? (
+          <AssistantContent text={m.content} citations={normalizeCitations(m)} />
+        ) : (
+          <span>{m.content}</span>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/UnifiedUpload.tsx
+++ b/components/UnifiedUpload.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useState } from "react";
 import { safeJson } from "@/lib/safeJson";
+import { AssistantContent } from "@/components/citations/AssistantContent";
+import { normalizeCitations } from "@/lib/normalizeCitations";
 
 export default function UnifiedUpload() {
   const [loading, setLoading] = useState(false);
@@ -75,12 +77,12 @@ export default function UnifiedUpload() {
             <>
               <section className="p-3 border rounded">
                 <h3 className="font-semibold mb-1">Wellness Summary</h3>
-                <p className="whitespace-pre-wrap text-sm">{out.patient}</p>
+                <AssistantContent text={out.patient} citations={normalizeCitations(out)} />
               </section>
               {out.doctor && (
                 <section className="p-3 border rounded">
                   <h3 className="font-semibold mb-1">Doctor Summary</h3>
-                  <p className="whitespace-pre-wrap text-sm">{out.doctor}</p>
+                  <AssistantContent text={out.doctor} citations={normalizeCitations(out)} />
                 </section>
               )}
             </>
@@ -88,10 +90,12 @@ export default function UnifiedUpload() {
           {out.type === "image" && (
             <section className="p-3 border rounded">
               <h3 className="font-semibold mb-1">Imaging Report</h3>
-              <p className="whitespace-pre-wrap text-sm">{out.report}</p>
+              <AssistantContent text={out.report} citations={normalizeCitations(out)} />
             </section>
           )}
-          <p className="text-xs text-gray-400">{out.disclaimer}</p>
+          <div className="text-xs text-gray-400">
+            <AssistantContent text={out.disclaimer} citations={normalizeCitations(out)} />
+          </div>
         </div>
       )}
     </div>

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,14 +1,15 @@
-import Markdown from "react-markdown";
 import FeedbackControls from "./FeedbackControls";
+import { AssistantContent } from "@/components/citations/AssistantContent";
+import { normalizeCitations } from "@/lib/normalizeCitations";
 
 interface MessageProps {
-  message: { id: string; text: string };
+  message: { id: string; text: string; citations?: any };
 }
 
 export default function Message({ message }: MessageProps) {
   return (
     <div>
-      <Markdown>{message.text}</Markdown>
+      <AssistantContent text={message.text} citations={normalizeCitations(message)} />
       <div className="mt-2">
         <FeedbackControls messageId={message.id} />
       </div>

--- a/components/citations/AssistantContent.tsx
+++ b/components/citations/AssistantContent.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import ChatMarkdown from "@/components/ChatMarkdown";
+import { stripNumericCitations } from "@/utils/stripCitations";
+import { SourceChips, type Cite } from "./SourceChips";
+
+export function AssistantContent({
+  text,
+  citations
+}: {
+  text: string;
+  citations?: Cite[];
+}) {
+  const clean = stripNumericCitations(text ?? "");
+  return (
+    <div className="so-assistant">
+      <div className="so-body">
+        <ChatMarkdown content={clean} />
+      </div>
+      <SourceChips items={citations} />
+    </div>
+  );
+}

--- a/components/citations/SourceChips.tsx
+++ b/components/citations/SourceChips.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import type { Cite } from "@/lib/normalizeCitations";
+
+export type { Cite } from "@/lib/normalizeCitations";
+
+const short = (s: string, n = 28) => (s.length > n ? s.slice(0, n - 1) + "…" : s);
+
+const labelFor = (c: Cite) => {
+  if (c.title?.trim()) return short(c.title.trim());
+  try {
+    return new URL(c.url).hostname.replace(/^www\./, "");
+  } catch {
+    return "Source";
+  }
+};
+
+export function SourceChips({ items }: { items?: Cite[] }) {
+  if (!items?.length) return null;
+  return (
+    <div className="so-source-chips">
+      {items.map((c, i) => (
+        <a
+          key={i}
+          href={c.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="so-chip"
+          aria-label={`Open source: ${labelFor(c)}`}
+        >
+          <span className="so-dot" />
+          {labelFor(c)}
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { safeJson } from "@/lib/safeJson";
 import { useProfile } from "@/lib/hooks/useAppData";
+import { AssistantContent } from "@/components/citations/AssistantContent";
+import { normalizeCitations } from "@/lib/normalizeCitations";
 
 const SEXES = ["male", "female", "other"] as const;
 const BLOOD_GROUPS = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
@@ -57,6 +59,7 @@ export default function MedicalProfile() {
 
   const [summary, setSummary] = useState<string>("");
   const [reasons, setReasons] = useState<string>("");
+  const [summaryPayload, setSummaryPayload] = useState<any>(null);
 
   const loadSummary = async () => {
     try {
@@ -65,6 +68,7 @@ export default function MedicalProfile() {
       if (j?.text) setSummary(j.text);
       else if (j?.summary) setSummary(j.summary);
       if (j?.reasons) setReasons(j.reasons);
+      setSummaryPayload(j);
     } catch {}
   };
   useEffect(() => { loadSummary(); }, []);
@@ -472,7 +476,16 @@ export default function MedicalProfile() {
             >Recompute Risk</button>
           </div>
         </div>
-        <p className="mt-2 text-sm whitespace-pre-wrap">{summary || "No summary yet."}</p>
+        <div className="mt-2">
+          {summary ? (
+            <AssistantContent
+              text={summary}
+              citations={normalizeCitations(summaryPayload)}
+            />
+          ) : (
+            <span className="text-sm">No summary yet.</span>
+          )}
+        </div>
         <div className="mt-3 text-[11px] text-muted-foreground">
           ⚠️ This is AI-generated support, not a medical diagnosis. Always consult a qualified clinician.
         </div>

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -2,6 +2,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useTimeline } from "@/lib/hooks/useAppData";
+import { AssistantContent } from "@/components/citations/AssistantContent";
+import { normalizeCitations } from "@/lib/normalizeCitations";
 
 type Cat = "ALL"|"LABS"|"VITALS"|"IMAGING"|"AI"|"NOTES";
 const catOf = (it:any):Cat => {
@@ -167,9 +169,10 @@ export default function Timeline(){
                   )}
                   {(long || short) && (
                     <TabsContent value="summary">
-                      <article className="prose prose-zinc dark:prose-invert max-w-none whitespace-pre-wrap select-text">
-                        {(long || short) as string}
-                      </article>
+                      <AssistantContent
+                        text={(long || short) as string}
+                        citations={normalizeCitations(active?.meta)}
+                      />
                     </TabsContent>
                   )}
                   {text && (

--- a/lib/normalizeCitations.ts
+++ b/lib/normalizeCitations.ts
@@ -1,0 +1,103 @@
+export type Cite = { url: string; title?: string; kind?: string };
+
+type MaybeArray = any[] | null | undefined;
+type MaybeMap = Record<string, any> | null | undefined;
+
+const arrayLikeKeys = ["citations", "sources", "references", "refs"];
+const mapKeys = ["citationsMap", "citations", "sources", "references", "refs"];
+
+function toCite(entry: any): Cite | null {
+  if (!entry) return null;
+  if (typeof entry === "string") {
+    const url = entry.trim();
+    return url ? { url } : null;
+  }
+  if (typeof entry !== "object") return null;
+  const url =
+    typeof entry.url === "string" && entry.url.trim()
+      ? entry.url.trim()
+      : typeof entry.href === "string" && entry.href.trim()
+      ? entry.href.trim()
+      : typeof entry.link === "string" && entry.link.trim()
+      ? entry.link.trim()
+      : null;
+  if (!url) return null;
+  const titleCandidate =
+    typeof entry.title === "string"
+      ? entry.title
+      : typeof entry.label === "string"
+      ? entry.label
+      : typeof entry.name === "string"
+      ? entry.name
+      : typeof entry.text === "string"
+      ? entry.text
+      : undefined;
+  const kindCandidate =
+    typeof entry.kind === "string"
+      ? entry.kind
+      : typeof entry.source === "string"
+      ? entry.source
+      : typeof entry.type === "string"
+      ? entry.type
+      : undefined;
+  return {
+    url,
+    title: titleCandidate,
+    kind: kindCandidate,
+  };
+}
+
+function collect(items: MaybeArray, seen: Set<string>): Cite[] | null {
+  if (!Array.isArray(items)) return null;
+  const out: Cite[] = [];
+  for (const item of items) {
+    const cite = toCite(item);
+    if (!cite) continue;
+    const key = cite.url.trim();
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      out.push(cite);
+    }
+  }
+  return out.length ? out : null;
+}
+
+function collectMap(map: MaybeMap, seen: Set<string>): Cite[] | null {
+  if (!map || typeof map !== "object" || Array.isArray(map)) return null;
+  const keys = Object.keys(map);
+  if (!keys.length) return null;
+  const sorted = keys.sort((a, b) => Number(a) - Number(b));
+  const items = sorted.map((k) => (map as Record<string, any>)[k]);
+  return collect(items, seen);
+}
+
+export function normalizeCitations(payload: any): Cite[] {
+  const seen = new Set<string>();
+
+  // payload itself might be an array of citations
+  const direct = collect(payload, seen);
+  if (direct) return direct;
+
+  for (const key of arrayLikeKeys) {
+    const picked = collect(payload?.[key], seen);
+    if (picked) return picked;
+  }
+
+  for (const key of mapKeys) {
+    const picked = collectMap(payload?.[key], seen);
+    if (picked) return picked;
+  }
+
+  // Look for nested map under payload?.citations?.map style structures
+  if (payload && typeof payload === "object") {
+    for (const key of mapKeys) {
+      const candidate = payload[key];
+      if (candidate && typeof candidate === "object") {
+        const nested = collect(candidate?.items as MaybeArray, seen);
+        if (nested) return nested;
+      }
+    }
+  }
+
+  return [];
+}

--- a/styles/citations.css
+++ b/styles/citations.css
@@ -1,0 +1,41 @@
+.so-assistant .so-body {
+  white-space: pre-wrap;
+}
+
+.so-source-chips {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.so-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 9999px;
+  border: 1px solid rgba(2,6,23,0.12);
+  background: rgba(255,255,255,0.7);
+  font-size: 12px;
+  line-height: 1;
+  color: #0ea5e9;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.so-chip:hover {
+  background: #fff;
+  border-color: rgba(2,6,23,0.2);
+  text-decoration: underline;
+}
+
+.so-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: #10b981;
+}
+
+.message-content, .so-assistant, .so-assistant * { pointer-events: auto; }
+.message-overlay, .fade-mask { pointer-events: none; }

--- a/utils/stripCitations.ts
+++ b/utils/stripCitations.ts
@@ -1,0 +1,3 @@
+export function stripNumericCitations(text: string) {
+  return text.replace(/\s*\[(\d+)\]\s*/g, " ");
+}


### PR DESCRIPTION
## Summary
- add a shared AssistantContent renderer that strips numeric markers and renders source chips
- normalize citation payloads and reuse the renderer across chat, timeline, medical profile, and uploads
- introduce shared citation styles so source buttons appear consistently site-wide

## Testing
- `npm run lint` *(aborted: interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3be89338832f940ea7887976db40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant responses, wellness/doctor summaries, imaging reports, timeline summaries, and lab summaries now display citations alongside content.
  * Added clickable source chips that open references in a new tab and show readable titles or hostnames.
  * AI-generated medical profile summaries now include citations when available.

* **Style**
  * Introduced global styles for citation layouts and source chips, improving readability and interaction across messages and panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->