### PR TITLE
Allow SafeLink to accept https and render chat links as chips

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -161,3 +161,15 @@
   animation: caret 1s steps(1, end) infinite;
 }
 
+/* Ensure message content is always clickable */
+.message-content,
+.message-content * {
+  pointer-events: auto;
+}
+/* Any decorative overlays should not intercept clicks */
+.message-overlay,
+.fade-mask,
+.gradient-mask {
+  pointer-events: none;
+}
+

--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -96,7 +96,7 @@ export default function ChatMarkdown({ content }: { content: string }) {
   return (
     <div
       className="
-        prose prose-slate dark:prose-invert max-w-[72ch]
+        message-content prose prose-slate dark:prose-invert max-w-[72ch]
         prose-headings:font-semibold prose-headings:mb-2 prose-headings:mt-3
         prose-h3:text-lg prose-h4:text-base
         prose-p:my-2 prose-li:my-1 prose-strong:font-medium

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -6,12 +6,14 @@ import { persistIfTemp } from "@/lib/chat/persist";
 import { AnalyzingInline } from "@/components/chat/AnalyzingInline";
 import ScrollToBottom from "@/components/ui/ScrollToBottom";
 import { getResearchFlagFromUrl } from "@/utils/researchFlag";
+import ChatMarkdown from "@/components/ChatMarkdown";
+import { LinkBadge } from "@/components/SafeLink";
 
 function MessageRow({ m }: { m: { id: string; role: string; content: string } }) {
   return (
-    <div className="p-2">
-      <strong>{m.role}:</strong>{" "}
-      {m.content}
+    <div className="p-2 space-y-1">
+      <div className="text-xs uppercase tracking-wide text-slate-500">{m.role}</div>
+      <ChatMarkdown content={m.content} />
     </div>
   );
 }
@@ -72,11 +74,19 @@ export function ChatWindow() {
               <div key={place.id} className="result-card border p-2 rounded">
                 <p>{place.name}</p>
                 <p className="text-sm opacity-80">{place.address}</p>
-                {place.mapLink && (
-                  <a className="text-blue-600 underline" href={place.mapLink} target="_blank" rel="noopener noreferrer">
-                    Directions
-                  </a>
-                )}
+                <div className="flex flex-wrap items-center gap-3 text-sm">
+                  {place.phone && (
+                    <a href={`tel:${place.phone}`} className="underline">
+                      Call
+                    </a>
+                  )}
+                  {place.mapLink && (
+                    <LinkBadge href={place.mapLink}>
+                      Directions
+                    </LinkBadge>
+                  )}
+                  <span className="opacity-70">{place.distance_km} km</span>
+                </div>
               </div>
             ))}
           </div>

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -25,5 +25,10 @@ export default function Markdown({ text }: { text: string }) {
       <span>${useLabel}</span><span aria-hidden="true" class="opacity-70">↗</span>
   </a>`;
   });
-  return <div className="markdown" dangerouslySetInnerHTML={{ __html: withSafeLinks }} />;
+  return (
+    <div
+      className="markdown message-content"
+      dangerouslySetInnerHTML={{ __html: withSafeLinks }}
+    />
+  );
 }

--- a/components/SafeLink.tsx
+++ b/components/SafeLink.tsx
@@ -1,38 +1,24 @@
 import React from "react";
 import { sourceLabelFromUrl } from "@/lib/url";
 
-const ALLOW = [
-  "nih.gov",
-  "ncbi.nlm.nih.gov",
-  "cancer.gov",
-  "who.int",
-  "cdc.gov",
-  "nhs.uk",
-  "mayoclinic.org",
-  "uptodate.com",
-  "clinicaltrials.gov",
-  "europepmc.org",
-  "ctri.nic.in", // allow CTRI
-];
-
 export function normalizeExternalHref(input?: string): string | null {
   if (!input) return null;
   let href = input.trim();
+  if (!href) return null;
 
   // If model returned "[Learn more](www.nhs.uk/)" (no protocol), add https
   if (/^www\./i.test(href)) href = "https://" + href;
 
-  // If relative or missing protocol → invalid
-  if (!/^https?:\/\//i.test(href)) return null;
-
   try {
-    const url = new URL(href);
-    // encode spaces etc.
+    const base =
+      typeof window !== "undefined" ? window.location.origin : "https://example.org";
+    const url = new URL(href, base);
+
+    // allow only http/https, block javascript:, data:, etc.
+    if (!/^https?:$/i.test(url.protocol)) return null;
+
+    // encode spaces etc. (path segments only)
     url.pathname = url.pathname.split("/").map(encodeURIComponent).join("/");
-    const hostOk = ALLOW.some(
-      d => url.hostname === d || url.hostname.endsWith(`.${d}`)
-    );
-    if (!hostOk) return null;
     return url.toString();
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- update `normalizeExternalHref` to drop the host allow-list while still constraining urls to http/https and encoding path segments
- add the shared `message-content` class plus pointer-event safety styles so chat markdown remains clickable and consistent
- render chat window messages through `ChatMarkdown` and swap nearby map links to `LinkBadge` chips for the unified chip treatment

## Testing
- npm run lint *(fails: Next.js lint prompts for interactive setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce49b5f3a4832f8a7f375d77187535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages show small role labels and render rich content.
  * Results include compact action badges: a Call link when a phone is available and distance displayed in km.

* **Bug Fixes**
  * Links and interactive elements in messages are now clickable; decorative overlays no longer intercept clicks.
  * External links are restricted to http/https with improved handling of www-only inputs and normalized paths to reduce broken links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->