### PR TITLE
Render markdown summaries with unified chat styling

### DIFF
--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -90,8 +90,13 @@ function normalizeLLM(s: string) {
     .trim();
 }
 
-export default function ChatMarkdown({ content }: { content: string }) {
-  const prepared = normalizeLLM(normalize(content));
+type ChatMarkdownProps = {
+  content?: string | null;
+  text?: string | null;
+};
+
+export default function ChatMarkdown({ content, text }: ChatMarkdownProps) {
+  const prepared = normalizeLLM(normalize(content ?? text ?? ""));
 
   return (
     <div

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,4 +1,4 @@
-import Markdown from "react-markdown";
+import ChatMarkdown from "@/components/ChatMarkdown";
 import FeedbackControls from "./FeedbackControls";
 
 interface MessageProps {
@@ -8,7 +8,7 @@ interface MessageProps {
 export default function Message({ message }: MessageProps) {
   return (
     <div>
-      <Markdown>{message.text}</Markdown>
+      <ChatMarkdown text={message.text} />
       <div className="mt-2">
         <FeedbackControls messageId={message.id} />
       </div>

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import ChatMarkdown from "@/components/ChatMarkdown";
 import { safeJson } from "@/lib/safeJson";
 import { useProfile } from "@/lib/hooks/useAppData";
 
@@ -472,7 +473,11 @@ export default function MedicalProfile() {
             >Recompute Risk</button>
           </div>
         </div>
-        <p className="mt-2 text-sm whitespace-pre-wrap">{summary || "No summary yet."}</p>
+        <div className="mt-2">
+          {summary
+            ? <ChatMarkdown text={summary} />
+            : <p className="text-sm text-muted-foreground">No summary yet.</p>}
+        </div>
         <div className="mt-3 text-[11px] text-muted-foreground">
           ⚠️ This is AI-generated support, not a medical diagnosis. Always consult a qualified clinician.
         </div>

--- a/lib/prompts/doctor.ts
+++ b/lib/prompts/doctor.ts
@@ -5,4 +5,5 @@ Clinician mode:
 - Evidence alignment (NICE/WHO/NCCN/AHA if applicable),
 - Patient-friendly summary and doctor-level detail,
 - Clear disclaimers; do not provide diagnosis or replace clinical care.
+Format: Use Markdown with \`##\` section headings, bullet lists, and **bold** for warnings.
 `.trim();

--- a/lib/prompts/domains.ts
+++ b/lib/prompts/domains.ts
@@ -1,21 +1,27 @@
 export const ALLIED_STYLE = `
 Allied Health expert tone. Provide stepwise, practical workflows, safety checks, and escalation criteria.
-Output: (1) brief context, (2) step-by-step protocol, (3) red flags, (4) patient & caregiver instructions, (5) references.`.trim();
+Output: (1) brief context, (2) step-by-step protocol, (3) red flags, (4) patient & caregiver instructions, (5) references.
+Format: Use Markdown with \`##\` section headings, bullet lists, and **bold** for warnings.`.trim();
 
 export const WELLNESS_STYLE = `
 Wellness & preventive tone. Evidence-based recommendations with ranges (macros, sets/reps, sleep hygiene).
-Output: (1) baseline, (2) plan with specifics, (3) adherence tips, (4) cautions/contraindications, (5) references.`.trim();
+Output: (1) baseline, (2) plan with specifics, (3) adherence tips, (4) cautions/contraindications, (5) references.
+Format: Use Markdown with \`##\` section headings, bullet lists, and **bold** for warnings.`.trim();
 
 export const TECHNICAL_SCI_STYLE = `
 Scientific/technical tone. Use correct units, equations, and methods. Cite authoritative sources (NIST, IUPAC, PubMed).
-Output: (1) framework/formulas, (2) calculation/logic, (3) result with units, (4) validation, (5) references.`.trim();
+Output: (1) framework/formulas, (2) calculation/logic, (3) result with units, (4) validation, (5) references.
+Format: Use Markdown with \`##\` section headings, bullet lists, and **bold** for warnings.`.trim();
 
 export const BEHAVIORAL_STYLE = `
 Behavioral health tone. Supportive, non-judgmental, evidence-based (CBT/MI). Safety first with crisis resources.
-Output: (1) concern summary, (2) brief formulation, (3) stepwise plan, (4) red flags + crisis links, (5) references.`.trim();
+Output: (1) concern summary, (2) brief formulation, (3) stepwise plan, (4) red flags + crisis links, (5) references.
+Format: Use Markdown with \`##\` section headings, bullet lists, and **bold** for warnings.`.trim();
 
 export const SUPPORTIVE_STYLE = `
-Supportive/adjacent specialties (dental/derm/occupational/travel/forensic/econ). Provide clear triage, when-to-refer, and concise patient advice with references.`.trim();
+Supportive/adjacent specialties (dental/derm/occupational/travel/forensic/econ). Provide clear triage, when-to-refer, and concise patient advice with references.
+Format: Use Markdown with \`##\` section headings, bullet lists, and **bold** for warnings.`.trim();
 
 export const COMPLIANCE_STYLE = `
-Tech + compliance tone. Be precise about standards (HIPAA, GDPR, HL7/FHIR/DICOM). Provide implementation steps and checklists. Avoid legal advice; provide references.`.trim();
+Tech + compliance tone. Be precise about standards (HIPAA, GDPR, HL7/FHIR/DICOM). Provide implementation steps and checklists. Avoid legal advice; provide references.
+Format: Use Markdown with \`##\` section headings, bullet lists, and **bold** for warnings.`.trim();


### PR DESCRIPTION
## Summary
- render the medical profile summary with the shared ChatMarkdown renderer and retain a clear empty state
- update chat message bubbles to reuse ChatMarkdown so patient and research chats share formatting
- request markdown formatting in doctor and domain prompt presets for consistent sectioned replies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce4f6a7e64832fa43c6efdbeff8903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat messages and medical profile summaries now render rich Markdown, including section headings, bullet lists, and bolded warnings for clearer readability.

* **Improvements**
  * AI responses across multiple domains use standardized Markdown formatting for more consistent, structured outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->