### PR TITLE
feat: add universal coding assistant workflow

### DIFF
--- a/app/api/tools/coding/route.ts
+++ b/app/api/tools/coding/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+import { generateUniversalAnswerServer } from '@/lib/coding/generateUniversalAnswer';
+import { CodingMode } from '@/types/coding';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const mode: CodingMode = body?.mode === 'doctor_research' ? 'doctor_research' : 'doctor';
+    const input = body?.input && typeof body.input === 'object' ? body.input : {};
+    const data = await generateUniversalAnswerServer(input, mode);
+    return NextResponse.json(data);
+  } catch (error: any) {
+    const message = error?.message || 'Unable to generate coding guidance';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/tools/coding/page.tsx
+++ b/app/tools/coding/page.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState } from 'react';
+
+import UniversalCodingCard from '@/components/coding/UniversalCodingCard';
+import { generateUniversalAnswer } from '@/lib/coding/generateUniversalAnswer';
+import type { CodingMode, UniversalCodingAnswer } from '@/types/coding';
+
+export default function CodingToolPage() {
+  const [data, setData] = useState<UniversalCodingAnswer | null>(null);
+  const [mode, setMode] = useState<CodingMode>('doctor');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function run(nextMode: CodingMode) {
+    setIsLoading(true);
+    setError(null);
+    setMode(nextMode);
+    try {
+      const input = collectForm();
+      const result = await generateUniversalAnswer(input, nextMode);
+      setData(result);
+    } catch (err: any) {
+      setError(err?.message || 'Failed to generate coding guidance.');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">Universal Coding Assistant</h1>
+        <p className="text-sm text-muted-foreground">
+          Provide clinical and billing context below, then generate a professional CMS-1500 oriented coding guide.
+        </p>
+      </div>
+
+      <form id="coding-form" className="space-y-4 rounded-2xl border bg-background p-4 shadow-sm">
+        <label className="block space-y-2">
+          <span className="text-sm font-medium">Case summary</span>
+          <textarea
+            name="caseSummary"
+            rows={4}
+            className="w-full rounded-lg border bg-background p-3 text-sm focus:outline-none focus:ring"
+            placeholder="Summarize the encounter, provider type, services performed, clinical findings, and payer requirements."
+          />
+        </label>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="block space-y-1">
+            <span className="text-sm font-medium">Place of service</span>
+            <input
+              name="placeOfService"
+              type="text"
+              className="w-full rounded-lg border bg-background p-2 text-sm focus:outline-none focus:ring"
+              placeholder="e.g., 11, 21, 24"
+            />
+          </label>
+          <label className="block space-y-1">
+            <span className="text-sm font-medium">Primary diagnosis</span>
+            <input
+              name="primaryDiagnosis"
+              type="text"
+              className="w-full rounded-lg border bg-background p-2 text-sm focus:outline-none focus:ring"
+              placeholder="ICD-10-CM code or description"
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="block space-y-1">
+            <span className="text-sm font-medium">Procedures performed</span>
+            <input
+              name="procedures"
+              type="text"
+              className="w-full rounded-lg border bg-background p-2 text-sm focus:outline-none focus:ring"
+              placeholder="List CPT/HCPCS or describe services"
+            />
+          </label>
+          <label className="block space-y-1">
+            <span className="text-sm font-medium">Payer/policy notes</span>
+            <input
+              name="payerNotes"
+              type="text"
+              className="w-full rounded-lg border bg-background p-2 text-sm focus:outline-none focus:ring"
+              placeholder="Authorization, frequency limits, medical necessity"
+            />
+          </label>
+        </div>
+      </form>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={() => run('doctor')}
+          className="rounded-lg border border-primary bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm transition hover:opacity-90 disabled:opacity-60"
+          disabled={isLoading}
+        >
+          {isLoading && mode === 'doctor' ? 'Generating…' : 'Doctor Mode'}
+        </button>
+        <button
+          type="button"
+          onClick={() => run('doctor_research')}
+          className="rounded-lg border border-primary/60 bg-background px-4 py-2 text-sm font-semibold text-primary shadow-sm transition hover:bg-muted disabled:opacity-60"
+          disabled={isLoading}
+        >
+          {isLoading && mode === 'doctor_research' ? 'Generating…' : 'Doctor + Research'}
+        </button>
+      </div>
+
+      {error && <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">{error}</div>}
+
+      {isLoading && !error && <div className="text-sm text-muted-foreground">Asking the coding assistant…</div>}
+
+      {data && !isLoading && !error && <UniversalCodingCard data={data} />}
+    </div>
+  );
+}
+
+function collectForm(): Record<string, any> {
+  if (typeof document === 'undefined') return {};
+  const form = document.getElementById('coding-form') as HTMLFormElement | null;
+  if (!form) return {};
+  const formData = new FormData(form);
+  const input: Record<string, any> = {};
+  formData.forEach((value, key) => {
+    if (key in input) {
+      const existing = input[key];
+      if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        input[key] = [existing, value];
+      }
+    } else {
+      input[key] = value;
+    }
+  });
+  return input;
+}

--- a/components/coding/UniversalCodingCard.tsx
+++ b/components/coding/UniversalCodingCard.tsx
@@ -1,0 +1,159 @@
+import type { ReactNode } from 'react';
+
+import { UniversalCodingAnswer } from '@/types/coding';
+
+export default function UniversalCodingCard({ data }: { data: UniversalCodingAnswer }) {
+  return (
+    <div className="rounded-2xl border p-6 space-y-6 bg-background text-sm">
+      <Section title="Quick Summary">
+        <table className="w-full border-separate border-spacing-y-1">
+          <tbody>
+            {(data.quickSummary || []).map((row, index) => (
+              <tr key={`${row.label}-${index}`}>
+                <td className="w-48 font-semibold align-top text-xs uppercase tracking-wide text-muted-foreground">
+                  {row.label}
+                </td>
+                <td className="py-1 text-sm">{row.value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Section>
+
+      <Section title="Modifiers">
+        {data.modifiers?.length ? (
+          <table className="w-full border text-left">
+            <thead>
+              <tr className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="px-3 py-2 w-32">Modifier</th>
+                <th className="px-3 py-2">Use Case</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.modifiers.map((row, index) => (
+                <tr key={`${row.modifier}-${index}`} className="border-t">
+                  <td className="px-3 py-2 font-medium">{row.modifier}</td>
+                  <td className="px-3 py-2">{row.useCase}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="text-muted-foreground">No routine modifiers indicated.</p>
+        )}
+      </Section>
+
+      <Section title="NCCI Rules">
+        {data.ncciBundlingBullets?.length ? (
+          <ul className="list-disc space-y-1 pl-6">
+            {data.ncciBundlingBullets.map((bullet, index) => (
+              <li key={`${bullet}-${index}`}>{bullet}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-muted-foreground">No bundling edits noted.</p>
+        )}
+      </Section>
+
+      <Section title="Claim Example">
+        <div className="space-y-2">
+          <div>
+            <b>Dx (Box 21):</b> {data.claimExample?.dxCodes?.join(', ') || '—'}
+          </div>
+          {data.claimExample?.authBox23 && (
+            <div>
+              <b>Auth (Box 23):</b> {data.claimExample.authBox23}
+            </div>
+          )}
+          <table className="w-full border text-left">
+            <thead>
+              <tr className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="px-3 py-2">CPT/HCPCS</th>
+                <th className="px-3 py-2">Modifiers</th>
+                <th className="px-3 py-2">Dx Ptr</th>
+                <th className="px-3 py-2">POS</th>
+                <th className="px-3 py-2">Units</th>
+                <th className="px-3 py-2">Charge</th>
+                <th className="px-3 py-2">Notes (Box 19)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(data.claimExample?.claimLines || []).map((line, index) => (
+                <tr key={`${line.cpt}-${index}`} className="border-t">
+                  <td className="px-3 py-2 font-medium">{line.cpt}</td>
+                  <td className="px-3 py-2">{(line.modifiers || []).join('-') || '—'}</td>
+                  <td className="px-3 py-2">{(line.dxPointers || []).join(',') || '—'}</td>
+                  <td className="px-3 py-2">{line.pos || '—'}</td>
+                  <td className="px-3 py-2">{line.units ?? 1}</td>
+                  <td className="px-3 py-2">{line.charge ?? '—'}</td>
+                  <td className="px-3 py-2">{line.notes || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      <Section title="Checklist">
+        {data.checklist?.length ? (
+          <ul className="list-disc space-y-1 pl-6">
+            {data.checklist.map((item, index) => (
+              <li key={`${item}-${index}`}>{item}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-muted-foreground">No checklist items provided.</p>
+        )}
+      </Section>
+
+      {data.rationale && <Section title="Rationale"><p>{data.rationale}</p></Section>}
+
+      {!!data.payerNotes?.length && (
+        <Section title="Payer Notes">
+          <ul className="list-disc space-y-1 pl-6">
+            {data.payerNotes.map((note, index) => (
+              <li key={`${note}-${index}`}>{note}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {!!data.icdSpecificity?.length && (
+        <Section title="ICD-10 Specificity">
+          <ul className="list-disc space-y-1 pl-6">
+            {data.icdSpecificity.map((note, index) => (
+              <li key={`${note}-${index}`}>{note}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {!!data.references?.length && (
+        <Section title="References">
+          <ul className="list-disc space-y-1 pl-6">
+            {data.references.map((ref, index) => (
+              <li key={`${ref.label}-${index}`}>
+                {ref.url ? (
+                  <a href={ref.url} target="_blank" rel="noreferrer" className="underline">
+                    {ref.label}
+                  </a>
+                ) : (
+                  ref.label
+                )}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h3 className="text-base font-semibold">{title}</h3>
+      <div className="space-y-2 text-sm leading-relaxed">{children}</div>
+    </section>
+  );
+}

--- a/lib/coding/generateUniversalAnswer.ts
+++ b/lib/coding/generateUniversalAnswer.ts
@@ -1,0 +1,122 @@
+import { CodingMode, UniversalCodingAnswer } from '@/types/coding';
+import { callLLM } from '@/lib/llm';
+
+const SYSTEM = `You are a U.S. medical coding assistant for PROFESSIONAL claims.
+Return ONLY valid JSON per schema. 
+Doctor = concise CPT/ICD/claim output. 
+Doctor+Research = adds rationale, payer notes, ICD-10 specificity, references. 
+Follow CMS/NCCI rules. No free text outside JSON.`;
+
+function buildPrompt(input: Record<string, any>, mode: CodingMode) {
+  return `
+CASE INPUT:
+${JSON.stringify(input, null, 2)}
+
+MODE: ${mode}
+
+OUTPUT:
+- quickSummary: CPT/HCPCS, ICD-10-CM (principal first), POS (21/22/24), Global period, Auth (Y/N)
+- modifiers: only relevant, with use cases
+- ncciBundlingBullets: 3–6 bullets
+- claimExample: dxCodes ≤4, claimLines CPT+modifiers+dxPointers+POS+units+notes(Box19)
+- checklist: 5–8 bullets
+
+Doctor+Research ALSO:
+- rationale (4–8 sentences)
+- payerNotes (2–6 bullets)
+- icdSpecificity (2–6 bullets)
+- references (CMS/NCCI/NUCC links)
+
+If details missing → pick most typical and note in rationale.
+JSON only.`;
+}
+
+function normalizeAnswer(raw: UniversalCodingAnswer, mode: CodingMode): UniversalCodingAnswer {
+  const quickSummary = Array.isArray(raw.quickSummary) ? raw.quickSummary : [];
+  const modifiers = Array.isArray(raw.modifiers) ? raw.modifiers : [];
+  const ncciBundlingBullets = Array.isArray(raw.ncciBundlingBullets) ? raw.ncciBundlingBullets : [];
+  const checklist = Array.isArray(raw.checklist) ? raw.checklist : [];
+  const payerNotes = raw.payerNotes?.filter(Boolean);
+  const icdSpecificity = raw.icdSpecificity?.filter(Boolean);
+  const references = raw.references?.filter((ref) => ref && ref.label);
+  const claim = raw.claimExample || { dxCodes: [], claimLines: [] };
+  const dxCodes = Array.isArray(claim.dxCodes) ? claim.dxCodes.slice(0, 4) : [];
+  const claimLines = Array.isArray(claim.claimLines)
+    ? claim.claimLines.map((line) => ({
+        cpt: typeof line.cpt === 'string' ? line.cpt : '',
+        modifiers: Array.isArray(line.modifiers) ? line.modifiers : [],
+        dxPointers: Array.isArray(line.dxPointers) ? line.dxPointers : [],
+        units: typeof line.units === 'number' ? line.units : 1,
+        pos: line.pos || '',
+        notes: line.notes || '',
+        charge:
+          typeof line.charge === 'number'
+            ? line.charge
+            : line.charge === null
+            ? null
+            : undefined,
+      }))
+    : [];
+
+  return {
+    mode,
+    quickSummary,
+    modifiers,
+    ncciBundlingBullets,
+    claimExample: {
+      dxCodes,
+      claimLines,
+      authBox23: claim.authBox23 ?? null,
+    },
+    checklist,
+    rationale: raw.rationale,
+    payerNotes: payerNotes && payerNotes.length ? payerNotes : undefined,
+    icdSpecificity: icdSpecificity && icdSpecificity.length ? icdSpecificity : undefined,
+    references: references && references.length ? references : undefined,
+  };
+}
+
+export async function generateUniversalAnswerServer(
+  input: Record<string, any>,
+  mode: CodingMode
+): Promise<UniversalCodingAnswer> {
+  const prompt = buildPrompt(input, mode);
+  const response = await callLLM({
+    system: SYSTEM,
+    prompt,
+    temperature: 0.1,
+    max_tokens: 1200,
+    response_format: { type: 'json_object' },
+  });
+
+  let parsed: UniversalCodingAnswer;
+  try {
+    parsed = JSON.parse(response);
+  } catch (error) {
+    throw new Error('LLM returned invalid JSON');
+  }
+
+  return normalizeAnswer(parsed, mode);
+}
+
+export async function generateUniversalAnswer(
+  input: Record<string, any>,
+  mode: CodingMode
+): Promise<UniversalCodingAnswer> {
+  if (typeof window === 'undefined') {
+    return generateUniversalAnswerServer(input, mode);
+  }
+
+  const res = await fetch('/api/tools/coding', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ input, mode }),
+  });
+
+  if (!res.ok) {
+    throw new Error('Unable to generate coding guidance');
+  }
+
+  const json = (await res.json()) as UniversalCodingAnswer;
+  return normalizeAnswer(json, mode);
+}

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -101,3 +101,31 @@ export function createLLM() {
     }
   };
 }
+
+export async function callLLM({
+  system,
+  prompt,
+  temperature = 0.2,
+  max_tokens = 1200,
+  response_format,
+}: {
+  system: string;
+  prompt: string;
+  temperature?: number;
+  max_tokens?: number;
+  response_format?: any;
+}) {
+  const llm = createLLM();
+  const resp: any = await llm.chat({
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: prompt }
+    ],
+    temperature,
+    max_tokens,
+    response_format
+  });
+  const text = typeof resp === 'string' ? resp : resp?.content ?? '';
+  if (!text) throw new Error('Empty response from LLM');
+  return text;
+}

--- a/types/coding.ts
+++ b/types/coding.ts
@@ -1,0 +1,38 @@
+export type CodingMode = 'doctor' | 'doctor_research';
+
+export interface CodingSummaryRow {
+  label: string;
+  value: string;
+}
+
+export interface ModifierRow {
+  modifier: string;
+  useCase: string;
+}
+
+export interface ClaimLine {
+  cpt: string;
+  modifiers?: string[];
+  dxPointers?: number[];
+  units?: number;
+  pos?: string;
+  notes?: string;
+  charge?: number | null;
+}
+
+export interface UniversalCodingAnswer {
+  mode: CodingMode;
+  quickSummary: CodingSummaryRow[];
+  modifiers: ModifierRow[];
+  ncciBundlingBullets: string[];
+  claimExample: {
+    dxCodes: string[];
+    claimLines: ClaimLine[];
+    authBox23?: string | null;
+  };
+  checklist: string[];
+  rationale?: string;
+  payerNotes?: string[];
+  icdSpecificity?: string[];
+  references?: { label: string; url?: string }[];
+}


### PR DESCRIPTION
## Summary
- add shared coding schema types and Groq-backed answer generator with normalization
- expose secure API endpoint and client tool page to request doctor vs doctor+research outputs
- create universal coding card UI with mandated headings, tables, and optional research sections

## Testing
- npm run lint *(fails: command enters interactive setup prompt and was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6202d7e4832fb0e23af1e9387ff4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces a Universal Coding Assistant tool.
  * Supports two modes: Doctor and Doctor + Research.
  * Form inputs: case summary, place of service, primary diagnosis, procedures, payer notes.
  * Generates structured results: quick summary, modifiers, NCCI rules, claim example, checklist, rationale, payer notes, ICD-10 specificity, references.
  * Includes loading states, disabled inputs during processing, and clear error messages.
  * Backend endpoint processes requests and returns structured responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->