### PR TITLE
feat: add universal coding guide generator

### DIFF
--- a/app/api/tools/coding/route.ts
+++ b/app/api/tools/coding/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { generateUniversalAnswer } from "@/lib/coding/generateUniversalAnswer";
+import type { CodingMode } from "@/types/coding";
+
+export async function POST(req: Request) {
+  try {
+    const { input, mode } = (await req.json()) as { input?: Record<string, any>; mode?: CodingMode };
+    if (mode !== "doctor" && mode !== "doctor_research") {
+      return NextResponse.json({ error: "Invalid coding mode" }, { status: 400 });
+    }
+    const data = await generateUniversalAnswer(input ?? {}, mode);
+    return NextResponse.json(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unable to generate coding guidance.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/tools/coding/page.tsx
+++ b/app/tools/coding/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import UniversalCodingCard from "@/components/coding/UniversalCodingCard";
+import { generateUniversalAnswer } from "@/lib/coding/generateUniversalAnswer";
+import type { CodingMode, UniversalCodingAnswer } from "@/types/coding";
+
+const FEATURE_ENABLED = [
+  process.env.NEXT_PUBLIC_FEATURE_CODING_GUIDE,
+  process.env.FEATURE_CODING_GUIDE,
+]
+  .filter((value): value is string => Boolean(value))
+  .some((value) => value === "1" || value.toLowerCase() === "true");
+
+export default function CodingToolPage() {
+  const [rawInput, setRawInput] = useState("{}");
+  const [data, setData] = useState<UniversalCodingAnswer | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const parsedPreview = useMemo(() => {
+    try {
+      return JSON.stringify(JSON.parse(rawInput), null, 2);
+    } catch {
+      return rawInput.trim();
+    }
+  }, [rawInput]);
+
+  const collectForm = (): Record<string, any> => {
+    const trimmed = rawInput.trim();
+    if (!trimmed) return {};
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return { narrative: trimmed };
+    }
+  };
+
+  const run = async (mode: CodingMode) => {
+    if (!FEATURE_ENABLED) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const input = collectForm();
+      const result = await generateUniversalAnswer(input, mode);
+      setData(result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to generate coding guidance.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!FEATURE_ENABLED) {
+    return (
+      <div className="p-4">
+        <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+          Coding guide is disabled. Set FEATURE_CODING_GUIDE=1 to enable Doctor and Doctor+Research modes.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="space-y-2">
+        <label className="block text-sm font-medium">Case details</label>
+        <textarea
+          className="h-40 w-full rounded-lg border p-2 font-mono text-sm"
+          value={rawInput}
+          onChange={(event) => setRawInput(event.target.value)}
+        />
+        <p className="text-xs text-muted-foreground">
+          Paste JSON or free text. If not JSON, content is wrapped under a "narrative" key before sending to the model.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button className="btn" disabled={loading} onClick={() => run("doctor")}>Doctor Mode</button>
+        <button className="btn" disabled={loading} onClick={() => run("doctor_research")}>Doctor + Research</button>
+      </div>
+
+      {error && <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div>}
+
+      {loading && (
+        <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">Generating coding guidance…</div>
+      )}
+
+      {data && !loading && <UniversalCodingCard data={data} />}
+
+      <div className="rounded-md border p-3 text-xs text-muted-foreground">
+        <div className="font-semibold">Preview payload</div>
+        <pre className="whitespace-pre-wrap break-words">{parsedPreview}</pre>
+      </div>
+    </div>
+  );
+}

--- a/components/coding/UniversalCodingCard.tsx
+++ b/components/coding/UniversalCodingCard.tsx
@@ -1,0 +1,146 @@
+import type { ReactNode } from "react";
+
+import type { UniversalCodingAnswer } from "@/types/coding";
+
+export default function UniversalCodingCard({ data }: { data: UniversalCodingAnswer }) {
+  const dxCodes = data.claimExample?.dxCodes ?? [];
+  const claimLines = data.claimExample?.claimLines ?? [];
+
+  return (
+    <div className="rounded-2xl border p-4 space-y-5">
+      <Section title="Quick Coding Summary">
+        <table className="w-full text-sm">
+          <tbody>
+            {(data.quickSummary || []).map((row, idx) => (
+              <tr key={idx}>
+                <td className="w-44 py-1 font-medium">{row.label}</td>
+                <td className="py-1">{row.value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Section>
+
+      {!!data.modifiers?.length && (
+        <Section title="Modifiers">
+          <ul className="ml-5 list-disc">
+            {data.modifiers.map((row, idx) => (
+              <li key={idx}>
+                <b>{row.modifier}</b> — {row.useCase}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {!!data.ncciBundlingBullets?.length && (
+        <Section title="NCCI / Bundling">
+          <ul className="ml-5 list-disc">
+            {data.ncciBundlingBullets.map((row, idx) => (
+              <li key={idx}>{row}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      <Section title="Claim Example (CMS-1500 / 837P)">
+        <div className="text-sm">
+          <div className="mb-2">
+            <b>Dx (Box 21):</b> {dxCodes.join(", ")}
+          </div>
+          <table className="w-full border text-sm">
+            <thead>
+              <tr>
+                <th>CPT</th>
+                <th>Modifiers</th>
+                <th>Dx Ptr</th>
+                <th>POS</th>
+                <th>Units</th>
+                <th>Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              {claimLines.map((line, idx) => (
+                <tr key={idx} className="border-t">
+                  <td>{line.cpt}</td>
+                  <td>{(line.modifiers || []).join("-")}</td>
+                  <td>{(line.dxPointers || []).join(",")}</td>
+                  <td>{line.pos || ""}</td>
+                  <td>{line.units ?? 1}</td>
+                  <td>{line.notes || ""}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      {!!data.claimExample?.authBox23 && (
+        <Section title="Authorization">
+          <div className="rounded-md bg-muted/40 p-3 text-sm">
+            <b>Box 23:</b> {data.claimExample.authBox23}
+          </div>
+        </Section>
+      )}
+
+      {!!data.checklist?.length && (
+        <Section title="Checklist">
+          <ul className="ml-5 list-disc">
+            {data.checklist.map((item, idx) => (
+              <li key={idx}>{item}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {data.rationale && <Section title="Coding Rationale">{data.rationale}</Section>}
+
+      {!!data.payerNotes?.length && (
+        <Section title="Payer Notes">
+          <ul className="ml-5 list-disc">
+            {data.payerNotes.map((item, idx) => (
+              <li key={idx}>{item}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {!!data.icdSpecificity?.length && (
+        <Section title="ICD-10 Specificity">
+          <ul className="ml-5 list-disc">
+            {data.icdSpecificity.map((item, idx) => (
+              <li key={idx}>{item}</li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {!!data.references?.length && (
+        <Section title="References">
+          <ul className="ml-5 list-disc">
+            {data.references.map((ref, idx) => (
+              <li key={idx}>
+                {ref.url ? (
+                  <a href={ref.url} className="underline" target="_blank" rel="noreferrer">
+                    {ref.label}
+                  </a>
+                ) : (
+                  ref.label
+                )}
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section>
+      <h3 className="mb-2 font-semibold">{title}</h3>
+      {children}
+    </section>
+  );
+}

--- a/lib/coding/generateUniversalAnswer.ts
+++ b/lib/coding/generateUniversalAnswer.ts
@@ -1,0 +1,58 @@
+import type { CodingMode, UniversalCodingAnswer } from "@/types/coding";
+
+const SYSTEM = `You are a U.S. medical coding assistant for PROFESSIONAL claims.
+Return ONLY valid JSON per schema. 
+Doctor = concise CPT/ICD/claim output. 
+Doctor+Research = adds rationale, payer notes, ICD-10 specificity, references. 
+Follow CMS/NCCI rules. No free text outside JSON.`;
+
+function buildPrompt(input: Record<string, any>, mode: CodingMode) {
+  return `
+CASE INPUT:
+${JSON.stringify(input, null, 2)}
+
+MODE: ${mode}
+
+OUTPUT:
+- quickSummary: CPT/HCPCS, ICD-10-CM (principal first), POS (21/22/24), Global period, Auth (Y/N)
+- modifiers: only relevant, with use cases
+- ncciBundlingBullets: 3–6 bullets
+- claimExample: dxCodes ≤4, claimLines CPT+modifiers+dxPointers+POS+units+notes(Box19)
+- checklist: 5–8 bullets
+
+Doctor+Research ALSO:
+- rationale (4–8 sentences)
+- payerNotes (2–6 bullets)
+- icdSpecificity (2–6 bullets)
+- references (CMS/NCCI/NUCC links)
+
+If details missing → pick most typical and note in rationale.
+JSON only.`;
+}
+
+export async function generateUniversalAnswer(
+  input: Record<string, any>,
+  mode: CodingMode,
+): Promise<UniversalCodingAnswer> {
+  if (typeof window !== "undefined") {
+    const res = await fetch("/api/tools/coding", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ input, mode }),
+    });
+    if (!res.ok) {
+      const message = await res.text().catch(() => "Unable to generate coding guidance.");
+      throw new Error(message || "Unable to generate coding guidance.");
+    }
+    return (await res.json()) as UniversalCodingAnswer;
+  }
+
+  const { callLLM } = await import("@/lib/llm");
+  const json = await callLLM({
+    system: SYSTEM,
+    prompt: buildPrompt(input, mode),
+    response_format: { type: "json_object" },
+    temperature: 0.1,
+  });
+  return JSON.parse(json) as UniversalCodingAnswer;
+}

--- a/lib/llm/index.ts
+++ b/lib/llm/index.ts
@@ -1,0 +1,62 @@
+"use server";
+
+import OpenAI from "openai";
+
+type ResponseFormat = { type: string; [key: string]: any };
+
+type CallLLMArgs = {
+  system: string;
+  prompt: string;
+  temperature?: number;
+  maxTokens?: number;
+  response_format?: ResponseFormat;
+};
+
+export async function callLLM({
+  system,
+  prompt,
+  temperature = 0.1,
+  maxTokens,
+  response_format,
+}: CallLLMArgs): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error("OPENAI_API_KEY missing");
+
+  const primary = process.env.OPENAI_TEXT_MODEL || "gpt-5";
+  const fallbacks = (process.env.OPENAI_FALLBACK_MODELS || "gpt-4o,gpt-4o-mini")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const models = [primary, ...fallbacks];
+
+  const messages = [
+    { role: "system" as const, content: system },
+    { role: "user" as const, content: prompt },
+  ];
+
+  const client = new OpenAI({ apiKey });
+  let lastError: unknown;
+
+  for (const model of models) {
+    try {
+      const forbidCustomTemp = /^gpt-5/i.test(model);
+      const payload = {
+        model,
+        messages,
+        max_tokens: maxTokens,
+        response_format,
+        temperature: forbidCustomTemp ? undefined : temperature,
+      } as const;
+
+      const res = await client.chat.completions.create(payload);
+      const content = res?.choices?.[0]?.message?.content;
+      if (content) return content;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("LLM call failed");
+}
+
+export type { CallLLMArgs };

--- a/types/coding.ts
+++ b/types/coding.ts
@@ -1,0 +1,38 @@
+export type CodingMode = "doctor" | "doctor_research";
+
+export interface CodingSummaryRow {
+  label: string;
+  value: string;
+}
+
+export interface ModifierRow {
+  modifier: string;
+  useCase: string;
+}
+
+export interface ClaimLine {
+  cpt: string;
+  modifiers?: string[];
+  dxPointers?: number[];
+  units?: number;
+  pos?: string;
+  notes?: string;
+  charge?: number | null;
+}
+
+export interface UniversalCodingAnswer {
+  mode: CodingMode;
+  quickSummary: CodingSummaryRow[];
+  modifiers: ModifierRow[];
+  ncciBundlingBullets: string[];
+  claimExample: {
+    dxCodes: string[];
+    claimLines: ClaimLine[];
+    authBox23?: string | null;
+  };
+  checklist: string[];
+  rationale?: string;
+  payerNotes?: string[];
+  icdSpecificity?: string[];
+  references?: { label: string; url?: string }[];
+}


### PR DESCRIPTION
## Summary
- add universal coding data types and server-side LLM helper for JSON-only responses
- implement universal coding answer generator with doctor and research prompt variants plus API wrapper
- build feature-flagged coding guide UI with reusable card renderer for summary, claim example, and research sections

## Testing
- npm run lint *(fails: Next.js lint configuration prompt appears and requires manual setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ce65637c74832f93daef772e79c443