### PR TITLE
Add doctor auto coding guide and tidy card output

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -156,7 +156,10 @@ export async function POST(req: Request) {
             assumeAdultIfUnknown: FLAGS.ASSUME_ADULT,
             maxReviewPasses: FLAGS.MAX_REVIEW,
           });
-          return NextResponse.json(result, { status: 200 });
+          return NextResponse.json(
+            { ...result, obsIds: doctorMode ? [] : obsIds },
+            { status: 200 }
+          );
         }
 
         if (FLAGS.DUAL && FLAGS.LLM && FLAGS.USE_CALC && category !== "lab_report") {
@@ -170,7 +173,10 @@ export async function POST(req: Request) {
             assumeAdultIfUnknown: FLAGS.ASSUME_ADULT,
             maxReviewPasses: FLAGS.MAX_REVIEW,
           });
-          return NextResponse.json(result, { status: 200 });
+          return NextResponse.json(
+            { ...result, obsIds: doctorMode ? [] : obsIds },
+            { status: 200 }
+          );
         }
 
         const basePrompt = promptForCategory(category, doctorMode);

--- a/app/api/coding/universal/route.ts
+++ b/app/api/coding/universal/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { generateUniversalAnswer, type UniversalCodingInput, type UniversalCodingMode } from '@/lib/coding/generateUniversalAnswer';
+
+export const runtime = 'nodejs';
+
+function isValidMode(value: unknown): value is UniversalCodingMode {
+  return value === 'doctor' || value === 'doctor_research';
+}
+
+function isValidInput(value: unknown): value is UniversalCodingInput {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  const clinicalContext = record.clinicalContext;
+  if (typeof clinicalContext !== 'string' || clinicalContext.trim().length === 0) {
+    return false;
+  }
+  if (record.specialty !== undefined && typeof record.specialty !== 'string') {
+    return false;
+  }
+  if (record.suspectedDiagnosis !== undefined && typeof record.suspectedDiagnosis !== 'string') {
+    return false;
+  }
+  if (record.procedureDetails !== undefined && typeof record.procedureDetails !== 'string') {
+    return false;
+  }
+  if (record.payer !== undefined && typeof record.payer !== 'string') {
+    return false;
+  }
+  if (record.placeOfService !== undefined && typeof record.placeOfService !== 'string') {
+    return false;
+  }
+  if (record.additionalNotes !== undefined && typeof record.additionalNotes !== 'string') {
+    return false;
+  }
+  return true;
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => null);
+    if (!body || typeof body !== 'object') {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+
+    const mode = (body as Record<string, unknown>).mode;
+    const input = (body as Record<string, unknown>).input;
+
+    if (!isValidMode(mode)) {
+      return NextResponse.json({ error: 'Invalid mode' }, { status: 400 });
+    }
+
+    if (!isValidInput(input)) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+    }
+
+    const answer = await generateUniversalAnswer(input, mode);
+    return NextResponse.json({ data: answer }, { status: 200 });
+  } catch (error) {
+    console.error('universal coding guide error', error);
+    return NextResponse.json({ error: 'Failed to generate coding guidance' }, { status: 500 });
+  }
+}

--- a/src/components/coding/UniversalCodingCard.tsx
+++ b/src/components/coding/UniversalCodingCard.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode, useMemo, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 import type { UniversalCodingAnswer, UniversalCodingClaimLine } from '@/types/coding';
 
 interface UniversalCodingCardProps {
@@ -18,183 +20,228 @@ function formatDxPointers(dxPointers: UniversalCodingClaimLine['dxPointers']): s
   return dxPointers.map((pointer) => pointer.toString()).join(', ');
 }
 
+function CollapsibleSection({
+  title,
+  children,
+  defaultOpen = true
+}: {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className="rounded-md border border-slate-200 bg-white">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-full items-center justify-between px-3 py-2 text-sm font-medium text-slate-800"
+      >
+        <span>{title}</span>
+        <ChevronDown className={`h-4 w-4 transition-transform ${open ? '-rotate-180' : 'rotate-0'}`} />
+      </button>
+      {open ? <div className="border-t border-slate-200 px-3 py-2 text-sm leading-6 text-slate-700">{children}</div> : null}
+    </div>
+  );
+}
+
+function maybeRenderCollapsible(
+  title: string,
+  content: ReactNode,
+  defaultOpen: boolean
+): ReactNode {
+  if (!content) return null;
+  return <CollapsibleSection title={title} defaultOpen={defaultOpen}>{content}</CollapsibleSection>;
+}
+
 export function UniversalCodingCard({ data }: UniversalCodingCardProps) {
   const { quickSummary, modifiers, ncciBundlingBullets, claimExample, checklist, mode } = data;
   const isResearch = mode === 'doctor_research';
+
+  const modifiersContent = useMemo(() => {
+    if (!modifiers.length) return null;
+    return (
+      <ul className="space-y-1">
+        {modifiers.map((item) => (
+          <li key={item.modifier} className="flex flex-col rounded-md bg-slate-50 px-3 py-2 text-slate-700">
+            <span className="font-semibold text-slate-900">{item.modifier}</span>
+            <span className="text-sm">{item.useCase}</span>
+          </li>
+        ))}
+      </ul>
+    );
+  }, [modifiers]);
+
+  const bundlingContent = useMemo(() => {
+    if (!ncciBundlingBullets.length) return null;
+    return (
+      <ul className="list-disc space-y-1 pl-4">
+        {ncciBundlingBullets.map((bullet, index) => (
+          <li key={index}>{bullet}</li>
+        ))}
+      </ul>
+    );
+  }, [ncciBundlingBullets]);
+
+  const checklistContent = useMemo(() => {
+    if (!checklist.length) return null;
+    return (
+      <ul className="list-disc space-y-1 pl-4">
+        {checklist.map((item, index) => (
+          <li key={index}>{item}</li>
+        ))}
+      </ul>
+    );
+  }, [checklist]);
+
   const payerNotes = data.payerNotes ?? [];
+  const payerNotesContent = useMemo(() => {
+    if (!payerNotes.length) return null;
+    return (
+      <ul className="list-disc space-y-1 pl-4">
+        {payerNotes.map((item, index) => (
+          <li key={index}>{item}</li>
+        ))}
+      </ul>
+    );
+  }, [payerNotes]);
+
   const icdSpecificity = data.icdSpecificity ?? [];
+  const icdContent = useMemo(() => {
+    if (!icdSpecificity.length) return null;
+    return (
+      <ul className="list-disc space-y-1 pl-4">
+        {icdSpecificity.map((item, index) => (
+          <li key={index}>{item}</li>
+        ))}
+      </ul>
+    );
+  }, [icdSpecificity]);
+
   const references = data.references ?? [];
+  const referencesContent = useMemo(() => {
+    if (!references.length) return null;
+    return (
+      <ul className="space-y-1">
+        {references.map((reference, index) => {
+          const href = reference.url && /^(https?:)/i.test(reference.url) ? reference.url : undefined;
+          return (
+            <li key={`${reference.label}-${reference.url ?? index}`}>
+              {href ? (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-blue-600 underline decoration-blue-400 decoration-2 underline-offset-4 hover:text-blue-700"
+                >
+                  {reference.label}
+                </a>
+              ) : (
+                <span>{reference.label}</span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }, [references]);
+
+  const claimLines = useMemo(() => {
+    if (!claimExample.claimLines.length) return null;
+    return (
+      <div className="overflow-hidden rounded-md border border-slate-200">
+        <table className="min-w-full text-xs">
+          <thead className="bg-slate-50 text-left uppercase tracking-wide text-slate-500">
+            <tr>
+              <th className="px-3 py-2">CPT</th>
+              <th className="px-3 py-2">Mods</th>
+              <th className="px-3 py-2">Dx Ptr</th>
+              <th className="px-3 py-2">POS</th>
+              <th className="px-3 py-2">Units</th>
+              <th className="px-3 py-2">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {claimExample.claimLines.map((line, index) => {
+              const formattedCharge = formatCharge(line.charge ?? undefined);
+              const notesParts = [line.notes];
+              if (formattedCharge) {
+                notesParts.push(`Charge ${formattedCharge}`);
+              }
+              return (
+                <tr key={`${line.cpt}-${index}`} className="border-t border-slate-200">
+                  <td className="px-3 py-2 font-medium text-slate-900">{line.cpt}</td>
+                  <td className="px-3 py-2 text-slate-700">
+                    {line.modifiers && line.modifiers.length > 0 ? line.modifiers.join(', ') : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-slate-700">{formatDxPointers(line.dxPointers)}</td>
+                  <td className="px-3 py-2 text-slate-700">{line.pos ?? '—'}</td>
+                  <td className="px-3 py-2 text-slate-700">{line.units ?? '—'}</td>
+                  <td className="px-3 py-2 text-slate-700">{notesParts.filter(Boolean).join(' • ') || '—'}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  }, [claimExample.claimLines]);
 
   return (
-    <div className="space-y-8 rounded-xl border border-neutral-200 bg-white p-6 shadow-sm">
-      <section className="space-y-3">
-        <h2 className="text-lg font-semibold">Quick Coding Summary</h2>
-        <div className="overflow-hidden rounded-lg border border-neutral-200">
-          <table className="min-w-full divide-y divide-neutral-200 text-sm">
-            <tbody className="divide-y divide-neutral-200">
-              {quickSummary.map((item) => (
-                <tr key={`${item.label}-${item.value}`} className="bg-white">
-                  <th scope="row" className="w-1/3 bg-neutral-50 px-4 py-3 text-left font-medium text-neutral-600">
-                    {item.label}
-                  </th>
-                  <td className="px-4 py-3 text-neutral-900">{item.value}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-lg font-semibold">Modifiers</h2>
-        {modifiers.length > 0 ? (
-          <ul className="space-y-2 text-sm text-neutral-800">
-            {modifiers.map((item) => (
-              <li key={item.modifier} className="rounded-md border border-neutral-200 px-3 py-2">
-                <div className="font-semibold">{item.modifier}</div>
-                <p className="mt-1 text-neutral-600">{item.useCase}</p>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-sm text-neutral-600">No modifier recommendations for this scenario.</p>
-        )}
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-lg font-semibold">NCCI / Bundling</h2>
-        {ncciBundlingBullets.length > 0 ? (
-          <ul className="list-disc space-y-2 pl-5 text-sm text-neutral-800">
-            {ncciBundlingBullets.map((bullet, index) => (
-              <li key={index}>{bullet}</li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-sm text-neutral-600">No common bundling edits identified.</p>
-        )}
-      </section>
-
-      <section className="space-y-4">
-        <h2 className="text-lg font-semibold">Claim Example (CMS-1500 / 837P)</h2>
-        <div className="space-y-2 text-sm text-neutral-800">
-          <div>
-            <span className="font-semibold">ICD-10-CM (Box 21):</span>{' '}
-            {claimExample.dxCodes.length > 0 ? claimExample.dxCodes.join(', ') : 'No diagnosis codes provided.'}
-          </div>
-          {claimExample.authBox23 ? (
-            <div>
-              <span className="font-semibold">Box 23 (Auth):</span> {claimExample.authBox23}
-            </div>
-          ) : null}
-        </div>
-        <div className="overflow-hidden rounded-lg border border-neutral-200">
-          <table className="min-w-full divide-y divide-neutral-200 text-sm">
-            <thead className="bg-neutral-50 text-left font-medium text-neutral-600">
-              <tr>
-                <th className="px-4 py-2">CPT/HCPCS</th>
-                <th className="px-4 py-2">Modifiers</th>
-                <th className="px-4 py-2">Dx Ptrs</th>
-                <th className="px-4 py-2">POS</th>
-                <th className="px-4 py-2">Units</th>
-                <th className="px-4 py-2">Notes</th>
-                <th className="px-4 py-2">Charge</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-neutral-200">
-              {claimExample.claimLines.map((line, index) => {
-                const formattedCharge = formatCharge(line.charge ?? undefined);
-                return (
-                  <tr key={`${line.cpt}-${index}`} className="bg-white">
-                    <td className="px-4 py-2 font-medium text-neutral-900">{line.cpt}</td>
-                    <td className="px-4 py-2 text-neutral-700">
-                      {line.modifiers && line.modifiers.length > 0 ? line.modifiers.join(', ') : '—'}
-                    </td>
-                    <td className="px-4 py-2 text-neutral-700">{formatDxPointers(line.dxPointers)}</td>
-                    <td className="px-4 py-2 text-neutral-700">{line.pos ?? '—'}</td>
-                    <td className="px-4 py-2 text-neutral-700">{line.units ?? '—'}</td>
-                    <td className="px-4 py-2 text-neutral-700">{line.notes ?? '—'}</td>
-                    <td className="px-4 py-2 text-neutral-700">{formattedCharge ?? '—'}</td>
+    <div className="space-y-4 rounded-lg border border-slate-200 bg-white p-4 text-sm shadow-sm">
+      {quickSummary.length > 0 ? (
+        <div>
+          <h2 className="mb-2 text-sm font-semibold text-slate-900">Quick Coding Summary</h2>
+          <div className="overflow-hidden rounded-md border border-slate-200">
+            <table className="min-w-full text-sm">
+              <tbody>
+                {quickSummary.map((item) => (
+                  <tr key={`${item.label}-${item.value}`} className="border-t border-slate-200 first:border-t-0">
+                    <th className="w-40 bg-slate-50 px-3 py-2 text-left text-slate-600">{item.label}</th>
+                    <td className="px-3 py-2 text-slate-900">{item.value}</td>
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
-      </section>
-
-      <section className="space-y-3">
-        <h2 className="text-lg font-semibold">Checklist</h2>
-        {checklist.length > 0 ? (
-          <ul className="list-disc space-y-2 pl-5 text-sm text-neutral-800">
-            {checklist.map((item, index) => (
-              <li key={index}>{item}</li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-sm text-neutral-600">No additional checklist items.</p>
-        )}
-      </section>
-
-      {isResearch ? (
-        <>
-          <section className="space-y-3">
-            <h2 className="text-lg font-semibold">Rationale</h2>
-            <p className="text-sm text-neutral-800">{data.rationale ?? 'No rationale provided.'}</p>
-          </section>
-
-          <section className="space-y-3">
-            <h2 className="text-lg font-semibold">Payer Notes</h2>
-            {payerNotes.length > 0 ? (
-              <ul className="list-disc space-y-2 pl-5 text-sm text-neutral-800">
-                {payerNotes.map((note, index) => (
-                  <li key={index}>{note}</li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-sm text-neutral-600">No payer-specific notes provided.</p>
-            )}
-          </section>
-
-          <section className="space-y-3">
-            <h2 className="text-lg font-semibold">ICD-10 Specificity</h2>
-            {icdSpecificity.length > 0 ? (
-              <ul className="list-disc space-y-2 pl-5 text-sm text-neutral-800">
-                {icdSpecificity.map((item, index) => (
-                  <li key={index}>{item}</li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-sm text-neutral-600">No ICD-10 specificity reminders provided.</p>
-            )}
-          </section>
-
-          <section className="space-y-3">
-            <h2 className="text-lg font-semibold">References</h2>
-            {references.length > 0 ? (
-              <ul className="space-y-2 text-sm text-neutral-800">
-                {references.map((reference, index) => (
-                  <li key={`${reference.label}-${reference.url ?? index}`}>
-                    {reference.url ? (
-                      <a
-                        href={reference.url}
-                        className="text-blue-600 underline decoration-blue-400 decoration-2 underline-offset-4 hover:text-blue-700"
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        {reference.label}
-                      </a>
-                    ) : (
-                      <span>{reference.label}</span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-sm text-neutral-600">No references provided.</p>
-            )}
-          </section>
-        </>
       ) : null}
+
+      {maybeRenderCollapsible('Modifiers', modifiersContent, mode === 'doctor')}
+      {maybeRenderCollapsible('NCCI / Bundling', bundlingContent, mode === 'doctor')}
+
+      {(claimExample.dxCodes.length > 0 || claimLines) && (
+        <div className="space-y-2">
+          <h2 className="text-sm font-semibold text-slate-900">Claim Example (CMS-1500 / 837P)</h2>
+          <div className="text-sm text-slate-700">
+            {claimExample.dxCodes.length > 0 ? (
+              <div>
+                <span className="font-medium text-slate-900">Dx:</span> {claimExample.dxCodes.join(', ')}
+              </div>
+            ) : null}
+            {claimExample.authBox23 ? (
+              <div>
+                <span className="font-medium text-slate-900">Auth:</span> {claimExample.authBox23}
+              </div>
+            ) : null}
+          </div>
+          {claimLines}
+        </div>
+      )}
+
+      {maybeRenderCollapsible('Checklist', checklistContent, false)}
+
+      {isResearch && data.rationale ? (
+        <div>
+          <h2 className="mb-1 text-sm font-semibold text-slate-900">Rationale</h2>
+          <p className="rounded-md bg-slate-50 px-3 py-2 text-slate-700">{data.rationale}</p>
+        </div>
+      ) : null}
+
+      {isResearch ? maybeRenderCollapsible('Payer Notes', payerNotesContent, true) : null}
+      {isResearch ? maybeRenderCollapsible('ICD-10 Specificity', icdContent, false) : null}
+      {isResearch ? maybeRenderCollapsible('References', referencesContent, false) : null}
     </div>
   );
 }

--- a/src/lib/coding/collectCaseInput.ts
+++ b/src/lib/coding/collectCaseInput.ts
@@ -1,0 +1,203 @@
+export interface CaseCodingInput {
+  specialty?: string;
+  procedureName: string;
+  side?: string;
+  siteOfService: string;
+  dxFreeText: string;
+  dxCodes?: string[];
+  payer?: string;
+}
+
+type CaseLike = Record<string, unknown> | null | undefined;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function toCleanString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function collectCandidates(source: CaseLike): Record<string, unknown>[] {
+  if (!isPlainObject(source)) {
+    return [];
+  }
+
+  const seen = new Set<CaseLike>();
+  const queue: CaseLike[] = [source];
+  const out: Record<string, unknown>[] = [];
+  const NESTED_KEYS = ['case', 'caseContext', 'context', 'details', 'metadata', 'data'];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!isPlainObject(current) || seen.has(current)) continue;
+    seen.add(current);
+    out.push(current);
+
+    for (const key of NESTED_KEYS) {
+      const next = current[key];
+      if (Array.isArray(next)) {
+        for (const item of next) {
+          if (isPlainObject(item)) {
+            queue.push(item);
+          }
+        }
+      } else if (isPlainObject(next)) {
+        queue.push(next);
+      }
+    }
+  }
+
+  return out;
+}
+
+function pickFirstString(candidates: Record<string, unknown>[], keys: string[]): string | undefined {
+  for (const candidate of candidates) {
+    for (const key of keys) {
+      if (!(key in candidate)) continue;
+      const value = candidate[key];
+      if (Array.isArray(value)) {
+        const joined = value
+          .map((item) => toCleanString(item))
+          .filter((item): item is string => !!item)
+          .join(', ');
+        if (joined.length > 0) return joined;
+      } else {
+        const str = toCleanString(value);
+        if (str) return str;
+      }
+    }
+  }
+  return undefined;
+}
+
+function collectStringArray(candidates: Record<string, unknown>[], keys: string[]): string[] {
+  const out: string[] = [];
+
+  for (const candidate of candidates) {
+    for (const key of keys) {
+      if (!(key in candidate)) continue;
+      const value = candidate[key];
+
+      if (typeof value === 'string') {
+        value
+          .split(/[,;\n]+/)
+          .map((item) => item.trim())
+          .filter(Boolean)
+          .forEach((item) => out.push(item));
+        continue;
+      }
+
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          if (typeof item === 'string') {
+            const trimmed = item.trim();
+            if (trimmed) out.push(trimmed);
+          } else if (isPlainObject(item)) {
+            const maybe =
+              toCleanString(item.code) ||
+              toCleanString(item.icd) ||
+              toCleanString(item.value) ||
+              toCleanString(item.text) ||
+              toCleanString(item.label);
+            if (maybe) out.push(maybe);
+          }
+        }
+      } else if (isPlainObject(value)) {
+        const maybe =
+          toCleanString(value.code) ||
+          toCleanString(value.icd) ||
+          toCleanString(value.value) ||
+          toCleanString(value.text) ||
+          toCleanString(value.label);
+        if (maybe) out.push(maybe);
+      }
+    }
+  }
+
+  return Array.from(new Set(out));
+}
+
+function buildDxText(dxFreeText: string | undefined, dxCodes: string[]): string | undefined {
+  if (dxFreeText && dxFreeText.trim().length > 0) {
+    return dxFreeText.trim();
+  }
+
+  if (dxCodes.length > 0) {
+    return dxCodes.join(', ');
+  }
+
+  return undefined;
+}
+
+const PROCEDURE_KEYS = [
+  'procedureName',
+  'procedure',
+  'primaryProcedure',
+  'procedureTitle',
+  'procedureSummary',
+  'procedure_details',
+  'procedureDetails',
+  'operation',
+  'cptDescription',
+];
+
+const POS_KEYS = ['siteOfService', 'placeOfService', 'pos', 'site', 'location', 'facility', 'site_of_service'];
+const SPECIALTY_KEYS = ['specialty', 'providerSpecialty', 'department', 'serviceLine'];
+const SIDE_KEYS = ['side', 'laterality', 'lateralityLabel'];
+const DX_TEXT_KEYS = ['dxFreeText', 'diagnosis', 'diagnosesText', 'dx', 'indication', 'reason', 'reasonForVisit'];
+const PAYER_KEYS = ['payer', 'insurance', 'payerName', 'plan'];
+const DX_CODE_KEYS = ['dxCodes', 'diagnosisCodes', 'icdCodes', 'icd10Codes', 'dx_code', 'icd_code', 'codes'];
+
+export function collectCaseInput(caseContext: CaseLike): CaseCodingInput | null {
+  const candidates = collectCandidates(caseContext);
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const procedureName = pickFirstString(candidates, PROCEDURE_KEYS);
+  const siteOfService = pickFirstString(candidates, POS_KEYS);
+  const specialty = pickFirstString(candidates, SPECIALTY_KEYS);
+  const side = pickFirstString(candidates, SIDE_KEYS);
+  const payer = pickFirstString(candidates, PAYER_KEYS);
+  const rawDxText = pickFirstString(candidates, DX_TEXT_KEYS);
+  const dxCodes = collectStringArray(candidates, DX_CODE_KEYS);
+  const dxFreeText = buildDxText(rawDxText, dxCodes);
+
+  if (!procedureName || !siteOfService || !dxFreeText) {
+    return null;
+  }
+
+  const result: CaseCodingInput = {
+    procedureName,
+    siteOfService,
+    dxFreeText,
+  };
+
+  if (specialty) {
+    result.specialty = specialty;
+  }
+
+  if (side) {
+    result.side = side;
+  }
+
+  if (payer) {
+    result.payer = payer;
+  }
+
+  if (dxCodes.length > 0) {
+    result.dxCodes = dxCodes;
+  }
+
+  return result;
+}

--- a/src/lib/coding/generateUniversalAnswer.ts
+++ b/src/lib/coding/generateUniversalAnswer.ts
@@ -47,28 +47,29 @@ function formatInputDetails(input: UniversalCodingInput): string {
 
 function buildPrompt(input: UniversalCodingInput, mode: UniversalCodingMode): string {
   const commonSections =
-    'Return a JSON object with these fields:\n' +
+    'Return a JSON object with these fields. Do not include any extra commentary.\n' +
     `- mode: the exact string "${mode}".\n` +
-    '- quickSummary: array of objects with { "label", "value" } and include rows for CPT/HCPCS, ICD-10-CM (principal first), POS (21/22/24), Global period, Authorization (Y/N).\n' +
-    '- modifiers: array of objects { "modifier", "useCase" } describing modifier intent (use empty array if not needed).\n' +
-    '- ncciBundlingBullets: array of concise bullet strings about common NCCI or payer edits.\n' +
-    '- claimExample: object with { "dxCodes" (max 4 ICD-10-CM codes ordered for Box 21), "claimLines" (array), optional "authBox23" }. Each claim line should include { "cpt", optional "modifiers" array, optional numeric "dxPointers" array (use 1-4 to map to Box 21 order), optional "pos", optional numeric "units", optional "notes", optional numeric "charge" }.\n' +
-    '- checklist: array of denial-prevention bullet strings.';
+    '- quickSummary: array (max 5) of objects with { "label", "value" } covering CPT/HCPCS, ICD-10-CM principal, POS (21/22/24), Global period, Authorization (Y/N). Keep labels terse.\n' +
+    '- modifiers: array (max 4) of objects { "modifier", "useCase" } describing modifier intent in a single sentence (use empty array if not needed).\n' +
+    '- ncciBundlingBullets: array of 3-5 concise bullet strings about common NCCI or payer edits.\n' +
+    '- claimExample: object with { "dxCodes" (max 3 ICD-10-CM codes ordered for Box 21), "claimLines" (array), optional "authBox23" }. Each claim line should include { "cpt", optional "modifiers" array, optional numeric "dxPointers" array (use 1-4 to map to Box 21 order), optional "pos", optional numeric "units", optional "notes", optional numeric "charge" }.\n' +
+    '- checklist: array (max 6) of denial-prevention bullet strings.';
 
-  const doctorOnly = 'Do not include rationale, payerNotes, icdSpecificity, or references.';
+  const doctorOnly = 'Do not include rationale, payerNotes, icdSpecificity, or references. Follow the limits above exactly.';
 
   const researchExtras =
     'Also include:\n' +
-    '- rationale: succinct prose explaining coding selection and any assumptions.\n' +
-    '- payerNotes: array of payer-specific considerations (authorization, bilateral rules, assistant surgery coverage, etc.).\n' +
-    '- icdSpecificity: array of ICD-10 specificity reminders (laterality, extensions, combination coding, 7th characters).\n' +
-    '- references: array of objects { "label", optional "url" } citing authoritative guidance (CMS, NCCI, specialty guidelines). If any information is missing, pick the typical option and state the assumption within rationale.';
+    '- rationale: 4-6 concise sentences explaining coding selection and assumptions.\n' +
+    '- payerNotes: array (max 4) of payer-agnostic reminders about authorization, bilateral rules, etc.\n' +
+    '- icdSpecificity: array (max 4) of ICD-10 specificity reminders (laterality, extensions, combination coding, 7th characters).\n' +
+    '- references: array (max 4) of objects { "label", optional "url" } citing authoritative guidance (CMS, NCCI, specialty guidelines). Keep labels short.';
 
   const instructions = [
     'You are an expert professional fee medical coding assistant.',
     'Provide coder-ready recommendations for the scenario below.',
     'Respond with valid JSON only. Do not include Markdown fences or commentary.',
-    'Each string should be concise and plain text without bullet prefixes unless explicitly asked.',
+    'Each string should be concise, plain text, and stay under ~160 characters.',
+    'Stay within the item counts specified above; omit sections that are not requested.',
     'Ensure claim lines align with the ICD-10 codes in Box 21 and reflect realistic CMS-1500/837P billing.'
   ];
 
@@ -187,7 +188,7 @@ function normalizeAnswer(raw: any, mode: UniversalCodingMode): UniversalCodingAn
   const claimExampleRaw = raw?.claimExample ?? {};
 
   const claimExample = {
-    dxCodes: ensureStringArray(claimExampleRaw.dxCodes).slice(0, 4),
+    dxCodes: ensureStringArray(claimExampleRaw.dxCodes).slice(0, 3),
     claimLines: normalizeClaimLines(claimExampleRaw.claimLines),
     authBox23:
       typeof claimExampleRaw.authBox23 === 'string'
@@ -206,28 +207,29 @@ function normalizeAnswer(raw: any, mode: UniversalCodingMode): UniversalCodingAn
     checklist: ensureStringArray(raw?.checklist)
   };
 
-  if (mode === 'doctor') {
-    return baseAnswer;
-  }
+  const researchExtras =
+    mode === 'doctor'
+      ? undefined
+      : {
+          rationale: typeof raw?.rationale === 'string' ? raw.rationale : undefined,
+          payerNotes: ensureStringArray(raw?.payerNotes),
+          icdSpecificity: ensureStringArray(raw?.icdSpecificity),
+          references: Array.isArray(raw?.references)
+            ? raw.references
+                .map((item: any) => {
+                  const label = String(item?.label ?? '');
+                  if (!label) return null;
+                  return {
+                    label,
+                    url: typeof item?.url === 'string' && item.url.length > 0 ? item.url : undefined
+                  };
+                })
+                .filter((item: { label: string } | null): item is { label: string; url?: string } => item !== null)
+            : []
+        };
 
-  return {
-    ...baseAnswer,
-    rationale: typeof raw?.rationale === 'string' ? raw.rationale : undefined,
-    payerNotes: ensureStringArray(raw?.payerNotes),
-    icdSpecificity: ensureStringArray(raw?.icdSpecificity),
-    references: Array.isArray(raw?.references)
-      ? raw.references
-          .map((item: any) => {
-            const label = String(item?.label ?? '');
-            if (!label) return null;
-            return {
-              label,
-              url: typeof item?.url === 'string' && item.url.length > 0 ? item.url : undefined
-            };
-          })
-          .filter((item: { label: string } | null): item is { label: string; url?: string } => item !== null)
-      : []
-  };
+  const answer = researchExtras ? { ...baseAnswer, ...researchExtras } : baseAnswer;
+  return applyPresentationLimits(answer);
 }
 
 export async function generateUniversalAnswer(
@@ -248,4 +250,77 @@ export async function generateUniversalAnswer(
   const raw = cleanJsonContent(content);
 
   return normalizeAnswer(raw, mode);
+}
+
+function truncateText(value: string, max = 160): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1).trimEnd()}…`;
+}
+
+function limitSentences(text: string, maxSentences: number): string {
+  const sentences = text
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+  if (sentences.length <= maxSentences) {
+    return truncateText(sentences.join(' '));
+  }
+  return truncateText(sentences.slice(0, maxSentences).join(' '));
+}
+
+function applyPresentationLimits(answer: UniversalCodingAnswer): UniversalCodingAnswer {
+  const quickSummary = answer.quickSummary.slice(0, 5).map((item) => ({
+    label: truncateText(item.label, 80),
+    value: truncateText(item.value)
+  }));
+
+  const modifiers = answer.modifiers.slice(0, 4).map((item) => ({
+    modifier: truncateText(item.modifier, 24),
+    useCase: truncateText(item.useCase)
+  }));
+
+  const ncciBundlingBullets = answer.ncciBundlingBullets.slice(0, 5).map((bullet) => truncateText(bullet));
+
+  const claimLines = answer.claimExample.claimLines.map((line) => ({
+    ...line,
+    modifiers: line.modifiers?.map((modifier) => truncateText(modifier, 16)),
+    notes: line.notes ? truncateText(line.notes) : undefined,
+    pos: line.pos ? truncateText(line.pos, 16) : line.pos
+  }));
+
+  const claimExample = {
+    dxCodes: answer.claimExample.dxCodes.slice(0, 3).map((code) => truncateText(code, 20)),
+    claimLines,
+    authBox23:
+      typeof answer.claimExample.authBox23 === 'string'
+        ? truncateText(answer.claimExample.authBox23)
+        : answer.claimExample.authBox23
+  };
+
+  const checklist = answer.checklist.slice(0, 6).map((item) => truncateText(item));
+
+  let rationale = answer.rationale;
+  if (answer.mode === 'doctor_research' && typeof rationale === 'string') {
+    rationale = limitSentences(rationale, 6);
+  }
+
+  const payerNotes = answer.payerNotes?.slice(0, 4).map((note) => truncateText(note));
+  const icdSpecificity = answer.icdSpecificity?.slice(0, 4).map((note) => truncateText(note));
+  const references = answer.references?.slice(0, 4).map((ref) => ({
+    label: truncateText(ref.label, 120),
+    url: ref.url
+  }));
+
+  return {
+    ...answer,
+    quickSummary,
+    modifiers,
+    ncciBundlingBullets,
+    claimExample,
+    checklist,
+    rationale,
+    payerNotes,
+    icdSpecificity,
+    references
+  };
 }

--- a/src/lib/coding/generateUniversalAnswer.ts
+++ b/src/lib/coding/generateUniversalAnswer.ts
@@ -1,6 +1,8 @@
 import { createLLM } from '@/lib/llm';
 import type { UniversalCodingAnswer, UniversalCodingClaimLine } from '@/types/coding';
 
+export type { UniversalCodingAnswer } from '@/types/coding';
+
 export interface UniversalCodingInput {
   clinicalContext: string;
   specialty?: string;

--- a/src/lib/coding/useAutoCodingGuide.ts
+++ b/src/lib/coding/useAutoCodingGuide.ts
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  UniversalCodingAnswer,
+  UniversalCodingInput,
+  UniversalCodingMode
+} from '@/lib/coding/generateUniversalAnswer';
+import type { CaseCodingInput } from '@/lib/coding/collectCaseInput';
+
+type HookMode = UniversalCodingMode;
+
+type UseAutoCodingGuideArgs = {
+  mode: HookMode;
+  getCaseInput: () => CaseCodingInput | null;
+};
+
+type AutoCodingState = {
+  data: UniversalCodingAnswer | null;
+  loading: boolean;
+  error: Error | null;
+  refresh: () => void;
+};
+
+type CacheEntry = {
+  data?: UniversalCodingAnswer;
+  error?: Error;
+  promise?: Promise<UniversalCodingAnswer> | null;
+};
+
+const CACHE = new Map<string, CacheEntry>();
+const FLAG_ENABLED = typeof process !== 'undefined' ? process.env.NEXT_PUBLIC_ENABLE_AUTO_CODES === 'true' : false;
+const DEBOUNCE_MS = 500;
+
+async function requestUniversalAnswer(input: UniversalCodingInput, mode: HookMode): Promise<UniversalCodingAnswer> {
+  const response = await fetch('/api/coding/universal', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ input, mode })
+  });
+
+  if (!response.ok) {
+    const message = await response
+      .json()
+      .then((body) => (typeof body?.error === 'string' ? body.error : null))
+      .catch(() => null);
+    throw new Error(message || 'Failed to load coding guidance');
+  }
+
+  const payload = await response.json().catch(() => null);
+  if (!payload || typeof payload !== 'object' || !payload.data) {
+    throw new Error('Unexpected response from coding guide');
+  }
+
+  return payload.data as UniversalCodingAnswer;
+}
+
+function hasRequiredFields(input: CaseCodingInput | null): input is CaseCodingInput {
+  if (!input) return false;
+  const hasProcedure = typeof input.procedureName === 'string' && input.procedureName.trim().length > 0;
+  const hasPos = typeof input.siteOfService === 'string' && input.siteOfService.trim().length > 0;
+  const hasDxNarrative = typeof input.dxFreeText === 'string' && input.dxFreeText.trim().length > 0;
+  const hasDxCodes = Array.isArray(input.dxCodes) && input.dxCodes.length > 0;
+  return hasProcedure && hasPos && (hasDxNarrative || hasDxCodes);
+}
+
+function buildCaseKey(input: CaseCodingInput, mode: HookMode): string {
+  const parts = [
+    input.procedureName.trim().toLowerCase(),
+    input.siteOfService.trim(),
+    input.dxFreeText.trim().toLowerCase(),
+    Array.isArray(input.dxCodes) ? input.dxCodes.join('|') : '',
+    input.specialty ?? '',
+    input.side ?? '',
+    input.payer ?? '',
+    mode,
+  ];
+  return parts.join('::');
+}
+
+function toUniversalInput(input: CaseCodingInput): UniversalCodingInput {
+  const { procedureName, siteOfService, dxFreeText, dxCodes, specialty, side, payer } = input;
+  const dxLabel = Array.isArray(dxCodes) && dxCodes.length > 0 ? `ICD-10: ${dxCodes.join(', ')}` : dxFreeText;
+
+  const contextBits = [
+    `Procedure: ${procedureName}${side ? ` (${side})` : ''}`,
+    `Place of service: ${siteOfService}`,
+    `Diagnosis focus: ${dxLabel}`,
+  ];
+
+  const additionalNotes: string[] = [];
+  if (dxCodes?.length) {
+    additionalNotes.push(`ICD-10 codes: ${dxCodes.join(', ')}`);
+  }
+  if (dxFreeText && dxCodes?.length) {
+    additionalNotes.push(`Narrative dx: ${dxFreeText}`);
+  }
+
+  return {
+    clinicalContext: contextBits.join(' | '),
+    specialty,
+    suspectedDiagnosis: dxFreeText,
+    procedureDetails: side ? `Laterality: ${side}` : procedureName,
+    payer,
+    placeOfService: siteOfService,
+    additionalNotes: additionalNotes.length > 0 ? additionalNotes.join(' | ') : undefined,
+  };
+}
+
+const DEFAULT_STATE: AutoCodingState = {
+  data: null,
+  loading: false,
+  error: null,
+  refresh: () => undefined,
+};
+
+export function useAutoCodingGuide({ mode, getCaseInput }: UseAutoCodingGuideArgs): AutoCodingState {
+  const enabled = FLAG_ENABLED;
+  const [data, setData] = useState<UniversalCodingAnswer | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeKeyRef = useRef<string | null>(null);
+
+  const snapshot = useMemo(() => {
+    if (!enabled) return null;
+    try {
+      return getCaseInput();
+    } catch (err) {
+      console.error('collectCaseInput threw', err);
+      return null;
+    }
+  }, [enabled, getCaseInput]);
+
+  const caseKey = useMemo(() => {
+    if (!enabled || !hasRequiredFields(snapshot)) {
+      return null;
+    }
+    return buildCaseKey(snapshot, mode);
+  }, [snapshot, enabled, mode]);
+
+  const runFetch = useCallback(
+    async (force = false) => {
+      if (!enabled || !snapshot || !hasRequiredFields(snapshot) || !caseKey) {
+        return;
+      }
+
+      const cached = CACHE.get(caseKey);
+      if (!force && cached?.data) {
+        setData(cached.data);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+
+      if (!force && cached?.promise) {
+        setLoading(true);
+        cached.promise
+          .then((answer) => {
+            if (activeKeyRef.current !== caseKey) return;
+            setData(answer);
+            setError(null);
+            setLoading(false);
+          })
+          .catch((err) => {
+            if (activeKeyRef.current !== caseKey) return;
+            setError(err instanceof Error ? err : new Error('Unknown error'));
+            setLoading(false);
+          });
+        return;
+      }
+
+      const universalInput = toUniversalInput(snapshot);
+      const promise = requestUniversalAnswer(universalInput, mode);
+      CACHE.set(caseKey, { promise });
+      setLoading(true);
+      setError(null);
+
+      promise
+        .then((answer) => {
+          CACHE.set(caseKey, { data: answer });
+          if (activeKeyRef.current !== caseKey) return;
+          setData(answer);
+          setError(null);
+          setLoading(false);
+        })
+        .catch((err) => {
+          const errorObj = err instanceof Error ? err : new Error('Failed to load coding guidance');
+          CACHE.set(caseKey, { error: errorObj });
+          if (activeKeyRef.current !== caseKey) return;
+          setError(errorObj);
+          setLoading(false);
+        });
+    },
+    [enabled, snapshot, caseKey, mode],
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    if (!snapshot || !hasRequiredFields(snapshot) || !caseKey) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      activeKeyRef.current = null;
+      return;
+    }
+
+    activeKeyRef.current = caseKey;
+
+    const cached = CACHE.get(caseKey);
+    if (cached?.data) {
+      setData(cached.data);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    if (cached?.error && !cached.promise) {
+      setError(cached.error);
+      setLoading(false);
+      return;
+    }
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(() => {
+      runFetch();
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+    };
+  }, [enabled, snapshot, caseKey, runFetch]);
+
+  const refresh = useCallback(() => {
+    if (!enabled || !snapshot || !hasRequiredFields(snapshot) || !caseKey) return;
+    CACHE.delete(caseKey);
+    runFetch(true);
+  }, [enabled, snapshot, caseKey, runFetch]);
+
+  if (!enabled) {
+    return DEFAULT_STATE;
+  }
+
+  return {
+    data,
+    loading,
+    error,
+    refresh,
+  };
+}

--- a/src/lib/coding/useAutoCodingGuide.ts
+++ b/src/lib/coding/useAutoCodingGuide.ts
@@ -1,9 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type {
-  UniversalCodingAnswer,
-  UniversalCodingInput,
-  UniversalCodingMode
-} from '@/lib/coding/generateUniversalAnswer';
+import type { UniversalCodingAnswer } from '@/types/coding';
+import type { UniversalCodingInput, UniversalCodingMode } from '@/lib/coding/generateUniversalAnswer';
 import type { CaseCodingInput } from '@/lib/coding/collectCaseInput';
 
 type HookMode = UniversalCodingMode;


### PR DESCRIPTION
## Summary
- add a case input collector and auto-coding hook that debounce & cache Universal Coding Guide requests behind the feature flag
- tighten the coding generator prompt and post-process results plus refresh the card UI with collapsible sections and compact tables
- integrate the automatic guide on the doctor chat surface and make dual-engine analyze responses include obsIds consistently

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce8d121c08832f802cb42094fed1a7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-coding guidance in Chat: compact, collapsible card with summary, modifiers, bundling, checklist, payer notes, ICD-10 specificity, references, claim example, rationale in research mode, and retry support.
  * On-device auto-coding flow: case extraction utility, reusable coding hook, and a universal coding POST endpoint.
  * Standardized, size‑capped outputs and presentation limits for clearer, bounded guidance.

* **Bug Fixes**
  * Analysis responses consistently include observation IDs across early and final responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->