### PR TITLE
Add live shell layout with updated header and styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -173,3 +173,19 @@
   pointer-events: none;
 }
 
+/* ----- MedX Live UI look ----- */
+:root.dark {
+  --medx-bg-grad: linear-gradient(180deg,#06122E 0%,#071534 15%,#0A1C45 100%);
+  --medx-text: #ffffff;
+  --medx-pane: rgba(15, 23, 42, 0.6);
+  --medx-pane-ring: rgba(255,255,255,0.10);
+  --medx-composer: rgba(15, 23, 42, 0.7);
+  --medx-border: #1f2937;
+}
+
+.dark body { background: var(--medx-bg-grad) !important; color: var(--medx-text) !important; }
+.dark .medx-pane { background: var(--medx-pane); box-shadow: none; }
+.dark .medx-ring { box-shadow: 0 0 0 1px var(--medx-pane-ring) inset; }
+.dark .medx-border { border-color: var(--medx-border) !important; }
+.dark .medx-text { color: var(--medx-text) !important; }
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
+body,
+#__next {
+  height: 100%;
+}
+
 /* smooth theme transitions */
 * { transition: background-color .15s ease, color .15s ease, border-color .15s ease; }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import "./globals.css";
 import { ThemeProvider } from "next-themes";
-import Sidebar from "../components/Sidebar";
 import { CountryProvider } from "@/lib/country";
 import { ContextProvider } from "@/lib/context";
 import { TopicProvider } from "@/lib/topic";
@@ -27,15 +26,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <CountryProvider>
             <ContextProvider>
               <TopicProvider>
-                <div className="flex medx-gradient">
-                  <Suspense fallback={null}>
-                    <Sidebar />
-                  </Suspense>
-                  <main className="flex-1 md:ml-64 min-h-dvh flex flex-col relative z-0">
-                    {children}
-                    <MemorySnackbar />
-                    <UndoToast />
-                  </main>
+                <div className="min-h-screen flex flex-col relative">
+                  <Suspense fallback={null}>{children}</Suspense>
+                  <MemorySnackbar />
+                  <UndoToast />
                 </div>
               </TopicProvider>
             </ContextProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,39 +1,14 @@
-"use client";
-import { useEffect, useRef } from "react";
-import ChatPane from "@/components/panels/ChatPane";
-import MedicalProfile from "@/components/panels/MedicalProfile";
-import Timeline from "@/components/panels/Timeline";
-import AlertsPane from "@/components/panels/AlertsPane";
-import SettingsPane from "@/components/panels/SettingsPane";
-import { ResearchFiltersProvider } from "@/store/researchFilters";
-import AiDocPane from "@/components/panels/AiDocPane";
+import ShellLive from "@/components/layout/ShellLive";
+import SidebarAdapter from "@/components/layout/SidebarAdapter";
+import MainAdapter from "@/components/layout/MainAdapter";
+import ComposerAdapter from "@/components/layout/ComposerAdapter";
 
-type Search = { panel?: string };
-
-export default function Page({ searchParams }: { searchParams: Search }) {
-  const panel = searchParams.panel?.toLowerCase() || "chat";
-  const chatInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const handler = () => chatInputRef.current?.focus();
-    window.addEventListener("focus-chat-input", handler);
-    return () => window.removeEventListener("focus-chat-input", handler);
-  }, []);
-
+export default function Page() {
   return (
-    <main className="flex-1 overflow-y-auto content-layer">
-      {panel === "chat" && (
-        <section className="block h-full">
-          <ResearchFiltersProvider>
-            <ChatPane inputRef={chatInputRef} />
-          </ResearchFiltersProvider>
-        </section>
-      )}
-      {panel === "profile" && <MedicalProfile />}
-      {panel === "timeline" && <Timeline />}
-      {panel === "alerts" && <AlertsPane />}
-      {panel === "settings" && <SettingsPane />}
-      {panel === "ai-doc" && <AiDocPane />}
-    </main>
+    <ShellLive
+      Sidebar={SidebarAdapter}
+      Main={MainAdapter}
+      Composer={ComposerAdapter}
+    />
   );
 }

--- a/components/SafeLink.tsx
+++ b/components/SafeLink.tsx
@@ -34,12 +34,17 @@ export function normalizeExternalHref(input?: string): string | null {
   }
 }
 
-export const SafeAnchor: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({ href, children, ...rest }) => {
+export const SafeAnchor: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({
+  href,
+  children,
+  className = "",
+  ...rest
+}) => {
   const safe = normalizeExternalHref(href);
   if (!safe) {
     return (
       <span
-        className="text-slate-500 dark:text-slate-400 cursor-not-allowed"
+        className={`inline-flex items-center rounded-full border border-slate-200 dark:border-slate-700 bg-gray-200 dark:bg-slate-800 px-2 py-1 text-xs text-gray-500 cursor-not-allowed ${className}`.trim()}
         title="Link unavailable"
       >
         {children}
@@ -51,10 +56,13 @@ export const SafeAnchor: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>>
       href={safe}
       target="_blank"
       rel="noopener noreferrer"
-      className="underline underline-offset-2 decoration-slate-400 hover:decoration-slate-600 dark:decoration-slate-500 dark:hover:decoration-slate-300"
+      className={`inline-flex items-center gap-1 rounded-full border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-2 py-1 text-xs font-medium text-slate-700 dark:text-white shadow-sm hover:bg-slate-50 dark:hover:bg-slate-800 transition ${className}`.trim()}
       {...rest}
     >
       {children}
+      <span aria-hidden className="opacity-70">
+        ↗
+      </span>
     </a>
   );
 };
@@ -137,9 +145,8 @@ export function LinkBadge(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) 
 
   if (!safe || verdict === "dead") {
     const disabledClass =
-      "inline-flex items-center rounded-full border px-2 py-1 text-xs opacity-70 cursor-not-allowed " +
-      "border-slate-200 dark:border-gray-700 text-slate-400" +
-      (className ? " " + className : "");
+      "inline-flex items-center rounded-full border border-slate-200 dark:border-slate-700 bg-gray-200 dark:bg-slate-800 px-2 py-1 text-xs text-gray-500 cursor-not-allowed " +
+      (className ? className : "");
     return (
       <span className={disabledClass} title="Link unavailable">
         {label}
@@ -153,11 +160,7 @@ export function LinkBadge(props: React.AnchorHTMLAttributes<HTMLAnchorElement>) 
       target="_blank"
       rel="noopener noreferrer"
       aria-busy={verdict === null ? "true" : "false"}
-      className={
-        "inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs shadow-sm hover:bg-slate-50 dark:hover:bg-gray-800 transition " +
-        "border-slate-200 dark:border-gray-700" +
-        (className ? " " + className : "")
-      }
+      className={`inline-flex items-center gap-1 rounded-full border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-2 py-1 text-xs font-medium text-slate-700 dark:text-white shadow-sm hover:bg-slate-50 dark:hover:bg-slate-800 transition ${className}`.trim()}
       {...rest}
     >
       <span>{label}</span>

--- a/components/layout/ComposerAdapter.tsx
+++ b/components/layout/ComposerAdapter.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function ComposerAdapter() {
+  return null;
+}

--- a/components/layout/HeaderLive.tsx
+++ b/components/layout/HeaderLive.tsx
@@ -48,7 +48,7 @@ export default function HeaderLive({
 
   return (
     <header
-      className={`sticky top-0 z-10 h-[62px] flex items-center justify-between px-4 border-b backdrop-blur-sm text-sm transition-colors
+      className={`sticky top-0 z-20 h-[62px] flex items-center justify-between px-4 border-b backdrop-blur-sm text-sm transition-colors
       ${dark ? "bg-slate-900/60 border-slate-800 text-white" : "bg-white/70 border-slate-200/70 text-slate-900"}`}
     >
       <div className="flex items-center gap-1 font-semibold text-base">

--- a/components/layout/HeaderLive.tsx
+++ b/components/layout/HeaderLive.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Globe2 } from "lucide-react";
+
+const MODES: { key: ModeKey; label: string; icon: string }[] = [
+  { key: "wellness", label: "Wellness", icon: "💙" },
+  { key: "therapy", label: "Therapy", icon: "🧠" },
+  { key: "research", label: "Research", icon: "📚" },
+  { key: "doctor", label: "Doctor", icon: "🩺" },
+  { key: "ai_doc", label: "AI Doc", icon: "🧪" },
+];
+
+const COUNTRY_CHOICES: readonly string[] = ["IND", "USA", "GBR"];
+const FLAG_BY_CODE: Record<string, string> = { IND: "🇮🇳", USA: "🇺🇸", GBR: "🇬🇧" };
+
+function flagFor(code3: string) {
+  return FLAG_BY_CODE[code3] ?? "🌐";
+}
+
+type ModeKey = "wellness" | "therapy" | "research" | "doctor" | "ai_doc";
+
+type Props = {
+  dark: boolean;
+  toggleDark: () => void;
+  country: string;
+  setCountry: (code3: string) => void;
+  isActive: (key: ModeKey) => boolean;
+  disabled: (key: ModeKey) => boolean;
+  onModePress: (key: ModeKey) => void;
+};
+
+export default function HeaderLive({
+  dark,
+  toggleDark,
+  country,
+  setCountry,
+  isActive,
+  disabled,
+  onModePress,
+}: Props) {
+  const seen = new Set<string>();
+  const optionList = (COUNTRY_CHOICES.includes(country) ? COUNTRY_CHOICES : [country, ...COUNTRY_CHOICES]).filter(code => {
+    if (!code) return false;
+    if (seen.has(code)) return false;
+    seen.add(code);
+    return true;
+  });
+
+  return (
+    <header
+      className={`sticky top-0 z-10 h-[62px] flex items-center justify-between px-4 border-b backdrop-blur-sm text-sm transition-colors
+      ${dark ? "bg-slate-900/60 border-slate-800 text-white" : "bg-white/70 border-slate-200/70 text-slate-900"}`}
+    >
+      <div className="flex items-center gap-1 font-semibold text-base">
+        <span className="text-lg">🫶</span>
+        Second
+        <span className="text-blue-300 ml-1">Opinion</span>
+      </div>
+
+      <div className="hidden md:flex items-center gap-1">
+        {MODES.map(mode => (
+          <button
+            key={mode.key}
+            type="button"
+            onClick={() => onModePress(mode.key)}
+            disabled={disabled(mode.key)}
+            className={`px-2.5 py-1 rounded-md border transition-colors flex items-center
+              ${isActive(mode.key)
+                ? "bg-blue-600 border-blue-600 text-white shadow-sm"
+                : dark
+                  ? "bg-slate-800/70 border-slate-700 text-white hover:bg-slate-800"
+                  : "bg-white/70 border-slate-200 text-slate-900 hover:bg-slate-100"}
+              ${disabled(mode.key) ? "opacity-60 cursor-not-allowed" : ""}`}
+          >
+            <span className="mr-1" aria-hidden>
+              {mode.icon}
+            </span>
+            {mode.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={toggleDark}
+          className={`px-2.5 py-1 rounded-md border transition-colors
+            ${dark ? "bg-slate-800/80 border-slate-700 text-white" : "bg-white/80 border-slate-200 text-slate-900"}`}
+        >
+          {dark ? "🌙" : "☀️"}
+        </button>
+
+        <div
+          className={`relative flex items-center border rounded-full pl-2 pr-6 py-1 gap-1 shadow-sm
+          ${dark ? "bg-slate-800/80 border-slate-700 text-white" : "bg-white/80 border-slate-200 text-slate-900"}`}
+        >
+          <Globe2 className="w-4 h-4" aria-hidden />
+          <select
+            value={country}
+            onChange={event => setCountry(event.target.value)}
+            className={`appearance-none bg-transparent outline-none text-sm pl-1 pr-6 py-0.5 rounded-full
+              focus:ring-2 focus:ring-blue-500 hover:bg-blue-800/10 ${dark ? "text-white" : "text-slate-900"}`}
+          >
+            {optionList.map(code => (
+              <option
+                key={code}
+                value={code}
+                className={dark ? "bg-slate-900 text-white" : "bg-white text-slate-900"}
+              >
+                {flagFor(code)} {code}
+              </option>
+            ))}
+          </select>
+          <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 opacity-70" aria-hidden>
+            ▾
+          </span>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/layout/MainAdapter.tsx
+++ b/components/layout/MainAdapter.tsx
@@ -51,7 +51,7 @@ export default function MainAdapter({ ui, panel }: Props) {
       {activePanel === "chat" && (
         <section className="block h-full">
           <ResearchFiltersProvider>
-            <ChatPane inputRef={chatInputRef} />
+            <ChatPane inputRef={chatInputRef} showHeader={false} />
           </ResearchFiltersProvider>
         </section>
       )}

--- a/components/layout/MainAdapter.tsx
+++ b/components/layout/MainAdapter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
 import Timeline from "@/components/panels/Timeline";
@@ -36,9 +36,26 @@ export default function MainAdapter({ ui, panel }: Props) {
       ? "Research assist: ON"
       : "Research assist: OFF";
 
+  const panelContent = useMemo(() => {
+    switch (activePanel) {
+      case "profile":
+        return <MedicalProfile />;
+      case "timeline":
+        return <Timeline />;
+      case "alerts":
+        return <AlertsPane />;
+      case "settings":
+        return <SettingsPane />;
+      case "ai-doc":
+        return <AiDocPane />;
+      default:
+        return null;
+    }
+  }, [activePanel]);
+
   return (
-    <div className="space-y-6">
-      <div>
+    <div className="flex h-full flex-col">
+      <div className="shrink-0">
         <h1 className="text-3xl font-semibold">Get a quick second opinion</h1>
         <ul className="mt-3 list-disc pl-6 space-y-1 text-base opacity-90">
           {HERO_POINTS.map(point => (
@@ -48,19 +65,17 @@ export default function MainAdapter({ ui, panel }: Props) {
         </ul>
       </div>
 
-      {activePanel === "chat" && (
-        <section className="block h-full">
-          <ResearchFiltersProvider>
-            <ChatPane inputRef={chatInputRef} showHeader={false} />
-          </ResearchFiltersProvider>
-        </section>
-      )}
-
-      {activePanel === "profile" && <MedicalProfile />}
-      {activePanel === "timeline" && <Timeline />}
-      {activePanel === "alerts" && <AlertsPane />}
-      {activePanel === "settings" && <SettingsPane />}
-      {activePanel === "ai-doc" && <AiDocPane />}
+      <div className="mt-6 flex-1 min-h-0">
+        {activePanel === "chat" ? (
+          <div className="flex h-full flex-col">
+            <ResearchFiltersProvider>
+              <ChatPane inputRef={chatInputRef} showHeader={false} />
+            </ResearchFiltersProvider>
+          </div>
+        ) : (
+          <div className="h-full overflow-y-auto pr-1">{panelContent}</div>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/layout/MainAdapter.tsx
+++ b/components/layout/MainAdapter.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import ChatPane from "@/components/panels/ChatPane";
+import MedicalProfile from "@/components/panels/MedicalProfile";
+import Timeline from "@/components/panels/Timeline";
+import AlertsPane from "@/components/panels/AlertsPane";
+import SettingsPane from "@/components/panels/SettingsPane";
+import AiDocPane from "@/components/panels/AiDocPane";
+import { ResearchFiltersProvider } from "@/store/researchFilters";
+import type { UiState } from "./ShellLive";
+
+const HERO_POINTS = [
+  "Upload labs, prescriptions, or scans",
+  "Ask questions in plain English",
+];
+
+type Props = {
+  ui: UiState;
+  panel: string;
+};
+
+export default function MainAdapter({ ui, panel }: Props) {
+  const chatInputRef = useRef<HTMLInputElement>(null);
+  const activePanel = panel.toLowerCase();
+
+  useEffect(() => {
+    const handler = () => chatInputRef.current?.focus();
+    window.addEventListener("focus-chat-input", handler);
+    return () => window.removeEventListener("focus-chat-input", handler);
+  }, []);
+
+  const statusLine = ui.aiDoc
+    ? "AI Doc is active — Click any other mode to switch back"
+    : ui.research
+      ? "Research assist: ON"
+      : "Research assist: OFF";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-semibold">Get a quick second opinion</h1>
+        <ul className="mt-3 list-disc pl-6 space-y-1 text-base opacity-90">
+          {HERO_POINTS.map(point => (
+            <li key={point}>{point}</li>
+          ))}
+          <li>{statusLine}</li>
+        </ul>
+      </div>
+
+      {activePanel === "chat" && (
+        <section className="block h-full">
+          <ResearchFiltersProvider>
+            <ChatPane inputRef={chatInputRef} />
+          </ResearchFiltersProvider>
+        </section>
+      )}
+
+      {activePanel === "profile" && <MedicalProfile />}
+      {activePanel === "timeline" && <Timeline />}
+      {activePanel === "alerts" && <AlertsPane />}
+      {activePanel === "settings" && <SettingsPane />}
+      {activePanel === "ai-doc" && <AiDocPane />}
+    </div>
+  );
+}

--- a/components/layout/ShellLive.tsx
+++ b/components/layout/ShellLive.tsx
@@ -187,8 +187,8 @@ export default function ShellLive({ Sidebar, Main, Composer }: ShellProps) {
         onModePress={onModePress}
       />
 
-      <div className="flex-1 min-h-0 overflow-hidden">
-        <div className="grid grid-cols-12 flex-1 min-h-[calc(100vh-62px)] overflow-hidden">
+      <div className="flex-1 min-h-0">
+        <div className="grid grid-cols-12 flex-1 min-h-[calc(100vh-62px)]">
           <aside
             className={`col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 backdrop-blur-sm p-3 flex h-full flex-col gap-3 text-sm border-r min-h-0
             ${dark ? "bg-slate-900/40 border-slate-800 text-white" : "bg-white/70 border-slate-200/60 text-slate-900"}`}
@@ -197,25 +197,27 @@ export default function ShellLive({ Sidebar, Main, Composer }: ShellProps) {
           </aside>
 
           <main
-            className={`col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 flex flex-col min-h-[calc(100vh-62px)] overflow-hidden ${
+            className={`col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 flex min-h-[calc(100vh-62px)] ${
               dark ? "text-white" : "text-slate-900"
             }`}
           >
-            <div className="flex-1 min-h-0 overflow-y-auto">
-              <div className={`m-6 rounded-2xl p-6 ring-1 ${paneSurface}`}>
-                <MainComponent ui={ui} panel={panel} />
-              </div>
-            </div>
-
-            {composerElement ? (
-              <div className={`sticky bottom-0 z-20 border-t ${dark ? "border-slate-800" : "border-slate-200/70"}`}>
-                <div className="px-6 pt-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
-                  <div className={`rounded-xl border ${composerSurface} bg-transparent`}>
-                    {composerElement}
-                  </div>
+            <div className="flex flex-col flex-1">
+              <div className="flex-1 overflow-y-auto">
+                <div className={`m-6 rounded-2xl p-6 ring-1 ${paneSurface}`}>
+                  <MainComponent ui={ui} panel={panel} />
                 </div>
               </div>
-            ) : null}
+
+              {composerElement ? (
+                <div className="mt-auto">
+                  <div className="px-6 pb-[max(16px,env(safe-area-inset-bottom))]">
+                    <div className={`rounded-xl border ${composerSurface} bg-transparent`}>
+                      {composerElement}
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+            </div>
           </main>
         </div>
       </div>

--- a/components/layout/ShellLive.tsx
+++ b/components/layout/ShellLive.tsx
@@ -184,29 +184,36 @@ export default function ShellLive({ Sidebar, Main, Composer }: ShellProps) {
         onModePress={onModePress}
       />
 
-      <div className="flex-1 grid grid-cols-12 relative">
-        <aside
-          className={`col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 backdrop-blur-sm p-3 flex flex-col gap-3 text-sm border-r
-          ${dark ? "bg-slate-900/40 border-slate-800 text-white" : "bg-white/70 border-slate-200/60 text-slate-900"}`}
-        >
-          <SidebarComponent />
-        </aside>
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <div className="grid h-full min-h-0 grid-cols-12">
+          <aside
+            className={`col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 backdrop-blur-sm p-3 flex h-full flex-col gap-3 text-sm border-r min-h-0
+            ${dark ? "bg-slate-900/40 border-slate-800 text-white" : "bg-white/70 border-slate-200/60 text-slate-900"}`}
+          >
+            <SidebarComponent />
+          </aside>
 
-        <main className="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 overflow-y-auto pb-28">
-          <div className="m-6 rounded-2xl p-6 medx-pane medx-ring">
-            <MainComponent ui={ui} panel={panel} />
-          </div>
-        </main>
-
-        {composerElement ? (
-          <div className="absolute bottom-0 left-[20%] right-6 px-6 pb-4">
-            <div
-              className={`rounded-xl border shadow-lg ${dark ? "bg-slate-900/70 border-slate-800" : "bg-white/80 border-slate-200/70"}`}
-            >
-              {composerElement}
+          <section
+            className={`col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 flex flex-col min-h-0 overflow-hidden
+            ${dark ? "text-white" : "text-slate-900"}`}
+          >
+            <div className="flex-1 overflow-y-auto px-6 pt-6 pb-4">
+              <div className="rounded-2xl p-6 medx-pane medx-ring">
+                <MainComponent ui={ui} panel={panel} />
+              </div>
             </div>
-          </div>
-        ) : null}
+
+            {composerElement ? (
+              <div className="px-6 pb-6">
+                <div
+                  className={`rounded-xl border shadow-lg ${dark ? "bg-slate-900/70 border-slate-800" : "bg-white/80 border-slate-200/70"}`}
+                >
+                  {composerElement}
+                </div>
+              </div>
+            ) : null}
+          </section>
+        </div>
       </div>
     </div>
   );

--- a/components/layout/ShellLive.tsx
+++ b/components/layout/ShellLive.tsx
@@ -197,8 +197,8 @@ export default function ShellLive({ Sidebar, Main, Composer }: ShellProps) {
             className={`col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 flex flex-col min-h-0 overflow-hidden
             ${dark ? "text-white" : "text-slate-900"}`}
           >
-            <div className="flex-1 overflow-y-auto px-6 pt-6 pb-4">
-              <div className="rounded-2xl p-6 medx-pane medx-ring">
+            <div className="flex-1 min-h-0 px-6 pt-6 pb-4">
+              <div className="flex h-full flex-col overflow-hidden rounded-2xl p-6 medx-pane medx-ring">
                 <MainComponent ui={ui} panel={panel} />
               </div>
             </div>

--- a/components/layout/ShellLive.tsx
+++ b/components/layout/ShellLive.tsx
@@ -194,11 +194,11 @@ export default function ShellLive({ Sidebar, Main, Composer }: ShellProps) {
           </aside>
 
           <section
-            className={`col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 flex flex-col min-h-0 overflow-hidden
+            className={`col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 flex min-h-0 flex-col overflow-hidden
             ${dark ? "text-white" : "text-slate-900"}`}
           >
-            <div className="flex-1 min-h-0 px-6 pt-6 pb-4">
-              <div className="flex h-full flex-col overflow-hidden rounded-2xl p-6 medx-pane medx-ring">
+            <div className="flex-1 min-h-0 overflow-y-auto px-6 pt-6 pb-4">
+              <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl p-6 medx-pane medx-ring">
                 <MainComponent ui={ui} panel={panel} />
               </div>
             </div>

--- a/components/layout/ShellLive.tsx
+++ b/components/layout/ShellLive.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useTheme } from "next-themes";
+import HeaderLive from "./HeaderLive";
+import { useCountry } from "@/lib/country";
+import { fromSearchParams } from "@/lib/modes/url";
+
+export type UiState = {
+  primary: "wellness" | "therapy" | "doctor";
+  research: boolean;
+  aiDoc: boolean;
+};
+
+type ModeKey = "wellness" | "therapy" | "research" | "doctor" | "ai_doc";
+
+type ShellProps = {
+  Sidebar: React.ComponentType;
+  Main: React.ComponentType<{ ui: UiState; panel: string }>;
+  Composer?: React.ComponentType;
+};
+
+export default function ShellLive({ Sidebar, Main, Composer }: ShellProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { theme, setTheme, systemTheme } = useTheme();
+  const { country: activeCountry, setCountry } = useCountry();
+
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const resolvedTheme = theme === "system" ? systemTheme ?? "light" : theme ?? "light";
+  const dark = (mounted ? resolvedTheme : "light") === "dark";
+
+  const params = useMemo(() => new URLSearchParams(searchParams.toString()), [searchParams]);
+  const panel = params.get("panel")?.toLowerCase() ?? "chat";
+
+  const modeState = useMemo(
+    () => fromSearchParams(params, dark ? "dark" : "light"),
+    [params, dark],
+  );
+
+  const lastNonAiDocRef = useRef({ base: modeState.base, therapy: modeState.therapy, research: modeState.research });
+
+  const aiDocActive = panel === "ai-doc" || modeState.base === "aidoc";
+  useEffect(() => {
+    if (!aiDocActive) {
+      lastNonAiDocRef.current = {
+        base: modeState.base === "aidoc" ? "patient" : modeState.base,
+        therapy: modeState.therapy,
+        research: modeState.research,
+      };
+    }
+  }, [aiDocActive, modeState.base, modeState.therapy, modeState.research]);
+
+  const ui = useMemo<UiState>(() => {
+    const last = lastNonAiDocRef.current;
+    const base = aiDocActive ? last.base : modeState.base;
+    let primary: UiState["primary"] = "wellness";
+    if (base === "doctor") primary = "doctor";
+    else if (aiDocActive ? last.therapy : modeState.therapy) primary = "therapy";
+    return {
+      primary,
+      research: aiDocActive ? last.research : modeState.research,
+      aiDoc: aiDocActive,
+    };
+  }, [aiDocActive, modeState.base, modeState.research, modeState.therapy]);
+
+  const pushParams = useCallback(
+    (next: URLSearchParams) => {
+      const query = next.toString();
+      if (query === searchParams.toString()) return;
+      const url = query ? `${pathname}?${query}` : pathname;
+      router.push(url);
+    },
+    [pathname, router, searchParams],
+  );
+
+  const onModePress = useCallback(
+    (key: ModeKey) => {
+      const next = new URLSearchParams(searchParams.toString());
+      if (key === "ai_doc") {
+        if (panel === "ai-doc") {
+          const last = lastNonAiDocRef.current;
+          next.set("panel", "chat");
+          next.set("mode", last.base === "doctor" ? "doctor" : "patient");
+          if (last.therapy && last.base !== "doctor") next.set("therapy", "1");
+          else next.delete("therapy");
+          if (last.research && last.base !== "aidoc") next.set("research", "1");
+          else next.delete("research");
+          next.delete("context");
+          if (next.get("threadId") === "med-profile") next.delete("threadId");
+          pushParams(next);
+        } else {
+          next.set("panel", "ai-doc");
+          next.delete("mode");
+          next.delete("therapy");
+          next.delete("research");
+          pushParams(next);
+        }
+        return;
+      }
+
+      next.set("panel", "chat");
+      next.delete("context");
+      if (key === "wellness") {
+        next.set("mode", "patient");
+        next.delete("therapy");
+      } else if (key === "therapy") {
+        const toggled = ui.primary === "therapy";
+        next.set("mode", "patient");
+        if (toggled) next.delete("therapy");
+        else next.set("therapy", "1");
+        next.delete("research");
+      } else if (key === "doctor") {
+        if (ui.primary === "doctor") {
+          next.set("mode", "patient");
+        } else {
+          next.set("mode", "doctor");
+        }
+        next.delete("therapy");
+      } else if (key === "research") {
+        if (ui.aiDoc || ui.primary === "therapy") return;
+        const isResearch = ui.research;
+        const base = ui.primary === "doctor" ? "doctor" : "patient";
+        next.set("mode", base);
+        if (isResearch) next.delete("research");
+        else next.set("research", "1");
+        next.delete("therapy");
+      }
+      pushParams(next);
+    },
+    [panel, pushParams, searchParams, ui.aiDoc, ui.primary, ui.research],
+  );
+
+  const isActive = useCallback(
+    (key: ModeKey) => {
+      if (key === "ai_doc") return ui.aiDoc;
+      if (key === "research") return ui.research;
+      if (key === "therapy") return ui.primary === "therapy";
+      if (key === "doctor") return ui.primary === "doctor" && !ui.aiDoc;
+      return ui.primary === "wellness";
+    },
+    [ui.aiDoc, ui.primary, ui.research],
+  );
+
+  const disabled = useCallback(
+    (key: ModeKey) => {
+      if (key === "research") return ui.primary === "therapy" || ui.aiDoc;
+      if (key === "therapy") return ui.aiDoc;
+      return false;
+    },
+    [ui.aiDoc, ui.primary],
+  );
+
+  const toggleDark = useCallback(() => {
+    setTheme(dark ? "light" : "dark");
+  }, [dark, setTheme]);
+
+  const SidebarComponent = Sidebar;
+  const MainComponent = Main;
+  const ComposerComponent = Composer;
+  const composerElement = ComposerComponent ? <ComposerComponent /> : null;
+
+  const appBg = useMemo(
+    () =>
+      dark
+        ? "bg-[linear-gradient(180deg,#06122E_0%,#071534_15%,#0A1C45_100%)] text-white"
+        : "bg-gradient-to-b from-sky-50 via-indigo-50 to-violet-100 text-slate-900",
+    [dark],
+  );
+
+  return (
+    <div className={`min-h-screen flex flex-col transition-colors ${appBg}`}>
+      <HeaderLive
+        dark={dark}
+        toggleDark={toggleDark}
+        country={activeCountry.code3}
+        setCountry={setCountry}
+        isActive={isActive}
+        disabled={disabled}
+        onModePress={onModePress}
+      />
+
+      <div className="flex-1 grid grid-cols-12 relative">
+        <aside
+          className={`col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 backdrop-blur-sm p-3 flex flex-col gap-3 text-sm border-r
+          ${dark ? "bg-slate-900/40 border-slate-800 text-white" : "bg-white/70 border-slate-200/60 text-slate-900"}`}
+        >
+          <SidebarComponent />
+        </aside>
+
+        <main className="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 overflow-y-auto pb-28">
+          <div className="m-6 rounded-2xl p-6 medx-pane medx-ring">
+            <MainComponent ui={ui} panel={panel} />
+          </div>
+        </main>
+
+        {composerElement ? (
+          <div className="absolute bottom-0 left-[20%] right-6 px-6 pb-4">
+            <div
+              className={`rounded-xl border shadow-lg ${dark ? "bg-slate-900/70 border-slate-800" : "bg-white/80 border-slate-200/70"}`}
+            >
+              {composerElement}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/layout/ShellLive.tsx
+++ b/components/layout/ShellLive.tsx
@@ -172,6 +172,9 @@ export default function ShellLive({ Sidebar, Main, Composer }: ShellProps) {
     [dark],
   );
 
+  const paneSurface = dark ? "medx-pane medx-ring ring-white/10" : "bg-white/80 ring-slate-200/70";
+  const composerSurface = dark ? "border-slate-800 text-white" : "border-slate-200/70 text-slate-900";
+
   return (
     <div className={`min-h-screen flex flex-col transition-colors ${appBg}`}>
       <HeaderLive
@@ -185,7 +188,7 @@ export default function ShellLive({ Sidebar, Main, Composer }: ShellProps) {
       />
 
       <div className="flex-1 min-h-0 overflow-hidden">
-        <div className="grid h-full min-h-0 grid-cols-12">
+        <div className="grid grid-cols-12 flex-1 min-h-[calc(100vh-62px)] overflow-hidden">
           <aside
             className={`col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 backdrop-blur-sm p-3 flex h-full flex-col gap-3 text-sm border-r min-h-0
             ${dark ? "bg-slate-900/40 border-slate-800 text-white" : "bg-white/70 border-slate-200/60 text-slate-900"}`}
@@ -193,26 +196,27 @@ export default function ShellLive({ Sidebar, Main, Composer }: ShellProps) {
             <SidebarComponent />
           </aside>
 
-          <section
-            className={`col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 flex min-h-0 flex-col overflow-hidden
-            ${dark ? "text-white" : "text-slate-900"}`}
+          <main
+            className={`col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 flex flex-col min-h-[calc(100vh-62px)] overflow-hidden ${
+              dark ? "text-white" : "text-slate-900"
+            }`}
           >
-            <div className="flex-1 min-h-0 overflow-y-auto px-6 pt-6 pb-4">
-              <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-2xl p-6 medx-pane medx-ring">
+            <div className="flex-1 min-h-0 overflow-y-auto">
+              <div className={`m-6 rounded-2xl p-6 ring-1 ${paneSurface}`}>
                 <MainComponent ui={ui} panel={panel} />
               </div>
             </div>
 
             {composerElement ? (
-              <div className="px-6 pb-6">
-                <div
-                  className={`rounded-xl border shadow-lg ${dark ? "bg-slate-900/70 border-slate-800" : "bg-white/80 border-slate-200/70"}`}
-                >
-                  {composerElement}
+              <div className={`sticky bottom-0 z-20 border-t ${dark ? "border-slate-800" : "border-slate-200/70"}`}>
+                <div className="px-6 pt-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
+                  <div className={`rounded-xl border ${composerSurface} bg-transparent`}>
+                    {composerElement}
+                  </div>
                 </div>
               </div>
             ) : null}
-          </section>
+          </main>
         </div>
       </div>
     </div>

--- a/components/layout/SidebarAdapter.tsx
+++ b/components/layout/SidebarAdapter.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Search, Settings } from "lucide-react";
+import { useRouter } from "next/navigation";
+import Tabs from "@/components/sidebar/Tabs";
+import ThreadKebab from "@/components/chat/ThreadKebab";
+import { createNewThreadId, listThreads, Thread } from "@/lib/chatThreads";
+
+export default function SidebarAdapter() {
+  const router = useRouter();
+  const [threads, setThreads] = useState<Thread[]>([]);
+  const [aidocThreads, setAidocThreads] = useState<{ id: string; title: string | null }[]>([]);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    const load = () => setThreads(listThreads());
+    load();
+    window.addEventListener("storage", load);
+    window.addEventListener("chat-threads-updated", load);
+    return () => {
+      window.removeEventListener("storage", load);
+      window.removeEventListener("chat-threads-updated", load);
+    };
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/aidoc/threads")
+      .then(res => res.json())
+      .then(data => setAidocThreads(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  const filteredThreads = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return threads;
+    return threads.filter(thread => thread.title.toLowerCase().includes(q));
+  }, [threads, query]);
+
+  const handleNewChat = () => {
+    const id = createNewThreadId();
+    router.push(`/?panel=chat&threadId=${id}`);
+  };
+
+  const handleSearch = (value: string) => {
+    setQuery(value);
+    window.dispatchEvent(new CustomEvent("search-chats", { detail: value }));
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <button
+        type="button"
+        onClick={handleNewChat}
+        className="w-full flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg py-2.5 shadow-sm"
+      >
+        <span className="text-lg leading-none" aria-hidden>
+          ＋
+        </span>
+        New chat
+      </button>
+
+      <div className="space-y-3">
+        <div className="relative mt-3">
+          <input
+            type="search"
+            value={query}
+            onChange={event => handleSearch(event.target.value)}
+            placeholder="Search chats"
+            className="w-full h-10 rounded-lg pl-3 pr-9 text-sm bg-white/80 dark:bg-slate-900/70 border border-slate-200/70 dark:border-slate-700 placeholder:text-slate-500 dark:placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <Search className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500" size={16} aria-hidden />
+        </div>
+        <Tabs />
+      </div>
+
+      <div className="mt-3 space-y-1 flex-1 overflow-y-auto pr-1">
+        {filteredThreads.map(thread => (
+          <div
+            key={thread.id}
+            className="flex items-center gap-2 rounded-lg px-3 py-2.5 text-sm bg-white/70 dark:bg-slate-900/60 border border-transparent hover:border-blue-400/60 transition"
+          >
+            <button
+              type="button"
+              onClick={() => router.push(`/?panel=chat&threadId=${thread.id}`)}
+              className="flex-1 text-left truncate"
+              title={thread.title}
+            >
+              {thread.title}
+            </button>
+            <ThreadKebab
+              id={thread.id}
+              title={thread.title}
+              onRenamed={nextTitle => {
+                setThreads(prev => prev.map(t => (t.id === thread.id ? { ...t, title: nextTitle, updatedAt: Date.now() } : t)));
+              }}
+              onDeleted={() => {
+                setThreads(prev => prev.filter(t => t.id !== thread.id));
+              }}
+            />
+          </div>
+        ))}
+
+        {aidocThreads.length > 0 && (
+          <div className="pt-4 space-y-1">
+            <div className="px-3 text-xs font-semibold uppercase tracking-wide opacity-60">AI Doc</div>
+            {aidocThreads.map(thread => (
+              <button
+                key={thread.id}
+                type="button"
+                onClick={() => router.push(`/?panel=ai-doc&threadId=${thread.id}&context=profile`)}
+                className="w-full text-left px-3 py-2.5 rounded-lg bg-white/70 dark:bg-slate-900/60 border border-transparent hover:border-blue-400/60 transition"
+                title={thread.title ?? "AI Doc — New Case"}
+              >
+                {thread.title ?? "AI Doc — New Case"}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => router.push("/?panel=settings")}
+        className="mt-4 flex items-center gap-2 rounded-lg border border-slate-200/70 dark:border-slate-700 bg-white/70 dark:bg-slate-900/60 px-3 py-2 text-sm hover:bg-white/90 dark:hover:bg-slate-800"
+      >
+        <Settings size={16} />
+        Preferences
+      </button>
+    </div>
+  );
+}

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -2662,7 +2662,7 @@ ${systemCommon}` + baseSys;
   }, [busy]);
 
   return (
-    <div className="relative flex h-full flex-col">
+    <div className="relative flex h-full min-h-0 flex-col">
       {showHeader && <Header />}
       {mode === "doctor" && researchMode && (
         <>
@@ -2795,7 +2795,7 @@ ${systemCommon}` + baseSys;
       )}
       <div
         ref={chatRef}
-        className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 pt-4 md:pt-6 pb-28"
+        className="flex-1 min-h-0 overflow-y-auto px-4 pt-4 pb-6 sm:px-6 lg:px-8 md:pt-6"
       >
         {showDefaultSuggestions && showSuggestions && (
           <ChatSuggestions suggestions={defaultSuggestions} onSelect={handleSuggestionPick} />
@@ -2926,38 +2926,39 @@ ${systemCommon}` + baseSys;
         </div>
       )}
     </div>
-  <div className="absolute bottom-4 left-0 right-0 flex justify-center">
-        <div className="w-full max-w-3xl px-4">
-      {mode === 'doctor' && AIDOC_UI && (
-        <button
-          className="rounded-md px-3 py-1 border mb-2"
-          onClick={async () => {
-            if (AIDOC_PREFLIGHT) {
-              setShowPatientChooser(true);
-            } else {
-              runAiDocWith('current');
-            }
-          }}
-          aria-label="AI Doc Next Steps"
-          disabled={loadingAidoc}
-        >
-          {loadingAidoc ? 'Analyzing…' : 'Next steps (AI Doc)'}
-        </button>
-      )}
-      {showLiveSuggestions && (
-        <SuggestBar
-          title="Suggestions"
-          suggestions={liveSuggestions}
-          onPick={handleSuggestionPick}
-          className="rounded-2xl border border-zinc-200 bg-white/90 p-3 backdrop-blur dark:border-zinc-700 dark:bg-slate-900/80"
-        />
-      )}
-      <form
-        onSubmit={e => {
-          e.preventDefault();
-          onSubmit();
-        }}
-            className="w-full flex items-center gap-3 rounded-full medx-glass px-3 py-2"
+
+      <div className="shrink-0 border-t bg-white/80 px-4 py-4 backdrop-blur-sm medx-border medx-composer dark:bg-transparent sm:px-6 lg:px-8">
+        <div className="mx-auto w-full max-w-3xl space-y-3">
+          {mode === "doctor" && AIDOC_UI && (
+            <button
+              className="rounded-md border px-3 py-1"
+              onClick={async () => {
+                if (AIDOC_PREFLIGHT) {
+                  setShowPatientChooser(true);
+                } else {
+                  runAiDocWith('current');
+                }
+              }}
+              aria-label="AI Doc Next Steps"
+              disabled={loadingAidoc}
+            >
+              {loadingAidoc ? 'Analyzing…' : 'Next steps (AI Doc)'}
+            </button>
+          )}
+          {showLiveSuggestions && (
+            <SuggestBar
+              title="Suggestions"
+              suggestions={liveSuggestions}
+              onPick={handleSuggestionPick}
+              className="rounded-2xl border border-zinc-200 bg-white/90 p-3 backdrop-blur dark:border-zinc-700 dark:bg-slate-900/80"
+            />
+          )}
+          <form
+            onSubmit={e => {
+              e.preventDefault();
+              onSubmit();
+            }}
+            className="flex w-full items-center gap-3 rounded-full px-3 py-2 medx-glass"
           >
             <label
               className="cursor-pointer inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-md medx-surface text-medx"
@@ -3034,7 +3035,7 @@ ${systemCommon}` + baseSys;
 
               {!busy && (
                 <button
-                  className="w-10 h-10 rounded-full flex items-center justify-center text-lg medx-btn-accent disabled:opacity-50"
+                  className="flex h-10 w-10 items-center justify-center rounded-full text-lg medx-btn-accent disabled:opacity-50"
                   type="submit"
                   disabled={!pendingFile && !userText.trim()}
                   aria-label="Send"

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -613,7 +613,15 @@ function AssistantMessage({
   );
 }
 
-export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: RefObject<HTMLInputElement> } = {}) {
+type ChatPaneProps = {
+  inputRef?: RefObject<HTMLInputElement>;
+  showHeader?: boolean;
+};
+
+export default function ChatPane({
+  inputRef: externalInputRef,
+  showHeader = true,
+}: ChatPaneProps = {}) {
 
   const { country } = useCountry();
   const { active, setFromAnalysis, setFromChat, clear: clearContext } = useActiveContext();
@@ -2655,7 +2663,7 @@ ${systemCommon}` + baseSys;
 
   return (
     <div className="relative flex h-full flex-col">
-      <Header />
+      {showHeader && <Header />}
       {mode === "doctor" && researchMode && (
         <>
           <ResearchFilters mode="research" onResults={handleTrials} />


### PR DESCRIPTION
## Summary
- introduce a ShellLive wrapper with a refreshed header, sidebar, and main adapters to drive the new MedX live UI layout
- append dark-mode gradient tokens and update SafeLink badges to match the polished surface styling

## Testing
- npm run lint *(fails: command prompts for interactive ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cebba63310832f87c6d53339344589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live Shell with Header, Sidebar, Main, and Composer adapters enabling routed modes, panel-aware UI, and country/dark controls.
  * Responsive sidebar with chat & AI Doc threads, search, new chat, rename/delete, and preferences.
  * Main panels (Chat, Profile, Timeline, Alerts, Settings, AI Doc) and a placeholder Composer.

* **Style**
  * New MedX Live dark theme tokens applied sitewide; duplicate dark-theme block present.
  * Updated link visuals with external-link indicators and refined disabled/link-badge styles.

* **Refactor**
  * Layout simplified to a single-column flow; ChatPane now supports an optional showHeader prop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->