### PR TITLE
feat: refresh live shell layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body, #__next {
+  height: 100%;
+}
+
+:root.dark {
+  --medx-bg-grad: linear-gradient(180deg,#06122E 0%,#071534 15%,#0A1C45 100%);
+  --medx-text: #ffffff;
+}
+
 /* smooth theme transitions */
 * { transition: background-color .15s ease, color .15s ease, border-color .15s ease; }
 
@@ -56,7 +65,7 @@
 }
 
 /* Ensure body/content contrast in dark */
-.dark body { color: rgb(229 231 235); }           /* text-gray-200 */
+.dark body { background: var(--medx-bg-grad) !important; color: var(--medx-text) !important; }
 .dark .card,.dark .panel { background: #0f172a; } /* slate-900 */
 .dark .border { border-color: rgb(71 85 105); }   /* slate-600 */
 .dark .prose-medx :where(li)::marker { color: rgb(148 163 184); }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,9 @@
 import "./globals.css";
 import { ThemeProvider } from "next-themes";
-import Sidebar from "../components/Sidebar";
 import { CountryProvider } from "@/lib/country";
 import { ContextProvider } from "@/lib/context";
 import { TopicProvider } from "@/lib/topic";
 import { BRAND_NAME } from "@/lib/brand";
-import { Suspense } from "react";
 import MemorySnackbar from "@/components/memory/Snackbar";
 import UndoToast from "@/components/memory/UndoToast";
 import { Roboto } from "next/font/google";
@@ -22,20 +20,15 @@ const roboto = Roboto({
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={roboto.variable} suppressHydrationWarning>
-      <body className="min-h-screen bg-white dark:bg-slate-950 text-slate-900 dark:text-gray-100 font-sans antialiased">
+      <body className="min-h-screen bg-white dark:text-gray-100 text-slate-900 font-sans antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <CountryProvider>
             <ContextProvider>
               <TopicProvider>
-                <div className="flex medx-gradient">
-                  <Suspense fallback={null}>
-                    <Sidebar />
-                  </Suspense>
-                  <main className="flex-1 md:ml-64 min-h-dvh flex flex-col relative z-0">
-                    {children}
-                    <MemorySnackbar />
-                    <UndoToast />
-                  </main>
+                <div className="min-h-screen flex flex-col">
+                  {children}
+                  <MemorySnackbar />
+                  <UndoToast />
                 </div>
               </TopicProvider>
             </ContextProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,39 +1,6 @@
 "use client";
-import { useEffect, useRef } from "react";
-import ChatPane from "@/components/panels/ChatPane";
-import MedicalProfile from "@/components/panels/MedicalProfile";
-import Timeline from "@/components/panels/Timeline";
-import AlertsPane from "@/components/panels/AlertsPane";
-import SettingsPane from "@/components/panels/SettingsPane";
-import { ResearchFiltersProvider } from "@/store/researchFilters";
-import AiDocPane from "@/components/panels/AiDocPane";
+import ShellLive from "@/components/live/ShellLive";
 
-type Search = { panel?: string };
-
-export default function Page({ searchParams }: { searchParams: Search }) {
-  const panel = searchParams.panel?.toLowerCase() || "chat";
-  const chatInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const handler = () => chatInputRef.current?.focus();
-    window.addEventListener("focus-chat-input", handler);
-    return () => window.removeEventListener("focus-chat-input", handler);
-  }, []);
-
-  return (
-    <main className="flex-1 overflow-y-auto content-layer">
-      {panel === "chat" && (
-        <section className="block h-full">
-          <ResearchFiltersProvider>
-            <ChatPane inputRef={chatInputRef} />
-          </ResearchFiltersProvider>
-        </section>
-      )}
-      {panel === "profile" && <MedicalProfile />}
-      {panel === "timeline" && <Timeline />}
-      {panel === "alerts" && <AlertsPane />}
-      {panel === "settings" && <SettingsPane />}
-      {panel === "ai-doc" && <AiDocPane />}
-    </main>
-  );
+export default function Page() {
+  return <ShellLive />;
 }

--- a/components/live/ComposerLive.tsx
+++ b/components/live/ComposerLive.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function ComposerLive() {
+  return null;
+}

--- a/components/live/HeaderLive.tsx
+++ b/components/live/HeaderLive.tsx
@@ -1,0 +1,118 @@
+"use client";
+import { Globe2 } from "lucide-react";
+import { COUNTRIES } from "@/data/countries";
+
+type ModeKey = "wellness" | "therapy" | "research" | "doctor" | "ai_doc";
+
+type HeaderLiveProps = {
+  dark: boolean;
+  setDark: (v: boolean) => void;
+  country: string;
+  setCountry: (v: string) => void;
+  isActive: (k: ModeKey) => boolean;
+  disabled: (k: ModeKey) => boolean;
+  onModePress: (k: ModeKey) => void;
+};
+
+const MODES: { key: ModeKey; label: string; icon: string }[] = [
+  { key: "wellness", label: "Wellness", icon: "💙" },
+  { key: "therapy", label: "Therapy", icon: "🧠" },
+  { key: "research", label: "Research", icon: "📚" },
+  { key: "doctor", label: "Doctor", icon: "🩺" },
+  { key: "ai_doc", label: "AI Doc", icon: "🧪" },
+];
+
+export default function HeaderLive({
+  dark,
+  setDark,
+  country,
+  setCountry,
+  isActive,
+  disabled,
+  onModePress,
+}: HeaderLiveProps) {
+  return (
+    <header
+      className={`sticky top-0 z-10 h-[62px] flex items-center justify-between px-4 border-b backdrop-blur-sm
+      ${
+        dark
+          ? "bg-slate-900/60 border-slate-800 text-white"
+          : "bg-white/70 border-slate-200/70 text-slate-900"
+      }`}
+    >
+      <div className="flex items-center gap-1 font-semibold text-base">
+        <span className="text-lg">🫶</span>
+        Second <span className="text-blue-300 ml-1">Opinion</span>
+      </div>
+
+      <div className="hidden md:flex items-center gap-1">
+        {MODES.map((m) => {
+          const active = isActive(m.key);
+          const isDisabled = disabled(m.key);
+          return (
+            <button
+              key={m.key}
+              onClick={() => onModePress(m.key)}
+              disabled={isDisabled}
+              className={`px-2.5 py-1 rounded-md border transition-colors
+              ${
+                active
+                  ? "bg-blue-600 border-blue-600 text-white shadow-sm"
+                  : dark
+                  ? "bg-slate-800/70 border-slate-700 text-white hover:bg-slate-800"
+                  : "bg-white/70 border-slate-200 text-slate-900 hover:bg-slate-100"
+              }
+              ${isDisabled ? "opacity-60 cursor-not-allowed" : ""}`}
+            >
+              <span className="mr-1">{m.icon}</span>
+              {m.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => setDark(!dark)}
+          className={`px-2.5 py-1 rounded-md border ${
+            dark
+              ? "bg-slate-800/80 border-slate-700 text-white"
+              : "bg-white/80 border-slate-200 text-slate-900"
+          }`}
+          aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
+        >
+          {dark ? "🌙" : "☀️"}
+        </button>
+
+        <div
+          className={`relative flex items-center border rounded-full pl-2 pr-6 py-1 gap-1 shadow-sm
+          ${
+            dark
+              ? "bg-slate-800/80 border-slate-700 text-white"
+              : "bg-white/80 border-slate-200 text-slate-900"
+          }`}
+        >
+          <Globe2 className="w-4 h-4" aria-hidden="true" />
+          <select
+            value={country}
+            onChange={(e) => setCountry(e.target.value)}
+            className={`appearance-none bg-transparent outline-none text-sm pl-1 pr-6 py-0.5 rounded-full
+              focus:ring-2 focus:ring-blue-500 hover:bg-blue-800/10 ${dark ? "text-white" : "text-slate-900"}`}
+            aria-label="Select country"
+          >
+            {COUNTRIES.map((c) => (
+              <option
+                key={c.code3}
+                value={c.code3}
+                className={dark ? "bg-slate-900 text-white" : "bg-white text-slate-900"}
+              >
+                {c.flag} {c.code3}
+              </option>
+            ))}
+          </select>
+          <span className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 opacity-70">▾</span>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/live/MainLive.tsx
+++ b/components/live/MainLive.tsx
@@ -1,0 +1,48 @@
+"use client";
+import { RefObject, useMemo } from "react";
+import ChatPane from "@/components/panels/ChatPane";
+import MedicalProfile from "@/components/panels/MedicalProfile";
+import Timeline from "@/components/panels/Timeline";
+import AlertsPane from "@/components/panels/AlertsPane";
+import SettingsPane from "@/components/panels/SettingsPane";
+import AiDocPane from "@/components/panels/AiDocPane";
+import { ResearchFiltersProvider } from "@/store/researchFilters";
+
+type MainLiveProps = {
+  panel: string;
+  chatInputRef: RefObject<HTMLInputElement>;
+};
+
+export default function MainLive({ panel, chatInputRef }: MainLiveProps) {
+  const normalized = panel.toLowerCase();
+
+  const content = useMemo(() => {
+    switch (normalized) {
+      case "profile":
+        return <MedicalProfile />;
+      case "timeline":
+        return <Timeline />;
+      case "alerts":
+        return <AlertsPane />;
+      case "settings":
+        return <SettingsPane />;
+      case "ai-doc":
+        return <AiDocPane />;
+      case "chat":
+      default:
+        return (
+          <ResearchFiltersProvider>
+            <ChatPane inputRef={chatInputRef} />
+          </ResearchFiltersProvider>
+        );
+    }
+  }, [normalized, chatInputRef]);
+
+  return (
+    <div className="m-6 flex-1 overflow-hidden">
+      <div className="h-full rounded-2xl p-6 ring-1 bg-white/80 dark:bg-slate-900/60 ring-black/5 dark:ring-white/10 flex flex-col">
+        {content}
+      </div>
+    </div>
+  );
+}

--- a/components/live/ShellLive.tsx
+++ b/components/live/ShellLive.tsx
@@ -1,0 +1,142 @@
+"use client";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTheme } from "next-themes";
+import HeaderLive from "./HeaderLive";
+import SidebarLive from "./SidebarLive";
+import MainLive from "./MainLive";
+import { useCountry } from "@/lib/country";
+import { fromSearchParams, toQuery } from "@/lib/modes/url";
+import { canonicalize } from "@/lib/modes/modeMachine";
+import type { ModeState } from "@/lib/modes/types";
+
+type ModeKey = "wellness" | "therapy" | "research" | "doctor" | "ai_doc";
+
+export default function ShellLive() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  const { country, setCountry } = useCountry();
+  const chatInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const handler = () => chatInputRef.current?.focus();
+    window.addEventListener("focus-chat-input", handler);
+    return () => window.removeEventListener("focus-chat-input", handler);
+  }, []);
+
+  const currentTheme = (theme === "system" ? resolvedTheme : theme) ?? "light";
+  const dark = currentTheme === "dark";
+
+  const modeState = useMemo(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    return canonicalize(fromSearchParams(params, dark ? "dark" : "light"));
+  }, [searchParams, dark]);
+
+  const handleModePress = useCallback(
+    (key: ModeKey) => {
+      let next: ModeState = { ...modeState };
+      switch (key) {
+        case "ai_doc":
+          next.base = modeState.base === "aidoc" ? "patient" : "aidoc";
+          next.therapy = false;
+          next.research = false;
+          break;
+        case "doctor":
+          next.base = "doctor";
+          next.therapy = false;
+          break;
+        case "therapy":
+          next.base = "patient";
+          next.therapy = !modeState.therapy;
+          if (next.therapy) next.research = false;
+          break;
+        case "research":
+          next.research = !modeState.research;
+          if (next.research) {
+            next.base = modeState.base === "doctor" ? "doctor" : "patient";
+            next.therapy = false;
+          }
+          break;
+        case "wellness":
+        default:
+          next.base = "patient";
+          next.therapy = false;
+          break;
+      }
+      next = canonicalize(next);
+      router.push(toQuery(next, searchParams));
+    },
+    [modeState, router, searchParams],
+  );
+
+  const isActive = useCallback(
+    (key: ModeKey) => {
+      switch (key) {
+        case "ai_doc":
+          return modeState.base === "aidoc";
+        case "research":
+          return modeState.research;
+        case "therapy":
+          return modeState.therapy;
+        case "doctor":
+          return modeState.base === "doctor";
+        case "wellness":
+        default:
+          return modeState.base === "patient" && !modeState.therapy;
+      }
+    },
+    [modeState],
+  );
+
+  const disabled = useCallback(
+    (key: ModeKey) => {
+      if (key === "therapy") return modeState.base !== "patient" || modeState.base === "aidoc";
+      if (key === "research") return modeState.therapy || modeState.base === "aidoc";
+      return false;
+    },
+    [modeState],
+  );
+
+  const appBg = useMemo(
+    () =>
+      dark
+        ? "bg-[linear-gradient(180deg,#06122E_0%,#071534_15%,#0A1C45_100%)] text-white"
+        : "bg-gradient-to-b from-sky-50 via-indigo-50 to-violet-100 text-slate-900",
+    [dark],
+  );
+
+  const panel = (searchParams.get("panel") ?? "chat").toLowerCase();
+
+  return (
+    <div className={`h-full min-h-screen flex flex-col ${appBg}`}>
+      <HeaderLive
+        dark={dark}
+        setDark={(value) => setTheme(value ? "dark" : "light")}
+        country={country.code3}
+        setCountry={setCountry}
+        isActive={isActive}
+        disabled={disabled}
+        onModePress={handleModePress}
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-12 flex-1 min-h-[calc(100vh-62px)]">
+        <aside
+          className={`hidden md:flex md:col-span-3 lg:col-span-2 backdrop-blur-sm p-3 flex-col gap-3 text-sm border-r ${
+            dark
+              ? "bg-slate-900/40 border-slate-800 text-white"
+              : "bg-white/70 border-slate-200/60 text-slate-900"
+          }`}
+        >
+          <SidebarLive />
+        </aside>
+
+        <main className="col-span-1 md:col-span-9 lg:col-span-10 flex min-h-[calc(100vh-62px)]">
+          <div className="flex flex-col flex-1 overflow-hidden">
+            <MainLive panel={panel} chatInputRef={chatInputRef} />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/components/live/SidebarLive.tsx
+++ b/components/live/SidebarLive.tsx
@@ -1,0 +1,208 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  createNewThreadId,
+  listThreads,
+  Thread,
+} from "@/lib/chatThreads";
+import ThreadKebab from "@/components/chat/ThreadKebab";
+import { useCountry } from "@/lib/country";
+
+const NAV_ITEMS = [
+  { key: "chat", label: "Chat", panel: "chat" },
+  {
+    key: "ai-doc",
+    label: "AI Doc",
+    panel: "chat",
+    threadId: "med-profile",
+    context: "profile",
+  },
+  { key: "profile", label: "Medical Profile", panel: "profile" },
+  { key: "timeline", label: "Timeline", panel: "timeline" },
+  { key: "alerts", label: "Alerts", panel: "alerts" },
+  { key: "settings", label: "Settings", panel: "settings" },
+];
+
+type AidocThread = { id: string; title: string | null };
+
+export default function SidebarLive() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { country } = useCountry();
+  const [threads, setThreads] = useState<Thread[]>([]);
+  const [aidocThreads, setAidocThreads] = useState<AidocThread[]>([]);
+  const [q, setQ] = useState("");
+
+  useEffect(() => {
+    const load = () => setThreads(listThreads());
+    load();
+    window.addEventListener("storage", load);
+    window.addEventListener("chat-threads-updated", load);
+    return () => {
+      window.removeEventListener("storage", load);
+      window.removeEventListener("chat-threads-updated", load);
+    };
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/aidoc/threads")
+      .then((r) => r.json())
+      .then((data) => setAidocThreads(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  const currentPanel = (searchParams.get("panel") ?? "chat").toLowerCase();
+  const currentThreadId = searchParams.get("threadId") ?? undefined;
+  const currentContext = searchParams.get("context") ?? undefined;
+
+  const filteredThreads = useMemo(() => {
+    const query = q.trim().toLowerCase();
+    if (!query) return threads;
+    return threads.filter((t) => t.title.toLowerCase().includes(query));
+  }, [threads, q]);
+
+  const handleNewChat = () => {
+    const id = createNewThreadId();
+    router.push(`/?panel=chat&threadId=${id}`);
+  };
+
+  const handleSearch = (value: string) => {
+    setQ(value);
+    window.dispatchEvent(new CustomEvent("search-chats", { detail: value }));
+  };
+
+  const handleNavigate = (item: (typeof NAV_ITEMS)[number]) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("panel", item.panel);
+    if (item.threadId || (item.key === "chat" && currentThreadId)) {
+      const threadTarget =
+        item.key === "chat" ? currentThreadId ?? undefined : item.threadId;
+      if (threadTarget) params.set("threadId", threadTarget);
+      else params.delete("threadId");
+    } else {
+      params.delete("threadId");
+    }
+    if (item.context) params.set("context", item.context);
+    else params.delete("context");
+    router.push(`/?${params.toString()}`);
+  };
+
+  const isActive = (item: (typeof NAV_ITEMS)[number]) => {
+    if (currentPanel !== item.panel) return false;
+    if (item.threadId) {
+      const matchThread = currentThreadId === item.threadId;
+      const matchContext = item.context
+        ? currentContext === item.context
+        : !currentContext;
+      return matchThread && matchContext;
+    }
+    if (item.key === "chat" && currentThreadId) return true;
+    return !currentThreadId;
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-3 text-sm">
+      <button
+        className="w-full flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg py-2 shadow-sm"
+        type="button"
+        onClick={handleNewChat}
+      >
+        <span className="text-lg leading-none">＋</span> New chat
+      </button>
+
+      <input
+        className="w-full rounded-md border px-2 py-1.5 bg-white/80 dark:bg-slate-800 border-slate-200 dark:border-slate-700 text-sm"
+        placeholder="Search chats"
+        value={q}
+        onChange={(e) => handleSearch(e.target.value)}
+      />
+
+      <nav className="grid gap-1 text-sm">
+        {NAV_ITEMS.map((item) => (
+          <button
+            key={item.key}
+            type="button"
+            onClick={() => handleNavigate(item)}
+            className={`px-2 py-1.5 rounded-md border transition-colors text-left ${
+              isActive(item)
+                ? "bg-blue-600 text-white border-blue-500 shadow-sm"
+                : "border-transparent hover:bg-blue-800/10 hover:border-blue-200/30"
+            }`}
+          >
+            {item.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="flex-1 overflow-y-auto rounded-lg border border-slate-200/60 dark:border-slate-700/60 bg-white/60 dark:bg-slate-900/40 p-2 space-y-2">
+        {filteredThreads.length === 0 && (
+          <div className="text-xs text-slate-500 dark:text-slate-400 px-2">
+            No chats in {country.code3} yet.
+          </div>
+        )}
+        {filteredThreads.map((thread) => (
+          <div
+            key={thread.id}
+            className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors ${
+              currentThreadId === thread.id && currentPanel === "chat"
+                ? "border-blue-400/70 bg-blue-500/10"
+                : "border-transparent hover:border-blue-200/40 hover:bg-blue-800/5"
+            }`}
+          >
+            <button
+              onClick={() => router.push(`/?panel=chat&threadId=${thread.id}`)}
+              className="flex-1 text-left truncate"
+              title={thread.title}
+            >
+              {thread.title}
+            </button>
+            <ThreadKebab
+              id={thread.id}
+              title={thread.title}
+              onRenamed={(nextTitle) => {
+                setThreads((prev) =>
+                  prev.map((t) =>
+                    t.id === thread.id
+                      ? { ...t, title: nextTitle, updatedAt: Date.now() }
+                      : t
+                  )
+                );
+              }}
+              onDeleted={() => {
+                setThreads((prev) => prev.filter((t) => t.id !== thread.id));
+              }}
+            />
+          </div>
+        ))}
+
+        {aidocThreads.length > 0 && (
+          <div className="pt-2 border-t border-slate-200/60 dark:border-slate-700/60 space-y-1">
+            <div className="px-2 text-xs font-semibold opacity-70">AI Doc</div>
+            {aidocThreads.map((thread) => (
+              <button
+                key={thread.id}
+                onClick={() =>
+                  router.push(`/?panel=ai-doc&threadId=${thread.id}&context=profile`)
+                }
+                className="w-full text-left rounded-md border border-transparent px-3 py-2 text-sm hover:border-blue-200/40 hover:bg-blue-800/5"
+              >
+                {thread.title ?? "AI Doc — New Case"}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-auto pt-2">
+        <button
+          className="w-full border rounded-md px-2 py-1.5 text-left hover:bg-blue-800/10"
+          type="button"
+          onClick={() => handleNavigate(NAV_ITEMS.find((i) => i.key === "settings")!)}
+        >
+          ⚙️ Preferences
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -3,7 +3,6 @@ import dynamic from "next/dynamic";
 import { useEffect, useRef, useState, useMemo, RefObject, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { fromSearchParams } from '@/lib/modes/url';
-import Header from '../Header';
 import { useRouter } from 'next/navigation';
 import ChatMarkdown from '@/components/ChatMarkdown';
 import ResearchFilters from '@/components/ResearchFilters';
@@ -13,7 +12,6 @@ import type { TrialRow } from "@/types/trials";
 import { useResearchFilters } from '@/store/researchFilters';
 import { Send, Paperclip, Clipboard, Stethoscope, Users, ChevronDown, ChevronUp } from 'lucide-react';
 import { useCountry } from '@/lib/country';
-import { getRandomWelcome } from '@/lib/welcomeMessages';
 import { useActiveContext } from '@/lib/context';
 import { isFollowUp } from '@/lib/followup';
 import { detectFollowupIntent } from '@/lib/intents';
@@ -1467,12 +1465,6 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   }, [isProfileThread, threadId, therapyMode]);
 
   useEffect(() => {
-    if (!isProfileThread && messages.length === 0) {
-      addOnce('welcome:chat', getRandomWelcome());
-    }
-  }, [isProfileThread, messages.length]);
-
-  useEffect(() => {
     const tid = threadId || (isProfileThread ? 'med-profile' : null);
     if (tid) saveMessages(tid, messages as any);
   }, [messages, threadId, isProfileThread]);
@@ -2655,7 +2647,6 @@ ${systemCommon}` + baseSys;
 
   return (
     <div className="relative flex h-full flex-col">
-      <Header />
       {mode === "doctor" && researchMode && (
         <>
           <ResearchFilters mode="research" onResults={handleTrials} />
@@ -2787,7 +2778,7 @@ ${systemCommon}` + baseSys;
       )}
       <div
         ref={chatRef}
-        className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 pt-4 md:pt-6 pb-28"
+        className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 pt-4 md:pt-6 pb-6"
       >
         {showDefaultSuggestions && showSuggestions && (
           <ChatSuggestions suggestions={defaultSuggestions} onSelect={handleSuggestionPick} />
@@ -2918,39 +2909,39 @@ ${systemCommon}` + baseSys;
         </div>
       )}
     </div>
-  <div className="absolute bottom-4 left-0 right-0 flex justify-center">
-        <div className="w-full max-w-3xl px-4">
-      {mode === 'doctor' && AIDOC_UI && (
-        <button
-          className="rounded-md px-3 py-1 border mb-2"
-          onClick={async () => {
-            if (AIDOC_PREFLIGHT) {
-              setShowPatientChooser(true);
-            } else {
-              runAiDocWith('current');
-            }
-          }}
-          aria-label="AI Doc Next Steps"
-          disabled={loadingAidoc}
-        >
-          {loadingAidoc ? 'Analyzing…' : 'Next steps (AI Doc)'}
-        </button>
-      )}
-      {showLiveSuggestions && (
-        <SuggestBar
-          title="Suggestions"
-          suggestions={liveSuggestions}
-          onPick={handleSuggestionPick}
-          className="rounded-2xl border border-zinc-200 bg-white/90 p-3 backdrop-blur dark:border-zinc-700 dark:bg-slate-900/80"
-        />
-      )}
-      <form
-        onSubmit={e => {
-          e.preventDefault();
-          onSubmit();
-        }}
-            className="w-full flex items-center gap-3 rounded-full medx-glass px-3 py-2"
+    <div className="px-4 sm:px-6 lg:px-8 pt-4 pb-4 border-t border-slate-200 dark:border-slate-800">
+      <div className="mx-auto max-w-3xl space-y-3">
+        {mode === 'doctor' && AIDOC_UI && (
+          <button
+            className="rounded-md px-3 py-1 border"
+            onClick={async () => {
+              if (AIDOC_PREFLIGHT) {
+                setShowPatientChooser(true);
+              } else {
+                runAiDocWith('current');
+              }
+            }}
+            aria-label="AI Doc Next Steps"
+            disabled={loadingAidoc}
           >
+            {loadingAidoc ? 'Analyzing…' : 'Next steps (AI Doc)'}
+          </button>
+        )}
+        {showLiveSuggestions && (
+          <SuggestBar
+            title="Suggestions"
+            suggestions={liveSuggestions}
+            onPick={handleSuggestionPick}
+            className="rounded-2xl border border-zinc-200 bg-white/90 p-3 backdrop-blur dark:border-zinc-700 dark:bg-slate-900/80"
+          />
+        )}
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            onSubmit();
+          }}
+          className="w-full flex items-center gap-3 rounded-xl border border-slate-200 dark:border-slate-800 bg-white/90 dark:bg-slate-900/80 px-4 py-3"
+        >
             <label
               className="cursor-pointer inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-md medx-surface text-medx"
               title="Upload PDF or image"
@@ -3024,20 +3015,20 @@ ${systemCommon}` + baseSys;
               )}
             </div>
 
-              {!busy && (
-                <button
-                  className="w-10 h-10 rounded-full flex items-center justify-center text-lg medx-btn-accent disabled:opacity-50"
-                  type="submit"
-                  disabled={!pendingFile && !userText.trim()}
-                  aria-label="Send"
-                  title="Send"
-                >
-                  <Send size={16} />
-                </button>
-              )}
-          </form>
-        </div>
+            {!busy && (
+              <button
+                className="w-10 h-10 rounded-full flex items-center justify-center text-lg medx-btn-accent disabled:opacity-50"
+                type="submit"
+                disabled={!pendingFile && !userText.trim()}
+                aria-label="Send"
+                title="Send"
+              >
+                <Send size={16} />
+              </button>
+            )}
+        </form>
       </div>
+    </div>
       {/* Preflight chooser (flagged) */}
       {AIDOC_UI && AIDOC_PREFLIGHT && showPatientChooser && (
         <div className="fixed inset-0 z-50 grid place-items-center bg-black/20">


### PR DESCRIPTION
## Summary
- introduce a new live shell with dedicated header, sidebar, and main containers for the chat experience
- update the app layout and global styles to support the redesigned full-height gradient shell
- adjust the chat pane composer placement and remove legacy welcome/header content to fit the new structure

## Testing
- `npm run lint` *(fails: interactive configuration prompt from next lint)*

------
https://chatgpt.com/codex/tasks/task_e_68ced0acced8832f9bd06f2619037de3