### PR TITLE
Refresh shell layout and chat surfaces

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -91,6 +91,7 @@
 :root {
   --medx-bg-a: #e9efff;   /* light indigo */
   --medx-bg-b: #d0f3ff;   /* light cyan */
+  --medx-bg-c: #ffffff;   /* fallback third stop */
   --medx-text: #0F172A;
   --medx-subtext: #334155;
 
@@ -107,8 +108,9 @@
   --medx-outline: rgba(15, 23, 42, 0.10);
 }
 .dark {
-  --medx-bg-a: #342eec;   /* deep indigo */
-  --medx-bg-b: #27b6da;   /* cyan/teal */
+  --medx-bg-a: #06122E;   /* deep navy */
+  --medx-bg-b: #071534;   /* mid navy */
+  --medx-bg-c: #0A1C45;   /* rich midnight */
   --medx-text: #E6E9F1;
   --medx-subtext: #B6C2D0;
 
@@ -131,7 +133,7 @@
   inset: 0;
   z-index: -1;
   pointer-events: none;
-  background: linear-gradient(135deg, var(--medx-bg-a), var(--medx-bg-b));
+  background: linear-gradient(135deg, var(--medx-bg-a), var(--medx-bg-b), var(--medx-bg-c));
 }
 
 /* Glass helpers */
@@ -171,5 +173,16 @@
 .fade-mask,
 .gradient-mask {
   pointer-events: none;
+}
+
+html,
+body,
+#__next {
+  height: 100%;
+}
+
+html,
+body {
+  overflow: hidden;
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { ThemeProvider } from "next-themes";
 import Sidebar from "../components/Sidebar";
+import Header from "../components/Header";
 import { CountryProvider } from "@/lib/country";
 import { ContextProvider } from "@/lib/context";
 import { TopicProvider } from "@/lib/topic";
@@ -22,20 +23,27 @@ const roboto = Roboto({
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={roboto.variable} suppressHydrationWarning>
-      <body className="min-h-screen bg-white dark:bg-slate-950 text-slate-900 dark:text-gray-100 font-sans antialiased">
+      <body className="h-full bg-slate-100 text-slate-900 dark:bg-transparent dark:text-slate-100 font-sans antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <CountryProvider>
             <ContextProvider>
               <TopicProvider>
-                <div className="flex medx-gradient">
-                  <Suspense fallback={null}>
-                    <Sidebar />
-                  </Suspense>
-                  <main className="flex-1 md:ml-64 min-h-dvh flex flex-col relative z-0">
-                    {children}
-                    <MemorySnackbar />
-                    <UndoToast />
-                  </main>
+                <div className="flex h-full min-h-screen flex-col medx-gradient">
+                  <Header />
+                  <div className="grid grow min-h-0 grid-cols-12">
+                    <aside className="hidden min-h-0 overflow-y-auto border-r border-black/5 bg-white/70 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/40 md:col-span-3 md:flex lg:col-span-2">
+                      <Suspense fallback={null}>
+                        <Sidebar />
+                      </Suspense>
+                    </aside>
+                    <main className="col-span-12 flex min-h-0 md:col-span-9 lg:col-span-10">
+                      <div className="flex flex-1 min-h-0 flex-col">
+                        {children}
+                      </div>
+                    </main>
+                  </div>
+                  <MemorySnackbar />
+                  <UndoToast />
                 </div>
               </TopicProvider>
             </ContextProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <ContextProvider>
               <TopicProvider>
                 <div className="flex h-full min-h-screen flex-col medx-gradient">
-                  <Header />
+                  <Suspense fallback={<div className="h-[62px]" />}>
+                    <Header />
+                  </Suspense>
                   <div className="grid grow min-h-0 grid-cols-12">
                     <aside className="hidden min-h-0 overflow-y-auto border-r border-black/5 bg-white/70 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/40 md:col-span-3 md:flex lg:col-span-2">
                       <Suspense fallback={null}>
@@ -38,7 +40,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     </aside>
                     <main className="col-span-12 flex min-h-0 md:col-span-9 lg:col-span-10">
                       <div className="flex flex-1 min-h-0 flex-col">
-                        {children}
+                        <Suspense fallback={<div className="flex-1 min-h-0" />}>
+                          {children}
+                        </Suspense>
                       </div>
                     </main>
                   </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,20 +20,36 @@ export default function Page({ searchParams }: { searchParams: Search }) {
     return () => window.removeEventListener("focus-chat-input", handler);
   }, []);
 
+  const renderPane = () => {
+    switch (panel) {
+      case "profile":
+        return <MedicalProfile />;
+      case "timeline":
+        return <Timeline />;
+      case "alerts":
+        return <AlertsPane />;
+      case "settings":
+        return <SettingsPane />;
+      case "ai-doc":
+        return <AiDocPane />;
+      default:
+        return null;
+    }
+  };
+
   return (
-    <main className="flex-1 overflow-y-auto content-layer">
-      {panel === "chat" && (
-        <section className="block h-full">
-          <ResearchFiltersProvider>
-            <ChatPane inputRef={chatInputRef} />
-          </ResearchFiltersProvider>
-        </section>
+    <div className="flex flex-1 min-h-0 flex-col">
+      {panel === "chat" ? (
+        <ResearchFiltersProvider>
+          <ChatPane inputRef={chatInputRef} />
+        </ResearchFiltersProvider>
+      ) : (
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          <div className="m-6 rounded-2xl p-6 ring-1 ring-black/5 bg-white/80 dark:bg-slate-900/60 dark:ring-white/10">
+            {renderPane()}
+          </div>
+        </div>
       )}
-      {panel === "profile" && <MedicalProfile />}
-      {panel === "timeline" && <Timeline />}
-      {panel === "alerts" && <AlertsPane />}
-      {panel === "settings" && <SettingsPane />}
-      {panel === "ai-doc" && <AiDocPane />}
-    </main>
+    </div>
   );
 }

--- a/components/CountryGlobe.tsx
+++ b/components/CountryGlobe.tsx
@@ -2,7 +2,7 @@
 import { useMemo, useState } from "react";
 import { useCountry } from "@/lib/country";
 import { COUNTRIES } from "@/data/countries";
-import { Globe2, Check } from "lucide-react";
+import { Globe2, Check, Search } from "lucide-react";
 
 export default function CountryGlobe() {
   const { country, setCountry } = useCountry();
@@ -25,25 +25,26 @@ export default function CountryGlobe() {
         aria-label="Choose country"
         title={`Country: ${country.name} (${country.code3}) — click to change`}
         onClick={() => setOpen(v => !v)}
-        className="inline-flex items-center gap-1 rounded-full border border-slate-300 dark:border-gray-700 bg-white/60 dark:bg-gray-900/60 px-3 py-1.5 text-sm shadow-sm hover:bg-white/80 dark:hover:bg-gray-900"
+        className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/70 pl-3 pr-6 py-1.5 text-sm font-medium text-slate-900 shadow-sm transition hover:bg-white dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100 dark:hover:bg-slate-900"
       >
         <Globe2 className="h-4 w-4" />
-        <span className="font-medium">{country.code3}</span>
+        <span className="tabular-nums">{country.code3}</span>
       </button>
 
       {open && (
         <div
           role="dialog"
           aria-label="Select country"
-          className="absolute right-0 mt-2 w-80 rounded-xl border border-slate-200 dark:border-gray-800 bg-white dark:bg-gray-900 shadow-xl p-3 z-50"
+          className="absolute right-0 top-[110%] z-50 mt-2 w-72 rounded-xl border border-black/10 bg-white/95 p-3 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-950/90"
         >
-          <div className="mb-2">
+          <div className="mb-2 flex items-center gap-2 rounded-lg border border-black/10 bg-white/80 px-3 py-1.5 dark:border-white/10 dark:bg-slate-900/60">
+            <Search className="h-4 w-4 text-slate-500 dark:text-slate-400" />
             <input
               autoFocus
               value={q}
               onChange={e => setQ(e.target.value)}
               placeholder="Search country or code…"
-              className="w-full rounded-lg border border-slate-300 dark:border-gray-700 bg-transparent px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-teal-500/50"
+              className="w-full bg-transparent text-sm text-slate-700 placeholder:text-slate-400 focus:outline-none dark:text-slate-100 dark:placeholder:text-slate-500"
             />
           </div>
 
@@ -55,15 +56,15 @@ export default function CountryGlobe() {
                   setCountry(c.code3);
                   setOpen(false);
                 }}
-                className="w-full flex items-center justify-between rounded-lg px-2 py-2 hover:bg-slate-50 dark:hover:bg-gray-800"
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition hover:bg-slate-100 dark:hover:bg-slate-800"
               >
-                <span className="flex items-center gap-2">
-                  <span className="text-base">{c.flag}</span>
-                  <span className="text-sm">{c.name}</span>
-                </span>
-                <span className="text-xs font-semibold tabular-nums">{c.code3}</span>
+                <span className="text-lg">{c.flag}</span>
+                <div className="flex flex-1 items-center justify-between gap-3">
+                  <span className="truncate text-sm">{c.name}</span>
+                  <span className="text-xs font-semibold tabular-nums text-slate-500 dark:text-slate-400">{c.code3}</span>
+                </div>
                 {country.code3 === c.code3 && (
-                  <Check className="h-4 w-4 text-teal-500" />
+                  <Check className="h-4 w-4 text-blue-500" />
                 )}
               </button>
             ))}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,16 +2,24 @@
 import CountryGlobe from '@/components/CountryGlobe';
 import Brand from '@/components/nav/Brand';
 import ModeBar from '@/components/modes/ModeBar';
+import ThemeToggle from '@/components/ThemeToggle';
 
 export default function Header() {
   return (
-    <header className="sticky top-0 z-40 h-14 md:h-16 medx-glass">
-      <div className="max-w-6xl mx-auto h-full px-4 sm:px-6 flex items-center justify-between">
-        <div className="flex items-center gap-2 text-base md:text-lg font-semibold">
+    <header className="sticky top-0 z-40 border-b border-black/10 bg-white/80 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/40">
+      <div className="mx-auto flex h-[62px] w-full max-w-screen-2xl items-center gap-4 px-6">
+        <div className="flex shrink-0 items-center gap-3 text-base font-semibold md:text-lg">
           <Brand />
+        </div>
+
+        <div className="flex flex-1 justify-center">
+          <ModeBar />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <ThemeToggle />
           <CountryGlobe />
         </div>
-        <ModeBar />
       </div>
     </header>
   );

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -40,24 +40,32 @@ export default function Sidebar() {
   };
   const filtered = threads.filter(t => t.title.toLowerCase().includes(q.toLowerCase()));
   return (
-    <aside className="sidebar-click-guard hidden md:flex md:flex-col justify-between !fixed inset-y-0 left-0 w-64 h-full medx-glass text-medx">
-      <button type="button" onClick={handleNew} className="w-full text-left px-4 py-3 rounded-xl mb-4 font-medium medx-btn-accent">
+    <div className="sidebar-click-guard flex h-full w-full flex-col gap-4 px-4 py-6 text-medx">
+      <button
+        type="button"
+        onClick={handleNew}
+        className="w-full rounded-full bg-blue-600 px-4 py-2.5 text-left text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
+      >
         + New Chat
       </button>
 
-      <div className="px-3">
+      <div>
         <div className="relative">
-          <input className="w-full h-10 rounded-lg pl-3 pr-8 text-sm medx-surface text-medx placeholder:text-slate-500 dark:placeholder:text-slate-400" placeholder="Search chats" onChange={e => handleSearch(e.target.value)} />
-          <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500" />
+          <input
+            className="w-full h-10 rounded-full border border-black/10 bg-white/70 pl-3 pr-8 text-sm text-slate-700 placeholder:text-slate-500 backdrop-blur dark:border-white/10 dark:bg-slate-900/50 dark:text-slate-100 dark:placeholder:text-slate-400"
+            placeholder="Search chats"
+            onChange={e => handleSearch(e.target.value)}
+          />
+          <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 dark:text-slate-400" />
         </div>
         <Tabs />
       </div>
 
-      <div className="mt-3 space-y-1 px-2 flex-1 overflow-y-auto">
+      <div className="mt-2 flex-1 space-y-1 overflow-y-auto pr-1">
         {filtered.map(t => (
           <div
             key={t.id}
-            className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm mb-1.5 medx-surface text-medx"
+            className="flex items-center gap-2 rounded-xl border border-black/5 bg-white/70 px-4 py-2.5 text-sm shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
           >
             <button
               onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
@@ -83,9 +91,12 @@ export default function Sidebar() {
 
         {aidocThreads.length > 0 && (
           <div className="mt-4">
-            <div className="px-4 text-xs font-semibold opacity-60 mb-1">AI Doc</div>
+            <div className="px-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">AI Doc</div>
             {aidocThreads.map(t => (
-              <div key={t.id} className="flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm mb-1.5 medx-surface text-medx">
+              <div
+                key={t.id}
+                className="mt-2 flex items-center gap-2 rounded-xl border border-black/5 bg-white/70 px-4 py-2.5 text-sm shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
+              >
                 <button
                   onClick={() => router.push(`/?panel=ai-doc&threadId=${t.id}&context=profile`)}
                   className="flex-1 text-left truncate text-sm"
@@ -99,9 +110,12 @@ export default function Sidebar() {
         )}
       </div>
 
-      <button type="button" className="mx-3 mt-auto mb-3 h-10 rounded-lg px-3 text-left flex items-center gap-2 medx-surface text-medx">
+      <button
+        type="button"
+        className="mt-auto flex h-11 items-center gap-2 rounded-full border border-black/10 bg-white/70 px-4 text-left text-sm backdrop-blur transition hover:bg-white dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900"
+      >
         <Settings size={16} /> Preferences
       </button>
-    </aside>
+    </div>
   );
 }

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -13,10 +13,7 @@ export default function ThemeToggle() {
     <button
       aria-label="Toggle theme"
       onClick={() => setTheme(next)}
-      className="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm
-                 bg-slate-100 text-slate-800 border-slate-200
-                 hover:bg-slate-200
-                 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700 dark:hover:bg-gray-700"
+      className="inline-flex h-10 items-center gap-2 rounded-full border border-black/10 bg-white/70 px-4 text-sm font-medium text-slate-900 transition hover:bg-white dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100 dark:hover:bg-slate-900"
     >
       {theme === "dark" ? "Light" : "Dark"}
     </button>

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -1,14 +1,14 @@
 "use client";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef } from "react";
-import { useTheme } from "next-themes";
 import { reduce } from "@/lib/modes/modeMachine";
 import { fromSearchParams, toQuery } from "@/lib/modes/url";
+import { useTheme } from "next-themes";
 
 export default function ModeBar() {
   const router = useRouter();
   const sp = useSearchParams();
-  const { theme, setTheme } = useTheme();
+  const { theme } = useTheme();
 
   const state = useMemo(
     () => fromSearchParams(sp, (theme as "light"|"dark") ?? "light"),
@@ -36,50 +36,50 @@ export default function ModeBar() {
   };
 
   const btn = (active: boolean, disabled?: boolean) =>
-    `h-9 px-3 rounded-lg border text-sm transition
-     ${active ? "bg-[var(--medx-accent)] text-white border-[var(--medx-accent)]"
-              : "bg-card text-foreground border-border hover:bg-muted"}
-     ${disabled ? "opacity-50 cursor-not-allowed" : ""}`;
+    [
+      "h-9 rounded-full border px-4 text-sm font-medium transition",
+      active
+        ? "bg-blue-600 border-blue-600 text-white shadow-sm"
+        : "bg-white/70 text-slate-900 border-slate-200 hover:bg-slate-100 dark:bg-slate-800/70 dark:text-white dark:border-slate-700 dark:hover:bg-slate-800",
+      disabled ? "opacity-60 cursor-not-allowed" : "",
+    ].filter(Boolean).join(" ");
 
   const aidocOn = state.base === "aidoc";
 
   return (
-    <div className="sticky top-0 z-40 border-b border-border bg-background/70 backdrop-blur">
-      <div className="mx-auto flex max-w-screen-xl items-center gap-2 px-4 py-2">
-        <button className={btn(state.base === "patient")}
-                onClick={() => apply({ type: "toggle/patient" })}>
-          Wellness
-        </button>
-        <button className={btn(state.therapy, aidocOn || state.base !== "patient")}
-                disabled={aidocOn || state.base !== "patient"}
-                onClick={() => apply({ type: "toggle/therapy" })}>
-          Therapy
-        </button>
-        <button className={btn(state.research, aidocOn)} disabled={aidocOn}
-                onClick={() => apply({ type: "toggle/research" })}>
-          Research
-        </button>
-        <button className={btn(state.base === "doctor")}
-                onClick={() => apply({ type: "toggle/doctor" })}>
-          Doctor
-        </button>
+    <div className="inline-flex flex-wrap items-center gap-2 rounded-full border border-black/10 bg-white/60 px-2 py-1 backdrop-blur dark:border-white/10 dark:bg-slate-900/40">
+      <button
+        className={btn(state.base === "patient")}
+        onClick={() => apply({ type: "toggle/patient" })}
+      >
+        Wellness
+      </button>
+      <button
+        className={btn(state.therapy, aidocOn || state.base !== "patient")}
+        disabled={aidocOn || state.base !== "patient"}
+        onClick={() => apply({ type: "toggle/therapy" })}
+      >
+        Therapy
+      </button>
+      <button
+        className={btn(state.research, aidocOn)}
+        disabled={aidocOn}
+        onClick={() => apply({ type: "toggle/research" })}
+      >
+        Research
+      </button>
+      <button
+        className={btn(state.base === "doctor")}
+        onClick={() => apply({ type: "toggle/doctor" })}
+      >
+        Doctor
+      </button>
 
-        <div className="mx-2 h-6 w-px bg-border" />
+      <div className="mx-1 h-5 w-px bg-black/10 dark:bg-white/10" />
 
-        <button className={btn(aidocOn)} onClick={() => apply({ type: "toggle/aidoc" })}>
-          AI Doc
-        </button>
-
-        <div className="ml-auto" />
-
-        <button
-          className={btn(theme === "dark")}
-          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-          aria-label="Toggle dark mode"
-        >
-          {theme === "dark" ? "Light" : "Dark"}
-        </button>
-      </div>
+      <button className={btn(aidocOn)} onClick={() => apply({ type: "toggle/aidoc" })}>
+        AI Doc
+      </button>
     </div>
   );
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -3,7 +3,6 @@ import dynamic from "next/dynamic";
 import { useEffect, useRef, useState, useMemo, RefObject, useCallback } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { fromSearchParams } from '@/lib/modes/url';
-import Header from '../Header';
 import { useRouter } from 'next/navigation';
 import ChatMarkdown from '@/components/ChatMarkdown';
 import ResearchFilters from '@/components/ResearchFilters';
@@ -2654,388 +2653,388 @@ ${systemCommon}` + baseSys;
   }, [busy]);
 
   return (
-    <div className="relative flex h-full flex-col">
-      <Header />
-      {mode === "doctor" && researchMode && (
-        <>
-          <ResearchFilters mode="research" onResults={handleTrials} />
-          {searched && trialRows.length === 0 && (
-            <div className="text-gray-600 text-sm my-2 mx-4 md:mx-4">
-              No trials found. Try removing a filter, switching country, or using broader keywords.
-            </div>
-          )}
-          {summary && (
-            <div className="my-2 mx-4 text-sm p-3 rounded border bg-slate-50 dark:bg-slate-800 dark:border-slate-700">
-              <div className="flex items-start gap-2">
-                <div className="mt-0.5 shrink-0">
-                  {mode === "doctor" ? <Stethoscope size={16}/> : <Users size={16}/>}
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div ref={chatRef} className="flex-1 min-h-0 overflow-y-auto">
+        <div className="m-6 rounded-2xl bg-white/80 p-6 ring-1 ring-black/5 dark:bg-slate-900/60 dark:ring-white/10">
+          {mode === "doctor" && researchMode && (
+            <div className="mb-6 space-y-4">
+              <ResearchFilters mode="research" onResults={handleTrials} />
+              {searched && trialRows.length === 0 && (
+                <div className="rounded-xl border border-slate-200 bg-white/80 p-3 text-sm text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-300">
+                  No trials found. Try removing a filter, switching country, or using broader keywords.
                 </div>
+              )}
+              {summary && (
+                <div className="space-y-4 rounded-xl border border-slate-200 bg-white/85 p-4 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex items-start gap-2">
+                      <div className="mt-0.5 shrink-0">
+                        {mode === "doctor" ? <Stethoscope size={16} /> : <Users size={16} />}
+                      </div>
+                      <div className="flex-1 whitespace-pre-wrap">{summary}</div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {stats?.recruitingCount ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-800 dark:bg-green-900/40 dark:text-green-200">
+                          • Recruiting: {stats.recruitingCount}
+                        </span>
+                      ) : null}
+                      <button
+                        type="button"
+                        onClick={() => navigator.clipboard.writeText(summary!)}
+                        className="rounded-full border border-slate-200 px-2 py-1 text-xs hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
+                        title="Copy summary"
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          <Clipboard size={14} /> Copy
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setShowDetails(s => !s)}
+                        className="rounded-full border border-slate-200 px-2 py-1 text-xs hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
+                        title="View details"
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          {showDetails ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                          {showDetails ? "Hide details" : "View details"}
+                        </span>
+                      </button>
+                    </div>
+                  </div>
 
-                <div className="flex-1 whitespace-pre-wrap">{summary}</div>
+                  {showDetails && stats && (
+                    <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+                      <div className="rounded border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+                        <div className="border-b border-slate-200 pb-2 font-medium dark:border-slate-700">Phases</div>
+                        <ul className="px-3 py-2 space-y-1">
+                          {Object.entries(stats.byPhase).sort((a,b)=>b[1]-a[1]).map(([k,v])=>(
+                            <li key={k} className="flex justify-between"><span>Phase {k}</span><span>{v}</span></li>
+                          ))}
+                          {Object.keys(stats.byPhase).length===0 && <li className="text-slate-500">—</li>}
+                        </ul>
+                      </div>
 
-                <div className="flex items-center gap-2">
-                  {stats?.recruitingCount ? (
-                    <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200">
-                      • Recruiting: {stats.recruitingCount}
-                    </span>
-                  ) : null}
+                      <div className="rounded border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+                        <div className="border-b border-slate-200 pb-2 font-medium dark:border-slate-700">Statuses</div>
+                        <ul className="px-3 py-2 space-y-1">
+                          {Object.entries(stats.byStatus).sort((a,b)=>b[1]-a[1]).map(([k,v])=>(
+                            <li key={k} className="flex justify-between"><span>{k}</span><span>{v}</span></li>
+                          ))}
+                          {Object.keys(stats.byStatus).length===0 && <li className="text-slate-500">—</li>}
+                        </ul>
+                      </div>
 
-                  <button
-                    type="button"
-                    onClick={() => navigator.clipboard.writeText(summary!)}
-                    className="px-2 py-1 text-xs border rounded hover:bg-slate-100 dark:hover:bg-slate-700"
-                    title="Copy summary"
-                  >
-                    <span className="inline-flex items-center gap-1">
-                      <Clipboard size={14}/> Copy
-                    </span>
-                  </button>
+                      <div className="rounded border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+                        <div className="border-b border-slate-200 pb-2 font-medium dark:border-slate-700">Top countries</div>
+                        <ul className="px-3 py-2 space-y-1">
+                          {Object.entries(stats.byCountry).sort((a,b)=>b[1]-a[1]).slice(0,5).map(([k,v])=>(
+                            <li key={k} className="flex justify-between"><span>{k}</span><span>{v}</span></li>
+                          ))}
+                          {Object.keys(stats.byCountry).length===0 && <li className="text-slate-500">—</li>}
+                        </ul>
+                      </div>
 
-                  <button
-                    type="button"
-                    onClick={() => setShowDetails(s => !s)}
-                    className="px-2 py-1 text-xs border rounded hover:bg-slate-100 dark:hover:bg-slate-700"
-                    title="View details"
-                  >
-                    <span className="inline-flex items-center gap-1">
-                      {showDetails ? <ChevronUp size={14}/> : <ChevronDown size={14}/> }
-                      {showDetails ? "Hide details" : "View details"}
-                    </span>
-                  </button>
+                      <div className="rounded border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+                        <div className="border-b border-slate-200 pb-2 font-medium dark:border-slate-700">Top genes</div>
+                        <ul className="px-3 py-2 space-y-1">
+                          {stats.genesTop.length ? stats.genesTop.map(([g,c])=>(
+                            <li key={g} className="flex justify-between"><span>{g}</span><span>{c}</span></li>
+                          )) : <li className="text-slate-500">—</li>}
+                        </ul>
+                      </div>
+
+                      <div className="rounded border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+                        <div className="border-b border-slate-200 pb-2 font-medium dark:border-slate-700">Top conditions</div>
+                        <ul className="px-3 py-2 space-y-1">
+                          {stats.conditionsTop.length ? stats.conditionsTop.map(([k,c])=>(
+                            <li key={k} className="flex justify-between capitalize"><span>{k}</span><span>{c}</span></li>
+                          )) : <li className="text-slate-500">—</li>}
+                        </ul>
+                      </div>
+                    </div>
+                  )}
                 </div>
-              </div>
-
-              {showDetails && stats && (
-                <div className="mt-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                  {/* Phases */}
-                  <div className="rounded border bg-white dark:bg-slate-900 dark:border-slate-700">
-                    <div className="px-3 py-2 font-medium border-b dark:border-slate-700">Phases</div>
-                    <ul className="px-3 py-2 space-y-1">
-                      {Object.entries(stats.byPhase).sort((a,b)=>b[1]-a[1]).map(([k,v])=>(
-                        <li key={k} className="flex justify-between"><span>Phase {k}</span><span>{v}</span></li>
-                      ))}
-                      {Object.keys(stats.byPhase).length===0 && <li className="text-slate-500">—</li>}
-                    </ul>
+              )}
+              {trialRows.length > 0 && (
+                <div className="rounded-xl border border-slate-200 bg-white/85 p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+                  <div className="mb-2 flex justify-end">
+                    <button
+                      onClick={async ()=>{
+                        const res = await fetch("/api/trials/export", { method:"POST", headers:{ "Content-Type":"application/json" }, body: JSON.stringify({ rows: trialRows }) });
+                        const blob = await res.blob();
+                        const url = URL.createObjectURL(blob);
+                        const a = document.createElement("a");
+                        a.href = url; a.download = "trials.csv"; a.click();
+                        URL.revokeObjectURL(url);
+                      }}
+                      className="rounded-full border border-slate-200 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
+                    >
+                      Export CSV
+                    </button>
                   </div>
-
-                  {/* Statuses */}
-                  <div className="rounded border bg-white dark:bg-slate-900 dark:border-slate-700">
-                    <div className="px-3 py-2 font-medium border-b dark:border-slate-700">Statuses</div>
-                    <ul className="px-3 py-2 space-y-1">
-                      {Object.entries(stats.byStatus).sort((a,b)=>b[1]-a[1]).map(([k,v])=>(
-                        <li key={k} className="flex justify-between"><span>{k}</span><span>{v}</span></li>
-                      ))}
-                      {Object.keys(stats.byStatus).length===0 && <li className="text-slate-500">—</li>}
-                    </ul>
-                  </div>
-
-                  {/* Countries */}
-                  <div className="rounded border bg-white dark:bg-slate-900 dark:border-slate-700">
-                    <div className="px-3 py-2 font-medium border-b dark:border-slate-700">Top countries</div>
-                    <ul className="px-3 py-2 space-y-1">
-                      {Object.entries(stats.byCountry).sort((a,b)=>b[1]-a[1]).slice(0,5).map(([k,v])=>(
-                        <li key={k} className="flex justify-between"><span>{k}</span><span>{v}</span></li>
-                      ))}
-                      {Object.keys(stats.byCountry).length===0 && <li className="text-slate-500">—</li>}
-                    </ul>
-                  </div>
-
-                  {/* Genes */}
-                  <div className="rounded border bg-white dark:bg-slate-900 dark:border-slate-700">
-                    <div className="px-3 py-2 font-medium border-b dark:border-slate-700">Top genes</div>
-                    <ul className="px-3 py-2 space-y-1">
-                      {stats.genesTop.length ? stats.genesTop.map(([g,c])=>(
-                        <li key={g} className="flex justify-between"><span>{g}</span><span>{c}</span></li>
-                      )) : <li className="text-slate-500">—</li>}
-                    </ul>
-                  </div>
-
-                  {/* Conditions */}
-                  <div className="rounded border bg-white dark:bg-slate-900 dark:border-slate-700">
-                    <div className="px-3 py-2 font-medium border-b dark:border-slate-700">Top conditions</div>
-                    <ul className="px-3 py-2 space-y-1">
-                      {stats.conditionsTop.length ? stats.conditionsTop.map(([k,c])=>(
-                        <li key={k} className="flex justify-between capitalize"><span>{k}</span><span>{c}</span></li>
-                      )) : <li className="text-slate-500">—</li>}
-                    </ul>
-                  </div>
+                  <TrialsTable rows={trialRows} />
                 </div>
               )}
             </div>
           )}
-          {trialRows.length > 0 && (
-            <div className="mx-4 md:mx-4">
-              <div className="flex justify-end mb-2">
+
+          {showDefaultSuggestions && showSuggestions && (
+            <div className="mx-auto mb-4 max-w-3xl">
+              <ChatSuggestions suggestions={defaultSuggestions} onSelect={handleSuggestionPick} />
+            </div>
+          )}
+
+          {ui.topic && (
+            <div className="mx-auto mb-2 max-w-3xl">
+              <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-xs dark:border-slate-700 dark:bg-slate-900/70">
+                <span className="opacity-70">Topic:</span>
+                <strong className="truncate max-w-[16rem]">{ui.topic}</strong>
+                <button onClick={() => setUi(prev => ({ ...prev, topic: null }))} className="opacity-60 hover:opacity-100">Clear</button>
+              </div>
+            </div>
+          )}
+          {ui.contextFrom && (
+            <div className="mx-auto mb-2 max-w-3xl">
+              <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-xs dark:border-slate-700 dark:bg-slate-900/70">
+                <span className="opacity-70">Using context from:</span>
+                <strong>{ui.contextFrom}</strong>
+                <button onClick={() => { clearContext(); setUi(prev => ({ ...prev, contextFrom: null })); }} className="opacity-60 hover:opacity-100">Clear</button>
+              </div>
+            </div>
+          )}
+
+          <div className="mx-auto w-full max-w-3xl space-y-4">
+            {renderedMessages}
+          </div>
+
+          {AIDOC_UI && aidoc && (
+            <div className="mx-auto mt-6 w-full max-w-3xl">
+              <div className="space-y-2 rounded-xl border border-slate-200 bg-white/85 p-4 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+                <div className="font-medium">Observations</div>
+                <div className="text-sm opacity-90">
+                  {labSummaryCard ? (
+                    <ChatMarkdown content={labSummaryCard} />
+                  ) : (
+                    <ChatMarkdown content={NO_LABS_MESSAGE} />
+                  )}
+                </div>
+
+                {Array.isArray(aidoc?.plan?.steps) && aidoc.plan.steps.length > 0 && (
+                  <>
+                    <div className="text-sm font-medium">Plan</div>
+                    <ul className="list-disc pl-5">
+                      {aidoc.plan.steps.map((s: string, i: number) => (
+                        <li key={i} className="text-sm">{s}</li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+
+                {softAlerts.length > 0 && (
+                  <div className="rounded-lg border border-red-300/70 bg-red-50/80 p-3 dark:border-red-500/40 dark:bg-red-900/40">
+                    <div className="text-sm font-semibold text-red-700 dark:text-red-200">Important</div>
+                    <ul className="list-disc pl-5 text-red-800 dark:text-red-200">
+                      {softAlerts.map((a: string, i: number) => (
+                        <li key={i} className="text-sm">{a}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {Array.isArray(aidoc?.rulesFired) && aidoc.rulesFired.length > 0 && (
+                  <details className="rounded-lg border border-slate-200/70 p-3 text-sm dark:border-slate-700/60">
+                    <summary className="cursor-pointer text-sm">Why these?</summary>
+                    <ul className="list-disc pl-5">
+                      {aidoc.rulesFired.map((r: string, i: number) => (
+                        <li key={i} className="text-xs opacity-70">{r}</li>
+                      ))}
+                    </ul>
+                  </details>
+                )}
+              </div>
+            </div>
+          )}
+
+          {pendingCommitIds.length > 0 && (
+            <div className="mx-auto my-4 w-full max-w-3xl">
+              <div className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white/85 p-3 text-sm shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+                <span>Add this to your Medical Profile?</span>
+                {commitError && <span className="text-xs text-rose-600">{commitError}</span>}
                 <button
-                  onClick={async ()=>{
-                    const res = await fetch("/api/trials/export", { method:"POST", headers:{ "Content-Type":"application/json" }, body: JSON.stringify({ rows: trialRows }) });
-                    const blob = await res.blob();
-                    const url = URL.createObjectURL(blob);
-                    const a = document.createElement("a");
-                    a.href = url; a.download = "trials.csv"; a.click();
-                    URL.revokeObjectURL(url);
+                  onClick={async () => {
+                    setCommitBusy('save');
+                    setCommitError(null);
+                    try {
+                      for (const id of pendingCommitIds) {
+                        const res = await fetch('/api/observations/commit', {
+                          method: 'POST',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({ id }),
+                        });
+                        if (!res.ok) throw new Error('commit');
+                      }
+                      setPendingCommitIds([]);
+                      window.dispatchEvent(new Event('observations-updated'));
+                    } catch {
+                      setCommitError('Could not save. Are you signed in?');
+                    } finally {
+                      setCommitBusy(null);
+                    }
                   }}
-                  className="px-2 py-1 text-xs border rounded"
-                >
-                  Export CSV
-                </button>
+                  disabled={commitBusy !== null}
+                  className="rounded-full border border-slate-200 px-3 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
+                >{commitBusy === 'save' ? 'Saving…' : 'Save'}</button>
+                <button
+                  onClick={async () => {
+                    setCommitBusy('discard');
+                    setCommitError(null);
+                    try {
+                      for (const id of pendingCommitIds) {
+                        const res = await fetch('/api/observations/discard', {
+                          method: 'POST',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({ id }),
+                        });
+                        if (!res.ok) throw new Error('discard');
+                      }
+                      setPendingCommitIds([]);
+                    } catch {
+                      setCommitError('Could not discard.');
+                    } finally {
+                      setCommitBusy(null);
+                    }
+                  }}
+                  disabled={commitBusy !== null}
+                  className="rounded-full border border-slate-200 px-3 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
+                >{commitBusy === 'discard' ? 'Discarding…' : 'Discard'}</button>
               </div>
-              <TrialsTable rows={trialRows} />
             </div>
           )}
-        </>
-      )}
-      <div
-        ref={chatRef}
-        className="flex-1 overflow-y-auto px-4 sm:px-6 lg:px-8 pt-4 md:pt-6 pb-28"
-      >
-        {showDefaultSuggestions && showSuggestions && (
-          <ChatSuggestions suggestions={defaultSuggestions} onSelect={handleSuggestionPick} />
-        )}
-        {ui.topic && (
-          <div className="mx-auto mb-2 max-w-3xl px-4 sm:px-6">
-            <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs bg-white dark:bg-gray-900 border-slate-200 dark:border-gray-800">
-              <span className="opacity-70">Topic:</span>
-              <strong className="truncate max-w-[16rem]">{ui.topic}</strong>
-              <button onClick={() => setUi(prev => ({ ...prev, topic: null }))} className="opacity-60 hover:opacity-100">Clear</button>
-            </div>
-          </div>
-        )}
-        {ui.contextFrom && (
-          <div className="mx-auto mb-2 max-w-3xl px-4 sm:px-6">
-            <div className="inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs bg-white dark:bg-gray-900 border-slate-200 dark:border-gray-800">
-              <span className="opacity-70">Using context from:</span>
-              <strong>{ui.contextFrom}</strong>
-              <button onClick={() => { clearContext(); setUi(prev => ({ ...prev, contextFrom: null })); }} className="opacity-60 hover:opacity-100">Clear</button>
-            </div>
-          </div>
-        )}
-      <div className="mx-auto w-full max-w-3xl space-y-4">
-        {renderedMessages}
+        </div>
       </div>
-      {AIDOC_UI && aidoc && (
-        <div className="mx-auto w-full max-w-3xl">
-          <div className="mt-3 rounded-lg border p-3 space-y-2">
-            <div className="text-sm font-medium">Observations</div>
-            <div className="text-sm opacity-90">
-              {labSummaryCard ? (
-                <ChatMarkdown content={labSummaryCard} />
-              ) : (
-                <ChatMarkdown content={NO_LABS_MESSAGE} />
-              )}
-            </div>
 
-            {Array.isArray(aidoc?.plan?.steps) && aidoc.plan.steps.length > 0 && (
-              <>
-                <div className="text-sm font-medium mt-2">Plan</div>
-                <ul className="list-disc pl-5 space-y-1">
-                  {aidoc.plan.steps.map((s: string, i: number) => (
-                    <li key={i} className="text-sm">{s}</li>
-                  ))}
-                </ul>
-              </>
-            )}
-
-            {/* Show alerts from both the top level and plan, deduplicated */}
-            {softAlerts.length > 0 && (
-              <div className="mt-2 rounded-md border border-red-300 p-2">
-                <div className="text-sm font-semibold text-red-700">Important</div>
-                <ul className="list-disc pl-5 text-red-800">
-                  {softAlerts.map((a: string, i: number) => (
-                    <li key={i} className="text-sm">{a}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-
-            {Array.isArray(aidoc?.rulesFired) && aidoc.rulesFired.length > 0 && (
-              <details className="mt-2">
-                <summary className="cursor-pointer text-sm">Why these?</summary>
-                <ul className="list-disc pl-5">
-                  {aidoc.rulesFired.map((r: string, i: number) => (
-                    <li key={i} className="text-xs opacity-70">{r}</li>
-                  ))}
-                </ul>
-              </details>
-            )}
-          </div>
-        </div>
-      )}
-      {pendingCommitIds.length > 0 && (
-        <div className="mx-auto my-4 max-w-3xl px-4 sm:px-6">
-          <div className="rounded-lg border p-3 text-sm flex items-center gap-2 bg-white dark:bg-gray-800">
-            <span>Add this to your Medical Profile?</span>
-            {commitError && <span className="text-xs text-rose-600">{commitError}</span>}
-            <button
-              onClick={async () => {
-                setCommitBusy('save');
-                setCommitError(null);
-                try {
-                  for (const id of pendingCommitIds) {
-                    const res = await fetch('/api/observations/commit', {
-                      method: 'POST',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({ id }),
-                    });
-                    if (!res.ok) throw new Error('commit');
-                  }
-                  setPendingCommitIds([]);
-                  window.dispatchEvent(new Event('observations-updated'));
-                } catch {
-                  setCommitError('Could not save. Are you signed in?');
-                } finally {
-                  setCommitBusy(null);
-                }
-              }}
-              disabled={commitBusy !== null}
-              className="text-xs px-2 py-1 rounded-md border disabled:opacity-50 disabled:cursor-not-allowed"
-            >{commitBusy === 'save' ? 'Saving…' : 'Save'}</button>
-            <button
-              onClick={async () => {
-                setCommitBusy('discard');
-                setCommitError(null);
-                try {
-                  for (const id of pendingCommitIds) {
-                    const res = await fetch('/api/observations/discard', {
-                      method: 'POST',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({ id }),
-                    });
-                    if (!res.ok) throw new Error('discard');
-                  }
-                  setPendingCommitIds([]);
-                  window.dispatchEvent(new Event('observations-updated'));
-                } catch {
-                  setCommitError('Could not discard. Are you signed in?');
-                } finally {
-                  setCommitBusy(null);
-                }
-              }}
-              disabled={commitBusy !== null}
-              className="text-xs px-2 py-1 rounded-md border disabled:opacity-50 disabled:cursor-not-allowed"
-            >{commitBusy === 'discard' ? 'Discarding…' : 'Discard'}</button>
-          </div>
-        </div>
-      )}
-    </div>
-  <div className="absolute bottom-4 left-0 right-0 flex justify-center">
-        <div className="w-full max-w-3xl px-4">
-      {mode === 'doctor' && AIDOC_UI && (
-        <button
-          className="rounded-md px-3 py-1 border mb-2"
-          onClick={async () => {
-            if (AIDOC_PREFLIGHT) {
-              setShowPatientChooser(true);
-            } else {
-              runAiDocWith('current');
-            }
-          }}
-          aria-label="AI Doc Next Steps"
-          disabled={loadingAidoc}
-        >
-          {loadingAidoc ? 'Analyzing…' : 'Next steps (AI Doc)'}
-        </button>
-      )}
-      {showLiveSuggestions && (
-        <SuggestBar
-          title="Suggestions"
-          suggestions={liveSuggestions}
-          onPick={handleSuggestionPick}
-          className="rounded-2xl border border-zinc-200 bg-white/90 p-3 backdrop-blur dark:border-zinc-700 dark:bg-slate-900/80"
-        />
-      )}
-      <form
-        onSubmit={e => {
-          e.preventDefault();
-          onSubmit();
-        }}
-            className="w-full flex items-center gap-3 rounded-full medx-glass px-3 py-2"
-          >
-            <label
-              className="cursor-pointer inline-flex items-center gap-2 px-3 py-1.5 text-sm rounded-md medx-surface text-medx"
-              title="Upload PDF or image"
-            >
-              <Paperclip size={16} aria-hidden="true" />
-              <span className="hidden sm:inline">Upload</span>
-              <input
-                type="file"
-                accept="application/pdf,image/*"
-                className="hidden"
-                onChange={e => {
-                  const f = e.target.files?.[0];
-                  if (f) onFileSelected(f);
-                  e.currentTarget.value = '';
-                }}
-              />
-            </label>
-            {pendingFile && (
-              <div className="flex items-center gap-2 rounded-full bg-white/70 dark:bg-gray-800/70 px-3 py-1 text-xs">
-                <span className="truncate max-w-[8rem]">{pendingFile.name}</span>
+      <div className="mt-auto">
+        <div className="px-6 pt-3 pb-[max(16px,env(safe-area-inset-bottom))]">
+          <div className="rounded-xl border border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
+            <div className="mx-auto max-w-3xl space-y-3 px-4 py-4">
+              {mode === 'doctor' && AIDOC_UI && (
                 <button
-                  type="button"
-                  onClick={() => setPendingFile(null)}
-                  className="text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
-                  aria-label="Remove file"
+                  className="rounded-full border border-slate-200 px-3 py-1 text-sm hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
+                  onClick={async () => {
+                    if (AIDOC_PREFLIGHT) {
+                      setShowPatientChooser(true);
+                    } else {
+                      runAiDocWith('current');
+                    }
+                  }}
+                  aria-label="AI Doc Next Steps"
+                  disabled={loadingAidoc}
                 >
-                  ✕
+                  {loadingAidoc ? 'Analyzing…' : 'Next steps (AI Doc)'}
                 </button>
-              </div>
-            )}
-            <div className="relative flex-1">
-              <textarea
-                ref={inputRef as unknown as RefObject<HTMLTextAreaElement>}
-                rows={1}
-                className="flex-1 resize-none bg-transparent outline-none text-sm md:text-base leading-6 placeholder:text-slate-500 dark:placeholder:text-slate-400 px-2 pr-[44px] text-medx"
-                placeholder={
-                  pendingFile
-                    ? 'Add a note or question for this document (optional)'
-                    : 'Send a message'
-                }
-                value={userText}
-                onChange={(e) => setUserText(e.target.value)}
-                onFocus={() => setInputFocused(true)}
-                onBlur={(e) => {
-                  const next = e.relatedTarget as HTMLElement | null;
-                  if (next?.dataset?.suggestionButton === 'true') {
-                    return;
-                  }
-                  setInputFocused(false);
-                }}
-                onKeyDown={(e) => {
-                  // Send on Enter (no Shift), allow newline on Shift+Enter.
-                  // Respect IME composition (don't send while composing).
-                  // NOTE: keep behavior identical to ChatGPT.
-                  const isComposing = (e.nativeEvent as any).isComposing;
-                  if (e.key === 'Enter' && !e.shiftKey && !isComposing) {
-                    e.preventDefault();
-                    onSubmit();
-                  }
-                }}
-              />
+              )}
 
-              {busy && (
-                <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center">
-                  <StopButton
-                    onClick={onStop}
-                    className="pointer-events-auto"
-                    title="Stop (Esc)"
+              {showLiveSuggestions && (
+                <SuggestBar
+                  title="Suggestions"
+                  suggestions={liveSuggestions}
+                  onPick={handleSuggestionPick}
+                  className="rounded-2xl border border-slate-200 bg-white/85 p-3 backdrop-blur dark:border-slate-700 dark:bg-slate-900/70"
+                />
+              )}
+
+              <form
+                onSubmit={e => {
+                  e.preventDefault();
+                  onSubmit();
+                }}
+                className="flex w-full items-end gap-3 rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 dark:border-slate-700 dark:bg-slate-900/80"
+              >
+                <label
+                  className="inline-flex cursor-pointer items-center gap-2 rounded-full bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-white dark:bg-slate-900/70 dark:text-slate-200"
+                  title="Upload PDF or image"
+                >
+                  <Paperclip size={16} aria-hidden="true" />
+                  <span className="hidden sm:inline">Upload</span>
+                  <input
+                    type="file"
+                    accept="application/pdf,image/*"
+                    className="hidden"
+                    onChange={e => {
+                      const f = e.target.files?.[0];
+                      if (f) onFileSelected(f);
+                      e.currentTarget.value = '';
+                    }}
                   />
-                </div>
-              )}
-            </div>
+                </label>
+                {pendingFile && (
+                  <div className="flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 text-xs text-slate-700 dark:bg-slate-900/70 dark:text-slate-200">
+                    <span className="max-w-[8rem] truncate">{pendingFile.name}</span>
+                    <button
+                      type="button"
+                      onClick={() => setPendingFile(null)}
+                      className="text-slate-500 transition hover:text-slate-700 dark:hover:text-slate-300"
+                      aria-label="Remove file"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                )}
+                <div className="relative flex-1">
+                  <textarea
+                    ref={inputRef as unknown as RefObject<HTMLTextAreaElement>}
+                    rows={1}
+                    className="w-full resize-none bg-transparent px-2 pr-12 text-sm leading-6 text-slate-900 outline-none placeholder:text-slate-500 dark:text-slate-100 dark:placeholder:text-slate-400"
+                    placeholder={
+                      pendingFile
+                        ? 'Add a note or question for this document (optional)'
+                        : 'Send a message'
+                    }
+                    value={userText}
+                    onChange={(e) => setUserText(e.target.value)}
+                    onFocus={() => setInputFocused(true)}
+                    onBlur={(e) => {
+                      const next = e.relatedTarget as HTMLElement | null;
+                      if (next?.dataset?.suggestionButton === 'true') {
+                        return;
+                      }
+                      setInputFocused(false);
+                    }}
+                    onKeyDown={(e) => {
+                      const isComposing = (e.nativeEvent as any).isComposing;
+                      if (e.key === 'Enter' && !e.shiftKey && !isComposing) {
+                        e.preventDefault();
+                        onSubmit();
+                      }
+                    }}
+                  />
 
-              {!busy && (
-                <button
-                  className="w-10 h-10 rounded-full flex items-center justify-center text-lg medx-btn-accent disabled:opacity-50"
-                  type="submit"
-                  disabled={!pendingFile && !userText.trim()}
-                  aria-label="Send"
-                  title="Send"
-                >
-                  <Send size={16} />
-                </button>
-              )}
-          </form>
+                  {busy && (
+                    <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center">
+                      <StopButton
+                        onClick={onStop}
+                        className="pointer-events-auto"
+                        title="Stop (Esc)"
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {!busy && (
+                  <button
+                    className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:opacity-50"
+                    type="submit"
+                    disabled={!pendingFile && !userText.trim()}
+                    aria-label="Send"
+                    title="Send"
+                  >
+                    <Send size={16} />
+                  </button>
+                )}
+              </form>
+            </div>
+          </div>
         </div>
       </div>
       {/* Preflight chooser (flagged) */}


### PR DESCRIPTION
## Summary
- lock the app to a full-height, non-scrolling viewport with the updated gradient palette
- rebuild the root layout so the new header, sidebar, and scrollable main column match the refreshed design
- restyle the header controls, sidebar, theme toggle, mode bar, country selector, and chat pane to deliver the new card + pinned composer experience

## Testing
- `npm run lint` *(cannot run: command prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68cf86ce15f4832fbdc2c9cb524cd394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  - Overhauled chat: centered card, richer summaries (copy/toggle), observations panel, live suggestions, file upload preview, Stop/Send controls, CSV export for trials, and AI-Doc preflight/flows.
  - Persistent header with centered mode controls and theme/country selectors; in-dialog country search.

* Style
  - App-wide visual refresh: responsive grid layout with sidebar, redesigned ModeBar, Sidebar, ThemeToggle, and country dialog.
  - Updated gradients (adds third color stop) and global full-height layout with scroll locked (overflow hidden).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->