### PR TITLE
Fix timeline gating for timeline panel

### DIFF
--- a/hooks/useIsAiDocMode.ts
+++ b/hooks/useIsAiDocMode.ts
@@ -9,6 +9,7 @@ export function useIsAiDocMode() {
   const context = sp.get("context")?.toLowerCase();
 
   if (mode === "ai-doc") return true;
+  if (panel === "timeline") return true;
   if (panel === "ai-doc") return true;
   if (panel === "chat" && threadId === "med-profile" && context === "profile") return true;
   if (context === "ai-doc-med-profile") return true;


### PR DESCRIPTION
## Summary
- treat the timeline panel as an AI Doc context so the observations fetch can run when the tab is opened

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf912c13e4832f9af0a720a508738e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Timeline panel now correctly opens in AI Doc mode when accessed via URL parameters, ensuring consistent behavior and navigation.
  * Improved URL handling so the Timeline panel is recognized regardless of letter case, reducing confusion from mixed-case links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->