### PR TITLE
Gate saved report warning for saved history requests

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -5,6 +5,7 @@ import { analyzeLabText } from "@/lib/labReport";
 import { extractAll, canonicalizeInputs } from "@/lib/medical/engine/extract";
 import { computeAll } from "@/lib/medical/engine/computeAll";
 import { dualEngineSummarize } from "@/lib/reports/dualEngine";
+import { markHasFreshUpload } from "@/lib/chat/session/uploadState";
 
 const OAI_KEY = process.env.OPENAI_API_KEY!;
 const MODEL_TEXT = process.env.OPENAI_TEXT_MODEL || "gpt-5";
@@ -232,7 +233,7 @@ export async function POST(req: Request) {
       report = data?.choices?.[0]?.message?.content || "";
     }
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       type: "auto",
       filename: name,
       category,
@@ -240,6 +241,10 @@ export async function POST(req: Request) {
       disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
       obsIds: doctorMode ? [] : obsIds,
     });
+    if (threadId) {
+      markHasFreshUpload(threadId);
+    }
+    return response;
   } catch (e: any) {
     return NextResponse.json({ error: e.message || "analyze failed" }, { status: 500 });
   }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -36,6 +36,7 @@ import { singleTrialPatientPrompt, singleTrialClinicianPrompt } from "@/lib/prom
 import { searchTrials, dedupeTrials, rankValue } from "@/lib/trials/search";
 import { byName } from "@/data/countries";
 import { searchNearby } from "@/lib/openpass";
+import { shouldShowSavedReportWarning, REPORTS_LOCKED_MESSAGE } from "@/lib/chat/intent/savedReportWarning";
 
 type WebHit = { title: string; snippet: string; url: string; source: string };
 
@@ -109,6 +110,10 @@ export async function POST(req: Request) {
   };
   if (isNewChat) {
     console.log("new_chat_started", { conversationId });
+  }
+  const threadIdForWarning = typeof thread_id === "string" ? thread_id : undefined;
+  if (shouldShowSavedReportWarning({ mode, message: userMessage, threadId: threadIdForWarning })) {
+    return respond({ ok: true, threadId: threadIdForWarning ?? null, text: REPORTS_LOCKED_MESSAGE });
   }
   const ISOLATE = process.env.NEW_CHAT_ISOLATION !== "false";
   const ALLOW_ROLL = process.env.ALLOW_CONTEXT_ROLLFORWARD === "true";

--- a/app/api/ingest/from-text/route.ts
+++ b/app/api/ingest/from-text/route.ts
@@ -6,6 +6,7 @@ import { supabaseAdmin } from "@/lib/supabase/admin";
 import { extractReportDate } from "@/lib/reportDate";
 import { summarizeMedicalDoc } from "@/lib/summarizeDoc";
 import { buildShortSummaryFromText } from "@/lib/shortSummary";
+import { markHasFreshUpload } from "@/lib/chat/session/uploadState";
 import OpenAI from "openai";
 
 const HAVE_OPENAI = !!process.env.OPENAI_API_KEY;
@@ -213,5 +214,8 @@ meta.category in {lab|vital|imaging|medication|diagnosis|procedure|immunization|
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
   const ids = (inserted || []).map((r: any) => r.id);
+  if (typeof threadId === "string" && threadId) {
+    markHasFreshUpload(threadId);
+  }
   return NextResponse.json({ ok: true, ids, inserted: ids.length, usedFallback });
 }

--- a/lib/chat/intent/isSavedReportRequest.ts
+++ b/lib/chat/intent/isSavedReportRequest.ts
@@ -1,0 +1,19 @@
+export function isSavedReportRequest(raw: string): boolean {
+  const m = (raw ?? "").toLowerCase();
+
+  // Require first-person ownership + retrieval intent
+  const hasFirstPerson =
+    /\b(my|my report|my reports|my labs|my test results|my bloodwork|my history)\b/.test(m);
+
+  const hasRetrievalVerb =
+    /\b(pull|show|fetch|compare|retrieve|load|bring up|what do my reports say)\b/.test(m);
+
+  // Treat general/newsy mentions as NOT saved-history requests
+  const genericCues =
+    /\b(latest|recent|global|guidelines|update|news|summary|who|cdc|icmr|nhs|mohfw|covid|influenza|dengue|202[0-9]|jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b/.test(m);
+
+  const hasUrl = /https?:\/\//.test(m);
+
+  // Saved-history intent only if: first-person + retrieval verb AND not generic/news AND no URL
+  return hasFirstPerson && hasRetrievalVerb && !genericCues && !hasUrl;
+}

--- a/lib/chat/intent/savedReportWarning.ts
+++ b/lib/chat/intent/savedReportWarning.ts
@@ -1,0 +1,32 @@
+import { isSavedReportRequest } from "./isSavedReportRequest";
+import { hasFreshUpload } from "../session/uploadState";
+
+function normalizeModeKey(mode?: string): string {
+  return (mode || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function isAiDocMode(mode?: string): boolean {
+  const norm = normalizeModeKey(mode);
+  return norm === "aidoc" || norm === "docai" || norm === "docmode" || norm === "aidocmode";
+}
+
+export function shouldShowSavedReportWarning({
+  mode,
+  message,
+  threadId,
+}: {
+  mode?: string;
+  message?: string | null;
+  threadId?: string | null;
+}): boolean {
+  if (isAiDocMode(mode)) return false;
+
+  const text = message ?? "";
+  if (!isSavedReportRequest(text)) return false;
+
+  const id = typeof threadId === "string" ? threadId : undefined;
+  const freshUploadPresent = id ? hasFreshUpload(id) : false;
+  return !freshUploadPresent;
+}
+
+export const REPORTS_LOCKED_MESSAGE = "Reports are available only in AI Doc mode";

--- a/lib/chat/session/uploadState.ts
+++ b/lib/chat/session/uploadState.ts
@@ -1,0 +1,16 @@
+const uploadState = new Map<string, boolean>();
+
+export function markHasFreshUpload(threadId: string) {
+  if (!threadId) return;
+  uploadState.set(threadId, true);
+}
+
+export function clearFreshUpload(threadId: string) {
+  if (!threadId) return;
+  uploadState.set(threadId, false);
+}
+
+export function hasFreshUpload(threadId: string): boolean {
+  if (!threadId) return false;
+  return uploadState.get(threadId) === true;
+}

--- a/test/chat/warningGate.test.ts
+++ b/test/chat/warningGate.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hasFreshUploadMock = vi.fn<(threadId: string) => boolean>();
+
+vi.mock("../../lib/chat/session/uploadState", () => ({
+  hasFreshUpload: (threadId: string) => hasFreshUploadMock(threadId)
+}));
+
+import { shouldShowSavedReportWarning, REPORTS_LOCKED_MESSAGE } from "../../lib/chat/intent/savedReportWarning";
+
+function makeWarningCheck(mode: string, message: string, freshUpload: boolean) {
+  hasFreshUploadMock.mockReturnValue(freshUpload);
+  return shouldShowSavedReportWarning({ mode, message, threadId: "thread-1" });
+}
+
+describe("saved report warning gate", () => {
+  beforeEach(() => {
+    hasFreshUploadMock.mockReset();
+  });
+
+  it("warns in wellness when saved history is requested without fresh uploads", () => {
+    expect(makeWarningCheck("wellness", "pull my reports", false)).toBe(true);
+    expect(hasFreshUploadMock).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("does not warn when fresh uploads exist", () => {
+    expect(makeWarningCheck("doctor", "compare my reports", true)).toBe(false);
+    expect(hasFreshUploadMock).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("ignores generic news queries", () => {
+    expect(makeWarningCheck("research", "latest reports on covid", false)).toBe(false);
+    expect(hasFreshUploadMock).not.toHaveBeenCalled();
+  });
+
+  it("allows AI Doc saved history requests", () => {
+    expect(makeWarningCheck("ai-doc", "show my previous reports", false)).toBe(false);
+  });
+
+  it("handles edge phrasing", () => {
+    expect(makeWarningCheck("doctor", "what do my reports say", false)).toBe(true);
+  });
+
+  it("exposes the message constant", () => {
+    expect(REPORTS_LOCKED_MESSAGE).toBe("Reports are available only in AI Doc mode");
+  });
+});

--- a/test/intent/isSavedReportRequest.test.ts
+++ b/test/intent/isSavedReportRequest.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isSavedReportRequest } from "../../lib/chat/intent/isSavedReportRequest";
+
+describe("isSavedReportRequest", () => {
+  it("detects direct saved report pulls", () => {
+    expect(isSavedReportRequest("pull my reports")).toBe(true);
+    expect(isSavedReportRequest("compare my reports")).toBe(true);
+    expect(isSavedReportRequest("show my previous reports")).toBe(true);
+    expect(isSavedReportRequest("what do my reports say")).toBe(true);
+  });
+
+  it("ignores news-style queries", () => {
+    expect(isSavedReportRequest("latest reports on covid")).toBe(false);
+    expect(isSavedReportRequest("WHO report on boosters")).toBe(false);
+  });
+
+  it("ignores requests containing URLs", () => {
+    expect(isSavedReportRequest("news report: https://example.com")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add saved-report intent detection and a per-thread upload flag for chat sessions
- mark threads with fresh uploads from ingest and analyze endpoints
- gate chat handlers to return the AI Doc warning only for saved-history requests without fresh uploads

## Testing
- npx vitest run test/intent/isSavedReportRequest.test.ts test/chat/warningGate.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cfa0e4f8d4832f92fa402de460c2fe