### PR TITLE
Refine labs trend intent detection

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -74,8 +74,8 @@ const NEARBY_NEAR_WORD_RE = /\b(near|nearby|around|close to|within)\b/i;
 
 const NO_LABS_MESSAGE = "I couldn't find structured lab values yet.";
 const REPORTS_LOCKED_MESSAGE = "Reports are available only in AI Doc mode.";
-// Updated LABS_TREND_INTENT: full phrases only, prevents partial matches
-const LABS_TREND_INTENT = /\b(pull my reports|show my reports|fetch my reports|what do my reports say|compare my reports|trend|date\s*wise|datewise|history|lab history)\b/i;
+// Updated LABS_TREND_INTENT: only triggers on explicit lab/report phrases
+const LABS_TREND_INTENT = /\b(pull my reports|show my reports|fetch my reports|what do my reports say|compare my reports|lab history|lab trend|report history|report trend|date\s*wise|datewise)\b/i;
 const RAW_TEXT_INTENT = /(raw text|full text|show .*report text)/i;
 
 const formatTrendDate = (iso?: string) => {

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -74,7 +74,8 @@ const NEARBY_NEAR_WORD_RE = /\b(near|nearby|around|close to|within)\b/i;
 
 const NO_LABS_MESSAGE = "I couldn't find structured lab values yet.";
 const REPORTS_LOCKED_MESSAGE = "Reports are available only in AI Doc mode.";
-const LABS_INTENT = /(report|reports|observation|observations|blood|lab|labs|lipid|cholesterol|ldl|hdl|triglycerides|a1c|hba1c|vitamin\s*d|crp|esr|uibc|tibc|creatinine|egfr|urea|bilirubin|ast|alt|sgot|sgpt|ggt|alkaline|alp|date\s*wise|datewise|trend|changes?)/i;
+// Updated LABS_TREND_INTENT: full phrases only, prevents partial matches
+const LABS_TREND_INTENT = /\b(pull my reports|show my reports|fetch my reports|what do my reports say|compare my reports|trend|date\s*wise|datewise|history|lab history)\b/i;
 const RAW_TEXT_INTENT = /(raw text|full text|show .*report text)/i;
 
 const formatTrendDate = (iso?: string) => {
@@ -2334,7 +2335,7 @@ ${systemCommon}` + baseSys;
           return;
         }
 
-        if (LABS_INTENT.test(trimmed)) {
+        if (LABS_TREND_INTENT.test(trimmed)) {
           setMessages(prev => [
             ...prev,
             { id: uid(), role: 'user', kind: 'chat', content: trimmed, pending: false } as any,


### PR DESCRIPTION
## Summary
- narrow the labs trend intent regex to only match explicit history/report phrases and avoid partial word matches
- route report timeline card logic through the updated intent constant

## Testing
- npm run lint *(fails: next lint prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68cfaf986f10832fa9aedb93538d7582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat intent recognition for trend-related requests by matching whole phrases only, reducing false positives and accidental triggers.
  * Enhanced input handling to route trend and report queries more reliably, yielding more consistent chat responses.
  * Reduced misinterpretation of partial words, preventing unexpected activations and smoothing interactions when asking trend-oriented questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->