### PR TITLE
feat: refresh scroll to bottom control

### DIFF
--- a/components/ui/ScrollToBottom.tsx
+++ b/components/ui/ScrollToBottom.tsx
@@ -16,6 +16,8 @@ type Props = {
   onJump?: () => void;
   /** Auto hide timeout */
   autohideMs?: number;
+  /** Distance from the bottom of the viewport */
+  offsetBottom?: number;
 };
 
 export default function ScrollToBottom({
@@ -25,6 +27,7 @@ export default function ScrollToBottom({
   unread = 0,
   onJump,
   autohideMs = 2500,
+  offsetBottom = 132,
 }: Props) {
   const [container, setContainer] = useState<HTMLElement | null>(containerProp ?? targetRef?.current ?? null);
   const [visible, setVisible] = useState(false);
@@ -138,7 +141,7 @@ export default function ScrollToBottom({
         "pointer-events-none fixed left-1/2 z-[60] -translate-x-1/2 transition-all",
         visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2",
       ].join(" ")}
-      style={{ bottom: 96 }}
+      style={{ bottom: offsetBottom }}
       aria-hidden={!visible}
     >
       <button

--- a/components/ui/ScrollToBottom.tsx
+++ b/components/ui/ScrollToBottom.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 import { ArrowDown } from "lucide-react";
-import { Button } from "@/components/ui/button";
 
 type Props = {
   /** Ref to the scrollable chat container (div) */
@@ -142,14 +141,14 @@ export default function ScrollToBottom({
       style={{ bottom: 96 }}
       aria-hidden={!visible}
     >
-      <Button
-        size="icon"
-        className="pointer-events-auto h-9 w-9 rounded-full shadow-lg bg-primary text-primary-foreground hover:opacity-90"
+      <button
+        type="button"
+        className="pointer-events-auto inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition hover:opacity-90"
         aria-label="Jump to newest messages"
         onClick={scrollToBottom}
       >
         <ArrowDown className="h-4 w-4" />
-      </Button>
+      </button>
     </div>
   );
 }

--- a/components/ui/ScrollToBottom.tsx
+++ b/components/ui/ScrollToBottom.tsx
@@ -1,64 +1,155 @@
 "use client";
-import { useEffect, useState, type RefObject } from "react";
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { ArrowDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 type Props = {
   /** Ref to the scrollable chat container (div) */
-  targetRef: RefObject<HTMLElement>;
-  /** Show threshold (px from bottom) before button appears */
-  threshold?: number;
+  targetRef?: RefObject<HTMLElement>;
+  /** Optional container override */
+  container?: HTMLElement | null;
   /** optional key to force rebind on thread change */
   rebindKey?: string | number;
+  /** Unread messages count */
+  unread?: number;
+  /** Callback fired when user jumps to bottom */
+  onJump?: () => void;
+  /** Auto hide timeout */
+  autohideMs?: number;
 };
 
-export default function ScrollToBottom({ targetRef, threshold = 120, rebindKey }: Props) {
-  const [show, setShow] = useState(false);
-  const [boundEl, setBoundEl] = useState<HTMLElement | null>(null);
+export default function ScrollToBottom({
+  targetRef,
+  container: containerProp,
+  rebindKey,
+  unread = 0,
+  onJump,
+  autohideMs = 2500,
+}: Props) {
+  const [container, setContainer] = useState<HTMLElement | null>(containerProp ?? targetRef?.current ?? null);
+  const [visible, setVisible] = useState(false);
+  const lastScrollTop = useRef(0);
+  const hideTimer = useRef<number | null>(null);
 
-  // Bind to the ref element when it becomes available or when rebindKey changes
+  const isNearBottom = useCallback((el: HTMLElement) => {
+    return el.scrollHeight - (el.scrollTop + el.clientHeight) < 24;
+  }, []);
+
+  const show = useCallback(() => {
+    setVisible(true);
+    if (hideTimer.current) window.clearTimeout(hideTimer.current);
+    hideTimer.current = window.setTimeout(() => setVisible(false), autohideMs);
+  }, [autohideMs]);
+
   useEffect(() => {
-    if (targetRef?.current && targetRef.current !== boundEl) {
-      setBoundEl(targetRef.current);
+    if (containerProp !== undefined) {
+      setContainer(containerProp);
+      lastScrollTop.current = containerProp?.scrollTop ?? 0;
+      return;
     }
+
+    if (!targetRef) {
+      setContainer(null);
+      return;
+    }
+
+    if (targetRef.current) {
+      setContainer(targetRef.current);
+      lastScrollTop.current = targetRef.current.scrollTop;
+      return;
+    }
+
     let raf: number | null = null;
-    if (!targetRef?.current) {
-      const tick = () => {
-        if (targetRef?.current) setBoundEl(targetRef.current);
-        else raf = requestAnimationFrame(tick);
-      };
-      raf = requestAnimationFrame(tick);
-    }
-    return () => { if (raf) cancelAnimationFrame(raf); };
-  }, [targetRef, rebindKey, boundEl]);
-
-  // Listen for scroll to determine when to show the button
-  useEffect(() => {
-    const el = boundEl ?? document.documentElement;
-    const listener = () => {
-      const scrollTop = el.scrollTop || document.documentElement.scrollTop || document.body.scrollTop;
-      const height = el.scrollHeight || document.documentElement.scrollHeight;
-      const client = el.clientHeight || window.innerHeight;
-      const distanceFromBottom = height - (scrollTop + client);
-      setShow(distanceFromBottom > threshold);
+    const tick = () => {
+      if (targetRef.current) {
+        setContainer(targetRef.current);
+        lastScrollTop.current = targetRef.current.scrollTop;
+      } else {
+        raf = window.requestAnimationFrame(tick);
+      }
     };
-    listener();
-    const on: any = boundEl ?? window;
-    on.addEventListener("scroll", listener, { passive: true });
-    return () => on.removeEventListener("scroll", listener as any);
-  }, [boundEl, threshold]);
 
-  if (!show) return null;
+    raf = window.requestAnimationFrame(tick);
+
+    return () => {
+      if (raf) window.cancelAnimationFrame(raf);
+    };
+  }, [containerProp, targetRef, rebindKey]);
+
+  useEffect(() => {
+    return () => {
+      if (hideTimer.current) {
+        window.clearTimeout(hideTimer.current);
+        hideTimer.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!container) return;
+
+    const el = container;
+    const onScroll = () => {
+      const curr = el.scrollTop;
+      const goingUp = curr < lastScrollTop.current;
+      lastScrollTop.current = curr;
+
+      if (!isNearBottom(el)) {
+        if (goingUp) show();
+        else setVisible(true);
+      } else {
+        setVisible(false);
+        if (hideTimer.current) {
+          window.clearTimeout(hideTimer.current);
+          hideTimer.current = null;
+        }
+        onJump?.();
+      }
+    };
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+    };
+  }, [container, isNearBottom, onJump, show]);
+
+  useEffect(() => {
+    if (!container) return;
+    if (unread > 0 && !isNearBottom(container)) show();
+  }, [unread, container, isNearBottom, show]);
+
+  const scrollToBottom = () => {
+    if (!container) return;
+    container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
+    onJump?.();
+    setVisible(false);
+    if (hideTimer.current) {
+      window.clearTimeout(hideTimer.current);
+      hideTimer.current = null;
+    }
+  };
+
+  if (!container) return null;
 
   return (
-    <button
-      type="button"
-      onClick={() => {
-        (boundEl ?? window).scrollTo({ top: (boundEl?.scrollHeight ?? document.documentElement.scrollHeight), behavior: "smooth" });
-      }}
-      className="fixed bottom-5 right-5 z-50 rounded-full bg-neutral-900 px-4 py-2 text-sm text-white shadow-lg transition active:scale-95 dark:bg-neutral-100 dark:text-neutral-900"
-      aria-label="Scroll to bottom"
+    <div
+      className={[
+        "pointer-events-none fixed left-1/2 z-[60] -translate-x-1/2 transition-all",
+        visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2",
+      ].join(" ")}
+      style={{ bottom: 96 }}
+      aria-hidden={!visible}
     >
-      ↓ New messages
-    </button>
+      <Button
+        size="icon"
+        className="pointer-events-auto h-9 w-9 rounded-full shadow-lg bg-primary text-primary-foreground hover:opacity-90"
+        aria-label="Jump to newest messages"
+        onClick={scrollToBottom}
+      >
+        <ArrowDown className="h-4 w-4" />
+      </Button>
+    </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- replace the old "New messages" pill with a floating action button that centers above the composer
- add auto-hide, unread awareness, and jump handling tied directly to the scroll container

## Testing
- npm run lint *(fails locally because `next lint` prompts to create a config in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbbc87644832f97c3ba40121ceaaf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Floating, animated scroll-to-bottom control with auto-hide and configurable hide timing.
  * Appears when you’re away from the bottom or when there are unread messages; supports an optional callback on jump.
  * Works with a custom scroll container or detected target, and handles rebinds gracefully.

* **Bug Fixes**
  * More reliable visibility using container-scoped proximity logic, reducing false shows/hides and flicker.
  * Improved cleanup prevents lingering timers/listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->