### PR TITLE
Remove white wrapper around chat panel

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -2949,7 +2949,7 @@ ${systemCommon}` + baseSys;
                   e.preventDefault();
                   onSubmit();
                 }}
-                className="flex w-full items-end gap-3 rounded-2xl border border-slate-200/60 bg-transparent px-3 py-2 dark:border-slate-700/60 dark:bg-transparent"
+                className="flex w-full items-end gap-3 rounded-2xl border border-slate-200/60 bg-white/90 px-3 py-2 dark:border-slate-700/60 dark:bg-slate-900/80"
               >
                 <label
                   className="inline-flex cursor-pointer items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-200/60 dark:text-slate-200 dark:hover:bg-slate-800/60"

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -2656,7 +2656,7 @@ ${systemCommon}` + baseSys;
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div ref={chatRef} className="flex-1 min-h-0 overflow-y-auto">
-        <div className="m-6 rounded-2xl bg-white/80 p-6 ring-1 ring-black/5 dark:bg-slate-900/60 dark:ring-white/10">
+        <div className="m-6 p-6">
           {mode === "doctor" && researchMode && (
             <div className="mb-6 space-y-4">
               <ResearchFilters mode="research" onResults={handleTrials} />
@@ -2917,8 +2917,7 @@ ${systemCommon}` + baseSys;
 
       <div className="mt-auto">
         <div className="px-6 pt-3 pb-[max(16px,env(safe-area-inset-bottom))]">
-          <div className="rounded-xl border border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
-            <div className="mx-auto max-w-3xl space-y-3 px-4 py-4">
+          <div className="mx-auto max-w-3xl space-y-3 px-4 py-4">
               {mode === 'doctor' && AIDOC_UI && (
                 <button
                   className="rounded-full border border-slate-200 px-3 py-1 text-sm hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
@@ -2950,10 +2949,10 @@ ${systemCommon}` + baseSys;
                   e.preventDefault();
                   onSubmit();
                 }}
-                className="flex w-full items-end gap-3 rounded-2xl border border-slate-200 bg-white/90 px-3 py-2 dark:border-slate-700 dark:bg-slate-900/80"
+                className="flex w-full items-end gap-3 rounded-2xl border border-slate-200/60 bg-transparent px-3 py-2 dark:border-slate-700/60 dark:bg-transparent"
               >
                 <label
-                  className="inline-flex cursor-pointer items-center gap-2 rounded-full bg-white/70 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-white dark:bg-slate-900/70 dark:text-slate-200"
+                  className="inline-flex cursor-pointer items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-200/60 dark:text-slate-200 dark:hover:bg-slate-800/60"
                   title="Upload PDF or image"
                 >
                   <Paperclip size={16} aria-hidden="true" />

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -3034,7 +3034,6 @@ ${systemCommon}` + baseSys;
                 )}
               </form>
             </div>
-          </div>
         </div>
       </div>
       {/* Preflight chooser (flagged) */}


### PR DESCRIPTION
## Summary
- remove the white container background around the chat pane so the conversation blends with the app backdrop
- simplify the chat composer wrapper and make the input surface transparent while keeping hover styling on the upload button

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc166efc4832fa854d30bbe3e861c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Simplified chat layout with cleaner margins/padding and a centered, narrower content width.
  - Removed heavy borders/backdrops; introduced lighter borders and subtler hover states.
  - Streamlined wrappers across chat, search/filters, and proposal sections for a flatter look.
  - Refreshed buttons and input labels for improved clarity and contrast.
  - Improved spacing and alignment for better readability, including dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->