### PR TITLE
Align legal footer with composer width

### DIFF
--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -217,17 +217,19 @@ export default function LegalPrivacyFooter() {
   return (
     <>
       <footer className="flex-shrink-0 border-t border-black/10 bg-white/80 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/60">
-        <div className="mx-auto flex w-full max-w-screen-2xl flex-col items-center justify-center gap-1.5 px-6 py-1.5 text-center text-[11px] text-slate-600 dark:text-slate-300 sm:flex-row sm:gap-3 sm:text-xs">
-          <p className="leading-4 sm:max-w-3xl">
-            {BRAND} can make mistakes. This is not medical advice. Always consult a clinician.
-          </p>
-          <button
-            type="button"
-            onClick={openModal}
-            className="rounded-md px-2.5 py-1 text-xs font-medium text-primary transition hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:ml-2 sm:text-xs dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
-          >
-            Legal &amp; Privacy
-          </button>
+        <div className="px-6">
+          <div className="mx-auto flex w-full max-w-3xl flex-col items-center justify-center gap-1.5 px-4 py-1.5 text-center text-[11px] text-slate-600 dark:text-slate-300 sm:flex-row sm:gap-3 sm:text-xs">
+            <p className="leading-4 sm:max-w-3xl">
+              {BRAND} can make mistakes. This is not medical advice. Always consult a clinician.
+            </p>
+            <button
+              type="button"
+              onClick={openModal}
+              className="rounded-md px-2.5 py-1 text-xs font-medium text-primary transition hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:ml-2 sm:text-xs dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
+            >
+              Legal &amp; Privacy
+            </button>
+          </div>
         </div>
       </footer>
 


### PR DESCRIPTION
## Summary
- update the legal footer layout container to use the same max width and padding pattern as the message composer
- ensure the disclaimer text and modal button remain centered within the new container

## Testing
- npm run lint *(fails: command prompts for eslint setup and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68cfefd0de0c832f8c4e87e9b2c6a7c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Legal & Privacy footer layout for a cleaner, more balanced appearance on wide screens.
  * Replaced full-width container with a narrower, constrained layout and refined padding/spacing for improved readability.
  * Alignment and visual hierarchy adjusted; text and interactions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->