### PR TITLE
Adjust sidebar preferences button placement

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -40,7 +40,7 @@ export default function Sidebar() {
   };
   const filtered = threads.filter(t => t.title.toLowerCase().includes(q.toLowerCase()));
   return (
-    <div className="sidebar-click-guard flex h-full w-full flex-col gap-4 px-4 py-6 text-medx">
+    <div className="sidebar-click-guard flex h-full w-full flex-col gap-4 px-4 pt-6 pb-0 text-medx">
       <button
         type="button"
         onClick={handleNew}
@@ -110,12 +110,16 @@ export default function Sidebar() {
         )}
       </div>
 
-      <button
-        type="button"
-        className="mt-auto flex h-11 items-center gap-2 rounded-full border border-black/10 bg-white/70 px-4 text-left text-sm backdrop-blur transition hover:bg-white dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900"
-      >
-        <Settings size={16} /> Preferences
-      </button>
+      <div className="mt-auto">
+        <div className="sticky bottom-0 left-0 -mx-4 border-t border-black/5 bg-white/80 px-4 py-3 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/50">
+          <button
+            type="button"
+            className="flex items-center gap-1.5 rounded-md border border-black/10 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-white/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 dark:hover:bg-slate-900"
+          >
+            <Settings size={14} /> Preferences
+          </button>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- shrink the sidebar preferences control and restyle it with a compact button treatment
- anchor the preferences control to the bottom of the sidebar so it aligns with the legal footer on the page

## Testing
- not run (next lint prompts for interactive configuration)

------
https://chatgpt.com/codex/tasks/task_e_68cff0be533c832fa65b487f955c56e9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar spacing (top padding increased; bottom padding removed) for cleaner layout.
  * Moved Preferences button into a sticky bottom bar to keep it anchored and always accessible.
  * Added subtle border, translucent background, and backdrop blur to the bottom bar.
  * Reduced Settings icon size for better visual balance.
  * Refined hover/focus states and improved dark mode styling.
  * No changes to existing functionality (search, new chat, threads, AI Doc).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->