### PR TITLE
Align legal footer with chat composer

### DIFF
--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -217,7 +217,7 @@ export default function LegalPrivacyFooter() {
   return (
     <>
       <footer className="flex-shrink-0 border-t border-black/10 bg-white/80 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/60">
-        <div className="mx-auto flex w-full max-w-screen-2xl flex-col items-center justify-center gap-1.5 px-6 py-1.5 text-center text-[11px] text-slate-600 dark:text-slate-300 sm:flex-row sm:gap-3 sm:text-xs">
+        <div className="mx-auto flex w-full max-w-3xl flex-col items-center justify-center gap-1.5 px-4 py-1.5 text-center text-[11px] text-slate-600 dark:text-slate-300 sm:flex-row sm:gap-3 sm:text-xs">
           <p className="leading-4 sm:max-w-3xl">
             {BRAND} can make mistakes. This is not medical advice. Always consult a clinician.
           </p>


### PR DESCRIPTION
## Summary
- match the legal footer container width and padding to the chat composer so the disclaimer aligns centrally

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cff1530d90832fa5098a0fe7205d52