### PR TITLE
Add structured fracture analysis and multi-view imaging UI

### DIFF
--- a/app/api/imaging/analyze/route.ts
+++ b/app/api/imaging/analyze/route.ts
@@ -1,8 +1,71 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { applyHandHeuristics } from "@/lib/imaging/handHeuristics";
 
 const OAI_KEY = process.env.OPENAI_API_KEY!;
 const MODEL_VISION = process.env.OPENAI_VISION_MODEL || "gpt-5"; // images
 const MODEL_TEXT   = process.env.OPENAI_TEXT_MODEL   || "gpt-5"; // PDFs
+
+const FRACTURE_SCHEMA = {
+  type: "object",
+  properties: {
+    fracture_present: { type: "boolean" },
+    suspected_type: { type: "string" },
+    bone: { type: "string" },
+    region: { type: "string" },
+    angulation_deg: { type: "number" },
+    displacement_mm: { type: "number" },
+    rotation_suspected: { type: "boolean" },
+    need_additional_views: { type: "boolean" },
+    red_flags: { type: "array", items: { type: "string" } },
+    confidence_0_1: { type: "number" },
+  },
+  required: ["fracture_present", "confidence_0_1"],
+} as const;
+
+const FRACTURE_SYSTEM_PROMPT = `You are a radiologist. Return ONLY compact JSON matching this schema: ${JSON.stringify(
+  FRACTURE_SCHEMA,
+)}. No prose. If unsure, set confidence_0_1 conservatively.`;
+
+const FindingsSchema = z.object({
+  fracture_present: z.boolean(),
+  suspected_type: z.string().nullable().optional(),
+  bone: z.string().nullable().optional(),
+  region: z.string().nullable().optional(),
+  angulation_deg: z.number().nullable().optional(),
+  displacement_mm: z.number().nullable().optional(),
+  rotation_suspected: z.boolean().nullable().optional(),
+  need_additional_views: z.boolean().nullable().optional(),
+  red_flags: z.array(z.string()).nullable().optional(),
+  confidence_0_1: z.number(),
+});
+
+type ImagingFindings = {
+  fracture_present: boolean | null;
+  suspected_type: string | null;
+  bone: string | null;
+  region: string | null;
+  angulation_deg: number | null;
+  displacement_mm: number | null;
+  rotation_suspected: boolean | null;
+  need_additional_views: boolean | null;
+  red_flags: string[];
+  confidence_0_1: number;
+};
+
+const BASE_FINDINGS: ImagingFindings = {
+  fracture_present: null,
+  suspected_type: null,
+  bone: null,
+  region: null,
+  angulation_deg: null,
+  displacement_mm: null,
+  rotation_suspected: null,
+  need_additional_views: null,
+  red_flags: [],
+  confidence_0_1: 0,
+};
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -142,7 +205,47 @@ export async function POST(req: Request) {
       mime = ext ? `image/${ext === "jpg" ? "jpeg" : ext}` : "image/jpeg";
     }
 
-    const dataUrl = toDataUrl(buf, mime);
+    const imageFiles = multi.length ? multi : [file];
+    const encodedImages: { dataUrl: string }[] = [];
+    for (let i = 0; i < imageFiles.length; i++) {
+      const current = imageFiles[i];
+      const displayName = (current as any).name || name || "upload";
+      const currentName = displayName.toLowerCase();
+      const currentBuf = i === 0 ? buf : Buffer.from(await current.arrayBuffer());
+      let currentMime = current.type || (i === 0 ? mime : "");
+      const isImage =
+        (currentMime && currentMime.startsWith("image/")) ||
+        /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(currentName);
+      if (!isImage) {
+        console.warn("[/api/imaging/analyze] unsupported MIME", {
+          name: displayName,
+          mime: currentMime,
+          size: currentBuf.length,
+        });
+        return NextResponse.json(
+          { error: `Unsupported MIME type for imaging: ${currentMime || "unknown"} (name: ${displayName})` },
+          { status: 415 }
+        );
+      }
+      if (!currentMime || currentMime === "application/octet-stream") {
+        const ext = currentName.split(".").pop() || "";
+        if (ext === "jpg" || ext === "jpeg") currentMime = "image/jpeg";
+        else if (ext === "tif" || ext === "tiff") currentMime = "image/tiff";
+        else currentMime = ext ? `image/${ext}` : "image/jpeg";
+      }
+      encodedImages.push({ dataUrl: toDataUrl(currentBuf, currentMime) });
+    }
+
+    const userContent = [
+      {
+        type: "text",
+        text:
+          "Multiple hand radiographs (may include PA, lateral, oblique). Aggregate across views to decide." +
+          " Task: detect fracture on a HAND radiograph. If 5th metacarpal neck fracture → suspected_type='Boxer’s fracture'." +
+          " Estimate angulation in degrees if visible on this view; otherwise set angulation_deg=null and need_additional_views=true.",
+      },
+      ...encodedImages,
+    ];
 
     const resp = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
@@ -152,15 +255,11 @@ export async function POST(req: Request) {
         messages: [
           {
             role: "system",
-            content:
-              "You are a radiologist. Write a structured X-ray report: Technique, Findings, Impression (≤3 bullets, cautious language), Recommendations, Limitations.",
+            content: FRACTURE_SYSTEM_PROMPT,
           },
           {
             role: "user",
-            content: [
-              { type: "text", text: "Analyze this X-ray and generate a radiology-style report." },
-              { type: "image_url", image_url: { url: dataUrl } },
-            ],
+            content: userContent,
           },
         ],
       }),
@@ -168,13 +267,42 @@ export async function POST(req: Request) {
 
     const j = await resp.json();
     if (!resp.ok) throw new Error(j?.error?.message || resp.statusText);
+    const raw = j.choices?.[0]?.message?.content?.trim() || "{}";
+    let findings: ImagingFindings = { ...BASE_FINDINGS };
+    try {
+      const parsed = JSON.parse(raw);
+      const validated = FindingsSchema.safeParse(parsed);
+      if (validated.success) {
+        findings = {
+          ...BASE_FINDINGS,
+          ...validated.data,
+          angulation_deg:
+            validated.data.angulation_deg ?? null,
+          displacement_mm:
+            validated.data.displacement_mm ?? null,
+          rotation_suspected:
+            validated.data.rotation_suspected ?? null,
+          need_additional_views:
+            validated.data.need_additional_views ?? null,
+          suspected_type: validated.data.suspected_type ?? null,
+          bone: validated.data.bone ?? null,
+          region: validated.data.region ?? null,
+          red_flags: validated.data.red_flags ?? [],
+          confidence_0_1: Math.max(0, Math.min(1, validated.data.confidence_0_1)),
+        };
+      } else {
+        console.warn("[/api/imaging/analyze] vision JSON validation failed", validated.error.format());
+      }
+    } catch (err) {
+      console.warn("[/api/imaging/analyze] vision JSON parse failed", { err, raw });
+    }
 
-    const report = j.choices?.[0]?.message?.content || "";
+    findings = applyHandHeuristics(findings);
 
     const res = NextResponse.json({
       type: "image",
       filename: name,
-      report,
+      findings,
       disclaimer: "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
     });
     res.headers.set("x-branch", "image");

--- a/components/UnifiedUpload.tsx
+++ b/components/UnifiedUpload.tsx
@@ -9,16 +9,36 @@ export default function UnifiedUpload() {
   const [err, setErr] = useState<string | null>(null);
 
   async function onChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
+    const files = Array.from(e.target.files ?? []);
+    if (!files.length) return;
 
-    const name = file.name?.toLowerCase() || "";
-    const isPdf = file.type === "application/pdf" || name.endsWith(".pdf");
-    const isImage =
-      file.type.startsWith("image/") ||
-      /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(name);
-    if (!isPdf && !isImage) {
-      setErr(`Unsupported file type: ${file.type || name}. Upload a PDF or an image.`);
+    const classify = (file: File) => {
+      const name = file.name?.toLowerCase() || "";
+      const isPdf = file.type === "application/pdf" || name.endsWith(".pdf");
+      const isImage =
+        file.type.startsWith("image/") ||
+        /\.(png|jpe?g|webp|bmp|gif|tif?f)$/i.test(name);
+      return { isPdf, isImage };
+    };
+
+    const pdfFiles = files.filter(file => classify(file).isPdf);
+    const imageFiles = files.filter(file => classify(file).isImage);
+
+    if (pdfFiles.length && imageFiles.length) {
+      setErr("Upload PDFs separately from radiograph images.");
+      e.target.value = "";
+      return;
+    }
+
+    if (pdfFiles.length > 1) {
+      setErr("Upload a single PDF at a time.");
+      e.target.value = "";
+      return;
+    }
+
+    if (!pdfFiles.length && !imageFiles.length) {
+      setErr("Unsupported file type. Upload DICOM/PDF/PNG/JPG.");
+      e.target.value = "";
       return;
     }
 
@@ -28,33 +48,62 @@ export default function UnifiedUpload() {
 
     const search = new URLSearchParams(window.location.search);
     const threadId = search.get("threadId");
-    const sourceHash = `${file.name}:${file.size}:${(file as any).lastModified ?? ""}`;
+    const orderedFiles = pdfFiles.length ? pdfFiles : imageFiles;
+    const sourceHash = orderedFiles
+      .map(file => `${file.name}:${file.size}:${(file as any).lastModified ?? ""}`)
+      .join("|");
 
     const fd = new FormData();
-    fd.append("file", file);
+    orderedFiles.forEach(file => fd.append("files[]", file));
+    if (orderedFiles[0]) {
+      fd.append("file", orderedFiles[0]);
+    }
     fd.append("doctorMode", String(doctorMode));
     if (threadId) fd.append("threadId", threadId);
-    fd.append("sourceHash", sourceHash);
+    if (sourceHash) fd.append("sourceHash", sourceHash);
 
     try {
-      const j = await safeJson(fetch("/api/analyze", { method: "POST", body: fd }));
+      const j = await safeJson(
+        fetch("/api/imaging/analyze", {
+          method: "POST",
+          body: fd,
+        }),
+      );
       setOut(j);
       if (typeof window !== "undefined") {
         window.dispatchEvent(new Event("observations-updated"));
       }
     } catch (e: any) {
-      setErr(String(e?.message || e) || "Upload failed");
+      const message = String(e?.message || e) || "Upload failed";
+      if (message.includes("415")) {
+        setErr("Unsupported file type. Upload DICOM/PDF/PNG/JPG.");
+      } else {
+        setErr(message);
+      }
     } finally {
       setLoading(false);
+      e.target.value = "";
     }
   }
+
+  const formatNumber = (value: number) => {
+    if (!Number.isFinite(value)) return null;
+    const rounded = parseFloat(value.toFixed(1));
+    return Number.isNaN(rounded) ? null : rounded.toString();
+  };
 
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-3">
         <label className="px-4 py-2 rounded bg-black text-white cursor-pointer">
           <span>Upload</span>
-          <input type="file" accept="application/pdf,image/*" onChange={onChange} className="hidden" />
+          <input
+            type="file"
+            accept="application/pdf,image/*,.dcm"
+            multiple
+            onChange={onChange}
+            className="hidden"
+          />
         </label>
         <label className="flex items-center gap-2 text-sm">
           <input type="checkbox" checked={doctorMode} onChange={e=>setDoctorMode(e.target.checked)} />
@@ -63,7 +112,7 @@ export default function UnifiedUpload() {
       </div>
 
       <p className="text-xs text-gray-500">
-        (Upload medical reports, prescriptions, discharge summaries, or X-rays — PDF or image.)
+        (Upload medical reports, prescriptions, discharge summaries, or X-rays — PDF or image. Multiple views supported.)
       </p>
 
       {loading && <p>Analyzing…</p>}
@@ -87,8 +136,79 @@ export default function UnifiedUpload() {
           )}
           {out.type === "image" && (
             <section className="p-3 border rounded">
-              <h3 className="font-semibold mb-1">Imaging Report</h3>
-              <p className="whitespace-pre-wrap text-sm">{out.report}</p>
+              <h3 className="font-semibold mb-1">Imaging Findings</h3>
+              {out.findings ? (
+                <div className="space-y-2 text-sm">
+                  {(() => {
+                    const findings = out.findings || {};
+                    const fracturePresent =
+                      typeof findings.fracture_present === "boolean"
+                        ? findings.fracture_present
+                        : null;
+                    const confidence =
+                      typeof findings.confidence_0_1 === "number"
+                        ? Math.round(findings.confidence_0_1 * 100)
+                        : null;
+                    const fractureLabel =
+                      fracturePresent === null ? "Unknown" : fracturePresent ? "Yes" : "No";
+                    const confidenceLabel =
+                      confidence === null ? null : `${confidence}%`;
+                    const segments: string[] = [];
+                    if (findings.bone) segments.push(`Bone: ${findings.bone}`);
+                    if (findings.region) segments.push(`Region: ${findings.region}`);
+                    const suspected = findings.suspected_type ? ` → ${findings.suspected_type}` : "";
+                    const angulation =
+                      typeof findings.angulation_deg === "number"
+                        ? formatNumber(findings.angulation_deg)
+                        : null;
+                    const displacement =
+                      typeof findings.displacement_mm === "number"
+                        ? formatNumber(findings.displacement_mm)
+                        : null;
+                    const rotation =
+                      typeof findings.rotation_suspected === "boolean"
+                        ? findings.rotation_suspected
+                        : null;
+                    const metrics: string[] = [];
+                    if (angulation) metrics.push(`Angulation: ${angulation}°`);
+                    if (displacement) metrics.push(`Displacement: ${displacement} mm`);
+                    if (rotation !== null) metrics.push(`Rotation suspected: ${rotation ? "Yes" : "No"}`);
+                    const redFlags = Array.isArray(findings.red_flags)
+                      ? findings.red_flags.filter((f: unknown) => typeof f === "string" && f.trim())
+                      : [];
+                    const nextLine =
+                      findings.need_additional_views === true
+                        ? "Next: Lateral/oblique views recommended."
+                        : findings.need_additional_views === false
+                        ? "Next: No additional views requested."
+                        : "Next: Await clinician review.";
+
+                    return (
+                      <div className="space-y-1">
+                        <p>
+                          Fracture: {fractureLabel}
+                          {confidenceLabel ? ` (${confidenceLabel})` : ""}
+                        </p>
+                        {(segments.length > 0 || suspected) && (
+                          <p>
+                            {segments.join(" — ")}
+                            {suspected}
+                          </p>
+                        )}
+                        {metrics.length > 0 && <p>{metrics.join(" • ")}</p>}
+                        <p>{nextLine}</p>
+                        {redFlags.length > 0 && (
+                          <p>Red flags: {redFlags.join(", ")}</p>
+                        )}
+                      </div>
+                    );
+                  })()}
+                </div>
+              ) : out.report ? (
+                <p className="whitespace-pre-wrap text-sm">{out.report}</p>
+              ) : (
+                <p className="text-sm">No findings returned.</p>
+              )}
             </section>
           )}
           <p className="text-xs text-gray-400">{out.disclaimer}</p>

--- a/lib/imaging/handHeuristics.ts
+++ b/lib/imaging/handHeuristics.ts
@@ -1,0 +1,21 @@
+export function applyHandHeuristics<T extends Record<string, any> | null | undefined>(input: T) {
+  if (!input || typeof input !== "object") return input;
+
+  try {
+    const serialized = JSON.stringify(input).toLowerCase();
+    if (
+      (input as any).fracture_present &&
+      serialized.includes("metacarp") &&
+      (serialized.includes("5th") || serialized.includes("fifth")) &&
+      serialized.includes("neck")
+    ) {
+      if (!(input as any).suspected_type) {
+        (input as any).suspected_type = "Boxer’s fracture";
+      }
+    }
+  } catch (err) {
+    console.warn("[handHeuristics] failed to stringify input", err);
+  }
+
+  return input;
+}


### PR DESCRIPTION
## Summary
- enforce schema-driven imaging analysis that accepts multiple hand radiograph views and validates JSON responses
- add a simple hand-specific heuristic to flag likely Boxer’s fractures when the 5th metacarpal neck is mentioned
- update the unified uploader to support multi-file submissions and render structured imaging findings with confidence and next steps

## Testing
- npm run lint *(fails: Next.js eslint setup prompt requires interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_68d00a31fb4c832fbab6f8d64c805148