### PR TITLE
Add image preview support in chat for uploads

### DIFF
--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,14 +1,41 @@
 import Markdown from "react-markdown";
 import FeedbackControls from "./FeedbackControls";
 
+type ChatMessage = {
+  id: string;
+  role: "user" | "assistant" | "system";
+  kind?: "text" | "image";
+  content?: string;
+  imageUrl?: string;
+  pending?: boolean;
+  createdAt?: number;
+};
+
 interface MessageProps {
-  message: { id: string; text: string };
+  message: ChatMessage;
 }
 
 export default function Message({ message }: MessageProps) {
+  if (message.kind === "image" && message.imageUrl) {
+    return (
+      <div className={`my-2 flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
+        <div className="max-w-[65%] rounded-2xl overflow-hidden border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900">
+          <img
+            src={message.imageUrl}
+            alt="Uploaded"
+            className="block max-h-[360px] w-auto object-contain sm:max-h-[240px]"
+          />
+          {message.pending && (
+            <div className="p-2 text-xs opacity-70 dark:text-gray-300 text-gray-600">Analyzing…</div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <Markdown>{message.text}</Markdown>
+      <Markdown>{message.content ?? ""}</Markdown>
       <div className="mt-2">
         <FeedbackControls messageId={message.id} />
       </div>

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -2270,22 +2270,6 @@ ${systemCommon}` + baseSys;
   function onFileSelected(file: File) {
     setPendingFile(file);
     setTimeout(() => inputRef.current?.focus(), 0);
-
-    if (file && file.type.startsWith('image/')) {
-      const url = URL.createObjectURL(file);
-      previewUrlRef.current = url;
-
-      setMessages(prev => [
-        ...prev,
-        {
-          id: uid(),
-          role: 'user',
-          kind: 'image',
-          imageUrl: url,
-          pending: true,
-        } as any,
-      ]);
-    }
   }
 
   async function analyzeFile(file: File, noteText: string) {
@@ -2370,6 +2354,26 @@ ${systemCommon}` + baseSys;
     inFlight = true;
     try {
       const trimmed = userText.trim();
+
+      if (pendingFile && pendingFile.type.startsWith('image/')) {
+        const url = URL.createObjectURL(pendingFile);
+        previewUrlRef.current = url;
+
+        setMessages(prev => [
+          ...prev,
+          {
+            id: uid(),
+            role: 'user',
+            kind: 'image',
+            imageUrl: url,
+          } as any,
+        ]);
+
+        await analyzeFile(pendingFile, trimmed);
+        setPendingFile(null);
+        setUserText('');
+        return;
+      }
       if (!pendingFile && trimmed) {
         const summarizeMatch = /^summarize\s+(NCT\d{8})$/i.exec(trimmed);
         if (summarizeMatch) {

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -563,6 +563,24 @@ function ChatCard({
 }) {
   const suggestions = normalizeSuggestions(m.followUps);
   if (m.pending) return <PendingChatCard label="Thinking…" active={pendingTimerActive} />;
+  if (typeof m.content === 'string' && m.content.startsWith('__IMG_BLOB__')) {
+    const url = m.content.slice('__IMG_BLOB__'.length);
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[65%] rounded-2xl overflow-hidden border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+          <img
+            src={url}
+            alt="Uploaded image"
+            className="block max-h-[360px] w-auto object-contain sm:max-h-[240px]"
+            loading="eager"
+          />
+          <div className="p-2 text-xs opacity-70 dark:text-gray-300 text-gray-600">
+            Analyzing…
+          </div>
+        </div>
+      </div>
+    );
+  }
   return (
     <div
       className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl"
@@ -2260,7 +2278,7 @@ ${systemCommon}` + baseSys;
           id: uid(),
           role: 'user',
           kind: 'chat',
-          content: `![Uploaded image](${url})`
+          content: `__IMG_BLOB__${url}`
         } as any,
       ]);
     }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -339,6 +339,16 @@ type ChatMessage =
       error?: string | null;
     })
   | (BaseChatMessage & {
+      role: "user";
+      kind: "image";
+      imageUrl?: string;
+      tempId?: string;
+      parentId?: string;
+      pending?: boolean;
+      error?: string | null;
+      createdAt?: number;
+    })
+  | (BaseChatMessage & {
       role: "assistant";
       kind: "chat";
       tempId?: string;
@@ -669,6 +679,42 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
 
   useEffect(() => {
     setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    function onPush(e: Event) {
+      const ce = e as CustomEvent<any>;
+      const msg = ce.detail;
+      if (!msg) return;
+      setMessages(prev => [...prev, msg as ChatMessage]);
+      setTimeout(() => {
+        const chatContainer = document.getElementById("chat-scroll-container");
+        if (chatContainer) {
+          chatContainer.scrollTop = chatContainer.scrollHeight;
+        }
+      }, 50);
+    }
+
+    function onMarkDone() {
+      setMessages(prev => {
+        for (let i = prev.length - 1; i >= 0; i -= 1) {
+          const candidate = prev[i];
+          if (candidate?.kind === "image" && candidate.pending) {
+            const next = [...prev];
+            next[i] = { ...candidate, pending: false } as ChatMessage;
+            return next;
+          }
+        }
+        return prev;
+      });
+    }
+
+    window.addEventListener("medx:chat:push", onPush as EventListener);
+    window.addEventListener("medx:chat:mark-done", onMarkDone as EventListener);
+    return () => {
+      window.removeEventListener("medx:chat:push", onPush as EventListener);
+      window.removeEventListener("medx:chat:mark-done", onMarkDone as EventListener);
+    };
   }, []);
 
   const fetchLabSummary = useCallback(async () => {
@@ -2578,9 +2624,24 @@ ${systemCommon}` + baseSys;
         return (
           <div key={derivedKey} className="space-y-2">
             {m.role === 'user' ? (
-              <div className="ml-auto max-w-3xl rounded-2xl px-4 py-3 shadow-sm bg-slate-200 text-slate-900 dark:bg-gray-700 dark:text-gray-100 text-left whitespace-normal">
-                <ChatMarkdown content={m.content} />
-              </div>
+              m.kind === 'image' && 'imageUrl' in m && m.imageUrl ? (
+                <div className="flex justify-end">
+                  <div className="max-w-[65%] overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+                    <img
+                      src={m.imageUrl}
+                      alt="Uploaded"
+                      className="block max-h-[360px] w-auto object-contain sm:max-h-[240px]"
+                    />
+                    {m.pending && (
+                      <div className="p-2 text-xs text-gray-600 opacity-70 dark:text-gray-300">Analyzing…</div>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div className="ml-auto max-w-3xl whitespace-normal rounded-2xl bg-slate-200 px-4 py-3 text-left text-slate-900 shadow-sm dark:bg-gray-700 dark:text-gray-100">
+                  <ChatMarkdown content={m.content ?? ''} />
+                </div>
+              )
             ) : (
               <div className="space-y-4">
                 <AssistantMessage
@@ -2655,7 +2716,11 @@ ${systemCommon}` + baseSys;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div ref={chatRef} className="flex-1 min-h-0 overflow-y-auto">
+      <div
+        ref={chatRef}
+        id="chat-scroll-container"
+        className="flex-1 min-h-0 overflow-y-auto"
+      >
         <div className="flex min-h-full flex-col justify-end px-6 pt-6">
           {mode === "doctor" && researchMode && (
             <div className="mb-6 space-y-4">


### PR DESCRIPTION
## Summary
- add an image message renderer so uploaded previews show with an Analyzing… badge
- push chat preview messages from the unified uploader and clear them once analysis starts
- hook the chat pane into global push/mark-done events and auto-scroll after injections

## Testing
- npm run lint *(fails: prompts to configure Next.js ESLint and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d100632794832fbc3d175d5662e944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat supports user image messages with inline, right-aligned image bubbles and an “Analyzing…” status while processing.
  * Image uploads show immediate client-side previews inserted into the chat; chat auto-scrolls to new previews/messages.
  * Text messages render content as Markdown.

* **Bug Fixes / Improvements**
  * Preview lifecycle now reliably marks previews complete on success or failure and revokes temporary preview data to prevent leaks.
  * Image pending state updates more reliably during upload/analysis.

* **Validation**
  * Existing upload rules preserved (no mixed PDF/image uploads, single-PDF constraint, image count and per-image size limits).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->