### PR TITLE
Show stop button during streaming responses

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -3352,10 +3352,10 @@ ${systemCommon}` + baseSys;
                     }}
                   />
 
-                  {queueActive && (
+                  {(queueActive || busy || abortRef.current) && (
                     <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center">
                       <StopButton
-                        onClick={onStopQueue}
+                        onClick={onStop}
                         className="pointer-events-auto"
                         title="Stop (Esc)"
                       />


### PR DESCRIPTION
## Summary
- show the stop button whenever chat streaming or queue activity is happening
- wire the stop button to the unified onStop handler so both chat and analysis streams are cancelled

## Testing
- npm run build *(fails: Next.js lockfile patching requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d22c7a0c58832f85aa9188ba2ba0b1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stop button now appears during active processing and while an abort is in progress, not just when a queue is running.
  * Unified stop action: pressing Stop cancels both the current operation and any queued tasks for more reliable interruption control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->