### PR TITLE
Add assistant message actions with share and refresh workflows

### DIFF
--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { supabaseServer } from "@/lib/supabaseServer";
+
+const shareSchema = z.object({
+  conversationId: z.string().min(1),
+  messageId: z.string().min(1),
+  content: z.string().min(1),
+  mode: z.enum(["patient", "doctor", "research", "therapy"]),
+  research: z.boolean().optional(),
+});
+
+function randomSlug() {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 10);
+}
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const parsed = shareSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: "bad_request" }, { status: 400 });
+    }
+
+    const payload = parsed.data;
+    const supabase = supabaseServer();
+    let attempts = 0;
+
+    while (attempts < 5) {
+      const slug = randomSlug();
+      const { error } = await supabase
+        .from("shared_answers")
+        .insert({
+          slug,
+          conversation_id: payload.conversationId,
+          message_id: payload.messageId,
+          content: payload.content,
+          mode: payload.mode,
+          research: payload.research ?? false,
+        });
+      if (!error) {
+        return NextResponse.json({ ok: true, slug });
+      }
+      if (error.code !== "23505") {
+        console.error("Share insert failed", error);
+        return NextResponse.json({ ok: false, error: "db_error" }, { status: 500 });
+      }
+      attempts += 1;
+    }
+
+    return NextResponse.json({ ok: false, error: "slug_conflict" }, { status: 500 });
+  } catch (err) {
+    console.error("Share route error", err);
+    return NextResponse.json({ ok: false, error: "server_error" }, { status: 500 });
+  }
+}

--- a/app/api/share/selftest/route.ts
+++ b/app/api/share/selftest/route.ts
@@ -1,0 +1,64 @@
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+import { supabaseAdmin } from '@/lib/supabase/admin';
+
+function buildAbsoluteUrl(slug: string) {
+  const headerStore = headers();
+  const proto = headerStore.get('x-forwarded-proto') ?? 'https';
+  const host =
+    headerStore.get('x-forwarded-host') ??
+    headerStore.get('host') ??
+    process.env.NEXT_PUBLIC_APP_URL?.replace(/^https?:\/\//, '') ??
+    null;
+
+  if (!host) {
+    return `/s/${slug}`;
+  }
+
+  const normalizedHost = host.replace(/\/$/, '');
+  return `${proto}://${normalizedHost}/s/${slug}`;
+}
+
+export async function GET() {
+  const diagEnabled = process.env.SHOW_SHARE_DIAG === '1';
+  if (!diagEnabled) {
+    return NextResponse.json({ ok: false }, { status: 404 });
+  }
+
+  const envStatus = {
+    NEXT_PUBLIC_SUPABASE_URL: Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL),
+    SUPABASE_SERVICE_ROLE_KEY: Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY),
+  } as const;
+
+  const supabase = supabaseAdmin();
+  const slug = `__selftest-${Date.now()}`;
+
+  const insertResult = await supabase
+    .from('shared_answers')
+    .insert({ slug, plain_text: 'ok', md_text: 'ok' })
+    .select('slug')
+    .maybeSingle();
+
+  const insertOk = !insertResult.error;
+
+  let selectOk = false;
+  if (insertOk) {
+    const { data, error } = await supabase
+      .from('shared_answers')
+      .select('slug')
+      .eq('slug', slug)
+      .maybeSingle();
+    selectOk = !error && !!data;
+  }
+
+  const absoluteUrl = buildAbsoluteUrl(slug);
+
+  return NextResponse.json({
+    env: envStatus,
+    insertOk,
+    selectOk,
+    absoluteUrl,
+    slug,
+  });
+}

--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -1,3 +1,6 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import ShareViewer from "@/components/share/ShareViewer";
@@ -56,7 +59,7 @@ export default async function SharedAnswerPage({ params }: PageParams) {
     .maybeSingle<ShareRecord>();
 
   if (error || !data) {
-    notFound();
+    return notFound();
   }
 
   const createdAt = data.created_at ? new Date(data.created_at) : null;

--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -63,6 +63,12 @@ export default async function SharedAnswerPage({ params }: PageParams) {
     return notFound();
   }
 
+  const plainText = data.plain_text ?? "";
+  const markdownText = data.md_text ?? "";
+  const hasPlainText = plainText.trim().length > 0;
+  const hasMarkdownText = markdownText.trim().length > 0;
+  const hasContent = hasPlainText || hasMarkdownText;
+
   const createdAt = data.created_at ? new Date(data.created_at) : null;
   const modeLabel = labelForMode(data.mode);
   const showResearch = Boolean(data.research);
@@ -90,7 +96,13 @@ export default async function SharedAnswerPage({ params }: PageParams) {
           ) : null}
         </header>
 
-        <ShareViewer plainText={data.plain_text} mdText={data.md_text} />
+        {hasContent ? (
+          <ShareViewer plainText={plainText} mdText={markdownText} />
+        ) : (
+          <div className="rounded-3xl border border-dashed border-slate-200 bg-white/80 p-6 text-center text-sm text-slate-500 shadow-inner dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-300">
+            No content stored for this link.
+          </div>
+        )}
 
         <footer className="text-center text-xs text-slate-500 dark:text-slate-400">
           Not medical advice. For personal guidance, consult a clinician.

--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -1,0 +1,83 @@
+import { notFound } from "next/navigation";
+import { supabaseServer } from "@/lib/supabaseServer";
+import ShareViewer from "@/components/share/ShareViewer";
+import { BRAND_NAME } from "@/lib/brand";
+
+const TITLE_FALLBACK = `${BRAND_NAME} • Shared answer`;
+
+type PageParams = { params: { slug: string } };
+
+type ShareRecord = {
+  content: string;
+  mode: string;
+  created_at: string | null;
+};
+
+export async function generateMetadata({ params }: PageParams) {
+  try {
+    const supabase = supabaseServer();
+    const { data } = await supabase
+      .from("shared_answers")
+      .select("mode")
+      .eq("slug", params.slug)
+      .maybeSingle();
+    if (!data) {
+      return { title: TITLE_FALLBACK };
+    }
+    const label =
+      data.mode === "doctor"
+        ? "Doctor mode"
+        : data.mode === "patient"
+        ? "Patient mode"
+        : data.mode === "therapy"
+        ? "Therapy answer"
+        : data.mode === "research"
+        ? "Research mode"
+        : "Shared answer";
+    return { title: `${BRAND_NAME} • ${label}` };
+  } catch {
+    return { title: TITLE_FALLBACK };
+  }
+}
+
+export default async function SharedAnswerPage({ params }: PageParams) {
+  const supabase = supabaseServer();
+  const { data, error } = await supabase
+    .from("shared_answers")
+    .select("content, mode, created_at")
+    .eq("slug", params.slug)
+    .maybeSingle();
+
+  if (error) {
+    console.error("Shared answer fetch error", error);
+  }
+
+  if (!data) {
+    notFound();
+  }
+
+  const record = data as ShareRecord;
+  const createdAt = record.created_at ? new Date(record.created_at) : null;
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+      <div className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 py-16">
+        <header className="space-y-2 text-center">
+          <p className="text-sm uppercase tracking-wide text-slate-500 dark:text-slate-400">Shared answer</p>
+          <h1 className="text-3xl font-semibold tracking-tight">{BRAND_NAME}</h1>
+          {createdAt ? (
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Generated {createdAt.toLocaleString()}
+            </p>
+          ) : null}
+        </header>
+
+        <ShareViewer content={record.content} />
+
+        <footer className="text-center text-xs text-slate-500 dark:text-slate-400">
+          Not medical advice. For personal guidance, consult a clinician.
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -1,5 +1,6 @@
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
+export const runtime = "nodejs";
 
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";

--- a/app/s/[slug]/page.tsx
+++ b/app/s/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
-import { supabaseServer } from "@/lib/supabaseServer";
+import type { Metadata } from "next";
 import ShareViewer from "@/components/share/ShareViewer";
+import { supabaseAdmin } from "@/lib/supabase/admin";
 import { BRAND_NAME } from "@/lib/brand";
 
 const TITLE_FALLBACK = `${BRAND_NAME} • Shared answer`;
@@ -8,63 +9,76 @@ const TITLE_FALLBACK = `${BRAND_NAME} • Shared answer`;
 type PageParams = { params: { slug: string } };
 
 type ShareRecord = {
-  content: string;
-  mode: string;
+  plain_text: string;
+  md_text: string | null;
+  mode: string | null;
+  research: boolean | null;
   created_at: string | null;
 };
 
-export async function generateMetadata({ params }: PageParams) {
+const MODE_LABELS: Record<string, string> = {
+  patient: "Patient mode",
+  doctor: "Doctor mode",
+  therapy: "Therapy answer",
+  research: "Research mode",
+};
+
+function labelForMode(mode?: string | null) {
+  if (!mode) return "Shared answer";
+  return MODE_LABELS[mode] ?? "Shared answer";
+}
+
+export async function generateMetadata({ params }: PageParams): Promise<Metadata> {
   try {
-    const supabase = supabaseServer();
+    const supabase = supabaseAdmin();
     const { data } = await supabase
       .from("shared_answers")
       .select("mode")
       .eq("slug", params.slug)
       .maybeSingle();
+
     if (!data) {
       return { title: TITLE_FALLBACK };
     }
-    const label =
-      data.mode === "doctor"
-        ? "Doctor mode"
-        : data.mode === "patient"
-        ? "Patient mode"
-        : data.mode === "therapy"
-        ? "Therapy answer"
-        : data.mode === "research"
-        ? "Research mode"
-        : "Shared answer";
-    return { title: `${BRAND_NAME} • ${label}` };
+
+    return { title: `${BRAND_NAME} • ${labelForMode(data.mode)}` };
   } catch {
     return { title: TITLE_FALLBACK };
   }
 }
 
 export default async function SharedAnswerPage({ params }: PageParams) {
-  const supabase = supabaseServer();
+  const supabase = supabaseAdmin();
   const { data, error } = await supabase
     .from("shared_answers")
-    .select("content, mode, created_at")
+    .select("plain_text, md_text, mode, research, created_at")
     .eq("slug", params.slug)
-    .maybeSingle();
+    .maybeSingle<ShareRecord>();
 
-  if (error) {
-    console.error("Shared answer fetch error", error);
-  }
-
-  if (!data) {
+  if (error || !data) {
     notFound();
   }
 
-  const record = data as ShareRecord;
-  const createdAt = record.created_at ? new Date(record.created_at) : null;
+  const createdAt = data.created_at ? new Date(data.created_at) : null;
+  const modeLabel = labelForMode(data.mode);
+  const showResearch = Boolean(data.research);
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
       <div className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 py-16">
-        <header className="space-y-2 text-center">
+        <header className="space-y-3 text-center">
           <p className="text-sm uppercase tracking-wide text-slate-500 dark:text-slate-400">Shared answer</p>
           <h1 className="text-3xl font-semibold tracking-tight">{BRAND_NAME}</h1>
+          <div className="flex flex-wrap items-center justify-center gap-2 text-xs">
+            <span className="rounded-full border border-slate-200 bg-white/70 px-3 py-1 font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200">
+              {modeLabel}
+            </span>
+            {showResearch ? (
+              <span className="rounded-full border border-sky-200 bg-sky-50/70 px-3 py-1 font-medium text-sky-700 dark:border-sky-700 dark:bg-sky-900/40 dark:text-sky-200">
+                Research on
+              </span>
+            ) : null}
+          </div>
           {createdAt ? (
             <p className="text-xs text-slate-500 dark:text-slate-400">
               Generated {createdAt.toLocaleString()}
@@ -72,7 +86,7 @@ export default async function SharedAnswerPage({ params }: PageParams) {
           ) : null}
         </header>
 
-        <ShareViewer content={record.content} />
+        <ShareViewer plainText={data.plain_text} mdText={data.md_text} />
 
         <footer className="text-center text-xs text-slate-500 dark:text-slate-400">
           Not medical advice. For personal guidance, consult a clinician.

--- a/components/chat/MessageActions.tsx
+++ b/components/chat/MessageActions.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Copy, RefreshCw, Share2, ThumbsDown, ThumbsUp } from 'lucide-react';
+import { pushToast } from '@/lib/ui/toast';
+import { useFeedback } from '@/hooks/useFeedback';
+import { trackEvent } from '@/lib/analytics/events';
+
+type MessageActionsProps = {
+  conversationId: string;
+  messageId: string;
+  mode: 'patient' | 'doctor' | 'research' | 'therapy';
+  getMessageText: () => string;
+  messageContent: string;
+  className?: string;
+  disabled?: boolean;
+  isRefreshing?: boolean;
+  onRefresh?: () => Promise<void> | void;
+  onShare?: () => void;
+  canRefresh?: boolean;
+  showFeedback?: boolean;
+};
+
+const baseButtonClasses =
+  'pointer-events-auto inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-slate-500 transition hover:bg-slate-200/60 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-300 dark:hover:bg-slate-700/60 dark:focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-40';
+
+export default function MessageActions(props: MessageActionsProps) {
+  const {
+    conversationId,
+    messageId,
+    mode,
+    getMessageText,
+    messageContent,
+    className,
+    disabled,
+    isRefreshing,
+    onRefresh,
+    onShare,
+    canRefresh = true,
+    showFeedback = true,
+  } = props;
+
+  const { submit, submittedFor, loading, error } = useFeedback();
+  const feedbackKey = `${conversationId}:${messageId}`;
+  const submitted = submittedFor[feedbackKey];
+  const busy = loading === feedbackKey;
+
+  useEffect(() => {
+    if (error) {
+      pushToast({ title: 'Could not send feedback', variant: 'destructive' });
+    }
+  }, [error]);
+
+  useEffect(() => {
+    if (submitted === 1 || submitted === -1) {
+      trackEvent('feedback_submitted', {
+        messageId,
+        conversationId,
+        rating: submitted,
+        mode,
+      });
+    }
+  }, [submitted, conversationId, messageId, mode]);
+
+  const handleCopy = async () => {
+    if (disabled) return;
+    try {
+      const text = (getMessageText() || messageContent || '').trim();
+      if (!text) throw new Error('empty');
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        throw new Error('clipboard_unavailable');
+      }
+      pushToast({ title: 'Copied' });
+      trackEvent('copy_clicked', { conversationId, messageId, mode });
+    } catch {
+      pushToast({ title: 'Could not copy message', variant: 'destructive' });
+    }
+  };
+
+  const handleRefresh = async () => {
+    if (disabled || !onRefresh || !canRefresh) return;
+    trackEvent('refresh_clicked', { conversationId, messageId, mode });
+    await onRefresh();
+  };
+
+  const handleFeedback = async (rating: 1 | -1) => {
+    if (busy || disabled) return;
+    await submit({ conversationId, messageId, mode, rating });
+  };
+
+  const copyClasses = baseButtonClasses;
+  const refreshClasses = `${baseButtonClasses} ${(!canRefresh || disabled) ? 'opacity-40' : ''}`;
+  const shareClasses = baseButtonClasses;
+  const upClasses = `${baseButtonClasses} ${submitted === 1 ? 'text-blue-600 dark:text-blue-300' : ''}`;
+  const downClasses = `${baseButtonClasses} ${submitted === -1 ? 'text-amber-600 dark:text-amber-300' : ''}`;
+
+  return (
+    <div
+      className={`flex items-center gap-2 text-xs text-slate-500 dark:text-slate-300 ${className ?? ''}`.trim()}
+      data-message-actions
+    >
+      <button
+        type="button"
+        onClick={handleCopy}
+        className={copyClasses}
+        title="Copy message"
+        aria-label="Copy message"
+        disabled={disabled}
+      >
+        <Copy size={14} strokeWidth={1.8} />
+      </button>
+      {onRefresh && canRefresh && (
+        <button
+          type="button"
+          onClick={handleRefresh}
+          className={refreshClasses}
+          title="Refresh answer"
+          aria-label="Refresh answer"
+          disabled={disabled || !canRefresh}
+        >
+          <RefreshCw
+            size={14}
+            strokeWidth={1.8}
+            className={isRefreshing ? 'animate-spin' : ''}
+          />
+        </button>
+      )}
+      {onShare && (
+        <button
+          type="button"
+          onClick={onShare}
+          className={shareClasses}
+          title="Share"
+          aria-label="Share"
+          disabled={disabled}
+        >
+          <Share2 size={14} strokeWidth={1.8} />
+        </button>
+      )}
+      {showFeedback && (
+        <>
+          <button
+            type="button"
+            onClick={() => handleFeedback(1)}
+            className={upClasses}
+            title="Good answer"
+            aria-pressed={submitted === 1}
+            disabled={disabled || submitted === 1}
+          >
+            <ThumbsUp size={14} strokeWidth={1.8} />
+          </button>
+          <button
+            type="button"
+            onClick={() => handleFeedback(-1)}
+            className={downClasses}
+            title="Needs work"
+            aria-pressed={submitted === -1}
+            disabled={disabled || submitted === -1}
+          >
+            <ThumbsDown size={14} strokeWidth={1.8} />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/chat/SharePanel.tsx
+++ b/components/chat/SharePanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { Clipboard, Download, Link as LinkIcon, Share2, Twitter, Facebook, Loader2 } from 'lucide-react';
+import type { ShareActionKey } from '@/lib/share/useShareActions';
 
 type SharePanelProps = {
   open: boolean;
@@ -9,12 +10,12 @@ type SharePanelProps = {
   preview: string;
   onCopyLink: () => Promise<void>;
   onDownloadImage: () => Promise<void>;
-  onShareX: () => void | Promise<void>;
-  onShareFacebook: () => void | Promise<void>;
+  onShareX: () => Promise<void>;
+  onShareFacebook: () => Promise<void>;
   onSystemShare?: () => Promise<void>;
   onCopyCaption: () => Promise<void>;
   canSystemShare: boolean;
-  busyAction: null | 'link' | 'download' | 'caption' | 'system' | 'x' | 'facebook';
+  busyAction: ShareActionKey | null;
 };
 
 export default function SharePanel(props: SharePanelProps) {

--- a/components/chat/SharePanel.tsx
+++ b/components/chat/SharePanel.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Clipboard, Download, Link as LinkIcon, Share2, Twitter, Facebook } from 'lucide-react';
+
+type SharePanelProps = {
+  open: boolean;
+  onClose: () => void;
+  preview: string;
+  onCopyLink: () => Promise<void>;
+  onDownloadImage: () => Promise<void>;
+  onShareX: () => void;
+  onShareFacebook: () => void;
+  onSystemShare?: () => Promise<void>;
+  onCopyCaption: () => Promise<void>;
+  canSystemShare: boolean;
+  busyAction: null | 'link' | 'download' | 'caption' | 'system';
+};
+
+export default function SharePanel(props: SharePanelProps) {
+  const {
+    open,
+    onClose,
+    preview,
+    onCopyLink,
+    onDownloadImage,
+    onShareX,
+    onShareFacebook,
+    onSystemShare,
+    onCopyCaption,
+    canSystemShare,
+    busyAction,
+  } = props;
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-end justify-center px-3 py-6 sm:items-center">
+      <div
+        className="absolute inset-0 bg-black/50"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+      <div className="relative z-10 w-full max-w-md rounded-t-3xl border border-black/10 bg-white/95 p-5 shadow-2xl backdrop-blur sm:rounded-2xl dark:border-white/10 dark:bg-slate-900/95">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">Share answer</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-2 text-slate-500 transition hover:bg-slate-200/70 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-300 dark:hover:bg-slate-800/70 dark:focus-visible:ring-offset-slate-900"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <p className="mt-3 rounded-lg border border-amber-200 bg-amber-50/80 px-3 py-2 text-xs font-medium text-amber-700 dark:border-amber-500/50 dark:bg-amber-500/10 dark:text-amber-200">
+          Make sure this doesn’t include personal info.
+        </p>
+        <div className="mt-4 max-h-36 overflow-y-auto rounded-xl border border-slate-200 bg-slate-50/70 px-3 py-2 text-sm leading-6 text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200">
+          {preview || 'No preview available.'}
+        </div>
+        <div className="mt-5 grid gap-2 text-sm">
+          <button
+            type="button"
+            onClick={onCopyLink}
+            className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            disabled={busyAction === 'link'}
+          >
+            <span className="inline-flex items-center gap-2"><LinkIcon size={16} /> Copy link</span>
+            {busyAction === 'link' && <span className="text-xs text-slate-500">Working…</span>}
+          </button>
+          <button
+            type="button"
+            onClick={onDownloadImage}
+            className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            disabled={busyAction === 'download'}
+          >
+            <span className="inline-flex items-center gap-2"><Download size={16} /> Download image</span>
+            {busyAction === 'download' && <span className="text-xs text-slate-500">Working…</span>}
+          </button>
+          <div className="grid gap-2 sm:grid-cols-2">
+            <button
+              type="button"
+              onClick={onShareX}
+              className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            >
+              <span className="inline-flex items-center gap-2"><Twitter size={16} /> Share to X</span>
+              <Share2 size={14} />
+            </button>
+            <button
+              type="button"
+              onClick={onShareFacebook}
+              className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            >
+              <span className="inline-flex items-center gap-2"><Facebook size={16} /> Share to Facebook</span>
+              <Share2 size={14} />
+            </button>
+          </div>
+          {canSystemShare && onSystemShare && (
+            <button
+              type="button"
+              onClick={onSystemShare}
+              className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              disabled={busyAction === 'system'}
+            >
+              <span className="inline-flex items-center gap-2"><Share2 size={16} /> Share via device</span>
+              {busyAction === 'system' && <span className="text-xs text-slate-500">Working…</span>}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onCopyCaption}
+            className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+            disabled={busyAction === 'caption'}
+          >
+            <span className="inline-flex items-center gap-2"><Clipboard size={16} /> Copy caption</span>
+            {busyAction === 'caption' && <span className="text-xs text-slate-500">Copied</span>}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/chat/SharePanel.tsx
+++ b/components/chat/SharePanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { Clipboard, Download, Link as LinkIcon, Share2, Twitter, Facebook } from 'lucide-react';
+import { Clipboard, Download, Link as LinkIcon, Share2, Twitter, Facebook, Loader2 } from 'lucide-react';
 
 type SharePanelProps = {
   open: boolean;
@@ -9,12 +9,12 @@ type SharePanelProps = {
   preview: string;
   onCopyLink: () => Promise<void>;
   onDownloadImage: () => Promise<void>;
-  onShareX: () => void;
-  onShareFacebook: () => void;
+  onShareX: () => void | Promise<void>;
+  onShareFacebook: () => void | Promise<void>;
   onSystemShare?: () => Promise<void>;
   onCopyCaption: () => Promise<void>;
   canSystemShare: boolean;
-  busyAction: null | 'link' | 'download' | 'caption' | 'system';
+  busyAction: null | 'link' | 'download' | 'caption' | 'system' | 'x' | 'facebook';
 };
 
 export default function SharePanel(props: SharePanelProps) {
@@ -31,6 +31,9 @@ export default function SharePanel(props: SharePanelProps) {
     canSystemShare,
     busyAction,
   } = props;
+
+  const actionsDisabled = !!busyAction;
+  const showSystemShare = canSystemShare && typeof navigator !== 'undefined' && 'share' in navigator;
 
   useEffect(() => {
     if (!open) return;
@@ -73,59 +76,81 @@ export default function SharePanel(props: SharePanelProps) {
         <div className="mt-5 grid gap-2 text-sm">
           <button
             type="button"
-            onClick={onCopyLink}
+            onClick={() => {
+              void onCopyLink();
+            }}
             className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-            disabled={busyAction === 'link'}
+            disabled={actionsDisabled}
           >
             <span className="inline-flex items-center gap-2"><LinkIcon size={16} /> Copy link</span>
-            {busyAction === 'link' && <span className="text-xs text-slate-500">Working…</span>}
+            {busyAction === 'link' && <Loader2 className="h-4 w-4 animate-spin text-slate-400" />}
           </button>
           <button
             type="button"
-            onClick={onDownloadImage}
+            onClick={() => {
+              void onDownloadImage();
+            }}
             className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-            disabled={busyAction === 'download'}
+            disabled={actionsDisabled}
           >
             <span className="inline-flex items-center gap-2"><Download size={16} /> Download image</span>
-            {busyAction === 'download' && <span className="text-xs text-slate-500">Working…</span>}
+            {busyAction === 'download' && <Loader2 className="h-4 w-4 animate-spin text-slate-400" />}
           </button>
           <div className="grid gap-2 sm:grid-cols-2">
             <button
               type="button"
-              onClick={onShareX}
-              className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              onClick={() => {
+                void onShareX();
+              }}
+              className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              disabled={actionsDisabled}
             >
               <span className="inline-flex items-center gap-2"><Twitter size={16} /> Share to X</span>
-              <Share2 size={14} />
+              {busyAction === 'x' ? (
+                <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+              ) : (
+                <Share2 size={14} />
+              )}
             </button>
             <button
               type="button"
-              onClick={onShareFacebook}
-              className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              onClick={() => {
+                void onShareFacebook();
+              }}
+              className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              disabled={actionsDisabled}
             >
               <span className="inline-flex items-center gap-2"><Facebook size={16} /> Share to Facebook</span>
-              <Share2 size={14} />
+              {busyAction === 'facebook' ? (
+                <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
+              ) : (
+                <Share2 size={14} />
+              )}
             </button>
           </div>
-          {canSystemShare && onSystemShare && (
+          {showSystemShare && onSystemShare && (
             <button
               type="button"
-              onClick={onSystemShare}
+              onClick={() => {
+                void onSystemShare();
+              }}
               className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-              disabled={busyAction === 'system'}
+              disabled={actionsDisabled}
             >
               <span className="inline-flex items-center gap-2"><Share2 size={16} /> Share via device</span>
-              {busyAction === 'system' && <span className="text-xs text-slate-500">Working…</span>}
+              {busyAction === 'system' && <Loader2 className="h-4 w-4 animate-spin text-slate-400" />}
             </button>
           )}
           <button
             type="button"
-            onClick={onCopyCaption}
+            onClick={() => {
+              void onCopyCaption();
+            }}
             className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 px-3 py-2 font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-            disabled={busyAction === 'caption'}
+            disabled={actionsDisabled}
           >
             <span className="inline-flex items-center gap-2"><Clipboard size={16} /> Copy caption</span>
-            {busyAction === 'caption' && <span className="text-xs text-slate-500">Copied</span>}
+            {busyAction === 'caption' && <Loader2 className="h-4 w-4 animate-spin text-slate-400" />}
           </button>
         </div>
       </div>

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -790,6 +790,28 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     handleCopyShareCaption,
   } = useShareActions();
 
+  const buildShareHandler = useCallback(
+    (message: ChatMessage, domId: string, messageContent: string) => {
+      const messageId = typeof message.id === 'string' ? message.id : '';
+      const isPending = Boolean((message as any)?.pending);
+      if (!messageId || isPending) return undefined;
+
+      return () => {
+        const plain = getMessageTextFromDom(domId, messageContent);
+        openShare({
+          conversationId,
+          messageId,
+          domId,
+          plainText: plain,
+          mdText: messageContent,
+          mode: currentMode,
+          research: researchMode,
+        });
+      };
+    },
+    [conversationId, currentMode, openShare, researchMode]
+  );
+
   const sp = useSearchParams();
   const isAiDocMode = useIsAiDocMode();
   const modeState = useMemo(() => fromSearchParams(sp, 'light'), [sp]);
@@ -3164,20 +3186,7 @@ ${systemCommon}` + baseSys;
           const showFeedback = currentMode !== 'therapy';
           const hasId = typeof m.id === 'string' && m.id.length > 0;
 
-          const shareHandler = hasId
-            ? () => {
-                const plain = getMessageTextFromDom(domId, messageContent);
-                openShare({
-                  conversationId,
-                  messageId: m.id!,
-                  domId,
-                  plainText: plain,
-                  mdText: messageContent,
-                  mode: currentMode,
-                  research: researchMode,
-                });
-              }
-            : undefined;
+          const shareHandler = buildShareHandler(m, domId, messageContent);
 
           return (
             <div key={derivedKey} className="space-y-2">
@@ -3219,20 +3228,7 @@ ${systemCommon}` + baseSys;
         const showFeedback = currentMode !== 'therapy';
         const hasId = typeof m.id === 'string' && m.id.length > 0;
 
-        const shareHandler = hasId
-          ? () => {
-              const plain = getMessageTextFromDom(domId, messageContent);
-              openShare({
-                conversationId,
-                messageId: m.id!,
-                domId,
-                plainText: plain,
-                mdText: messageContent,
-                mode: currentMode,
-                research: researchMode,
-              });
-            }
-          : undefined;
+        const shareHandler = buildShareHandler(m, domId, messageContent);
 
         return (
           <div key={derivedKey} className="space-y-2">
@@ -3284,7 +3280,7 @@ ${systemCommon}` + baseSys;
       currentMode,
       refreshingMessages,
       handleRefresh,
-      openShare
+      buildShareHandler
     ]
   );
 

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -101,7 +101,7 @@ type ShareTargetState = {
   messageId: string;
   domId: string;
   plainText: string;
-  content: string;
+  mdText?: string | null;
   mode: 'patient' | 'doctor' | 'research' | 'therapy';
   research: boolean;
 };
@@ -557,7 +557,11 @@ function AnalysisCard({
 }) {
   const header = titleForCategory(m.category);
   return (
-    <div id={contentId} className="relative max-w-3xl space-y-2 whitespace-normal rounded-2xl bg-white/90 p-4 text-left dark:bg-zinc-900/60">
+    <div
+      id={contentId}
+      data-shareable-message="assistant"
+      className="relative max-w-3xl space-y-2 whitespace-normal rounded-2xl bg-white/90 p-4 text-left dark:bg-zinc-900/60"
+    >
       <header className="flex items-center gap-2">
         <h2 className="text-lg md:text-xl font-semibold">{header}</h2>
         {researchOn && (
@@ -625,6 +629,7 @@ function ChatCard({
   return (
     <div
       id={contentId}
+      data-shareable-message={m.role === 'assistant' ? 'assistant' : undefined}
       className="relative max-w-3xl whitespace-normal rounded-2xl bg-white/90 p-4 text-left dark:bg-zinc-900/60"
     >
       <ChatMarkdown content={m.content} />
@@ -3103,7 +3108,8 @@ ${systemCommon}` + baseSys;
           body: JSON.stringify({
             conversationId: target.conversationId,
             messageId: target.messageId,
-            content: target.content,
+            plainText: target.plainText,
+            mdText: target.mdText,
             mode: target.mode,
             research: target.research,
           }),
@@ -3371,7 +3377,7 @@ ${systemCommon}` + baseSys;
                   messageId: m.id!,
                   domId,
                   plainText: plain,
-                  content: messageContent,
+                  mdText: messageContent,
                   mode: currentMode,
                   research: researchMode,
                 });
@@ -3445,13 +3451,13 @@ ${systemCommon}` + baseSys;
                 conversationId,
                 messageId: m.id!,
                 domId,
-                plainText: plain,
-                content: messageContent,
-                mode: currentMode,
-                research: researchMode,
-              });
-            }
-          : undefined;
+              plainText: plain,
+              mdText: messageContent,
+              mode: currentMode,
+              research: researchMode,
+            });
+          }
+        : undefined;
 
         return (
           <div key={derivedKey} className="space-y-2">

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -112,6 +112,70 @@ const getMessageTextFromDom = (domId: string, fallback: string) => {
   return (text || fallback || '').trim();
 };
 
+type AssistantActionsProps = {
+  conversationId: string;
+  messageId: string;
+  mode: 'patient' | 'doctor' | 'research' | 'therapy';
+  messageContent: string;
+  getMessageText: () => string;
+  onRefresh?: () => void;
+  canRefresh: boolean;
+  isRefreshing: boolean;
+  disabled?: boolean;
+  onShare?: () => void;
+  showFeedback: boolean;
+};
+
+function AssistantActions({
+  conversationId,
+  messageId,
+  mode,
+  messageContent,
+  getMessageText,
+  onRefresh,
+  canRefresh,
+  isRefreshing,
+  disabled,
+  onShare,
+  showFeedback,
+}: AssistantActionsProps) {
+  return (
+    <>
+      <div className="pointer-events-none absolute right-3 top-3 hidden gap-2 rounded-full bg-white/80 px-2 py-1 text-slate-600 opacity-0 shadow-sm backdrop-blur transition group-hover/message:opacity-80 group-focus-within/message:opacity-80 dark:bg-slate-900/70 dark:text-slate-200 sm:flex">
+        <MessageActions
+          conversationId={conversationId}
+          messageId={messageId}
+          mode={mode}
+          messageContent={messageContent}
+          getMessageText={getMessageText}
+          onRefresh={onRefresh}
+          canRefresh={canRefresh}
+          isRefreshing={isRefreshing}
+          disabled={disabled}
+          onShare={onShare}
+          showFeedback={showFeedback}
+        />
+      </div>
+      <div className="mt-3 flex justify-end sm:hidden">
+        <MessageActions
+          conversationId={conversationId}
+          messageId={messageId}
+          mode={mode}
+          messageContent={messageContent}
+          getMessageText={getMessageText}
+          onRefresh={onRefresh}
+          canRefresh={canRefresh}
+          isRefreshing={isRefreshing}
+          disabled={disabled}
+          onShare={onShare}
+          showFeedback={showFeedback}
+          className="rounded-full border border-slate-200/80 bg-white/80 px-3 py-1 text-slate-600 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200"
+        />
+      </div>
+    </>
+  );
+}
+
 const formatTrendDate = (iso?: string) => {
   if (!iso) return "—";
   const d = new Date(iso);
@@ -3126,39 +3190,19 @@ ${systemCommon}` + baseSys;
                   contentId={domId}
                 />
                 {hasId && (
-                  <>
-                    <div className="pointer-events-none absolute right-3 top-3 hidden sm:flex gap-2 rounded-full bg-white/80 px-2 py-1 text-slate-600 opacity-0 shadow-sm backdrop-blur transition group-hover/message:opacity-80 group-focus-within/message:opacity-80 dark:bg-slate-900/70 dark:text-slate-200">
-                      <MessageActions
-                        conversationId={conversationId}
-                        messageId={m.id!}
-                        mode={currentMode}
-                        messageContent={messageContent}
-                        getMessageText={() => getMessageTextFromDom(domId, messageContent)}
-                        onRefresh={canRefresh ? () => handleRefresh(m.id!) : undefined}
-                        canRefresh={canRefresh}
-                        isRefreshing={isRefreshing}
-                        disabled={isRefreshing}
-                        onShare={shareHandler}
-                        showFeedback={showFeedback}
-                      />
-                    </div>
-                    <div className="mt-3 flex justify-end sm:hidden">
-                      <MessageActions
-                        conversationId={conversationId}
-                        messageId={m.id!}
-                        mode={currentMode}
-                        messageContent={messageContent}
-                        getMessageText={() => getMessageTextFromDom(domId, messageContent)}
-                        onRefresh={canRefresh ? () => handleRefresh(m.id!) : undefined}
-                        canRefresh={canRefresh}
-                        isRefreshing={isRefreshing}
-                        disabled={isRefreshing}
-                        onShare={shareHandler}
-                        showFeedback={showFeedback}
-                        className="rounded-full border border-slate-200/80 bg-white/80 px-3 py-1 text-slate-600 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200"
-                      />
-                    </div>
-                  </>
+                  <AssistantActions
+                    conversationId={conversationId}
+                    messageId={m.id!}
+                    mode={currentMode}
+                    messageContent={messageContent}
+                    getMessageText={() => getMessageTextFromDom(domId, messageContent)}
+                    onRefresh={canRefresh ? () => handleRefresh(m.id!) : undefined}
+                    canRefresh={canRefresh}
+                    isRefreshing={isRefreshing}
+                    disabled={isRefreshing}
+                    onShare={shareHandler}
+                    showFeedback={showFeedback}
+                  />
                 )}
               </div>
               {(m as any).replaced && (
@@ -3205,39 +3249,19 @@ ${systemCommon}` + baseSys;
                 contentId={domId}
               />
               {hasId && !m.pending && (
-                <>
-                  <div className="pointer-events-none absolute right-3 top-3 hidden sm:flex gap-2 rounded-full bg-white/80 px-2 py-1 text-slate-600 opacity-0 shadow-sm backdrop-blur transition group-hover/message:opacity-80 group-focus-within/message:opacity-80 dark:bg-slate-900/70 dark:text-slate-200">
-                    <MessageActions
-                      conversationId={conversationId}
-                      messageId={m.id!}
-                      mode={currentMode}
-                      messageContent={messageContent}
-                      getMessageText={() => getMessageTextFromDom(domId, messageContent)}
-                      onRefresh={canRefresh ? () => handleRefresh(m.id!) : undefined}
-                      canRefresh={canRefresh}
-                      isRefreshing={isRefreshing}
-                      disabled={isRefreshing}
-                      onShare={shareHandler}
-                      showFeedback={showFeedback}
-                    />
-                  </div>
-                  <div className="mt-3 flex justify-end sm:hidden">
-                    <MessageActions
-                      conversationId={conversationId}
-                      messageId={m.id!}
-                      mode={currentMode}
-                      messageContent={messageContent}
-                      getMessageText={() => getMessageTextFromDom(domId, messageContent)}
-                      onRefresh={canRefresh ? () => handleRefresh(m.id!) : undefined}
-                      canRefresh={canRefresh}
-                      isRefreshing={isRefreshing}
-                      disabled={isRefreshing}
-                      onShare={shareHandler}
-                      showFeedback={showFeedback}
-                      className="rounded-full border border-slate-200/80 bg-white/80 px-3 py-1 text-slate-600 shadow-sm dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200"
-                    />
-                  </div>
-                </>
+                <AssistantActions
+                  conversationId={conversationId}
+                  messageId={m.id!}
+                  mode={currentMode}
+                  messageContent={messageContent}
+                  getMessageText={() => getMessageTextFromDom(domId, messageContent)}
+                  onRefresh={canRefresh ? () => handleRefresh(m.id!) : undefined}
+                  canRefresh={canRefresh}
+                  isRefreshing={isRefreshing}
+                  disabled={isRefreshing}
+                  onShare={shareHandler}
+                  showFeedback={showFeedback}
+                />
               )}
             </div>
             {(m as any).replaced && (

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -49,6 +49,7 @@ import { formatTrialBriefMarkdown } from "@/lib/trials/brief";
 import { useIsAiDocMode } from "@/hooks/useIsAiDocMode";
 import { pushToast } from "@/lib/ui/toast";
 import { useShareActions } from "@/lib/share/useShareActions";
+import { BRAND_NAME } from "@/lib/brand";
 
 const AIDOC_UI = process.env.NEXT_PUBLIC_AIDOC_UI === '1';
 const AIDOC_PREFLIGHT = process.env.NEXT_PUBLIC_AIDOC_PREFLIGHT === '1';

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -3111,12 +3111,21 @@ ${systemCommon}` + baseSys;
         });
         if (!res.ok) throw new Error('share_failed');
         const data = await res.json().catch(() => null);
-        const slug = typeof data?.slug === 'string' ? data.slug : null;
-        if (!slug) throw new Error('share_failed');
-        const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? window.location.origin;
-        const normalizedAppUrl = APP_URL ? APP_URL.replace(/\/$/, '') : '';
-        if (!normalizedAppUrl) throw new Error('share_failed');
-        const shareUrl = `${normalizedAppUrl}/s/${slug}`;
+        const absoluteUrl = typeof data?.absoluteUrl === 'string' ? data.absoluteUrl.trim() : '';
+        const slug = typeof data?.slug === 'string' ? data.slug : '';
+
+        let shareUrl = '';
+        if (absoluteUrl) {
+          shareUrl = absoluteUrl;
+        } else if (slug) {
+          const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? window.location.origin;
+          const normalizedAppUrl = APP_URL ? APP_URL.replace(/\/$/, '') : '';
+          if (!normalizedAppUrl) throw new Error('share_failed');
+          shareUrl = `${normalizedAppUrl}/s/${slug}`;
+        } else {
+          throw new Error('share_failed');
+        }
+
         shareLinksRef.current[target.messageId] = shareUrl;
         setShareLinks((prev) => {
           if (prev[target.messageId]) return prev;
@@ -3193,6 +3202,7 @@ ${systemCommon}` + baseSys;
         brand: BRAND_NAME,
         modeLabel,
         timestamp: new Date(),
+        fallbackText: shareTarget.plainText,
       });
       const anchor = document.createElement('a');
       anchor.href = dataUrl;

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -56,11 +56,6 @@ import { buildShareCaption, buildShareIntentCaption } from "@/lib/share/caption"
 const AIDOC_UI = process.env.NEXT_PUBLIC_AIDOC_UI === '1';
 const AIDOC_PREFLIGHT = process.env.NEXT_PUBLIC_AIDOC_PREFLIGHT === '1';
 
-const rawAppUrl =
-  process.env.NEXT_PUBLIC_APP_URL ??
-  (typeof window !== 'undefined' ? window.location.origin : '');
-const APP_URL = rawAppUrl ? rawAppUrl.replace(/\/$/, '') : '';
-
 const NEARBY_DEFAULT_RADIUS_KM = 2;
 const NEARBY_RADIUS_CHOICES = [1, 2, 3, 5, 8, 10] as const;
 const NEARBY_EXPAND_SEQUENCE = [2, 5, 8, 10];
@@ -3118,9 +3113,10 @@ ${systemCommon}` + baseSys;
         const data = await res.json().catch(() => null);
         const slug = typeof data?.slug === 'string' ? data.slug : null;
         if (!slug) throw new Error('share_failed');
-        const base = APP_URL || (typeof window !== 'undefined' ? window.location.origin : '');
-        if (!base) throw new Error('share_failed');
-        const shareUrl = `${base.replace(/\/$/, '')}/s/${slug}`;
+        const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? window.location.origin;
+        const normalizedAppUrl = APP_URL ? APP_URL.replace(/\/$/, '') : '';
+        if (!normalizedAppUrl) throw new Error('share_failed');
+        const shareUrl = `${normalizedAppUrl}/s/${slug}`;
         shareLinksRef.current[target.messageId] = shareUrl;
         setShareLinks((prev) => {
           if (prev[target.messageId]) return prev;

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -775,43 +775,6 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   const queueAbortRef = useRef<AbortController | null>(null);
   const { filters } = useResearchFilters();
 
-  const {
-    shareTarget,
-    shareBusy,
-    sharePreview,
-    systemShareSupported,
-    openShare,
-    closeShare,
-    handleCopyShareLink,
-    handleDownloadShareImage,
-    handleShareX,
-    handleShareFacebook,
-    handleSystemShare,
-    handleCopyShareCaption,
-  } = useShareActions();
-
-  const buildShareHandler = useCallback(
-    (message: ChatMessage, domId: string, messageContent: string) => {
-      const messageId = typeof message.id === 'string' ? message.id : '';
-      const isPending = Boolean((message as any)?.pending);
-      if (!messageId || isPending) return undefined;
-
-      return () => {
-        const plain = getMessageTextFromDom(domId, messageContent);
-        openShare({
-          conversationId,
-          messageId,
-          domId,
-          plainText: plain,
-          mdText: messageContent,
-          mode: currentMode,
-          research: researchMode,
-        });
-      };
-    },
-    [conversationId, currentMode, openShare, researchMode]
-  );
-
   const sp = useSearchParams();
   const isAiDocMode = useIsAiDocMode();
   const modeState = useMemo(() => fromSearchParams(sp, 'light'), [sp]);
@@ -1044,6 +1007,43 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     }
   }, [threadId, isProfileThread, router, sp]);
   const currentMode: 'patient'|'doctor'|'research'|'therapy' = therapyMode ? 'therapy' : (researchMode ? 'research' : mode);
+
+  const {
+    shareTarget,
+    shareBusy,
+    sharePreview,
+    systemShareSupported,
+    openShare,
+    closeShare,
+    handleCopyShareLink,
+    handleDownloadShareImage,
+    handleShareX,
+    handleShareFacebook,
+    handleSystemShare,
+    handleCopyShareCaption,
+  } = useShareActions();
+
+  const buildShareHandler = useCallback(
+    (message: ChatMessage, domId: string, messageContent: string) => {
+      const messageId = typeof message.id === 'string' ? message.id : '';
+      const isPending = Boolean((message as any)?.pending);
+      if (!messageId || isPending) return undefined;
+
+      return () => {
+        const plain = getMessageTextFromDom(domId, messageContent);
+        openShare({
+          conversationId,
+          messageId,
+          domId,
+          plainText: plain,
+          mdText: messageContent,
+          mode: currentMode,
+          research: researchMode,
+        });
+      };
+    },
+    [conversationId, currentMode, openShare, researchMode]
+  );
   const [pendingCommitIds, setPendingCommitIds] = useState<string[]>([]);
   const [commitBusy, setCommitBusy] = useState<null | 'save' | 'discard'>(null);
   const [commitError, setCommitError] = useState<string | null>(null);

--- a/components/share/ShareViewer.tsx
+++ b/components/share/ShareViewer.tsx
@@ -2,7 +2,14 @@
 
 import ChatMarkdown from "@/components/ChatMarkdown";
 
-export default function ShareViewer({ content }: { content: string }) {
+type ShareViewerProps = {
+  plainText: string;
+  mdText?: string | null;
+};
+
+export default function ShareViewer({ plainText, mdText }: ShareViewerProps) {
+  const content = (mdText && mdText.trim().length > 0 ? mdText : plainText) || plainText;
+
   return (
     <div className="rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-xl backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
       <ChatMarkdown content={content} />

--- a/components/share/ShareViewer.tsx
+++ b/components/share/ShareViewer.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import ChatMarkdown from "@/components/ChatMarkdown";
+
+export default function ShareViewer({ content }: { content: string }) {
+  return (
+    <div className="rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-xl backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
+      <ChatMarkdown content={content} />
+    </div>
+  );
+}

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -1,0 +1,34 @@
+export type AnalyticsEventName =
+  | "copy_clicked"
+  | "refresh_clicked"
+  | "share_opened"
+  | "share_copy_link"
+  | "share_download_image"
+  | "share_x"
+  | "share_facebook"
+  | "share_system"
+  | "feedback_submitted";
+
+const ANALYTICS_EVENT = "medx:analytics";
+
+export function trackEvent(name: AnalyticsEventName, payload: Record<string, unknown> = {}) {
+  if (typeof window === "undefined") return;
+
+  const detail = { name, payload, timestamp: Date.now() };
+
+  try {
+    window.dispatchEvent(new CustomEvent(ANALYTICS_EVENT, { detail }));
+  } catch {}
+
+  try {
+    const analytics = (window as unknown as { analytics?: { track?: (event: string, data?: Record<string, unknown>) => void } }).analytics;
+    analytics?.track?.(name, payload);
+  } catch {}
+
+  try {
+    const dataLayer = (window as unknown as { dataLayer?: Record<string, unknown>[] }).dataLayer;
+    if (Array.isArray(dataLayer)) {
+      dataLayer.push({ event: name, ...payload, timestamp: detail.timestamp });
+    }
+  } catch {}
+}

--- a/lib/share/caption.ts
+++ b/lib/share/caption.ts
@@ -1,0 +1,7 @@
+export function buildShareCaption(message: string, brand: string, url: string) {
+  const clean = (message || "").replace(/\s+/g, " ").trim();
+  const max = 180;
+  const trimmed = clean.length > max ? `${clean.slice(0, max - 1).trimEnd()}…` : clean;
+  const brandLine = brand ? `${brand}` : "";
+  return [trimmed, brandLine && url ? `${brandLine} • ${url}` : url].filter(Boolean).join("\n\n");
+}

--- a/lib/share/caption.ts
+++ b/lib/share/caption.ts
@@ -5,3 +5,42 @@ export function buildShareCaption(message: string, brand: string, url: string) {
   const brandLine = brand ? `${brand}` : "";
   return [trimmed, brandLine && url ? `${brandLine} • ${url}` : url].filter(Boolean).join("\n\n");
 }
+
+export function buildShareIntentCaption(message: string, brand: string) {
+  const prefix = `AI answer from ${brand}`.trim();
+  const cleanWords = (message || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .filter(Boolean);
+
+  const prefixWordCount = prefix.split(/\s+/).filter(Boolean).length;
+  const targetTotal = 12;
+  const snippetWordCount = Math.max(5, targetTotal - prefixWordCount);
+  const snippet = cleanWords.slice(0, snippetWordCount);
+
+  const fillerWords = [
+    "trusted",
+    "insights",
+    "to",
+    "share",
+    "with",
+    "others",
+    "today",
+  ];
+
+  if (!snippet.length) {
+    return `${prefix}: ${fillerWords.join(" ")}`;
+  }
+
+  while (prefixWordCount + snippet.length < 10 && fillerWords.length) {
+    snippet.push(fillerWords.shift()!);
+  }
+
+  if (cleanWords.length > snippetWordCount) {
+    const lastIndex = Math.max(0, snippet.length - 1);
+    snippet[lastIndex] = `${snippet[lastIndex].replace(/[.,;:!?]+$/, "")}…`;
+  }
+
+  return `${prefix}: ${snippet.join(" ")}`.trim();
+}

--- a/lib/share/exportImage.ts
+++ b/lib/share/exportImage.ts
@@ -157,29 +157,29 @@ async function imageLooksBlank(dataUrl: string) {
       }
       ctx.drawImage(img, 0, 0);
 
-      const center = ctx.getImageData(
-        Math.floor(img.naturalWidth / 2),
-        Math.floor(img.naturalHeight / 2),
-        1,
-        1
-      ).data;
-      if (center[3] > 0) {
-        resolve(false);
-        return;
-      }
+      const baseline = ctx.getImageData(0, 0, 1, 1).data;
+      const threshold = 8;
+      let hasVariation = false;
 
-      const stepX = Math.max(1, Math.floor(img.naturalWidth / 12));
-      const stepY = Math.max(1, Math.floor(img.naturalHeight / 12));
-      for (let y = 0; y < img.naturalHeight; y += stepY) {
+      const stepX = Math.max(1, Math.floor(img.naturalWidth / 18));
+      const stepY = Math.max(1, Math.floor(img.naturalHeight / 18));
+
+      for (let y = 0; y < img.naturalHeight && !hasVariation; y += stepY) {
         for (let x = 0; x < img.naturalWidth; x += stepX) {
           const pixel = ctx.getImageData(x, y, 1, 1).data;
-          if (pixel[3] > 0) {
-            resolve(false);
-            return;
+          if (
+            Math.abs(pixel[0] - baseline[0]) > threshold ||
+            Math.abs(pixel[1] - baseline[1]) > threshold ||
+            Math.abs(pixel[2] - baseline[2]) > threshold ||
+            Math.abs(pixel[3] - baseline[3]) > threshold
+          ) {
+            hasVariation = true;
+            break;
           }
         }
       }
-      resolve(true);
+
+      resolve(!hasVariation);
     };
     img.onerror = () => resolve(true);
     img.src = dataUrl;

--- a/lib/share/exportImage.ts
+++ b/lib/share/exportImage.ts
@@ -9,13 +9,22 @@ type ExportOptions = {
 };
 
 export async function exportMessageCardToPng(node: HTMLElement, options: ExportOptions) {
-  const target = node;
-  if (!target) throw new Error('message_node_missing');
+  if (!node) throw new Error('message_node_missing');
+
+  const nodeMatches = typeof node.matches === 'function' && node.matches('[data-shareable-message]');
+  const source = nodeMatches ? node : node.closest<HTMLElement>('[data-shareable-message]');
+
+  const target = source ?? node;
 
   const dark = document.documentElement.classList.contains('dark');
   const clone = target.cloneNode(true) as HTMLElement;
   clone.removeAttribute('id');
+  clone.removeAttribute('data-shareable-message');
+  clone
+    .querySelectorAll('[data-shareable-message]')
+    .forEach((el) => el.removeAttribute('data-shareable-message'));
   clone.querySelectorAll('[data-message-actions]').forEach((el) => el.remove());
+  clone.querySelectorAll('button').forEach((el) => el.remove());
   clone.querySelectorAll('img').forEach((img) => img.remove());
   clone.style.width = '100%';
   clone.style.maxWidth = '100%';
@@ -24,6 +33,7 @@ export async function exportMessageCardToPng(node: HTMLElement, options: ExportO
   clone.style.border = 'none';
   clone.style.margin = '0';
   clone.style.padding = '0';
+  clone.style.display = 'block';
 
   const wrapper = document.createElement('div');
   wrapper.style.position = 'fixed';

--- a/lib/share/exportImage.ts
+++ b/lib/share/exportImage.ts
@@ -45,6 +45,12 @@ export async function exportMessageCardToPng(node: HTMLElement | null, options: 
   clone.style.padding = '0';
   clone.style.display = 'block';
 
+  const cloneText = clone.textContent?.trim() ?? '';
+  if (!cloneText) {
+    const content = fallbackContent || 'Shared response unavailable.';
+    return renderFallbackImage(content, options, dark);
+  }
+
   const wrapper = document.createElement('div');
   wrapper.style.position = 'fixed';
   wrapper.style.left = '-10000px';

--- a/lib/share/exportImage.ts
+++ b/lib/share/exportImage.ts
@@ -1,0 +1,99 @@
+'use client';
+
+import { toPng } from 'html-to-image';
+
+type ExportOptions = {
+  brand: string;
+  modeLabel?: string;
+  timestamp?: Date;
+};
+
+function ensureClone(node: HTMLElement) {
+  const clone = node.cloneNode(true) as HTMLElement;
+  clone.removeAttribute('id');
+  clone.querySelectorAll('[data-message-actions]').forEach((el) => el.remove());
+  clone.style.width = '100%';
+  clone.style.maxWidth = '100%';
+  clone.style.background = 'transparent';
+  clone.style.boxShadow = 'none';
+  clone.style.border = 'none';
+  clone.style.margin = '0';
+  clone.style.padding = '0';
+  return clone;
+}
+
+export async function exportMessageCardToPng(node: HTMLElement, options: ExportOptions) {
+  const target = node;
+  if (!target) throw new Error('message_node_missing');
+
+  const dark = document.documentElement.classList.contains('dark');
+  const clone = ensureClone(target);
+
+  const width = Math.min(target.offsetWidth || 600, 640);
+  const wrapper = document.createElement('div');
+  wrapper.style.position = 'fixed';
+  wrapper.style.left = '-10000px';
+  wrapper.style.top = '0';
+  wrapper.style.padding = '32px';
+  wrapper.style.width = `${width}px`;
+  wrapper.style.boxSizing = 'border-box';
+  wrapper.style.borderRadius = '28px';
+  wrapper.style.border = dark ? '1px solid rgba(148, 163, 184, 0.3)' : '1px solid rgba(15, 23, 42, 0.08)';
+  wrapper.style.background = dark ? '#0f172a' : '#ffffff';
+  wrapper.style.color = dark ? '#e2e8f0' : '#0f172a';
+  wrapper.style.boxShadow = '0 30px 80px rgba(15, 23, 42, 0.18)';
+  wrapper.style.fontFamily = '"Inter", "SF Pro Text", system-ui, sans-serif';
+  wrapper.style.lineHeight = '1.55';
+
+  const header = document.createElement('div');
+  header.style.display = 'flex';
+  header.style.alignItems = 'center';
+  header.style.justifyContent = 'space-between';
+  header.style.gap = '12px';
+  header.style.marginBottom = '18px';
+  header.innerHTML = `
+    <span style="font-weight:600;font-size:16px;">${options.brand}</span>
+    <span style="font-size:12px;opacity:0.7;">${(options.timestamp || new Date()).toLocaleString()}</span>
+  `;
+
+  const bubble = document.createElement('div');
+  bubble.style.padding = '24px';
+  bubble.style.borderRadius = '22px';
+  bubble.style.background = dark ? 'rgba(30, 41, 59, 0.75)' : 'rgba(248, 250, 252, 0.9)';
+  bubble.style.color = 'inherit';
+  bubble.style.boxShadow = dark
+    ? 'inset 0 0 0 1px rgba(148, 163, 184, 0.3)'
+    : 'inset 0 0 0 1px rgba(15, 23, 42, 0.05)';
+  bubble.style.backdropFilter = 'blur(6px)';
+  bubble.style.width = '100%';
+  bubble.appendChild(clone);
+
+  const footer = document.createElement('div');
+  footer.style.marginTop = '18px';
+  footer.style.display = 'flex';
+  footer.style.justifyContent = 'space-between';
+  footer.style.alignItems = 'center';
+  footer.style.fontSize = '12px';
+  footer.style.opacity = '0.7';
+  footer.innerHTML = `
+    <span>${options.modeLabel || ''}</span>
+    <span>${options.brand}</span>
+  `;
+
+  wrapper.appendChild(header);
+  wrapper.appendChild(bubble);
+  wrapper.appendChild(footer);
+
+  document.body.appendChild(wrapper);
+
+  try {
+    const dataUrl = await toPng(wrapper, {
+      pixelRatio: 2,
+      cacheBust: true,
+      backgroundColor: dark ? '#0f172a' : '#ffffff',
+    });
+    return dataUrl;
+  } finally {
+    document.body.removeChild(wrapper);
+  }
+}

--- a/lib/share/exportImage.ts
+++ b/lib/share/exportImage.ts
@@ -6,6 +6,7 @@ type ExportOptions = {
   brand: string;
   modeLabel?: string;
   timestamp?: Date;
+  fallbackText?: string;
 };
 
 export async function exportMessageCardToPng(node: HTMLElement, options: ExportOptions) {
@@ -92,17 +93,175 @@ export async function exportMessageCardToPng(node: HTMLElement, options: ExportO
 
   document.body.appendChild(wrapper);
 
+  let dataUrl: string | null = null;
+
   try {
     await document.fonts?.ready?.catch(() => {});
     await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
 
-    const dataUrl = await toPng(wrapper, {
+    dataUrl = await toPng(wrapper, {
       pixelRatio: 2,
       cacheBust: true,
       backgroundColor: dark ? '#0b0f14' : '#ffffff',
     });
-    return dataUrl;
+  } catch (error) {
+    console.error('Share image export failed, falling back to text render', error);
+    dataUrl = null;
   } finally {
     document.body.removeChild(wrapper);
   }
+
+  if (dataUrl) {
+    const isBlank = await imageLooksBlank(dataUrl);
+    if (!isBlank) {
+      return dataUrl;
+    }
+  }
+
+  const fallbackContent =
+    options.fallbackText?.trim() || target.textContent?.trim() || 'Shared response unavailable.';
+  return renderFallbackImage(fallbackContent, options, dark);
+}
+
+async function imageLooksBlank(dataUrl: string) {
+  return new Promise<boolean>((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      if (img.naturalWidth <= 1 || img.naturalHeight <= 1) {
+        resolve(true);
+        return;
+      }
+
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        resolve(false);
+        return;
+      }
+      ctx.drawImage(img, 0, 0);
+
+      const center = ctx.getImageData(
+        Math.floor(img.naturalWidth / 2),
+        Math.floor(img.naturalHeight / 2),
+        1,
+        1
+      ).data;
+      if (center[3] > 0) {
+        resolve(false);
+        return;
+      }
+
+      const stepX = Math.max(1, Math.floor(img.naturalWidth / 12));
+      const stepY = Math.max(1, Math.floor(img.naturalHeight / 12));
+      for (let y = 0; y < img.naturalHeight; y += stepY) {
+        for (let x = 0; x < img.naturalWidth; x += stepX) {
+          const pixel = ctx.getImageData(x, y, 1, 1).data;
+          if (pixel[3] > 0) {
+            resolve(false);
+            return;
+          }
+        }
+      }
+      resolve(true);
+    };
+    img.onerror = () => resolve(true);
+    img.src = dataUrl;
+  });
+}
+
+function renderFallbackImage(text: string, options: ExportOptions, isDark: boolean) {
+  const content = text.trim() || 'Shared response unavailable.';
+  const brand = options.brand || 'MedX';
+  const timestamp = (options.timestamp || new Date()).toLocaleString();
+
+  const width = 1200;
+  const padding = 48;
+  const innerWidth = width - padding * 2;
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    return `data:,${encodeURIComponent(content)}`;
+  }
+
+  const measureCanvas = document.createElement('canvas');
+  const measureCtx = measureCanvas.getContext('2d');
+  const lineHeight = 32;
+  const textFont = "400 22px 'Inter', 'SF Pro Text', system-ui, sans-serif";
+  const brandFont = "600 28px 'Inter', 'SF Pro Text', system-ui, sans-serif";
+  const metaFont = "500 18px 'Inter', 'SF Pro Text', system-ui, sans-serif";
+  const footerFont = "500 20px 'Inter', 'SF Pro Text', system-ui, sans-serif";
+
+  if (measureCtx) {
+    measureCtx.font = textFont;
+  }
+
+  const words = content.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let currentLine = '';
+  for (const word of words.length ? words : ['']) {
+    const testLine = currentLine ? `${currentLine} ${word}` : word;
+    const metrics = measureCtx?.measureText(testLine);
+    const widthWithWord = metrics ? metrics.width : testLine.length * 10;
+    if (widthWithWord > innerWidth && currentLine) {
+      lines.push(currentLine);
+      currentLine = word;
+    } else {
+      currentLine = testLine;
+    }
+  }
+  if (currentLine) {
+    lines.push(currentLine);
+  }
+
+  const hasMode = Boolean(options.modeLabel);
+  const headerHeight = 36;
+  const timestampHeight = 28;
+  const modeHeight = hasMode ? 30 : 0;
+  const textHeight = Math.max(1, lines.length) * lineHeight;
+  const totalHeight =
+    padding * 2 +
+    headerHeight +
+    timestampHeight +
+    24 +
+    textHeight +
+    (hasMode ? modeHeight + 24 : 0);
+
+  canvas.width = width;
+  canvas.height = totalHeight;
+
+  const background = isDark ? '#0b0f14' : '#ffffff';
+  const foreground = isDark ? '#e2e8f0' : '#0f172a';
+  const muted = isDark ? 'rgba(148, 163, 184, 0.85)' : 'rgba(71, 85, 105, 0.85)';
+
+  ctx.fillStyle = background;
+  ctx.fillRect(0, 0, width, totalHeight);
+
+  let y = padding;
+  ctx.fillStyle = foreground;
+  ctx.font = brandFont;
+  ctx.fillText(brand, padding, y + 24);
+  y += headerHeight;
+
+  ctx.fillStyle = muted;
+  ctx.font = metaFont;
+  ctx.fillText(timestamp, padding, y);
+  y += timestampHeight + 8;
+
+  ctx.fillStyle = foreground;
+  ctx.font = textFont;
+  for (const line of lines) {
+    ctx.fillText(line, padding, y);
+    y += lineHeight;
+  }
+
+  if (hasMode) {
+    y += 16;
+    ctx.fillStyle = muted;
+    ctx.font = footerFont;
+    ctx.fillText(options.modeLabel ?? '', padding, y);
+  }
+
+  return canvas.toDataURL('image/png');
 }

--- a/lib/share/exportImage.ts
+++ b/lib/share/exportImage.ts
@@ -8,10 +8,15 @@ type ExportOptions = {
   timestamp?: Date;
 };
 
-function ensureClone(node: HTMLElement) {
-  const clone = node.cloneNode(true) as HTMLElement;
+export async function exportMessageCardToPng(node: HTMLElement, options: ExportOptions) {
+  const target = node;
+  if (!target) throw new Error('message_node_missing');
+
+  const dark = document.documentElement.classList.contains('dark');
+  const clone = target.cloneNode(true) as HTMLElement;
   clone.removeAttribute('id');
   clone.querySelectorAll('[data-message-actions]').forEach((el) => el.remove());
+  clone.querySelectorAll('img').forEach((img) => img.remove());
   clone.style.width = '100%';
   clone.style.maxWidth = '100%';
   clone.style.background = 'transparent';
@@ -19,27 +24,18 @@ function ensureClone(node: HTMLElement) {
   clone.style.border = 'none';
   clone.style.margin = '0';
   clone.style.padding = '0';
-  return clone;
-}
 
-export async function exportMessageCardToPng(node: HTMLElement, options: ExportOptions) {
-  const target = node;
-  if (!target) throw new Error('message_node_missing');
-
-  const dark = document.documentElement.classList.contains('dark');
-  const clone = ensureClone(target);
-
-  const width = Math.min(target.offsetWidth || 600, 640);
   const wrapper = document.createElement('div');
   wrapper.style.position = 'fixed';
   wrapper.style.left = '-10000px';
   wrapper.style.top = '0';
-  wrapper.style.padding = '32px';
-  wrapper.style.width = `${width}px`;
+  wrapper.style.padding = '24px';
+  wrapper.style.width = '1200px';
+  wrapper.style.maxWidth = '1200px';
   wrapper.style.boxSizing = 'border-box';
   wrapper.style.borderRadius = '28px';
   wrapper.style.border = dark ? '1px solid rgba(148, 163, 184, 0.3)' : '1px solid rgba(15, 23, 42, 0.08)';
-  wrapper.style.background = dark ? '#0f172a' : '#ffffff';
+  wrapper.style.background = dark ? '#0b0f14' : '#ffffff';
   wrapper.style.color = dark ? '#e2e8f0' : '#0f172a';
   wrapper.style.boxShadow = '0 30px 80px rgba(15, 23, 42, 0.18)';
   wrapper.style.fontFamily = '"Inter", "SF Pro Text", system-ui, sans-serif';
@@ -87,10 +83,13 @@ export async function exportMessageCardToPng(node: HTMLElement, options: ExportO
   document.body.appendChild(wrapper);
 
   try {
+    await document.fonts?.ready?.catch(() => {});
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
     const dataUrl = await toPng(wrapper, {
       pixelRatio: 2,
       cacheBust: true,
-      backgroundColor: dark ? '#0f172a' : '#ffffff',
+      backgroundColor: dark ? '#0b0f14' : '#ffffff',
     });
     return dataUrl;
   } finally {

--- a/lib/share/useShareActions.ts
+++ b/lib/share/useShareActions.ts
@@ -1,0 +1,384 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { BRAND_NAME } from '@/lib/brand';
+import { buildShareCaption, buildShareIntentCaption } from '@/lib/share/caption';
+import { exportMessageCardToPng } from '@/lib/share/exportImage';
+import { pushToast } from '@/lib/ui/toast';
+import { trackEvent } from '@/lib/analytics/events';
+
+export type ShareTargetState = {
+  conversationId: string;
+  messageId: string;
+  domId: string;
+  plainText: string;
+  mdText?: string | null;
+  mode: 'patient' | 'doctor' | 'research' | 'therapy';
+  research: boolean;
+};
+
+export type ShareActionKey =
+  | 'link'
+  | 'download'
+  | 'caption'
+  | 'system'
+  | 'x'
+  | 'facebook';
+
+const SHARE_FALLBACK_MESSAGE = 'Shared response unavailable.';
+
+type ShareLinks = Record<string, string>;
+
+type EnsureShareLink = (target: ShareTargetState) => Promise<string>;
+
+type UseShareActionsResult = {
+  shareTarget: ShareTargetState | null;
+  shareBusy: ShareActionKey | null;
+  sharePreview: string;
+  systemShareSupported: boolean;
+  openShare: (target: ShareTargetState) => void;
+  closeShare: () => void;
+  handleCopyShareLink: () => Promise<void>;
+  handleDownloadShareImage: () => Promise<void>;
+  handleShareX: () => Promise<void>;
+  handleShareFacebook: () => Promise<void>;
+  handleSystemShare: () => Promise<void>;
+  handleCopyShareCaption: () => Promise<void>;
+};
+
+const resolveNormalizedAppUrl = () => {
+  const envUrl = (process.env.NEXT_PUBLIC_APP_URL ?? '').trim();
+  if (envUrl) return envUrl.replace(/\/$/, '');
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin.replace(/\/$/, '');
+  }
+  return '';
+};
+
+const resolveAbsoluteUrl = (candidate: string, normalizedAppUrl: string) => {
+  if (!candidate) return '';
+  if (/^https?:\/\//i.test(candidate)) return candidate;
+  if (candidate.startsWith('//')) {
+    return `https:${candidate}`;
+  }
+  if (candidate.startsWith('/')) {
+    return normalizedAppUrl ? `${normalizedAppUrl}${candidate}` : '';
+  }
+  return normalizedAppUrl ? `${normalizedAppUrl}/${candidate.replace(/^\/+/, '')}` : '';
+};
+
+export function useShareActions(): UseShareActionsResult {
+  const [shareTarget, setShareTarget] = useState<ShareTargetState | null>(null);
+  const [shareBusy, setShareBusy] = useState<ShareActionKey | null>(null);
+  const [shareLinks, setShareLinks] = useState<ShareLinks>({});
+  const shareLinksRef = useRef<ShareLinks>({});
+  const shareInFlightRef = useRef<Map<string, Promise<string>>>(new Map());
+
+  useEffect(() => {
+    shareLinksRef.current = shareLinks;
+  }, [shareLinks]);
+
+  const systemShareSupported = useMemo(
+    () =>
+      typeof navigator !== 'undefined' &&
+      'share' in navigator &&
+      typeof (navigator as Navigator & { share?: unknown }).share === 'function',
+    []
+  );
+
+  const ensureShareLink: EnsureShareLink = useCallback(
+    async (target) => {
+      const cached = shareLinksRef.current[target.messageId];
+      if (cached) return cached;
+
+      const inflight = shareInFlightRef.current.get(target.messageId);
+      if (inflight) return inflight;
+
+      const request = (async () => {
+        const fallbackMessage = SHARE_FALLBACK_MESSAGE;
+        const safePlainText = (target.plainText || '').trim();
+        const safeMdText = (target.mdText || '').trim();
+        const plainTextPayload = safePlainText || safeMdText || fallbackMessage;
+        const mdTextPayload = safeMdText || undefined;
+
+        const res = await fetch('/api/share', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            conversationId: target.conversationId,
+            messageId: target.messageId,
+            plainText: plainTextPayload,
+            mdText: mdTextPayload,
+            mode: target.mode,
+            research: target.research,
+          }),
+        });
+        if (!res.ok) throw new Error('share_failed');
+        const data = await res.json().catch(() => null);
+        const absoluteUrlRaw = typeof data?.absoluteUrl === 'string' ? data.absoluteUrl.trim() : '';
+        const slug = typeof data?.slug === 'string' ? data.slug : '';
+
+        const normalizedAppUrl = resolveNormalizedAppUrl();
+        const absoluteUrl = resolveAbsoluteUrl(absoluteUrlRaw, normalizedAppUrl);
+
+        let shareUrl = '';
+        if (absoluteUrl) {
+          shareUrl = absoluteUrl;
+        } else if (slug) {
+          if (!normalizedAppUrl) throw new Error('share_failed');
+          shareUrl = `${normalizedAppUrl}/s/${slug}`;
+        } else {
+          throw new Error('share_failed');
+        }
+
+        shareLinksRef.current[target.messageId] = shareUrl;
+        setShareLinks((prev) => {
+          if (prev[target.messageId]) return prev;
+          return { ...prev, [target.messageId]: shareUrl };
+        });
+        return shareUrl;
+      })();
+
+      shareInFlightRef.current.set(target.messageId, request);
+      try {
+        return await request;
+      } finally {
+        shareInFlightRef.current.delete(target.messageId);
+      }
+    },
+    []
+  );
+
+  const closeShare = useCallback(() => {
+    setShareTarget(null);
+    setShareBusy(null);
+  }, []);
+
+  const openShare = useCallback((target: ShareTargetState) => {
+    const fallbackMessage = SHARE_FALLBACK_MESSAGE;
+    const normalizedPlain = target.plainText.trim();
+    const normalizedMd = target.mdText?.trim() ?? '';
+    const normalizedTarget: ShareTargetState = {
+      ...target,
+      plainText: normalizedPlain || normalizedMd || fallbackMessage,
+      mdText: normalizedMd || undefined,
+    };
+    setShareTarget(normalizedTarget);
+    setShareBusy(null);
+    trackEvent('share_opened', {
+      conversationId: normalizedTarget.conversationId,
+      messageId: normalizedTarget.messageId,
+      mode: normalizedTarget.mode,
+      research: normalizedTarget.research,
+    });
+  }, []);
+
+  const handleCopyShareLink = useCallback(async () => {
+    if (!shareTarget) return;
+    setShareBusy('link');
+    try {
+      const url = await ensureShareLink(shareTarget);
+      try {
+        if (!navigator?.clipboard?.writeText) throw new Error('clipboard_unsupported');
+        await navigator.clipboard.writeText(url);
+      } catch {
+        const textarea = document.createElement('textarea');
+        textarea.value = url;
+        textarea.setAttribute('readonly', 'true');
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        textarea.style.pointerEvents = 'none';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        const successful = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        if (!successful) {
+          throw new Error('copy_failed');
+        }
+      }
+      pushToast({ title: 'Link copied' });
+      trackEvent('share_copy_link', {
+        conversationId: shareTarget.conversationId,
+        messageId: shareTarget.messageId,
+        mode: shareTarget.mode,
+        research: shareTarget.research,
+      });
+    } catch {
+      pushToast({ title: 'Could not copy link', variant: 'destructive' });
+    } finally {
+      setShareBusy(null);
+    }
+  }, [ensureShareLink, shareTarget]);
+
+  const handleDownloadShareImage = useCallback(async () => {
+    if (!shareTarget) return;
+    setShareBusy('download');
+    try {
+      const node = document.getElementById(shareTarget.domId);
+      if (!node) throw new Error('missing_node');
+      const modeLabel =
+        shareTarget.mode === 'doctor'
+          ? 'Doctor mode'
+          : shareTarget.mode === 'research'
+          ? 'Research mode'
+          : shareTarget.mode === 'therapy'
+          ? 'Therapy mode'
+          : 'Patient mode';
+      const dataUrl = await exportMessageCardToPng(node, {
+        brand: BRAND_NAME,
+        modeLabel,
+        timestamp: new Date(),
+        fallbackText: shareTarget.plainText,
+      });
+      const anchor = document.createElement('a');
+      anchor.href = dataUrl;
+      anchor.download = 'medx-answer.png';
+      anchor.rel = 'noopener noreferrer';
+      anchor.click();
+      trackEvent('share_download_image', {
+        conversationId: shareTarget.conversationId,
+        messageId: shareTarget.messageId,
+        mode: shareTarget.mode,
+        research: shareTarget.research,
+      });
+    } catch {
+      pushToast({ title: 'Could not download image', variant: 'destructive' });
+    } finally {
+      setShareBusy(null);
+    }
+  }, [shareTarget]);
+
+  const handleShareX = useCallback(async () => {
+    if (!shareTarget) return;
+    const win = window.open('about:blank', '_blank', 'noopener,noreferrer');
+    setShareBusy('x');
+    try {
+      const url = await ensureShareLink(shareTarget);
+      const caption = buildShareIntentCaption(shareTarget.plainText, BRAND_NAME);
+      const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(caption)}&url=${encodeURIComponent(url)}`;
+      if (win) {
+        win.location.href = intentUrl;
+      } else {
+        window.open(intentUrl, '_blank', 'noopener,noreferrer');
+      }
+      trackEvent('share_x', {
+        conversationId: shareTarget.conversationId,
+        messageId: shareTarget.messageId,
+        mode: shareTarget.mode,
+        research: shareTarget.research,
+      });
+    } catch {
+      if (win) {
+        win.close();
+      }
+      pushToast({ title: 'Could not open X share', variant: 'destructive' });
+    } finally {
+      setShareBusy(null);
+    }
+  }, [ensureShareLink, shareTarget]);
+
+  const handleShareFacebook = useCallback(async () => {
+    if (!shareTarget) return;
+    const win = window.open('about:blank', '_blank', 'noopener,noreferrer');
+    setShareBusy('facebook');
+    try {
+      const url = await ensureShareLink(shareTarget);
+      const intentUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`;
+      if (win) {
+        win.location.href = intentUrl;
+      } else {
+        window.open(intentUrl, '_blank', 'noopener,noreferrer');
+      }
+      trackEvent('share_facebook', {
+        conversationId: shareTarget.conversationId,
+        messageId: shareTarget.messageId,
+        mode: shareTarget.mode,
+        research: shareTarget.research,
+      });
+    } catch {
+      if (win) {
+        win.close();
+      }
+      pushToast({ title: 'Could not open Facebook share', variant: 'destructive' });
+    } finally {
+      setShareBusy(null);
+    }
+  }, [ensureShareLink, shareTarget]);
+
+  const handleSystemShare = useCallback(async () => {
+    if (!shareTarget) return;
+    if (!systemShareSupported || !navigator?.share) {
+      pushToast({ title: 'Device sharing not available', variant: 'destructive' });
+      return;
+    }
+    setShareBusy('system');
+    try {
+      const url = await ensureShareLink(shareTarget);
+      const caption = buildShareCaption(shareTarget.plainText, BRAND_NAME, url);
+      await navigator.share({ title: 'MedX Answer', text: caption, url });
+      trackEvent('share_system', {
+        conversationId: shareTarget.conversationId,
+        messageId: shareTarget.messageId,
+        mode: shareTarget.mode,
+        research: shareTarget.research,
+      });
+    } catch (err: any) {
+      if (err?.name !== 'AbortError') {
+        pushToast({ title: 'Share cancelled', variant: 'destructive' });
+      }
+    } finally {
+      setShareBusy(null);
+    }
+  }, [ensureShareLink, shareTarget, systemShareSupported]);
+
+  const handleCopyShareCaption = useCallback(async () => {
+    if (!shareTarget) return;
+    setShareBusy('caption');
+    try {
+      const url = await ensureShareLink(shareTarget);
+      const caption = buildShareCaption(shareTarget.plainText, BRAND_NAME, url);
+      try {
+        if (!navigator?.clipboard?.writeText) throw new Error('clipboard_unsupported');
+        await navigator.clipboard.writeText(caption);
+      } catch {
+        const textarea = document.createElement('textarea');
+        textarea.value = caption;
+        textarea.setAttribute('readonly', 'true');
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        textarea.style.pointerEvents = 'none';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        const successful = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        if (!successful) {
+          throw new Error('copy_failed');
+        }
+      }
+      pushToast({ title: 'Caption copied' });
+    } catch {
+      pushToast({ title: 'Could not copy caption', variant: 'destructive' });
+    } finally {
+      setShareBusy(null);
+    }
+  }, [ensureShareLink, shareTarget]);
+
+  const sharePreview = shareTarget?.plainText ?? '';
+
+  return {
+    shareTarget,
+    shareBusy,
+    sharePreview,
+    systemShareSupported,
+    openShare,
+    closeShare,
+    handleCopyShareLink,
+    handleDownloadShareImage,
+    handleShareX,
+    handleShareFacebook,
+    handleSystemShare,
+    handleCopyShareCaption,
+  };
+}

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -5,7 +5,10 @@ export function supabaseAdmin() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) {
-    throw new Error("Supabase admin env vars missing (URL or SERVICE_ROLE).");
+    const missing: string[] = [];
+    if (!url) missing.push("NEXT_PUBLIC_SUPABASE_URL");
+    if (!key) missing.push("SUPABASE_SERVICE_ROLE_KEY");
+    throw new Error(`Supabase admin env vars missing: ${missing.join(", ") || "unknown"}`);
   }
   return createClient(url, key, { auth: { persistSession: false } });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@supabase/supabase-js": "^2.57.0",
         "@tanstack/react-query": "^5.89.0",
         "framer-motion": "^12.23.12",
+        "html-to-image": "^1.11.13",
         "isomorphic-dompurify": "2.13.0",
         "katex": "^0.16.22",
         "lucide-react": "0.441.0",
@@ -4114,6 +4115,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@supabase/supabase-js": "^2.57.0",
     "@tanstack/react-query": "^5.89.0",
     "framer-motion": "^12.23.12",
+    "html-to-image": "^1.11.13",
     "isomorphic-dompurify": "2.13.0",
     "katex": "^0.16.22",
     "lucide-react": "0.441.0",

--- a/supabase/migrations/20241010120000_create_shared_answers.sql
+++ b/supabase/migrations/20241010120000_create_shared_answers.sql
@@ -5,7 +5,8 @@ create table if not exists shared_answers (
   message_id text not null,
   mode text not null,
   research boolean default false,
-  content text not null,
+  plain_text text not null,
+  md_text text,
   created_at timestamptz default now()
 );
 

--- a/supabase/migrations/20241010120000_create_shared_answers.sql
+++ b/supabase/migrations/20241010120000_create_shared_answers.sql
@@ -1,0 +1,13 @@
+create table if not exists shared_answers (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  conversation_id text not null,
+  message_id text not null,
+  mode text not null,
+  research boolean default false,
+  content text not null,
+  created_at timestamptz default now()
+);
+
+create index if not exists idx_shared_answers_created
+  on shared_answers(created_at desc);


### PR DESCRIPTION
## Summary
- add a MessageActions control bar for assistant messages with copy, refresh, share, and feedback handling
- build themed SharePanel UI with sharing helpers, analytics events, and PNG export utility
- wire Supabase-backed share API and public read-only page for shared answers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d279991f54832fa88e88c214bff307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create/share short public links and a public view showing mode/research badges, timestamp, and content preview.
  * In-chat Share Panel and Share Viewer with actions: copy link, download image, share to X/Facebook/system, copy caption.
  * Message action bar (copy, refresh, feedback) and client-side image export for messages.
  * Self-test diagnostic endpoint for share infrastructure (toggleable).

* **Improvements**
  * Collision-tolerant link creation, robust absolute-URL resolution, analytics event dispatching, and clearer admin env validation.

* **Chores**
  * Added image-export dependency and DB migration for shared_answers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->