### PR TITLE
Align doctor mode terminology with clinical naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,10 +63,10 @@ PEDIATRIC_MINIMAL_QUESTIONS=true
 MEDS_SHORT_SUMMARY=true
 MEDS_SHORT_SUMMARY_MAX_CHARS=320
 
-# Show AI Doc “Next steps” card in Doctor mode (optional)
+# Show AI Doc “Next steps” card in Clinical mode (optional)
 AIDOC_UI=0
 
-# Optional: show AI Doc “Next steps” UI in Doctor mode
+# Optional: show AI Doc “Next steps” UI in Clinical mode
 NEXT_PUBLIC_AIDOC_UI=0
 
 # Ask “new or existing patient?” before AI Doc runs

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project includes:
 ## Endpoints
 - `GET /api/banner` — aggregated headlines
 - `POST /api/chat` — body: `{question, role: "patient"|"clinician"}`
-- `POST /api/analyze` — multipart form-data with `file` and optional `doctorMode`
+- `POST /api/analyze` — multipart form-data with `file` and optional `doctorMode` (Clinical mode toggle)
 - Plus wrappers: `/api/clinicaltrials`, `/api/pubmed`, `/api/who`, `/api/openfda`, `/api/dailymed`, `/api/rxnorm`, `/api/icd11`
 
 ## Notes

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -194,7 +194,7 @@ export async function POST(req: Request) {
           role: "system",
           content:
             mode === "doctor"
-              ? "You are a clinical evidence summarizer for doctors."
+              ? "You are a clinical evidence summarizer for clinicians."
               : "You are a health explainer for laypeople.",
         },
         { role: "user", content: prompt },
@@ -206,8 +206,8 @@ export async function POST(req: Request) {
     }
   }
 
-  // DEBUG LOG (remove later): verify we're actually in doctor path
-  console.log("[DoctorMode] mode=", mode, "thread_id=", thread_id);
+  // DEBUG LOG (remove later): verify we're actually in Clinical mode path
+  console.log("[ClinicalMode] mode=", mode, "thread_id=", thread_id);
 
   if (mode === "doctor") {
     const patient = await buildPatientSnapshot(thread_id);

--- a/app/api/imaging/analyze/route.ts
+++ b/app/api/imaging/analyze/route.ts
@@ -149,7 +149,7 @@ export async function POST(req: Request) {
       if (!pResp.ok) throw new Error(pJson?.error?.message || pResp.statusText);
       const patient = pJson.choices?.[0]?.message?.content || "";
 
-      // Doctor summary (optional)
+      // Clinical summary (optional)
       let doctor: string | null = null;
       if (doctorMode) {
         const dResp = await fetch("https://api.openai.com/v1/chat/completions", {
@@ -166,7 +166,7 @@ export async function POST(req: Request) {
               {
                 role: "user",
                 content: [
-                  { type: "text", text: "Summarize this report for a doctor." },
+                  { type: "text", text: "Summarize this report for a clinician." },
                   { type: "image_url", image_url: { url: dataUrl } },
                 ],
               },

--- a/components/TrialsRow.tsx
+++ b/components/TrialsRow.tsx
@@ -86,7 +86,7 @@ function formatTrialBriefMarkdown(nctId: string, brief: any) {
     .join("\n");
 
   return [
-    `### ${nctId} — Doctor Brief`,
+    `### ${nctId} — Clinical Brief`,
     brief.tldr ? `**TL;DR:** ${brief.tldr}` : "",
     bullets,
     lines,

--- a/components/UnifiedUpload.tsx
+++ b/components/UnifiedUpload.tsx
@@ -202,7 +202,7 @@ export default function UnifiedUpload() {
         </label>
         <label className="flex items-center gap-2 text-sm">
           <input type="checkbox" checked={doctorMode} onChange={e=>setDoctorMode(e.target.checked)} />
-          <span>Doctor Mode</span>
+          <span>Clinical Mode</span>
         </label>
       </div>
 
@@ -251,7 +251,7 @@ export default function UnifiedUpload() {
               </section>
               {out.doctor && (
                 <section className="p-3 border rounded">
-                  <h3 className="font-semibold mb-1">Doctor Summary</h3>
+                  <h3 className="font-semibold mb-1">Clinical Summary</h3>
                   <p className="whitespace-pre-wrap text-sm">{out.doctor}</p>
                 </section>
               )}

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -162,7 +162,7 @@ export default function ModeBar() {
         className={btn(doctorActive)}
         onClick={() => apply({ type: "toggle/doctor" })}
       >
-        Doctor
+        Clinical
       </button>
 
       <div className="mx-1 h-5 w-px bg-black/10 dark:bg-white/10" />

--- a/components/nearby/NearbyFinder.tsx
+++ b/components/nearby/NearbyFinder.tsx
@@ -71,7 +71,7 @@ export default function NearbyFinder() {
           onChange={(e) => setType(e.target.value)}
           className="border rounded px-2 py-1"
         >
-          <option value="doctor">Doctors</option>
+          <option value="doctor">Clinicians</option>
           <option value="specialist">Specialists</option>
           <option value="hospital">Hospitals</option>
           <option value="clinic">Clinics</option>

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -121,6 +121,8 @@ const NEARBY_KIND_SYNONYMS: Record<NearbyKind, string[]> = {
   doctor: [
     "doctor",
     "doctors",
+    "clinician",
+    "clinicians",
     "gp",
     "g.p.",
     "physician",
@@ -185,7 +187,7 @@ const NEARBY_KIND_SYNONYMS: Record<NearbyKind, string[]> = {
 
 const NEARBY_LABELS: Record<NearbyKind, { singular: string; plural: string }> = {
   pharmacy: { singular: "pharmacy", plural: "pharmacies" },
-  doctor: { singular: "doctor", plural: "doctors" },
+  doctor: { singular: "clinician", plural: "clinicians" },
   clinic: { singular: "clinic", plural: "clinics" },
   hospital: { singular: "hospital", plural: "hospitals" },
   lab: { singular: "lab", plural: "labs" },
@@ -513,7 +515,7 @@ function AnalysisCard({
             disabled={busy}
             onClick={() => onQuickAction("doctor")}
           >
-            Doctor’s view
+            Clinical view
           </button>
           <button
             type="button"
@@ -1270,7 +1272,7 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
       }
 
       if (NEARBY_CHANGE_CATEGORY_RE.test(lower) && inNearbyContext) {
-        pushAssistantText('Sure — tell me which category you need: pharmacy, doctor, clinic, hospital, or lab.');
+        pushAssistantText('Sure — tell me which category you need: pharmacy, clinician, clinic, hospital, or lab.');
         setNearbySession(key, { ...session, lastAction: 'nearby' });
         return true;
       }

--- a/components/panels/TrialsPane.tsx
+++ b/components/panels/TrialsPane.tsx
@@ -88,7 +88,7 @@ export default function TrialsPane() {
       <div className="flex gap-2">
         <button className="px-3 py-2 rounded bg-black text-white" onClick={onSearch} disabled={loading}>Search trials</button>
         <button className="px-3 py-2 rounded border" onClick={()=>summarize("patient")} disabled={!rows.length}>Summarize (Wellness)</button>
-        <button className="px-3 py-2 rounded border" onClick={()=>summarize("doctor")} disabled={!rows.length}>Summarize (Doctor)</button>
+        <button className="px-3 py-2 rounded border" onClick={()=>summarize("doctor")} disabled={!rows.length}>Summarize (Clinical)</button>
       </div>
 
       <div className="text-sm text-gray-500">Informational only; not medical advice. Confirm eligibility with the sponsor.</div>

--- a/lib/conversation/doctorGuard.ts
+++ b/lib/conversation/doctorGuard.ts
@@ -1,4 +1,4 @@
-// Doctor Mode Guard — strips research and enforces structure
+// Clinical Mode Guard — strips research and enforces structure
 export function enforceDoctorMode(output: string, template: string): string {
   let cleaned = output;
 

--- a/lib/conversation/doctorJson.ts
+++ b/lib/conversation/doctorJson.ts
@@ -1,7 +1,7 @@
 import { BRAND_NAME } from "@/lib/brand";
 
 export const DOCTOR_JSON_SYSTEM = `
-You are ${BRAND_NAME} Doctor Mode.
+You are ${BRAND_NAME} Clinical Mode.
 Return ONLY valid JSON matching this TypeScript type:
 {
   "clinical_implications": string[],

--- a/lib/medx.ts
+++ b/lib/medx.ts
@@ -12,8 +12,8 @@ const KEY = process.env.LLM_API_KEY!;
 
 const BASE_PROMPT = `India-aware; metric units.
 Patient = simple + home care + ≥3 red flags + when_to_test.
-Doctor = DDx + tests + initial management + ICD examples.
-If research requested: fill evidence (patient/doctor voice) or Research schema.
+Clinical (Doctor mode) = DDx + tests + initial management + ICD examples.
+If research requested: fill evidence (patient/clinical voice) or Research schema.
 Prefer WHO/ICMR/MoHFW/NHP or high-quality sources.
 Output ONLY JSON matching schema; end with </END_JSON>.`;
 

--- a/lib/medx/audience.ts
+++ b/lib/medx/audience.ts
@@ -2,7 +2,7 @@ export type Audience = "clinician" | "patient";
 
 /**
  * Map your app modes to output audience:
- * - "doctor" -> clinician
+ * - "doctor" (Clinical mode) -> clinician
  * - "doc ai"/"aidoc"/"doc_ai"/"doc-mode" -> patient explainer
  * - "patient"/"patient mode" -> patient explainer
  * Default -> patient explainer
@@ -15,7 +15,7 @@ export function detectAudience(mode?: string, hint?: string): Audience {
   if (raw === "clinician") return "clinician";
   if (raw === "patient") return "patient";
 
-  // Doctor-only, clinician-facing
+  // Clinical mode -> clinician-facing
   if (["doctor", "doctormode", "clinician", "research", "md"].includes(norm)) return "clinician";
 
   // Doc AI / Patient modes -> patient-facing explainer

--- a/lib/research/answerComposer.ts
+++ b/lib/research/answerComposer.ts
@@ -76,7 +76,7 @@ export function composeAnswer(
     ].filter(Boolean).join("\n\n");
   }
 
-  // Research or Doctor mode → keep full detail
+  // Research or Clinical mode → keep full detail
   return composeTrialsAnswer(userQuery, trials, papers, filters);
 }
 

--- a/lib/styles.ts
+++ b/lib/styles.ts
@@ -14,11 +14,11 @@ Return JSON exactly: {"tldr":"","bullets":[],"citations":[{"title":"","url":""}]
 `;
 
 /**
- * Doctor-focused clinical trial brief.
- * Adds a "details" object for downstream rendering in Doctor mode.
+ * Clinical-mode trial brief for clinicians.
+ * Adds a "details" object for downstream rendering in Clinical mode.
  */
 export const RESEARCH_TRIAL_BRIEF_STYLE = `
-You are a concise medical research assistant. Summarize clinical trial records for doctors in plain, factual language.
+You are a concise medical research assistant. Summarize clinical trial records for clinicians in plain, factual language.
 - One-line TL;DR (<= 20 words).
 - Up to 3 bullets (<= 18 words each) with concrete numbers/dates.
 - Prefer exact measures (phases, enrollment, outcomes) when available.

--- a/lib/trials/brief.ts
+++ b/lib/trials/brief.ts
@@ -14,7 +14,7 @@ function toLine(value: unknown, label: string): string | null {
 }
 
 export function formatTrialBriefMarkdown(nctId: string, brief: unknown): string {
-  const heading = `### ${nctId} — Doctor Brief`;
+  const heading = `### ${nctId} — Clinical Brief`;
   if (!brief || typeof brief !== 'object') {
     const fallback = String(brief ?? '').trim();
     return [heading, fallback].filter(Boolean).join('\n\n');

--- a/lib/welcomeMessages.ts
+++ b/lib/welcomeMessages.ts
@@ -3,17 +3,17 @@ export const WELCOME_MESSAGES = [
   `Get a Second Opinion—first.
 You can upload tests, prescriptions, or scans for AI-driven explanations.
 Ask about conditions, treatments, or local health resources, and get answers tailored to your country.
-Choose Wellness Mode for easy summaries or Doctor Mode for detailed analysis.`,
+Choose Wellness Mode for easy summaries or Clinical Mode for detailed analysis.`,
 
   `Because one opinion isn’t always enough.
 You can upload tests, prescriptions, or scans for AI-driven explanations.
 Ask about conditions, treatments, or local health resources, and get answers tailored to your country.
-Choose Wellness Mode for easy summaries or Doctor Mode for detailed analysis.`,
+Choose Wellness Mode for easy summaries or Clinical Mode for detailed analysis.`,
 
   `Your first stop for a Second Opinion.
 You can upload tests, prescriptions, or scans for AI-driven explanations.
 Ask about conditions, treatments, or local health resources, and get answers tailored to your country.
-Choose Wellness Mode for easy summaries or Doctor Mode for detailed analysis.`,
+Choose Wellness Mode for easy summaries or Clinical Mode for detailed analysis.`,
 ];
 
 export const getRandomWelcome = () =>

--- a/test/analyze.doctorMode.test.ts
+++ b/test/analyze.doctorMode.test.ts
@@ -47,7 +47,7 @@ const LONG_TEXT = Array(10)
   )
   .join(' ');
 
-test('doctor mode uploads skip ingest and return empty obsIds', async () => {
+test('Clinical mode uploads skip ingest and return empty obsIds', async () => {
   const file = await buildPdfFile(LONG_TEXT);
   const req = createRequest(true, file);
   const originalFetch = globalThis.fetch;
@@ -63,7 +63,7 @@ test('doctor mode uploads skip ingest and return empty obsIds', async () => {
       });
     }
     if (url.includes('api.openai.com')) {
-      const content = 'Doctor oriented summary';
+      const content = 'Clinical oriented summary';
       return new Response(JSON.stringify({ choices: [{ message: { content } }] }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- rename the Doctor mode tab label in the mode bar to "Clinical"
- update doctor-mode UI messaging (chat quick action, trial briefs, upload summaries, nearby finder, and welcome copy) to use the Clinical naming
- align backend prompts, logs, documentation, and tests with the Clinical terminology so the rebrand is consistent across the repo

## Testing
- npm run lint *(fails: command prompts for ESLint configuration and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d27f5fc9cc832f920adfc2fd6eb3f5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Trial briefs now include expanded details (design, population, interventions, primary outcomes, key eligibility) with updated citation guidance.
- Style
  - Renamed “Doctor Mode” to “Clinical Mode” across the UI, prompts, and messages, including buttons, toggles, summaries, nearby labels, and brief headers.
  - Added clinician-focused wording and synonyms for nearby search and chat flows.
- Documentation
  - Updated environment variable descriptions and API README to reference Clinical mode.
- Tests
  - Renamed tests and updated fixtures to reflect Clinical mode terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->