### PR TITLE
Add reusable welcome card for mode-specific welcome copy

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -11,7 +11,8 @@ import type { TrialRow } from "@/types/trials";
 import { useResearchFilters } from '@/store/researchFilters';
 import { Send, Paperclip, Clipboard, Stethoscope, Users, ChevronDown, ChevronUp } from 'lucide-react';
 import { useCountry } from '@/lib/country';
-import { getRandomWelcome } from '@/lib/welcomeMessages';
+import WelcomeCard from '@/components/ui/WelcomeCard';
+import { getWelcomeOptions, pickWelcome, type AppMode, type WelcomeMessage } from '@/lib/welcomeMessages';
 import { useActiveContext } from '@/lib/context';
 import { isFollowUp } from '@/lib/followup';
 import { detectFollowupIntent } from '@/lib/intents';
@@ -653,6 +654,8 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   const [thinkingStartedAt, setThinkingStartedAt] = useState<number | null>(null);
   const [loadingAction, setLoadingAction] = useState<null | 'simpler' | 'doctor' | 'next'>(null);
   const [labSummary, setLabSummary] = useState<any | null>(null);
+  const [showWelcome, setShowWelcome] = useState(false);
+  const [welcomeContent, setWelcomeContent] = useState<WelcomeMessage | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const chatRef = useRef<HTMLDivElement>(null);
   const inputRef =
@@ -668,6 +671,14 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   const mode: 'patient' | 'doctor' = modeState.base === 'doctor' ? 'doctor' : 'patient';
   const researchMode = modeState.research;
   const therapyMode = modeState.therapy;
+  const researchOn = Boolean(researchMode);
+  const uiMode: AppMode = isAiDocMode
+    ? 'aidoc'
+    : therapyMode
+      ? 'therapy'
+      : mode === 'doctor'
+        ? 'clinical'
+        : 'wellness';
   const defaultSuggestions = useMemo(() => getDefaultSuggestions(modeState), [modeState]);
   const liveSuggestions = useMemo(() => getInlineSuggestions(userText, modeState), [userText, modeState]);
   const visibleMessages = messages;
@@ -1528,15 +1539,71 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   }, [isProfileThread, threadId, therapyMode]);
 
   useEffect(() => {
-    if (!isProfileThread && messages.length === 0) {
-      addOnce('welcome:chat', getRandomWelcome());
+    if (typeof window === 'undefined') return;
+
+    const supportedModes: AppMode[] = ['wellness', 'therapy', 'clinical', 'aidoc'];
+    if (!supportedModes.includes(uiMode)) {
+      setShowWelcome(false);
+      setWelcomeContent(null);
+      return;
     }
-  }, [isProfileThread, messages.length]);
+
+    const options = getWelcomeOptions(uiMode, { researchOn });
+    if (options.length === 0) {
+      setShowWelcome(false);
+      setWelcomeContent(null);
+      return;
+    }
+
+    const seenKey = `welcome_seen_v2_${uiMode}`;
+    const pickKey = `welcome_pick_v2_${uiMode}`;
+
+    try {
+      const storage = window.localStorage;
+      if (storage?.getItem(seenKey)) {
+        setShowWelcome(false);
+        setWelcomeContent(null);
+        return;
+      }
+
+      const storedPick = storage?.getItem(pickKey);
+      const parsedPick = storedPick !== null ? Number.parseInt(storedPick, 10) : NaN;
+      if (storedPick === null || Number.isNaN(parsedPick) || parsedPick < 0 || parsedPick >= options.length) {
+        const randomIndex = Math.floor(Math.random() * options.length);
+        storage?.setItem(pickKey, String(randomIndex));
+      }
+
+      const selection = pickWelcome(uiMode, { researchOn });
+      setWelcomeContent(selection);
+      setShowWelcome(true);
+    } catch {
+      const fallback = options[0];
+      if (fallback) {
+        setWelcomeContent(fallback);
+        setShowWelcome(true);
+      } else {
+        setWelcomeContent(null);
+        setShowWelcome(false);
+      }
+    }
+  }, [uiMode, researchOn]);
 
   useEffect(() => {
     const tid = threadId || (isProfileThread ? 'med-profile' : null);
     if (tid) saveMessages(tid, messages as any);
   }, [messages, threadId, isProfileThread]);
+
+  const dismissWelcome = useCallback(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage?.setItem(`welcome_seen_v2_${uiMode}`, '1');
+      } catch {
+        /* ignore */
+      }
+    }
+    setShowWelcome(false);
+    setWelcomeContent(null);
+  }, [uiMode]);
 
   const draftKey = (threadId?: string|null)=> `chat:${threadId||'med-profile'}:draft`;
   // load draft and inject as past message (so it "reappears as past messages")
@@ -3132,6 +3199,14 @@ ${systemCommon}` + baseSys;
           )}
 
           <div className="mx-auto w-full max-w-3xl space-y-4">
+            {showWelcome && welcomeContent ? (
+              <WelcomeCard
+                header={welcomeContent.header}
+                body={welcomeContent.body}
+                status={welcomeContent.status}
+                onDismiss={dismissWelcome}
+              />
+            ) : null}
             {renderedMessages}
           </div>
 

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1548,15 +1548,13 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
       return;
     }
 
+    const seenKey = `welcome_seen_v2_${uiMode}`;
     const options = getWelcomeOptions(uiMode, { researchOn });
     if (options.length === 0) {
       setShowWelcome(false);
       setWelcomeContent(null);
       return;
     }
-
-    const seenKey = `welcome_seen_v2_${uiMode}`;
-    const pickKey = `welcome_pick_v2_${uiMode}`;
 
     try {
       const storage = window.localStorage;
@@ -1566,16 +1564,22 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
         return;
       }
 
-      const storedPick = storage?.getItem(pickKey);
-      const parsedPick = storedPick !== null ? Number.parseInt(storedPick, 10) : NaN;
-      if (storedPick === null || Number.isNaN(parsedPick) || parsedPick < 0 || parsedPick >= options.length) {
-        const randomIndex = Math.floor(Math.random() * options.length);
-        storage?.setItem(pickKey, String(randomIndex));
+      const selection = pickWelcome(uiMode, { researchOn });
+      if (selection) {
+        setWelcomeContent(selection);
+        setShowWelcome(true);
+        return;
       }
 
-      const selection = pickWelcome(uiMode, { researchOn });
-      setWelcomeContent(selection);
-      setShowWelcome(true);
+      // Fallback to the first option if pickWelcome returns an empty value.
+      const fallback = options[0];
+      if (fallback) {
+        setWelcomeContent(fallback);
+        setShowWelcome(true);
+      } else {
+        setWelcomeContent(null);
+        setShowWelcome(false);
+      }
     } catch {
       const fallback = options[0];
       if (fallback) {

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1549,6 +1549,7 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     }
 
     const seenKey = `welcome_seen_v2_${uiMode}`;
+    const pickKey = `welcome_pick_v2_${uiMode}`;
     const options = getWelcomeOptions(uiMode, { researchOn });
     if (options.length === 0) {
       setShowWelcome(false);
@@ -1556,39 +1557,42 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
       return;
     }
 
+    let storage: Storage | null = null;
     try {
-      const storage = window.localStorage;
-      if (storage?.getItem(seenKey)) {
-        setShowWelcome(false);
-        setWelcomeContent(null);
-        return;
-      }
+      storage = window.localStorage;
+    } catch {
+      storage = null;
+    }
 
+    if (storage?.getItem(seenKey)) {
+      setShowWelcome(false);
+      setWelcomeContent(null);
+      return;
+    }
+
+    try {
       const selection = pickWelcome(uiMode, { researchOn });
       if (selection) {
         setWelcomeContent(selection);
         setShowWelcome(true);
         return;
       }
-
-      // Fallback to the first option if pickWelcome returns an empty value.
-      const fallback = options[0];
-      if (fallback) {
-        setWelcomeContent(fallback);
-        setShowWelcome(true);
-      } else {
-        setWelcomeContent(null);
-        setShowWelcome(false);
-      }
     } catch {
-      const fallback = options[0];
-      if (fallback) {
-        setWelcomeContent(fallback);
-        setShowWelcome(true);
-      } else {
-        setWelcomeContent(null);
-        setShowWelcome(false);
+      // If pickWelcome fails we fall back to the first option below.
+    }
+
+    const fallback = options[0] ?? null;
+    if (fallback) {
+      try {
+        storage?.setItem(pickKey, '0');
+      } catch {
+        /* ignore */
       }
+      setWelcomeContent(fallback);
+      setShowWelcome(true);
+    } else {
+      setWelcomeContent(null);
+      setShowWelcome(false);
     }
   }, [uiMode, researchOn]);
 

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -2923,6 +2923,7 @@ ${systemCommon}` + baseSys;
 
   const assistantBusy = loadingAction !== null;
   const simpleMode = currentMode === 'patient';
+  const showWelcomeCard = showWelcome && !!welcomeContent;
 
   const renderedMessages = useMemo(
     () =>
@@ -3058,12 +3059,24 @@ ${systemCommon}` + baseSys;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
+      {showWelcomeCard && welcomeContent ? (
+        <div className="px-6 pt-6">
+          <div className="mx-auto w-full max-w-3xl">
+            <WelcomeCard
+              header={welcomeContent.header}
+              body={welcomeContent.body}
+              status={welcomeContent.status}
+              onDismiss={dismissWelcome}
+            />
+          </div>
+        </div>
+      ) : null}
       <div
         ref={chatRef}
         id="chat-scroll-container"
-        className="flex-1 min-h-0 overflow-y-auto"
+        className={`flex-1 min-h-0 overflow-y-auto${showWelcomeCard ? ' mt-4' : ''}`}
       >
-        <div className="flex min-h-full flex-col justify-end px-6 pt-6">
+        <div className={`flex min-h-full flex-col justify-end px-6${showWelcomeCard ? '' : ' pt-6'}`}>
           {mode === "doctor" && researchMode && (
             <div className="mb-6 space-y-4">
               <ResearchFilters mode="research" onResults={handleTrials} />
@@ -3207,14 +3220,6 @@ ${systemCommon}` + baseSys;
           )}
 
           <div className="mx-auto w-full max-w-3xl space-y-4">
-            {showWelcome && welcomeContent ? (
-              <WelcomeCard
-                header={welcomeContent.header}
-                body={welcomeContent.body}
-                status={welcomeContent.status}
-                onDismiss={dismissWelcome}
-              />
-            ) : null}
             {renderedMessages}
           </div>
 

--- a/components/ui/WelcomeCard.tsx
+++ b/components/ui/WelcomeCard.tsx
@@ -1,0 +1,50 @@
+import { X } from "lucide-react";
+
+export type WelcomeCardProps = {
+  header: string;
+  body: string;
+  status?: string;
+  onDismiss: () => void;
+  className?: string;
+};
+
+function joinClassNames(...values: (string | undefined)[]) {
+  return values.filter(Boolean).join(" ");
+}
+
+export default function WelcomeCard({
+  header,
+  body,
+  status,
+  onDismiss,
+  className,
+}: WelcomeCardProps) {
+  return (
+    <div
+      role="region"
+      aria-label="Welcome"
+      className={joinClassNames(
+        "relative rounded-lg border p-3 shadow-sm text-sm",
+        "bg-blue-50 border-blue-100 text-slate-700",
+        "dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100",
+        "break-words",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        aria-label="Dismiss welcome"
+        onClick={onDismiss}
+        tabIndex={0}
+        className="absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-full text-slate-500 transition hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-slate-300"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </button>
+      <div className="pr-6">
+        <div className="text-[0.95rem] font-semibold">{header}</div>
+        <div className="mt-1 leading-snug">{body}</div>
+        {status ? <div className="mt-1 text-xs opacity-80">{status}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/WelcomeCard.tsx
+++ b/components/ui/WelcomeCard.tsx
@@ -25,8 +25,8 @@ export default function WelcomeCard({
       aria-label="Welcome"
       className={joinClassNames(
         "relative rounded-lg border p-3 shadow-sm text-sm",
-        "bg-blue-50 border-blue-100 text-slate-700",
-        "dark:bg-slate-800 dark:border-slate-700 dark:text-slate-100",
+        "bg-blue-600 text-white border-blue-500",
+        "dark:bg-blue-700 dark:border-blue-600",
         "break-words",
         className,
       )}
@@ -36,14 +36,14 @@ export default function WelcomeCard({
         aria-label="Dismiss welcome"
         onClick={onDismiss}
         tabIndex={0}
-        className="absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-full text-slate-500 transition hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-slate-300"
+        className="absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-full text-white/80 transition hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-white/70"
       >
         <X className="h-4 w-4" aria-hidden="true" />
       </button>
       <div className="pr-6">
         <div className="text-[0.95rem] font-semibold">{header}</div>
-        <div className="mt-1 leading-snug">{body}</div>
-        {status ? <div className="mt-1 text-xs opacity-80">{status}</div> : null}
+        <div className="mt-1 leading-snug text-blue-50 dark:text-blue-100">{body}</div>
+        {status ? <div className="mt-1 text-xs opacity-90">{status}</div> : null}
       </div>
     </div>
   );

--- a/lib/welcomeMessages.ts
+++ b/lib/welcomeMessages.ts
@@ -1,20 +1,195 @@
-// lib/welcomeMessages.ts
-export const WELCOME_MESSAGES = [
-  `Get a Second Opinion—first.
-You can upload tests, prescriptions, or scans for AI-driven explanations.
-Ask about conditions, treatments, or local health resources, and get answers tailored to your country.
-Choose Wellness Mode for easy summaries or Clinical Mode for detailed analysis.`,
+export type AppMode = "wellness" | "therapy" | "clinical" | "aidoc";
 
-  `Because one opinion isn’t always enough.
-You can upload tests, prescriptions, or scans for AI-driven explanations.
-Ask about conditions, treatments, or local health resources, and get answers tailored to your country.
-Choose Wellness Mode for easy summaries or Clinical Mode for detailed analysis.`,
+export type WelcomeMessage = {
+  header: string;
+  body: string;
+  status?: string;
+};
 
-  `Your first stop for a Second Opinion.
-You can upload tests, prescriptions, or scans for AI-driven explanations.
-Ask about conditions, treatments, or local health resources, and get answers tailored to your country.
-Choose Wellness Mode for easy summaries or Clinical Mode for detailed analysis.`,
+type WelcomeMessageConfig = {
+  header: string;
+  body: string;
+};
+
+const WELLNESS_MESSAGES: WelcomeMessageConfig[] = [
+  {
+    header: "Wellness Mode: ON",
+    body: "Your health, made simple. Reports, tips, medication, diets, and fitness—explained in clear language.",
+  },
+  {
+    header: "Wellness Mode: ON",
+    body: "Everything health, without the jargon. From lab reports to daily habits—meds, diet, fitness—made easy to act on.",
+  },
+  {
+    header: "Wellness Mode: ON",
+    body: "Clarity for everyday care. Reports, guidance, medication, diet, and fitness—understood at a glance.",
+  },
+  {
+    header: "Wellness Mode: ON",
+    body: "All your health, decoded. Reports, tips, meds, diet, and fitness—concise and actionable.",
+  },
 ];
 
-export const getRandomWelcome = () =>
-  WELCOME_MESSAGES[Math.floor(Math.random() * WELCOME_MESSAGES.length)];
+const CLINICAL_MESSAGES: WelcomeMessageConfig[] = [
+  {
+    header: "Clinical Mode: ON",
+    body: "Clinical reasoning on demand. Built for doctors, nurses, and medical students.",
+  },
+  {
+    header: "Clinical Mode: ON",
+    body: "Depth when it matters. Structured differentials, red flags, and management—professional grade.",
+  },
+  {
+    header: "Clinical Mode: ON",
+    body: "Evidence-ready, clinician-first.",
+  },
+  {
+    header: "Clinical Mode: ON",
+    body: "Precision over prose. Concise clinical answers with clear next steps.",
+  },
+];
+
+const THERAPY_MESSAGES: WelcomeMessageConfig[] = [
+  {
+    header: "Therapy Mode: ON",
+    body: "Therapy guidance, made clear. Tools and support; not for emergencies.",
+  },
+  {
+    header: "Therapy Mode: ON",
+    body: "Calm, structured support. Practical techniques and next steps.",
+  },
+  {
+    header: "Therapy Mode: ON",
+    body: "Clarity for tough days. Grounded guidance, actionable exercises.",
+  },
+  {
+    header: "Therapy Mode: ON",
+    body: "Steady help, simple words. Skills you can use today.",
+  },
+];
+
+const AIDOC_MESSAGES: WelcomeMessageConfig[] = [
+  {
+    header: "AI Doc: ON",
+    body: "Your records, organized. Upload, store, and retrieve securely.",
+  },
+  {
+    header: "AI Doc: ON",
+    body: "All your reports in one place. Fast search, clear summaries.",
+  },
+  {
+    header: "AI Doc: ON",
+    body: "Medical files that make sense. Structured, searchable, shareable.",
+  },
+  {
+    header: "AI Doc: ON",
+    body: "From paper to clarity. Digitize reports; get clean overviews.",
+  },
+];
+
+const CLINICAL_STATUS_INDEX = 2;
+
+function cloneMessages(messages: WelcomeMessageConfig[]): WelcomeMessage[] {
+  return messages.map(message => ({ ...message }));
+}
+
+function normalizeIndex(index: number, total: number): number {
+  if (total <= 0) return 0;
+  const mod = index % total;
+  return mod < 0 ? mod + total : mod;
+}
+
+function getStoredIndex(mode: AppMode, total: number): number | null {
+  if (typeof window === "undefined" || total <= 0) return null;
+  try {
+    const stored = window.localStorage?.getItem(`welcome_pick_v2_${mode}`);
+    if (stored === null) return null;
+    const parsed = Number.parseInt(stored, 10);
+    if (Number.isNaN(parsed)) return null;
+    const normalized = normalizeIndex(parsed, total);
+    if (normalized < 0 || normalized >= total) return null;
+    return normalized;
+  } catch {
+    return null;
+  }
+}
+
+function setStoredIndex(mode: AppMode, index: number) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage?.setItem(`welcome_pick_v2_${mode}`, String(index));
+  } catch {
+    /* ignore */
+  }
+}
+
+function resolveSeed(mode: AppMode): number | null {
+  if (typeof window === "undefined") return null;
+  const candidates = [
+    (window as any).__medxWelcomeSeed,
+    (window as any).__medxWelcomeRotation,
+    (window as any).__medxRotationSeed,
+  ];
+  for (const source of candidates) {
+    if (source && typeof source === "object") {
+      const value = source[mode];
+      if (typeof value === "number" && Number.isFinite(value)) {
+        return Math.trunc(value);
+      }
+    }
+  }
+  return null;
+}
+
+export function getWelcomeOptions(
+  mode: AppMode,
+  opts: { researchOn?: boolean } = {},
+): WelcomeMessage[] {
+  switch (mode) {
+    case "therapy":
+      return cloneMessages(THERAPY_MESSAGES);
+    case "clinical": {
+      const base = cloneMessages(CLINICAL_MESSAGES);
+      if (base[CLINICAL_STATUS_INDEX]) {
+        base[CLINICAL_STATUS_INDEX] = {
+          ...base[CLINICAL_STATUS_INDEX],
+          status: opts.researchOn
+            ? "Research: On — web evidence"
+            : "Research: Off — enable web evidence",
+        };
+      }
+      return base;
+    }
+    case "aidoc":
+      return cloneMessages(AIDOC_MESSAGES);
+    case "wellness":
+    default:
+      return cloneMessages(WELLNESS_MESSAGES);
+  }
+}
+
+export function pickWelcome(
+  mode: AppMode,
+  opts: { researchOn?: boolean } = {},
+): WelcomeMessage {
+  const options = getWelcomeOptions(mode, opts);
+  if (options.length === 0) {
+    return { header: "", body: "" };
+  }
+
+  const seed = resolveSeed(mode);
+  if (typeof seed === "number") {
+    const index = normalizeIndex(seed, options.length);
+    setStoredIndex(mode, index);
+    return options[index];
+  }
+
+  const stored = getStoredIndex(mode, options.length);
+  if (typeof stored === "number") {
+    return options[stored];
+  }
+
+  const randomIndex = Math.floor(Math.random() * options.length);
+  setStoredIndex(mode, randomIndex);
+  return options[randomIndex];
+}


### PR DESCRIPTION
## Summary
- add a reusable WelcomeCard UI component for the chat header
- centralize welcome message rotations with clinical research status handling
- show the welcome card in ChatPane once per mode with persisted dismissal

## Testing
- NEXT_DISABLE_ESLINT_PLUGIN=1 npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d2916620d4832fb79d4166efb31e98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mode-aware welcome experience for wellness, therapy, clinical, and aidoc views.
  * Dismissible WelcomeCard showing header, body, and optional status; persists dismissals per UI mode to avoid repeats.
  * Shows enhanced status/details when research mode is active.
  * Accessible, keyboard-friendly controls and resilient behavior when welcome data or environment is unavailable.

* **Refactor**
  * Centralized, configurable welcome selection and persistence for consistent, predictable welcome flows across modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->