### PR TITLE
Revamp mobile chat shell

### DIFF
--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -12,6 +12,7 @@ import ThemeToggle from "@/components/ThemeToggle";
 import CountryGlobe from "@/components/CountryGlobe";
 import ChatErrorBoundary from "@/components/ChatErrorBoundary";
 import { ENABLE_MOBILE_UI } from "@/env";
+import FeatureDebug from "@/components/FeatureDebug";
 
 export default function ThreadPage() {
   const { id } = useParams<{ id: string }>();
@@ -90,6 +91,8 @@ export default function ThreadPage() {
           onStartNewChat={handleStartNewChat}
           onOpenOverflow={openOverflow}
         />
+
+        {process.env.NODE_ENV === "development" ? <FeatureDebug /> : null}
 
         {overflowMenu && (
           <div

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -85,13 +85,13 @@ export default function ThreadPage() {
   return (
     <ChatErrorBoundary>
       <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
-        {ENABLE_MOBILE_UI ? (
+        {ENABLE_MOBILE_UI && (
           <HeaderMobile
             onToggleSidebar={() => setSidebarOpen(true)}
             onStartNewChat={handleStartNewChat}
             onOpenOverflow={openOverflow}
           />
-        ) : null}
+        )}
 
         {overflowMenu && (
           <div
@@ -171,9 +171,15 @@ export default function ThreadPage() {
           </aside>
 
           <main className="relative flex flex-1 flex-col">
-            <div className="md:hidden px-3 pt-2">
-              <ModeBar />
-            </div>
+            {ENABLE_MOBILE_UI ? (
+              <div className="md:hidden">
+                <ModeBar />
+              </div>
+            ) : (
+              <div className="md:hidden px-3 pt-2">
+                <ModeBar />
+              </div>
+            )}
             <ThreadView id={id} />
           </main>
         </div>

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { hydrateFromLocalStorage } from "@/lib/state/hydrate";
@@ -10,6 +10,7 @@ import ModeBar from "@/components/modes/ModeBar";
 import { useChatStore } from "@/lib/state/chatStore";
 import ThemeToggle from "@/components/ThemeToggle";
 import CountryGlobe from "@/components/CountryGlobe";
+import ChatErrorBoundary from "@/components/ChatErrorBoundary";
 
 export default function ThreadPage() {
   const { id } = useParams<{ id: string }>();
@@ -23,22 +24,28 @@ export default function ThreadPage() {
   }, [id]);
 
   useEffect(() => {
+    if (typeof document === "undefined") return;
     if (sidebarOpen) {
       document.body.classList.add("overflow-hidden");
     } else {
       document.body.classList.remove("overflow-hidden");
     }
-    return () => document.body.classList.remove("overflow-hidden");
+    return () => {
+      if (typeof document !== "undefined") {
+        document.body.classList.remove("overflow-hidden");
+      }
+    };
   }, [sidebarOpen]);
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
     const handler = () => setOverflowMenu(null);
     window.addEventListener("resize", handler);
     return () => window.removeEventListener("resize", handler);
   }, []);
 
   useEffect(() => {
-    if (!overflowMenu) return;
+    if (!overflowMenu || typeof document === "undefined") return;
     const handleClick = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
       if (!target.closest("[data-overflow-menu]") && !target.closest("[data-overflow-trigger]")) {
@@ -57,11 +64,16 @@ export default function ThreadPage() {
   };
 
   const openOverflow = (anchor: HTMLElement) => {
-    const rect = anchor.getBoundingClientRect();
-    setOverflowMenu({
-      top: rect.bottom + 8,
-      right: Math.max(window.innerWidth - rect.right - 8, 12),
-    });
+    try {
+      const rect = anchor.getBoundingClientRect();
+      const win = typeof window !== "undefined" ? window : undefined;
+      setOverflowMenu({
+        top: rect.bottom + 8,
+        right: Math.max((win?.innerWidth ?? 0) - rect.right - 8, 12),
+      });
+    } catch (error) {
+      console.error('Failed to open overflow menu', error);
+    }
   };
 
   const overflowActions = useMemo(
@@ -70,98 +82,100 @@ export default function ThreadPage() {
   );
 
   return (
-    <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
-      <HeaderMobile
-        onToggleSidebar={() => setSidebarOpen(true)}
-        onStartNewChat={handleStartNewChat}
-        onOpenOverflow={openOverflow}
-      />
+    <ChatErrorBoundary>
+      <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
+        <HeaderMobile
+          onToggleSidebar={() => setSidebarOpen(true)}
+          onStartNewChat={handleStartNewChat}
+          onOpenOverflow={openOverflow}
+        />
 
-      {overflowMenu && (
-        <div
-          data-overflow-menu
-          className="fixed z-50 w-48 overflow-hidden rounded-xl border border-[#E2E8F0] bg-[#F8FAFC]/95 text-sm text-[#0F172A] shadow-2xl backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]"
-          style={{ top: overflowMenu.top, right: overflowMenu.right }}
-        >
-          <ul className="divide-y divide-[#E2E8F0]/70 dark:divide-[#1E3A5F]/80">
-            {overflowActions.map(action => (
-              <li key={action} className="px-3 py-2">
-                {action === "Dark Mode" ? (
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="text-sm font-medium">Dark mode</span>
-                    <ThemeToggle className="h-8 px-3 text-xs" />
-                  </div>
-                ) : action === "Country" ? (
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="text-sm font-medium">Country</span>
-                    <CountryGlobe />
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-sm font-medium transition hover:bg-[#E2E8F0]/60 dark:hover:bg-[#13233D]"
-                    onClick={() => {
-                      setOverflowMenu(null);
-                      if (action === "Settings") {
-                        router.push("/?panel=settings");
-                      }
-                    }}
-                  >
-                    <span>{action}</span>
-                    <svg viewBox="0 0 24 24" className="h-4 w-4 text-[#334155] dark:text-[#94A3B8]" fill="none" stroke="currentColor" strokeWidth="1.5">
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
-                    </svg>
-                  </button>
-                )}
-              </li>
-            ))}
-          </ul>
+        {overflowMenu && (
+          <div
+            data-overflow-menu
+            className="fixed z-50 w-48 overflow-hidden rounded-xl border border-[#E2E8F0] bg-[#F8FAFC]/95 text-sm text-[#0F172A] shadow-2xl backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]"
+            style={{ top: overflowMenu.top, right: overflowMenu.right }}
+          >
+            <ul className="divide-y divide-[#E2E8F0]/70 dark:divide-[#1E3A5F]/80">
+              {overflowActions.map(action => (
+                <li key={action} className="px-3 py-2">
+                  {action === "Dark Mode" ? (
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-medium">Dark mode</span>
+                      <ThemeToggle className="h-8 px-3 text-xs" />
+                    </div>
+                  ) : action === "Country" ? (
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-medium">Country</span>
+                      <CountryGlobe />
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-sm font-medium transition hover:bg-[#E2E8F0]/60 dark:hover:bg-[#13233D]"
+                      onClick={() => {
+                        setOverflowMenu(null);
+                        if (action === "Settings") {
+                          router.push("/?panel=settings");
+                        }
+                      }}
+                    >
+                      <span>{action}</span>
+                      <svg viewBox="0 0 24 24" className="h-4 w-4 text-[#334155] dark:text-[#94A3B8]" fill="none" stroke="currentColor" strokeWidth="1.5">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+                      </svg>
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
+          <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
+            <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
+              <span>Conversations</span>
+              <button
+                type="button"
+                onClick={handleStartNewChat}
+                className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+              >
+                New
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto pr-1">
+              <SidebarThreads />
+            </div>
+          </div>
+        </SidebarDrawer>
+
+        <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
+          <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col">
+            <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
+              <span>Conversations</span>
+              <button
+                type="button"
+                onClick={handleStartNewChat}
+                className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+              >
+                New
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto px-2 pb-4">
+              <SidebarThreads />
+            </div>
+          </aside>
+
+          <main className="relative flex flex-1 flex-col">
+            <div className="md:hidden px-3 pt-2">
+              <ModeBar />
+            </div>
+            <ThreadView id={id} />
+          </main>
         </div>
-      )}
-
-      <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
-        <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
-          <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
-            <span>Conversations</span>
-            <button
-              type="button"
-              onClick={handleStartNewChat}
-              className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-            >
-              New
-            </button>
-          </div>
-          <div className="flex-1 overflow-y-auto pr-1">
-            <SidebarThreads />
-          </div>
-        </div>
-      </SidebarDrawer>
-
-      <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
-        <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col">
-          <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
-            <span>Conversations</span>
-            <button
-              type="button"
-              onClick={handleStartNewChat}
-              className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-            >
-              New
-            </button>
-          </div>
-          <div className="flex-1 overflow-y-auto px-2 pb-4">
-            <SidebarThreads />
-          </div>
-        </aside>
-
-        <main className="relative flex flex-1 flex-col">
-          <div className="md:hidden px-3 pt-2">
-            <ModeBar />
-          </div>
-          <ThreadView id={id} />
-        </main>
       </div>
-    </div>
+    </ChatErrorBoundary>
   );
 }
 

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -11,7 +11,6 @@ import { useChatStore } from "@/lib/state/chatStore";
 import ThemeToggle from "@/components/ThemeToggle";
 import CountryGlobe from "@/components/CountryGlobe";
 import ChatErrorBoundary from "@/components/ChatErrorBoundary";
-import { ENABLE_MOBILE_UI } from "@/env";
 import FeatureDebug from "@/components/FeatureDebug";
 
 export default function ThreadPage() {
@@ -172,15 +171,9 @@ export default function ThreadPage() {
           </aside>
 
           <main className="relative flex flex-1 flex-col">
-            {ENABLE_MOBILE_UI ? (
-              <div className="md:hidden">
-                <ModeBar />
-              </div>
-            ) : (
-              <div className="md:hidden px-3 pt-2">
-                <ModeBar />
-              </div>
-            )}
+            <div className="md:hidden">
+              <ModeBar />
+            </div>
             <ThreadView id={id} />
           </main>
         </div>

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -1,16 +1,150 @@
 "use client";
-import { useEffect } from "react";
-import { useParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
 import { hydrateFromLocalStorage } from "@/lib/state/hydrate";
 import ThreadView from "@/components/ThreadView";
+import { HeaderMobile } from "@/components/Header";
+import { SidebarDrawer } from "@/components/Sidebar";
+import { SidebarThreads } from "@/components/SidebarThreads";
+import ModeBar from "@/components/modes/ModeBar";
+import { useChatStore } from "@/lib/state/chatStore";
 
 export default function ThreadPage() {
   const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const startNewThread = useChatStore(s => s.startNewThread);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [overflowMenu, setOverflowMenu] = useState<{ top: number; right: number } | null>(null);
 
   useEffect(() => {
     hydrateFromLocalStorage(id);
   }, [id]);
 
-  return <ThreadView id={id} />;
+  useEffect(() => {
+    if (sidebarOpen) {
+      document.body.classList.add("overflow-hidden");
+    } else {
+      document.body.classList.remove("overflow-hidden");
+    }
+    return () => document.body.classList.remove("overflow-hidden");
+  }, [sidebarOpen]);
+
+  useEffect(() => {
+    const handler = () => setOverflowMenu(null);
+    window.addEventListener("resize", handler);
+    return () => window.removeEventListener("resize", handler);
+  }, []);
+
+  useEffect(() => {
+    if (!overflowMenu) return;
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target.closest("[data-overflow-menu]") && !target.closest("[data-overflow-trigger]") ) {
+        setOverflowMenu(null);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [overflowMenu]);
+
+  const handleStartNewChat = () => {
+    const nextId = startNewThread();
+    router.push(`/chat/${nextId}`);
+    setSidebarOpen(false);
+    setOverflowMenu(null);
+  };
+
+  const openOverflow = (anchor: HTMLElement) => {
+    const rect = anchor.getBoundingClientRect();
+    setOverflowMenu({
+      top: rect.bottom + 8,
+      right: Math.max(window.innerWidth - rect.right - 8, 12),
+    });
+  };
+
+  const overflowActions = useMemo(
+    () => ["Rename", "Duplicate", "Share", "Delete", "Settings"],
+    [],
+  );
+
+  return (
+    <div className="h-dvh flex flex-col overscroll-none bg-slate-950 text-slate-100 md:bg-transparent md:text-inherit">
+      <HeaderMobile
+        onToggleSidebar={() => setSidebarOpen(true)}
+        onStartNewChat={handleStartNewChat}
+        onOpenOverflow={openOverflow}
+      />
+
+      {overflowMenu && (
+        <div
+          data-overflow-menu
+          className="fixed z-50 w-44 overflow-hidden rounded-xl border border-slate-700/60 bg-slate-900/95 text-sm shadow-xl backdrop-blur"
+          style={{ top: overflowMenu.top, right: overflowMenu.right }}
+        >
+          <ul className="py-1">
+            {overflowActions.map(action => (
+              <li key={action}>
+                <button
+                  type="button"
+                  className="flex w-full items-center px-4 py-2 text-left text-slate-200 transition hover:bg-slate-800"
+                  onClick={() => {
+                    setOverflowMenu(null);
+                    if (action === "Settings") {
+                      router.push("/?panel=settings");
+                    }
+                  }}
+                >
+                  {action}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
+        <div className="flex h-full flex-col gap-4 text-sm">
+          <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-slate-400">
+            <span>Conversations</span>
+            <button
+              type="button"
+              onClick={handleStartNewChat}
+              className="rounded-full bg-blue-600 px-3 py-1 text-xs font-semibold text-white"
+            >
+              New
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto pr-1">
+            <SidebarThreads />
+          </div>
+        </div>
+      </SidebarDrawer>
+
+      <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
+        <aside className="hidden border-r border-slate-200/60 bg-slate-900/10 md:flex md:flex-col">
+          <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <span>Conversations</span>
+            <button
+              type="button"
+              onClick={handleStartNewChat}
+              className="rounded-full bg-blue-600 px-3 py-1 text-xs font-semibold text-white"
+            >
+              New
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto px-2 pb-4">
+            <SidebarThreads />
+          </div>
+        </aside>
+
+        <main className="relative flex flex-1 flex-col">
+          <div className="md:hidden px-3 pt-2">
+            <ModeBar />
+          </div>
+          <ThreadView id={id} />
+        </main>
+      </div>
+    </div>
+  );
 }
 

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -8,6 +8,8 @@ import { SidebarDrawer } from "@/components/Sidebar";
 import { SidebarThreads } from "@/components/SidebarThreads";
 import ModeBar from "@/components/modes/ModeBar";
 import { useChatStore } from "@/lib/state/chatStore";
+import ThemeToggle from "@/components/ThemeToggle";
+import CountryGlobe from "@/components/CountryGlobe";
 
 export default function ThreadPage() {
   const { id } = useParams<{ id: string }>();
@@ -39,7 +41,7 @@ export default function ThreadPage() {
     if (!overflowMenu) return;
     const handleClick = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
-      if (!target.closest("[data-overflow-menu]") && !target.closest("[data-overflow-trigger]") ) {
+      if (!target.closest("[data-overflow-menu]") && !target.closest("[data-overflow-trigger]")) {
         setOverflowMenu(null);
       }
     };
@@ -63,12 +65,12 @@ export default function ThreadPage() {
   };
 
   const overflowActions = useMemo(
-    () => ["Rename", "Duplicate", "Share", "Delete", "Settings"],
+    () => ["Rename", "Duplicate", "Share", "Delete", "Settings", "Dark Mode", "Country"],
     [],
   );
 
   return (
-    <div className="h-dvh flex flex-col overscroll-none bg-slate-950 text-slate-100 md:bg-transparent md:text-inherit">
+    <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
       <HeaderMobile
         onToggleSidebar={() => setSidebarOpen(true)}
         onStartNewChat={handleStartNewChat}
@@ -78,24 +80,39 @@ export default function ThreadPage() {
       {overflowMenu && (
         <div
           data-overflow-menu
-          className="fixed z-50 w-44 overflow-hidden rounded-xl border border-slate-700/60 bg-slate-900/95 text-sm shadow-xl backdrop-blur"
+          className="fixed z-50 w-48 overflow-hidden rounded-xl border border-[#E2E8F0] bg-[#F8FAFC]/95 text-sm text-[#0F172A] shadow-2xl backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]"
           style={{ top: overflowMenu.top, right: overflowMenu.right }}
         >
-          <ul className="py-1">
+          <ul className="divide-y divide-[#E2E8F0]/70 dark:divide-[#1E3A5F]/80">
             {overflowActions.map(action => (
-              <li key={action}>
-                <button
-                  type="button"
-                  className="flex w-full items-center px-4 py-2 text-left text-slate-200 transition hover:bg-slate-800"
-                  onClick={() => {
-                    setOverflowMenu(null);
-                    if (action === "Settings") {
-                      router.push("/?panel=settings");
-                    }
-                  }}
-                >
-                  {action}
-                </button>
+              <li key={action} className="px-3 py-2">
+                {action === "Dark Mode" ? (
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium">Dark mode</span>
+                    <ThemeToggle className="h-8 px-3 text-xs" />
+                  </div>
+                ) : action === "Country" ? (
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium">Country</span>
+                    <CountryGlobe />
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-sm font-medium transition hover:bg-[#E2E8F0]/60 dark:hover:bg-[#13233D]"
+                    onClick={() => {
+                      setOverflowMenu(null);
+                      if (action === "Settings") {
+                        router.push("/?panel=settings");
+                      }
+                    }}
+                  >
+                    <span>{action}</span>
+                    <svg viewBox="0 0 24 24" className="h-4 w-4 text-[#334155] dark:text-[#94A3B8]" fill="none" stroke="currentColor" strokeWidth="1.5">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+                    </svg>
+                  </button>
+                )}
               </li>
             ))}
           </ul>
@@ -103,13 +120,13 @@ export default function ThreadPage() {
       )}
 
       <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
-        <div className="flex h-full flex-col gap-4 text-sm">
-          <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-slate-400">
+        <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
+          <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
             <span>Conversations</span>
             <button
               type="button"
               onClick={handleStartNewChat}
-              className="rounded-full bg-blue-600 px-3 py-1 text-xs font-semibold text-white"
+              className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
             >
               New
             </button>
@@ -121,13 +138,13 @@ export default function ThreadPage() {
       </SidebarDrawer>
 
       <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
-        <aside className="hidden border-r border-slate-200/60 bg-slate-900/10 md:flex md:flex-col">
-          <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col">
+          <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
             <span>Conversations</span>
             <button
               type="button"
               onClick={handleStartNewChat}
-              className="rounded-full bg-blue-600 px-3 py-1 text-xs font-semibold text-white"
+              className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
             >
               New
             </button>

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -135,37 +135,29 @@ export default function ThreadPage() {
           </div>
         )}
 
-        <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
-          <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
-            <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
-              <span>Conversations</span>
-              <button
-                type="button"
-                onClick={handleStartNewChat}
-                className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-              >
-                New
-              </button>
+        <div className="md:hidden">
+          <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
+            <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
+              <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
+                <span>Conversations</span>
+                <button
+                  type="button"
+                  onClick={handleStartNewChat}
+                  className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+                >
+                  New
+                </button>
+              </div>
+              <div className="flex-1 overflow-y-auto pr-1">
+                <SidebarThreads />
+              </div>
             </div>
-            <div className="flex-1 overflow-y-auto pr-1">
-              <SidebarThreads />
-            </div>
-          </div>
-        </SidebarDrawer>
+          </SidebarDrawer>
+        </div>
 
         <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
-          <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col">
-            <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
-              <span>Conversations</span>
-              <button
-                type="button"
-                onClick={handleStartNewChat}
-                className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-              >
-                New
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto px-2 pb-4">
+          <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col md:border-black/10 md:bg-transparent md:text-inherit md:dark:border-white/10 md:dark:bg-transparent">
+            <div className="flex-1 overflow-y-auto px-2 pb-4 md:px-0 md:pb-0">
               <SidebarThreads />
             </div>
           </aside>

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -85,13 +85,11 @@ export default function ThreadPage() {
   return (
     <ChatErrorBoundary>
       <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
-        {ENABLE_MOBILE_UI && (
-          <HeaderMobile
-            onToggleSidebar={() => setSidebarOpen(true)}
-            onStartNewChat={handleStartNewChat}
-            onOpenOverflow={openOverflow}
-          />
-        )}
+        <HeaderMobile
+          onToggleSidebar={() => setSidebarOpen(true)}
+          onStartNewChat={handleStartNewChat}
+          onOpenOverflow={openOverflow}
+        />
 
         {overflowMenu && (
           <div

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -4,8 +4,7 @@ import { useParams, useRouter } from "next/navigation";
 import { hydrateFromLocalStorage } from "@/lib/state/hydrate";
 import ThreadView from "@/components/ThreadView";
 import { HeaderMobile } from "@/components/Header";
-import { SidebarDrawer } from "@/components/Sidebar";
-import { SidebarThreads } from "@/components/SidebarThreads";
+import Sidebar, { SidebarDrawer } from "@/components/Sidebar";
 import ModeBar from "@/components/modes/ModeBar";
 import { useChatStore } from "@/lib/state/chatStore";
 import ThemeToggle from "@/components/ThemeToggle";
@@ -137,38 +136,16 @@ export default function ThreadPage() {
 
         <div className="md:hidden">
           <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
-            <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
-              <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
-                <span>Conversations</span>
-                <button
-                  type="button"
-                  onClick={handleStartNewChat}
-                  className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-                >
-                  New
-                </button>
-              </div>
-              <div className="flex-1 overflow-y-auto pr-1">
-                <SidebarThreads />
-              </div>
-            </div>
+            <Sidebar />
           </SidebarDrawer>
         </div>
 
-        <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
-          <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col md:border-black/10 md:bg-transparent md:text-inherit md:dark:border-white/10 md:dark:bg-transparent">
-            <div className="flex-1 overflow-y-auto px-2 pb-4 md:px-0 md:pb-0">
-              <SidebarThreads />
-            </div>
-          </aside>
-
-          <main className="relative flex flex-1 flex-col">
-            <div className="md:hidden">
-              <ModeBar />
-            </div>
-            <ThreadView id={id} />
-          </main>
-        </div>
+        <main className="relative flex flex-1 flex-col">
+          <div className="md:hidden">
+            <ModeBar />
+          </div>
+          <ThreadView id={id} />
+        </main>
       </div>
     </ChatErrorBoundary>
   );

--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -11,6 +11,7 @@ import { useChatStore } from "@/lib/state/chatStore";
 import ThemeToggle from "@/components/ThemeToggle";
 import CountryGlobe from "@/components/CountryGlobe";
 import ChatErrorBoundary from "@/components/ChatErrorBoundary";
+import { ENABLE_MOBILE_UI } from "@/env";
 
 export default function ThreadPage() {
   const { id } = useParams<{ id: string }>();
@@ -84,11 +85,13 @@ export default function ThreadPage() {
   return (
     <ChatErrorBoundary>
       <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
-        <HeaderMobile
-          onToggleSidebar={() => setSidebarOpen(true)}
-          onStartNewChat={handleStartNewChat}
-          onOpenOverflow={openOverflow}
-        />
+        {ENABLE_MOBILE_UI ? (
+          <HeaderMobile
+            onToggleSidebar={() => setSidebarOpen(true)}
+            onStartNewChat={handleStartNewChat}
+            onOpenOverflow={openOverflow}
+          />
+        ) : null}
 
         {overflowMenu && (
           <div

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -89,13 +89,13 @@ export default function ChatPage() {
   return (
     <ChatErrorBoundary>
       <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
-        {ENABLE_MOBILE_UI ? (
+        {ENABLE_MOBILE_UI && (
           <HeaderMobile
             onToggleSidebar={() => setSidebarOpen(true)}
             onStartNewChat={handleStartNewChat}
             onOpenOverflow={openOverflow}
           />
-        ) : null}
+        )}
 
         {overflowMenu && (
           <div
@@ -175,9 +175,15 @@ export default function ChatPage() {
           </aside>
 
           <main className="relative flex flex-1 flex-col">
-            <div className="md:hidden px-3 pt-2">
-              <ModeBar />
-            </div>
+            {ENABLE_MOBILE_UI ? (
+              <div className="md:hidden">
+                <ModeBar />
+              </div>
+            ) : (
+              <div className="md:hidden px-3 pt-2">
+                <ModeBar />
+              </div>
+            )}
             <ChatWindow />
           </main>
         </div>

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -89,13 +89,11 @@ export default function ChatPage() {
   return (
     <ChatErrorBoundary>
       <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
-        {ENABLE_MOBILE_UI && (
-          <HeaderMobile
-            onToggleSidebar={() => setSidebarOpen(true)}
-            onStartNewChat={handleStartNewChat}
-            onOpenOverflow={openOverflow}
-          />
-        )}
+        <HeaderMobile
+          onToggleSidebar={() => setSidebarOpen(true)}
+          onStartNewChat={handleStartNewChat}
+          onOpenOverflow={openOverflow}
+        />
 
         {overflowMenu && (
           <div

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useChatStore } from "@/lib/state/chatStore";
@@ -9,6 +9,7 @@ import { SidebarDrawer } from "@/components/Sidebar";
 import ModeBar from "@/components/modes/ModeBar";
 import ThemeToggle from "@/components/ThemeToggle";
 import CountryGlobe from "@/components/CountryGlobe";
+import ChatErrorBoundary from "@/components/ChatErrorBoundary";
 
 export default function ChatPage() {
   const pathname = usePathname();
@@ -27,22 +28,28 @@ export default function ChatPage() {
   }, [pathname, resetToEmpty]);
 
   useEffect(() => {
+    if (typeof document === "undefined") return;
     if (sidebarOpen) {
       document.body.classList.add("overflow-hidden");
     } else {
       document.body.classList.remove("overflow-hidden");
     }
-    return () => document.body.classList.remove("overflow-hidden");
+    return () => {
+      if (typeof document !== "undefined") {
+        document.body.classList.remove("overflow-hidden");
+      }
+    };
   }, [sidebarOpen]);
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
     const handler = () => setOverflowMenu(null);
     window.addEventListener("resize", handler);
     return () => window.removeEventListener("resize", handler);
   }, []);
 
   useEffect(() => {
-    if (!overflowMenu) return;
+    if (!overflowMenu || typeof document === "undefined") return;
     const handleClick = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
       if (!target.closest("[data-overflow-menu]") && !target.closest("[data-overflow-trigger]")) {
@@ -61,11 +68,16 @@ export default function ChatPage() {
   };
 
   const openOverflow = (anchor: HTMLElement) => {
-    const rect = anchor.getBoundingClientRect();
-    setOverflowMenu({
-      top: rect.bottom + 8,
-      right: Math.max(window.innerWidth - rect.right - 8, 12),
-    });
+    try {
+      const rect = anchor.getBoundingClientRect();
+      const win = typeof window !== "undefined" ? window : undefined;
+      setOverflowMenu({
+        top: rect.bottom + 8,
+        right: Math.max((win?.innerWidth ?? 0) - rect.right - 8, 12),
+      });
+    } catch (error) {
+      console.error('Failed to open overflow menu', error);
+    }
   };
 
   const overflowActions = useMemo(
@@ -74,98 +86,100 @@ export default function ChatPage() {
   );
 
   return (
-    <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
-      <HeaderMobile
-        onToggleSidebar={() => setSidebarOpen(true)}
-        onStartNewChat={handleStartNewChat}
-        onOpenOverflow={openOverflow}
-      />
+    <ChatErrorBoundary>
+      <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
+        <HeaderMobile
+          onToggleSidebar={() => setSidebarOpen(true)}
+          onStartNewChat={handleStartNewChat}
+          onOpenOverflow={openOverflow}
+        />
 
-      {overflowMenu && (
-        <div
-          data-overflow-menu
-          className="fixed z-50 w-48 overflow-hidden rounded-xl border border-[#E2E8F0] bg-[#F8FAFC]/95 text-sm text-[#0F172A] shadow-2xl backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]"
-          style={{ top: overflowMenu.top, right: overflowMenu.right }}
-        >
-          <ul className="divide-y divide-[#E2E8F0]/70 dark:divide-[#1E3A5F]/80">
-            {overflowActions.map(action => (
-              <li key={action} className="px-3 py-2">
-                {action === "Dark Mode" ? (
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="text-sm font-medium">Dark mode</span>
-                    <ThemeToggle className="h-8 px-3 text-xs" />
-                  </div>
-                ) : action === "Country" ? (
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="text-sm font-medium">Country</span>
-                    <CountryGlobe />
-                  </div>
-                ) : (
-                  <button
-                    type="button"
-                    className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-sm font-medium transition hover:bg-[#E2E8F0]/60 dark:hover:bg-[#13233D]"
-                    onClick={() => {
-                      setOverflowMenu(null);
-                      if (action === "Settings") {
-                        router.push("/?panel=settings");
-                      }
-                    }}
-                  >
-                    <span>{action}</span>
-                    <svg viewBox="0 0 24 24" className="h-4 w-4 text-[#334155] dark:text-[#94A3B8]" fill="none" stroke="currentColor" strokeWidth="1.5">
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
-                    </svg>
-                  </button>
-                )}
-              </li>
-            ))}
-          </ul>
+        {overflowMenu && (
+          <div
+            data-overflow-menu
+            className="fixed z-50 w-48 overflow-hidden rounded-xl border border-[#E2E8F0] bg-[#F8FAFC]/95 text-sm text-[#0F172A] shadow-2xl backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]"
+            style={{ top: overflowMenu.top, right: overflowMenu.right }}
+          >
+            <ul className="divide-y divide-[#E2E8F0]/70 dark:divide-[#1E3A5F]/80">
+              {overflowActions.map(action => (
+                <li key={action} className="px-3 py-2">
+                  {action === "Dark Mode" ? (
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-medium">Dark mode</span>
+                      <ThemeToggle className="h-8 px-3 text-xs" />
+                    </div>
+                  ) : action === "Country" ? (
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-sm font-medium">Country</span>
+                      <CountryGlobe />
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-sm font-medium transition hover:bg-[#E2E8F0]/60 dark:hover:bg-[#13233D]"
+                      onClick={() => {
+                        setOverflowMenu(null);
+                        if (action === "Settings") {
+                          router.push("/?panel=settings");
+                        }
+                      }}
+                    >
+                      <span>{action}</span>
+                      <svg viewBox="0 0 24 24" className="h-4 w-4 text-[#334155] dark:text-[#94A3B8]" fill="none" stroke="currentColor" strokeWidth="1.5">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+                      </svg>
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
+          <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
+            <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
+              <span>Conversations</span>
+              <button
+                type="button"
+                onClick={handleStartNewChat}
+                className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+              >
+                New
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto pr-1">
+              <SidebarThreads />
+            </div>
+          </div>
+        </SidebarDrawer>
+
+        <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
+          <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col">
+            <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
+              <span>Conversations</span>
+              <button
+                type="button"
+                onClick={handleStartNewChat}
+                className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+              >
+                New
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto px-2 pb-4">
+              <SidebarThreads />
+            </div>
+          </aside>
+
+          <main className="relative flex flex-1 flex-col">
+            <div className="md:hidden px-3 pt-2">
+              <ModeBar />
+            </div>
+            <ChatWindow />
+          </main>
         </div>
-      )}
-
-      <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
-        <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
-          <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
-            <span>Conversations</span>
-            <button
-              type="button"
-              onClick={handleStartNewChat}
-              className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-            >
-              New
-            </button>
-          </div>
-          <div className="flex-1 overflow-y-auto pr-1">
-            <SidebarThreads />
-          </div>
-        </div>
-      </SidebarDrawer>
-
-      <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
-        <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col">
-          <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
-            <span>Conversations</span>
-            <button
-              type="button"
-              onClick={handleStartNewChat}
-              className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-            >
-              New
-            </button>
-          </div>
-          <div className="flex-1 overflow-y-auto px-2 pb-4">
-            <SidebarThreads />
-          </div>
-        </aside>
-
-        <main className="relative flex flex-1 flex-col">
-          <div className="md:hidden px-3 pt-2">
-            <ModeBar />
-          </div>
-          <ChatWindow />
-        </main>
       </div>
-    </div>
+    </ChatErrorBoundary>
   );
 }
 

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -2,10 +2,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useChatStore } from "@/lib/state/chatStore";
-import { SidebarThreads } from "@/components/SidebarThreads";
+import Sidebar, { SidebarDrawer } from "@/components/Sidebar";
 import { ChatWindow } from "@/components/ChatWindow";
 import { HeaderMobile } from "@/components/Header";
-import { SidebarDrawer } from "@/components/Sidebar";
 import ModeBar from "@/components/modes/ModeBar";
 import ThemeToggle from "@/components/ThemeToggle";
 import CountryGlobe from "@/components/CountryGlobe";
@@ -141,38 +140,16 @@ export default function ChatPage() {
 
         <div className="md:hidden">
           <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
-            <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
-              <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
-                <span>Conversations</span>
-                <button
-                  type="button"
-                  onClick={handleStartNewChat}
-                  className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-                >
-                  New
-                </button>
-              </div>
-              <div className="flex-1 overflow-y-auto pr-1">
-                <SidebarThreads />
-              </div>
-            </div>
+            <Sidebar />
           </SidebarDrawer>
         </div>
 
-        <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
-          <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col md:border-black/10 md:bg-transparent md:text-inherit md:dark:border-white/10 md:dark:bg-transparent">
-            <div className="flex-1 overflow-y-auto px-2 pb-4 md:px-0 md:pb-0">
-              <SidebarThreads />
-            </div>
-          </aside>
-
-          <main className="relative flex flex-1 flex-col">
-            <div className="md:hidden">
-              <ModeBar />
-            </div>
-            <ChatWindow />
-          </main>
-        </div>
+        <main className="relative flex flex-1 flex-col">
+          <div className="md:hidden">
+            <ModeBar />
+          </div>
+          <ChatWindow />
+        </main>
       </div>
     </ChatErrorBoundary>
   );

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -10,6 +10,7 @@ import ModeBar from "@/components/modes/ModeBar";
 import ThemeToggle from "@/components/ThemeToggle";
 import CountryGlobe from "@/components/CountryGlobe";
 import ChatErrorBoundary from "@/components/ChatErrorBoundary";
+import { ENABLE_MOBILE_UI } from "@/env";
 
 export default function ChatPage() {
   const pathname = usePathname();
@@ -88,11 +89,13 @@ export default function ChatPage() {
   return (
     <ChatErrorBoundary>
       <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
-        <HeaderMobile
-          onToggleSidebar={() => setSidebarOpen(true)}
-          onStartNewChat={handleStartNewChat}
-          onOpenOverflow={openOverflow}
-        />
+        {ENABLE_MOBILE_UI ? (
+          <HeaderMobile
+            onToggleSidebar={() => setSidebarOpen(true)}
+            onStartNewChat={handleStartNewChat}
+            onOpenOverflow={openOverflow}
+          />
+        ) : null}
 
         {overflowMenu && (
           <div

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -11,6 +11,7 @@ import ThemeToggle from "@/components/ThemeToggle";
 import CountryGlobe from "@/components/CountryGlobe";
 import ChatErrorBoundary from "@/components/ChatErrorBoundary";
 import { ENABLE_MOBILE_UI } from "@/env";
+import FeatureDebug from "@/components/FeatureDebug";
 
 export default function ChatPage() {
   const pathname = usePathname();
@@ -94,6 +95,8 @@ export default function ChatPage() {
           onStartNewChat={handleStartNewChat}
           onOpenOverflow={openOverflow}
         />
+
+        {process.env.NODE_ENV === "development" ? <FeatureDebug /> : null}
 
         {overflowMenu && (
           <div

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -10,7 +10,6 @@ import ModeBar from "@/components/modes/ModeBar";
 import ThemeToggle from "@/components/ThemeToggle";
 import CountryGlobe from "@/components/CountryGlobe";
 import ChatErrorBoundary from "@/components/ChatErrorBoundary";
-import { ENABLE_MOBILE_UI } from "@/env";
 import FeatureDebug from "@/components/FeatureDebug";
 
 export default function ChatPage() {
@@ -176,15 +175,9 @@ export default function ChatPage() {
           </aside>
 
           <main className="relative flex flex-1 flex-col">
-            {ENABLE_MOBILE_UI ? (
-              <div className="md:hidden">
-                <ModeBar />
-              </div>
-            ) : (
-              <div className="md:hidden px-3 pt-2">
-                <ModeBar />
-              </div>
-            )}
+            <div className="md:hidden">
+              <ModeBar />
+            </div>
             <ChatWindow />
           </main>
         </div>

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,13 +1,20 @@
 "use client";
-import { useEffect } from "react";
-import { usePathname } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { useChatStore } from "@/lib/state/chatStore";
 import { SidebarThreads } from "@/components/SidebarThreads";
 import { ChatWindow } from "@/components/ChatWindow";
+import { HeaderMobile } from "@/components/Header";
+import { SidebarDrawer } from "@/components/Sidebar";
+import ModeBar from "@/components/modes/ModeBar";
 
 export default function ChatPage() {
   const pathname = usePathname();
+  const router = useRouter();
   const resetToEmpty = useChatStore(s => s.resetToEmpty);
+  const startNewThread = useChatStore(s => s.startNewThread);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [overflowMenu, setOverflowMenu] = useState<{ top: number; right: number } | null>(null);
 
   useEffect(() => {
     // fresh landing: no thread id in the url → reset everything
@@ -17,10 +24,130 @@ export default function ChatPage() {
     }
   }, [pathname, resetToEmpty]);
 
+  useEffect(() => {
+    if (sidebarOpen) {
+      document.body.classList.add("overflow-hidden");
+    } else {
+      document.body.classList.remove("overflow-hidden");
+    }
+    return () => document.body.classList.remove("overflow-hidden");
+  }, [sidebarOpen]);
+
+  useEffect(() => {
+    const handler = () => setOverflowMenu(null);
+    window.addEventListener("resize", handler);
+    return () => window.removeEventListener("resize", handler);
+  }, []);
+
+  useEffect(() => {
+    if (!overflowMenu) return;
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target.closest("[data-overflow-menu]") && !target.closest("[data-overflow-trigger]") ) {
+        setOverflowMenu(null);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [overflowMenu]);
+
+  const handleStartNewChat = () => {
+    const id = startNewThread();
+    router.push(`/chat/${id}`);
+    setSidebarOpen(false);
+    setOverflowMenu(null);
+  };
+
+  const openOverflow = (anchor: HTMLElement) => {
+    const rect = anchor.getBoundingClientRect();
+    setOverflowMenu({
+      top: rect.bottom + 8,
+      right: Math.max(window.innerWidth - rect.right - 8, 12),
+    });
+  };
+
+  const overflowActions = useMemo(
+    () => ["Rename", "Duplicate", "Share", "Delete", "Settings"],
+    [],
+  );
+
   return (
-    <div className="grid grid-cols-[280px_1fr] h-full">
-      <aside className="border-r"><SidebarThreads /></aside>
-      <main><ChatWindow /></main>
+    <div className="h-dvh flex flex-col overscroll-none bg-slate-950 text-slate-100 md:bg-transparent md:text-inherit">
+      <HeaderMobile
+        onToggleSidebar={() => setSidebarOpen(true)}
+        onStartNewChat={handleStartNewChat}
+        onOpenOverflow={openOverflow}
+      />
+
+      {overflowMenu && (
+        <div
+          data-overflow-menu
+          className="fixed z-50 w-44 overflow-hidden rounded-xl border border-slate-700/60 bg-slate-900/95 text-sm shadow-xl backdrop-blur"
+          style={{ top: overflowMenu.top, right: overflowMenu.right }}
+        >
+          <ul className="py-1">
+            {overflowActions.map(action => (
+              <li key={action}>
+                <button
+                  type="button"
+                  className="flex w-full items-center px-4 py-2 text-left text-slate-200 transition hover:bg-slate-800"
+                  onClick={() => {
+                    setOverflowMenu(null);
+                    if (action === "Settings") {
+                      router.push("/?panel=settings");
+                    }
+                  }}
+                >
+                  {action}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
+        <div className="flex h-full flex-col gap-4 text-sm">
+          <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-slate-400">
+            <span>Conversations</span>
+            <button
+              type="button"
+              onClick={handleStartNewChat}
+              className="rounded-full bg-blue-600 px-3 py-1 text-xs font-semibold text-white"
+            >
+              New
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto pr-1">
+            <SidebarThreads />
+          </div>
+        </div>
+      </SidebarDrawer>
+
+      <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
+        <aside className="hidden border-r border-slate-200/60 bg-slate-900/10 md:flex md:flex-col">
+          <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <span>Conversations</span>
+            <button
+              type="button"
+              onClick={handleStartNewChat}
+              className="rounded-full bg-blue-600 px-3 py-1 text-xs font-semibold text-white"
+            >
+              New
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto px-2 pb-4">
+            <SidebarThreads />
+          </div>
+        </aside>
+
+        <main className="relative flex flex-1 flex-col">
+          <div className="md:hidden px-3 pt-2">
+            <ModeBar />
+          </div>
+          <ChatWindow />
+        </main>
+      </div>
     </div>
   );
 }

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -7,6 +7,8 @@ import { ChatWindow } from "@/components/ChatWindow";
 import { HeaderMobile } from "@/components/Header";
 import { SidebarDrawer } from "@/components/Sidebar";
 import ModeBar from "@/components/modes/ModeBar";
+import ThemeToggle from "@/components/ThemeToggle";
+import CountryGlobe from "@/components/CountryGlobe";
 
 export default function ChatPage() {
   const pathname = usePathname();
@@ -43,7 +45,7 @@ export default function ChatPage() {
     if (!overflowMenu) return;
     const handleClick = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
-      if (!target.closest("[data-overflow-menu]") && !target.closest("[data-overflow-trigger]") ) {
+      if (!target.closest("[data-overflow-menu]") && !target.closest("[data-overflow-trigger]")) {
         setOverflowMenu(null);
       }
     };
@@ -67,12 +69,12 @@ export default function ChatPage() {
   };
 
   const overflowActions = useMemo(
-    () => ["Rename", "Duplicate", "Share", "Delete", "Settings"],
+    () => ["Rename", "Duplicate", "Share", "Delete", "Settings", "Dark Mode", "Country"],
     [],
   );
 
   return (
-    <div className="h-dvh flex flex-col overscroll-none bg-slate-950 text-slate-100 md:bg-transparent md:text-inherit">
+    <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
       <HeaderMobile
         onToggleSidebar={() => setSidebarOpen(true)}
         onStartNewChat={handleStartNewChat}
@@ -82,24 +84,39 @@ export default function ChatPage() {
       {overflowMenu && (
         <div
           data-overflow-menu
-          className="fixed z-50 w-44 overflow-hidden rounded-xl border border-slate-700/60 bg-slate-900/95 text-sm shadow-xl backdrop-blur"
+          className="fixed z-50 w-48 overflow-hidden rounded-xl border border-[#E2E8F0] bg-[#F8FAFC]/95 text-sm text-[#0F172A] shadow-2xl backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]"
           style={{ top: overflowMenu.top, right: overflowMenu.right }}
         >
-          <ul className="py-1">
+          <ul className="divide-y divide-[#E2E8F0]/70 dark:divide-[#1E3A5F]/80">
             {overflowActions.map(action => (
-              <li key={action}>
-                <button
-                  type="button"
-                  className="flex w-full items-center px-4 py-2 text-left text-slate-200 transition hover:bg-slate-800"
-                  onClick={() => {
-                    setOverflowMenu(null);
-                    if (action === "Settings") {
-                      router.push("/?panel=settings");
-                    }
-                  }}
-                >
-                  {action}
-                </button>
+              <li key={action} className="px-3 py-2">
+                {action === "Dark Mode" ? (
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium">Dark mode</span>
+                    <ThemeToggle className="h-8 px-3 text-xs" />
+                  </div>
+                ) : action === "Country" ? (
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium">Country</span>
+                    <CountryGlobe />
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-sm font-medium transition hover:bg-[#E2E8F0]/60 dark:hover:bg-[#13233D]"
+                    onClick={() => {
+                      setOverflowMenu(null);
+                      if (action === "Settings") {
+                        router.push("/?panel=settings");
+                      }
+                    }}
+                  >
+                    <span>{action}</span>
+                    <svg viewBox="0 0 24 24" className="h-4 w-4 text-[#334155] dark:text-[#94A3B8]" fill="none" stroke="currentColor" strokeWidth="1.5">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+                    </svg>
+                  </button>
+                )}
               </li>
             ))}
           </ul>
@@ -107,13 +124,13 @@ export default function ChatPage() {
       )}
 
       <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
-        <div className="flex h-full flex-col gap-4 text-sm">
-          <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-slate-400">
+        <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
+          <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
             <span>Conversations</span>
             <button
               type="button"
               onClick={handleStartNewChat}
-              className="rounded-full bg-blue-600 px-3 py-1 text-xs font-semibold text-white"
+              className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
             >
               New
             </button>
@@ -125,13 +142,13 @@ export default function ChatPage() {
       </SidebarDrawer>
 
       <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
-        <aside className="hidden border-r border-slate-200/60 bg-slate-900/10 md:flex md:flex-col">
-          <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col">
+          <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
             <span>Conversations</span>
             <button
               type="button"
               onClick={handleStartNewChat}
-              className="rounded-full bg-blue-600 px-3 py-1 text-xs font-semibold text-white"
+              className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
             >
               New
             </button>

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -88,7 +88,7 @@ export default function ChatPage() {
 
   return (
     <ChatErrorBoundary>
-      <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
+      <div className="h-dvh flex flex-col overscroll-none bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7] md:bg-transparent md:text-inherit md:dark:bg-transparent">
         <HeaderMobile
           onToggleSidebar={() => setSidebarOpen(true)}
           onStartNewChat={handleStartNewChat}
@@ -139,37 +139,29 @@ export default function ChatPage() {
           </div>
         )}
 
-        <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
-          <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
-            <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
-              <span>Conversations</span>
-              <button
-                type="button"
-                onClick={handleStartNewChat}
-                className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-              >
-                New
-              </button>
+        <div className="md:hidden">
+          <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
+            <div className="flex h-full flex-col gap-4 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
+              <div className="flex items-center justify-between pt-1 text-xs uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
+                <span>Conversations</span>
+                <button
+                  type="button"
+                  onClick={handleStartNewChat}
+                  className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+                >
+                  New
+                </button>
+              </div>
+              <div className="flex-1 overflow-y-auto pr-1">
+                <SidebarThreads />
+              </div>
             </div>
-            <div className="flex-1 overflow-y-auto pr-1">
-              <SidebarThreads />
-            </div>
-          </div>
-        </SidebarDrawer>
+          </SidebarDrawer>
+        </div>
 
         <div className="flex flex-1 md:grid md:grid-cols-[280px_1fr]">
-          <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col">
-            <div className="flex items-center justify-between px-4 pb-2 pt-4 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">
-              <span>Conversations</span>
-              <button
-                type="button"
-                onClick={handleStartNewChat}
-                className="rounded-full bg-[#2563EB] px-3 py-1 text-xs font-semibold text-white transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-              >
-                New
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto px-2 pb-4">
+          <aside className="hidden border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:flex md:flex-col md:border-black/10 md:bg-transparent md:text-inherit md:dark:border-white/10 md:dark:bg-transparent">
+            <div className="flex-1 overflow-y-auto px-2 pb-4 md:px-0 md:pb-0">
               <SidebarThreads />
             </div>
           </aside>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
 import Timeline from "@/components/panels/Timeline";
@@ -7,18 +8,102 @@ import AlertsPane from "@/components/panels/AlertsPane";
 import SettingsPane from "@/components/panels/SettingsPane";
 import { ResearchFiltersProvider } from "@/store/researchFilters";
 import AiDocPane from "@/components/panels/AiDocPane";
+import { HeaderMobile } from "@/components/Header";
+import { SidebarDrawer } from "@/components/Sidebar";
+import ThemeToggle from "@/components/ThemeToggle";
+import CountryGlobe from "@/components/CountryGlobe";
+import FeatureDebug from "@/components/FeatureDebug";
+import Sidebar from "@/components/Sidebar";
+import { createNewThreadId } from "@/lib/chatThreads";
 
-type Search = { panel?: string };
+type Search = Record<string, string | string[] | undefined>;
 
 export default function Page({ searchParams }: { searchParams: Search }) {
-  const panel = searchParams.panel?.toLowerCase() || "chat";
+  const panelParam = searchParams.panel;
+  const panelValue = Array.isArray(panelParam) ? panelParam[0] : panelParam;
+  const panel = panelValue?.toLowerCase() || "chat";
   const chatInputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [overflowMenu, setOverflowMenu] = useState<{ top: number; right: number } | null>(null);
+  const threadParam = searchParams.threadId;
+  const threadId = Array.isArray(threadParam) ? threadParam[0] : threadParam;
+
+  useEffect(() => {
+    if (!sidebarOpen) return;
+    if (typeof document === "undefined") return;
+    document.body.classList.add("overflow-hidden");
+    return () => {
+      document.body.classList.remove("overflow-hidden");
+    };
+  }, [sidebarOpen]);
+
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [threadId, panel]);
+
+  useEffect(() => {
+    if (!overflowMenu) return;
+    if (typeof document === "undefined") return;
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (!target.closest("[data-overflow-menu]") && !target.closest("[data-overflow-trigger]")) {
+        setOverflowMenu(null);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [overflowMenu]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onResize = () => setOverflowMenu(null);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
 
   useEffect(() => {
     const handler = () => chatInputRef.current?.focus();
     window.addEventListener("focus-chat-input", handler);
     return () => window.removeEventListener("focus-chat-input", handler);
   }, []);
+
+  const overflowActions = useMemo(
+    () => ["Rename", "Duplicate", "Share", "Delete", "Settings", "Dark Mode", "Country"],
+    [],
+  );
+
+  const handleStartNewChat = () => {
+    const id = createNewThreadId();
+    const params = new URLSearchParams();
+    Object.entries(searchParams ?? {}).forEach(([key, value]) => {
+      if (typeof value === "string") {
+        params.set(key, value);
+      } else if (Array.isArray(value)) {
+        value.forEach(v => {
+          if (typeof v === "string") params.append(key, v);
+        });
+      }
+    });
+    params.set("panel", "chat");
+    params.set("threadId", id);
+    router.push(`/?${params.toString()}`);
+    setSidebarOpen(false);
+    setOverflowMenu(null);
+  };
+
+  const openOverflow = (anchor: HTMLElement) => {
+    try {
+      const rect = anchor.getBoundingClientRect();
+      const win = typeof window !== "undefined" ? window : undefined;
+      setOverflowMenu({
+        top: rect.bottom + 8,
+        right: Math.max((win?.innerWidth ?? 0) - rect.right - 8, 12),
+      });
+    } catch (error) {
+      console.error("Failed to open overflow menu", error);
+    }
+  };
 
   const renderPane = () => {
     switch (panel) {
@@ -38,14 +123,76 @@ export default function Page({ searchParams }: { searchParams: Search }) {
   };
 
   return (
-    <div className="flex flex-1 min-h-0 flex-col">
+    <div className="flex flex-1 min-h-0 flex-col bg-[#FFFFFF] text-[#0F172A] dark:bg-[#0B1220] dark:text-[#E6EDF7]">
       {panel === "chat" ? (
-        <ResearchFiltersProvider>
-          <ChatPane inputRef={chatInputRef} />
-        </ResearchFiltersProvider>
+        <>
+          <HeaderMobile
+            onToggleSidebar={() => setSidebarOpen(true)}
+            onStartNewChat={handleStartNewChat}
+            onOpenOverflow={openOverflow}
+          />
+
+          {process.env.NODE_ENV === "development" ? <FeatureDebug /> : null}
+
+          {overflowMenu && (
+            <div
+              data-overflow-menu
+              className="fixed z-50 w-48 overflow-hidden rounded-xl border border-[#E2E8F0] bg-[#F8FAFC]/95 text-sm text-[#0F172A] shadow-2xl backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]"
+              style={{ top: overflowMenu.top, right: overflowMenu.right }}
+            >
+              <ul className="divide-y divide-[#E2E8F0]/70 dark:divide-[#1E3A5F]/80">
+                {overflowActions.map(action => (
+                  <li key={action} className="px-3 py-2">
+                    {action === "Dark Mode" ? (
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-sm font-medium">Dark mode</span>
+                        <ThemeToggle className="h-8 px-3 text-xs" />
+                      </div>
+                    ) : action === "Country" ? (
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-sm font-medium">Country</span>
+                        <CountryGlobe />
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        className="flex w-full items-center justify-between gap-3 rounded-lg px-2 py-1.5 text-left text-sm font-medium transition hover:bg-[#E2E8F0]/60 dark:hover:bg-[#13233D]"
+                        onClick={() => {
+                          setOverflowMenu(null);
+                          if (action === "Settings") {
+                            router.push("/?panel=settings");
+                          }
+                        }}
+                      >
+                        <span>{action}</span>
+                        <svg
+                          viewBox="0 0 24 24"
+                          className="h-4 w-4 text-[#334155] dark:text-[#94A3B8]"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M9 18l6-6-6-6" />
+                        </svg>
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <SidebarDrawer open={sidebarOpen} onClose={() => setSidebarOpen(false)}>
+            <Sidebar />
+          </SidebarDrawer>
+
+          <ResearchFiltersProvider>
+            <ChatPane inputRef={chatInputRef} />
+          </ResearchFiltersProvider>
+        </>
       ) : (
         <div className="flex-1 min-h-0 overflow-y-auto">
-          <div className="m-6 rounded-2xl p-6 ring-1 ring-black/5 bg-white/80 dark:bg-slate-900/60 dark:ring-white/10">
+          <div className="m-6 rounded-2xl bg-white/80 p-6 ring-1 ring-black/5 dark:bg-slate-900/60 dark:ring-white/10">
             {renderPane()}
           </div>
         </div>

--- a/components/ChatErrorBoundary.tsx
+++ b/components/ChatErrorBoundary.tsx
@@ -1,0 +1,39 @@
+'use client';
+import React from 'react';
+
+type ChatErrorBoundaryProps = {
+  children: React.ReactNode;
+};
+
+type ChatErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export default class ChatErrorBoundary extends React.Component<ChatErrorBoundaryProps, ChatErrorBoundaryState> {
+  constructor(props: ChatErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ChatErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: React.ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('ChatErrorBoundary', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="mx-auto max-w-[720px] p-4 text-sm text-red-400">
+          Something went wrong loading the chat UI. Please reload.
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -1,43 +1,194 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useChatStore } from "@/lib/state/chatStore";
 import { useOpenPass } from "@/hooks/useOpenPass";
 
-export function ChatInput({ onSend }: { onSend: (text: string, locationToken?: string)=>Promise<void> }) {
+type ChatInputProps = {
+  onSend: (text: string, locationToken?: string, files?: File[], messageId?: string) => Promise<void>;
+};
+
+type Preview = {
+  id: string;
+  file: File;
+  url: string;
+};
+
+const MAX_TEXTAREA_HEIGHT = 168; // ~6 lines
+
+export function ChatInput({ onSend }: ChatInputProps) {
   const [text, setText] = useState("");
+  const [previews, setPreviews] = useState<Preview[]>([]);
   const startNewThread = useChatStore(s => s.startNewThread);
   const currentId = useChatStore(s => s.currentId);
   const addMessage = useChatStore(s => s.addMessage);
   const openPass = useOpenPass();
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   // auto-create a new thread when the user starts typing in a fresh session
   useEffect(() => {
-    if (!currentId && text.trim().length > 0) {
+    if (!currentId && (text.trim().length > 0 || previews.length > 0)) {
       startNewThread();
     }
-  }, [text, currentId, startNewThread]);
+  }, [text, previews.length, currentId, startNewThread]);
+
+  useEffect(() => {
+    return () => {
+      previews.forEach(p => URL.revokeObjectURL(p.url));
+    };
+  }, [previews]);
+
+  const adjustTextareaHeight = () => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    const next = Math.min(el.scrollHeight, MAX_TEXTAREA_HEIGHT);
+    el.style.height = `${next}px`;
+  };
+
+  useEffect(() => {
+    adjustTextareaHeight();
+  }, [text]);
+
+  const handleFilesSelected = (files: File[]) => {
+    if (!files.length) return;
+    const next = files.map(file => ({
+      id: crypto.randomUUID(),
+      file,
+      url: URL.createObjectURL(file),
+    }));
+    setPreviews(prev => [...prev, ...next]);
+  };
+
+  const removePreview = (id: string) => {
+    setPreviews(prev => {
+      const target = prev.find(p => p.id === id);
+      if (target) URL.revokeObjectURL(target.url);
+      return prev.filter(p => p.id !== id);
+    });
+  };
 
   const handleSend = async () => {
     const content = text.trim();
-    if (!content) return;
+    if (!content && previews.length === 0) return;
     // ensure a thread exists
     if (!currentId) startNewThread();
     // add user message locally (this also sets the title from first words)
-    addMessage({ role: "user", content });
+    const messageId = crypto.randomUUID();
+    addMessage({ id: messageId, role: "user", content });
+
+    const files = previews.map(p => p.file);
+    const urlsToFlush = previews.map(p => p.url);
     setText("");
+    setPreviews([]);
 
     let locationToken: string | undefined;
     if (/near me/i.test(content)) {
       locationToken = await openPass.getLocationToken() || undefined;
     }
 
-    await onSend(content, locationToken); // your existing streaming/send logic
+    await onSend(content, locationToken, files, messageId); // existing streaming/send logic
+
+    urlsToFlush.forEach(url => URL.revokeObjectURL(url));
   };
 
   return (
-    <div className="flex gap-2">
-      <textarea value={text} onChange={e=>setText(e.target.value)} placeholder="Type a message…" />
-      <button onClick={handleSend}>Send</button>
-    </div>
+    <>
+      {previews.length > 0 && (
+        <div className="fixed bottom-[76px] left-0 right-0 z-30 md:hidden">
+          <div className="mx-auto max-w-screen-md px-3">
+            <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+              {previews.map(preview => (
+                <div
+                  key={preview.id}
+                  className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-slate-700 bg-slate-900"
+                >
+                  {preview.file.type.startsWith("image/") ? (
+                    <img
+                      src={preview.url}
+                      alt={preview.file.name}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center px-2 text-center text-[11px] text-slate-200">
+                      {preview.file.name}
+                    </div>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => removePreview(preview.id)}
+                    className="absolute right-1 top-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-black/70 text-white"
+                    aria-label="Remove file"
+                  >
+                    ×
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="fixed inset-x-0 bottom-0 z-30 bg-slate-950/90 backdrop-blur md:static md:bg-transparent md:backdrop-blur-none">
+        <div className="mx-auto max-w-screen-md px-3 pb-[max(env(safe-area-inset-bottom),12px)] pt-2 md:max-w-none md:px-0 md:pb-0 md:pt-0">
+          <div className="flex items-end gap-2 rounded-2xl border border-slate-700 bg-slate-900 px-3 py-2 md:border-slate-200/60 md:bg-white/90 md:shadow-sm">
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-slate-800/80 text-slate-200 transition hover:bg-slate-800"
+              aria-label="Upload file"
+            >
+              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V17a3.5 3.5 0 1 1-7 0V6.5a2.5 2.5 0 0 1 5 0v9a1.5 1.5 0 1 1-3 0V7" />
+              </svg>
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept="image/*,application/pdf"
+              className="hidden"
+              onChange={event => {
+                const files = Array.from(event.target.files ?? []);
+                handleFilesSelected(files);
+                if (event.currentTarget) event.currentTarget.value = "";
+              }}
+            />
+
+            <div className="relative flex-1">
+              <textarea
+                ref={textareaRef}
+                rows={1}
+                value={text}
+                onChange={event => {
+                  setText(event.target.value);
+                  adjustTextareaHeight();
+                }}
+                placeholder="Type a message…"
+                className="max-h-[168px] w-full resize-none bg-transparent px-1 text-sm leading-6 text-white placeholder:text-slate-400 outline-none md:text-slate-900"
+                onKeyDown={event => {
+                  if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+                    event.preventDefault();
+                    void handleSend();
+                  }
+                }}
+              />
+            </div>
+
+            <button
+              type="button"
+              onClick={() => void handleSend()}
+              disabled={!text.trim() && previews.length === 0}
+              className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-600 text-white shadow-sm transition hover:bg-blue-500 disabled:opacity-40"
+              aria-label="Send message"
+            >
+              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 12l14-7-4 7 4 7-14-7z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -100,7 +100,7 @@ export function ChatInput({ onSend }: ChatInputProps) {
               {previews.map(preview => (
                 <div
                   key={preview.id}
-                  className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-slate-700 bg-slate-900"
+                  className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-[#E2E8F0] bg-white text-[#0F172A] shadow-sm dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7]"
                 >
                   {preview.file.type.startsWith("image/") ? (
                     <img
@@ -109,14 +109,14 @@ export function ChatInput({ onSend }: ChatInputProps) {
                       className="h-full w-full object-cover"
                     />
                   ) : (
-                    <div className="flex h-full w-full items-center justify-center px-2 text-center text-[11px] text-slate-200">
+                    <div className="flex h-full w-full items-center justify-center px-2 text-center text-[11px] font-medium">
                       {preview.file.name}
                     </div>
                   )}
                   <button
                     type="button"
                     onClick={() => removePreview(preview.id)}
-                    className="absolute right-1 top-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-black/70 text-white"
+                    className="absolute right-1 top-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-[#0F172A]/80 text-white dark:bg-white/30"
                     aria-label="Remove file"
                   >
                     ×
@@ -128,13 +128,13 @@ export function ChatInput({ onSend }: ChatInputProps) {
         </div>
       )}
 
-      <div className="fixed inset-x-0 bottom-0 z-30 bg-slate-950/90 backdrop-blur md:static md:bg-transparent md:backdrop-blur-none">
+      <div className="fixed inset-x-0 bottom-0 z-30 bg-white/95 backdrop-blur md:static md:bg-transparent md:backdrop-blur-none dark:bg-[#0F1B2D]/95">
         <div className="mx-auto max-w-screen-md px-3 pb-[max(env(safe-area-inset-bottom),12px)] pt-2 md:max-w-none md:px-0 md:pb-0 md:pt-0">
-          <div className="flex items-end gap-2 rounded-2xl border border-slate-700 bg-slate-900 px-3 py-2 md:border-slate-200/60 md:bg-white/90 md:shadow-sm">
+          <div className="flex items-end gap-2 rounded-2xl border border-[#E2E8F0] bg-white px-3 py-2 shadow-sm transition md:border-[#E2E8F0] md:bg-white dark:border-[#1E3A5F] dark:bg-[#0F1B2D]">
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
-              className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-slate-800/80 text-slate-200 transition hover:bg-slate-800"
+              className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full border border-transparent bg-[#F1F5F9] text-[#0F172A] transition hover:border-[#2563EB] hover:text-[#2563EB] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:border-[#3B82F6] dark:hover:text-[#3B82F6]"
               aria-label="Upload file"
             >
               <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
@@ -164,7 +164,7 @@ export function ChatInput({ onSend }: ChatInputProps) {
                   adjustTextareaHeight();
                 }}
                 placeholder="Type a message…"
-                className="max-h-[168px] w-full resize-none bg-transparent px-1 text-sm leading-6 text-white placeholder:text-slate-400 outline-none md:text-slate-900"
+                className="max-h-[168px] w-full resize-none bg-transparent px-1 text-[15px] leading-[1.6] text-[#0F172A] placeholder:text-[#94A3B8] outline-none md:text-base dark:text-[#E6EDF7] dark:placeholder:text-[#64748B]"
                 onKeyDown={event => {
                   if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
                     event.preventDefault();
@@ -178,7 +178,7 @@ export function ChatInput({ onSend }: ChatInputProps) {
               type="button"
               onClick={() => void handleSend()}
               disabled={!text.trim() && previews.length === 0}
-              className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-600 text-white shadow-sm transition hover:bg-blue-500 disabled:opacity-40"
+              className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#2563EB] text-white shadow-sm transition hover:bg-[#1D4ED8] disabled:opacity-40 dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
               aria-label="Send message"
             >
               <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useChatStore } from "@/lib/state/chatStore";
 import { useOpenPass } from "@/hooks/useOpenPass";
-import { ENABLE_MOBILE_UI } from "@/env";
 
 type ChatInputProps = {
   onSend: (text: string, locationToken?: string, files?: File[], messageId?: string) => Promise<void>;
@@ -121,7 +120,7 @@ export function ChatInput({ onSend }: ChatInputProps) {
 
   return (
     <>
-      {ENABLE_MOBILE_UI && previewsLength > 0 && (
+      {previewsLength > 0 && (
         <div className="fixed bottom-[76px] left-0 right-0 z-30 md:hidden">
           <div className="mx-auto max-w-screen-md px-3">
             <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useChatStore } from "@/lib/state/chatStore";
 import { useOpenPass } from "@/hooks/useOpenPass";
+import { ENABLE_MOBILE_UI } from "@/env";
 
 type ChatInputProps = {
   onSend: (text: string, locationToken?: string, files?: File[], messageId?: string) => Promise<void>;
@@ -24,8 +25,8 @@ export function ChatInput({ onSend }: ChatInputProps) {
   const openPass = useOpenPass();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const previewList = Array.isArray(previews) ? previews : [];
-  const previewsLength = previewList.length;
+  const files = Array.isArray(previews) ? previews : [];
+  const previewsLength = files.length;
 
   // auto-create a new thread when the user starts typing in a fresh session
   useEffect(() => {
@@ -57,9 +58,9 @@ export function ChatInput({ onSend }: ChatInputProps) {
     adjustTextareaHeight();
   }, [text]);
 
-  const handleFilesSelected = (files: File[]) => {
-    if (!Array.isArray(files) || files.length === 0) return;
-    const next = files.map(file => ({
+  const handleFilesSelected = (selectedFiles: File[]) => {
+    if (!Array.isArray(selectedFiles) || selectedFiles.length === 0) return;
+    const next = selectedFiles.map(file => ({
       id:
         typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
           ? crypto.randomUUID()
@@ -91,8 +92,8 @@ export function ChatInput({ onSend }: ChatInputProps) {
         : `msg-${Date.now()}-${Math.random().toString(16).slice(2)}`;
     addMessage({ id: messageId, role: "user", content });
 
-    const files = previewList.map(p => p.file);
-    const urlsToFlush = previewList.map(p => p.url);
+    const filesToSend = files.map(p => p.file);
+    const urlsToFlush = files.map(p => p.url);
     setText("");
     setPreviews([]);
 
@@ -106,7 +107,7 @@ export function ChatInput({ onSend }: ChatInputProps) {
     }
 
     try {
-      await onSend(content, locationToken, files, messageId); // existing streaming/send logic
+      await onSend(content, locationToken, filesToSend, messageId); // existing streaming/send logic
     } catch (error) {
       console.error('ChatInput send error', error);
     } finally {
@@ -120,11 +121,11 @@ export function ChatInput({ onSend }: ChatInputProps) {
 
   return (
     <>
-      {previewsLength > 0 && (
+      {ENABLE_MOBILE_UI && previewsLength > 0 && (
         <div className="fixed bottom-[76px] left-0 right-0 z-30 md:hidden">
           <div className="mx-auto max-w-screen-md px-3">
             <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-              {previewList.map(preview => (
+              {files.map(preview => (
                 <div
                   key={preview.id}
                   className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-[#E2E8F0] bg-white text-[#0F172A] shadow-sm dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7]"

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -23,6 +23,7 @@ export function ChatInput({ onSend }: ChatInputProps) {
   const addMessage = useChatStore(s => s.addMessage);
   const openPass = useOpenPass();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const desktopTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const files = Array.isArray(previews) ? previews : [];
   const previewsLength = files.length;
@@ -120,97 +121,128 @@ export function ChatInput({ onSend }: ChatInputProps) {
 
   return (
     <>
-      {previewsLength > 0 && (
-        <div className="fixed bottom-[76px] left-0 right-0 z-30 md:hidden">
-          <div className="mx-auto max-w-screen-md px-3">
-            <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-              {files.map(preview => (
-                <div
-                  key={preview.id}
-                  className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-[#E2E8F0] bg-[#FFFFFF] text-[#0F172A] shadow-sm dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7]"
-                >
-                  {preview.file.type.startsWith("image/") ? (
-                    <img
-                      src={preview.url}
-                      alt={preview.file.name}
-                      className="h-full w-full object-cover"
-                    />
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center px-2 text-center text-[11px] font-medium">
-                      {preview.file.name}
-                    </div>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => removePreview(preview.id)}
-                    className="absolute right-1 top-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-[#0F172A]/80 text-white dark:bg-white/30"
-                    aria-label="Remove file"
+      <div className="md:hidden">
+        {previewsLength > 0 && (
+          <div className="fixed bottom-[76px] left-0 right-0 z-30">
+            <div className="mx-auto max-w-screen-md px-3">
+              <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+                {files.map(preview => (
+                  <div
+                    key={preview.id}
+                    className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-[#E2E8F0] bg-[#FFFFFF] text-[#0F172A] shadow-sm dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7]"
                   >
-                    ×
-                  </button>
-                </div>
-              ))}
+                    {preview.file.type.startsWith("image/") ? (
+                      <img
+                        src={preview.url}
+                        alt={preview.file.name}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center px-2 text-center text-[11px] font-medium">
+                        {preview.file.name}
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => removePreview(preview.id)}
+                      className="absolute right-1 top-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-[#0F172A]/80 text-white dark:bg-white/30"
+                      aria-label="Remove file"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="fixed inset-x-0 bottom-0 z-30 bg-[#F8FAFC]/95 backdrop-blur dark:bg-[#0F1B2D]/95">
+          <div className="mx-auto max-w-screen-md px-3 pb-[max(env(safe-area-inset-bottom),12px)] pt-2">
+            <div className="flex items-end gap-2 rounded-2xl border border-[#E2E8F0] bg-[#FFFFFF] px-3 py-2 shadow-sm transition dark:border-[#1E3A5F] dark:bg-[#0F1B2D]">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full border border-transparent bg-[#F1F5F9] text-[#0F172A] transition hover:border-[#2563EB] hover:text-[#2563EB] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:border-[#3B82F6] dark:hover:text-[#3B82F6]"
+                aria-label="Upload file"
+              >
+                <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V17a3.5 3.5 0 1 1-7 0V6.5a2.5 2.5 0 0 1 5 0v9a1.5 1.5 0 1 1-3 0V7" />
+                </svg>
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept="image/*,application/pdf"
+                className="hidden"
+                onChange={event => {
+                  const files = Array.from(event.target.files ?? []);
+                  handleFilesSelected(files);
+                  if (event.currentTarget) event.currentTarget.value = "";
+                }}
+              />
+
+              <div className="relative flex-1">
+                <textarea
+                  ref={textareaRef}
+                  rows={1}
+                  value={text}
+                  onChange={event => {
+                    setText(event.target.value);
+                    adjustTextareaHeight();
+                  }}
+                  placeholder="Type a message…"
+                  className="max-h-[168px] w-full resize-none bg-transparent px-1 text-[15px] leading-[1.6] text-[#0F172A] placeholder:text-[#94A3B8] outline-none dark:text-[#E6EDF7] dark:placeholder:text-[#64748B]"
+                  onKeyDown={event => {
+                    if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+                      event.preventDefault();
+                      void handleSend();
+                    }
+                  }}
+                />
+              </div>
+
+              <button
+                type="button"
+                onClick={() => void handleSend()}
+                disabled={!text.trim() && previewsLength === 0}
+                className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#2563EB] text-white shadow-sm transition hover:bg-[#1D4ED8] disabled:opacity-40 dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+                aria-label="Send message"
+              >
+                <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 12l14-7-4 7 4 7-14-7z" />
+                </svg>
+              </button>
             </div>
           </div>
         </div>
-      )}
+      </div>
 
-      <div className="fixed inset-x-0 bottom-0 z-30 bg-[#F8FAFC]/95 backdrop-blur md:static md:bg-transparent md:backdrop-blur-none dark:bg-[#0F1B2D]/95">
-        <div className="mx-auto max-w-screen-md px-3 pb-[max(env(safe-area-inset-bottom),12px)] pt-2 md:max-w-none md:px-0 md:pb-0 md:pt-0">
-          <div className="flex items-end gap-2 rounded-2xl border border-[#E2E8F0] bg-[#FFFFFF] px-3 py-2 shadow-sm transition md:border-[#E2E8F0] md:bg-[#FFFFFF] dark:border-[#1E3A5F] dark:bg-[#0F1B2D]">
-            <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full border border-transparent bg-[#F1F5F9] text-[#0F172A] transition hover:border-[#2563EB] hover:text-[#2563EB] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:border-[#3B82F6] dark:hover:text-[#3B82F6]"
-              aria-label="Upload file"
-            >
-              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 10.5V17a3.5 3.5 0 1 1-7 0V6.5a2.5 2.5 0 0 1 5 0v9a1.5 1.5 0 1 1-3 0V7" />
-              </svg>
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              accept="image/*,application/pdf"
-              className="hidden"
-              onChange={event => {
-                const files = Array.from(event.target.files ?? []);
-                handleFilesSelected(files);
-                if (event.currentTarget) event.currentTarget.value = "";
+      <div className="hidden md:block">
+        <div className="border-t border-black/5 bg-white/80 px-6 py-4 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/50">
+          <div className="mx-auto flex max-w-screen-md items-center gap-3">
+            <textarea
+              ref={desktopTextareaRef}
+              rows={2}
+              value={text}
+              onChange={event => setText(event.target.value)}
+              placeholder="Type a message…"
+              className="h-24 flex-1 resize-none rounded-xl border border-black/10 bg-white/80 px-3 py-2 text-sm text-slate-700 outline-none transition focus:border-blue-600 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100"
+              onKeyDown={event => {
+                if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
+                  event.preventDefault();
+                  void handleSend();
+                }
               }}
             />
-
-            <div className="relative flex-1">
-              <textarea
-                ref={textareaRef}
-                rows={1}
-                value={text}
-                onChange={event => {
-                  setText(event.target.value);
-                  adjustTextareaHeight();
-                }}
-                placeholder="Type a message…"
-                className="max-h-[168px] w-full resize-none bg-transparent px-1 text-[15px] leading-[1.6] text-[#0F172A] placeholder:text-[#94A3B8] outline-none md:text-base dark:text-[#E6EDF7] dark:placeholder:text-[#64748B]"
-                onKeyDown={event => {
-                  if (event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing) {
-                    event.preventDefault();
-                    void handleSend();
-                  }
-                }}
-              />
-            </div>
-
             <button
               type="button"
               onClick={() => void handleSend()}
-              disabled={!text.trim() && previewsLength === 0}
-              className="inline-flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#2563EB] text-white shadow-sm transition hover:bg-[#1D4ED8] disabled:opacity-40 dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
-              aria-label="Send message"
+              disabled={!text.trim()}
+              className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500 disabled:opacity-40"
             >
-              <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 12l14-7-4 7 4 7-14-7z" />
-              </svg>
+              Send
             </button>
           </div>
         </div>

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -128,7 +128,7 @@ export function ChatInput({ onSend }: ChatInputProps) {
               {files.map(preview => (
                 <div
                   key={preview.id}
-                  className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-[#E2E8F0] bg-white text-[#0F172A] shadow-sm dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7]"
+                  className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-xl border border-[#E2E8F0] bg-[#FFFFFF] text-[#0F172A] shadow-sm dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7]"
                 >
                   {preview.file.type.startsWith("image/") ? (
                     <img
@@ -156,9 +156,9 @@ export function ChatInput({ onSend }: ChatInputProps) {
         </div>
       )}
 
-      <div className="fixed inset-x-0 bottom-0 z-30 bg-white/95 backdrop-blur md:static md:bg-transparent md:backdrop-blur-none dark:bg-[#0F1B2D]/95">
+      <div className="fixed inset-x-0 bottom-0 z-30 bg-[#F8FAFC]/95 backdrop-blur md:static md:bg-transparent md:backdrop-blur-none dark:bg-[#0F1B2D]/95">
         <div className="mx-auto max-w-screen-md px-3 pb-[max(env(safe-area-inset-bottom),12px)] pt-2 md:max-w-none md:px-0 md:pb-0 md:pt-0">
-          <div className="flex items-end gap-2 rounded-2xl border border-[#E2E8F0] bg-white px-3 py-2 shadow-sm transition md:border-[#E2E8F0] md:bg-white dark:border-[#1E3A5F] dark:bg-[#0F1B2D]">
+          <div className="flex items-end gap-2 rounded-2xl border border-[#E2E8F0] bg-[#FFFFFF] px-3 py-2 shadow-sm transition md:border-[#E2E8F0] md:bg-[#FFFFFF] dark:border-[#1E3A5F] dark:bg-[#0F1B2D]">
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -141,7 +141,7 @@ export function ChatWindow() {
       </div>
 
       {ENABLE_MOBILE_UI && (
-        <div className="md:hidden">
+        <div className="lg:hidden">
           <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-[#FFFFFF]/95 to-transparent dark:from-[#0B1220]/95" />
         </div>
       )}
@@ -155,7 +155,7 @@ export function ChatWindow() {
             el.scrollTo?.({ top: el.scrollHeight, behavior: "smooth" });
             setShowJump(false);
           }}
-          className="fixed bottom-20 right-4 z-20 md:hidden rounded-full p-2 bg-[#2563EB] text-white shadow-lg transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+          className="fixed bottom-20 right-4 z-20 lg:hidden rounded-full p-2 bg-[#2563EB] text-white shadow-lg transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
           aria-label="Jump to latest"
         >
           <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -8,6 +8,7 @@ import ScrollToBottom from "@/components/ui/ScrollToBottom";
 import { getResearchFlagFromUrl } from "@/utils/researchFlag";
 import { LinkBadge } from "@/components/SafeLink";
 import Message from "@/components/chat/Message";
+import { ENABLE_MOBILE_UI } from "@/env";
 
 export function ChatWindow() {
   const messages = useChatStore(s => s.currentId ? s.threads[s.currentId]?.messages ?? [] : []);
@@ -131,17 +132,19 @@ export function ChatWindow() {
         </div>
       </div>
 
-      <div className="md:hidden">
-        <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-white/95 via-white/40 to-transparent dark:from-[#0B1220]/95 dark:via-[#0B1220]/40" />
-      </div>
+      {ENABLE_MOBILE_UI ? (
+        <div className="md:hidden">
+          <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-white/95 via-white/40 to-transparent dark:from-[#0B1220]/95 dark:via-[#0B1220]/40" />
+        </div>
+      ) : null}
 
-      {showJump && (
+      {ENABLE_MOBILE_UI && showJump && (
         <button
           type="button"
           onClick={() => {
             const el = chatRef.current;
             if (!el) return;
-            el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+            el.scrollTo?.({ top: el.scrollHeight, behavior: "smooth" });
             setShowJump(false);
           }}
           className="fixed bottom-28 right-4 z-20 inline-flex h-11 w-11 items-center justify-center rounded-full bg-[#2563EB] text-white shadow-lg transition hover:bg-[#1D4ED8] md:hidden dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -8,7 +8,6 @@ import ScrollToBottom from "@/components/ui/ScrollToBottom";
 import { getResearchFlagFromUrl } from "@/utils/researchFlag";
 import { LinkBadge } from "@/components/SafeLink";
 import Message from "@/components/chat/Message";
-import { ENABLE_MOBILE_UI } from "@/env";
 
 const EMPTY_MESSAGES: ReadonlyArray<any> = [];
 
@@ -140,13 +139,11 @@ export function ChatWindow() {
         </div>
       </div>
 
-      {ENABLE_MOBILE_UI && (
-        <div className="lg:hidden">
-          <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-[#FFFFFF]/95 to-transparent dark:from-[#0B1220]/95" />
-        </div>
-      )}
+      <div className="lg:hidden">
+        <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-[#FFFFFF]/95 to-transparent dark:from-[#0B1220]/95" />
+      </div>
 
-      {ENABLE_MOBILE_UI && showJump && (
+      {showJump && (
         <button
           type="button"
           onClick={() => {

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -10,8 +10,16 @@ import { LinkBadge } from "@/components/SafeLink";
 import Message from "@/components/chat/Message";
 import { ENABLE_MOBILE_UI } from "@/env";
 
+const EMPTY_MESSAGES: ReadonlyArray<any> = [];
+
 export function ChatWindow() {
-  const messages = useChatStore(s => s.currentId ? s.threads[s.currentId]?.messages ?? [] : []);
+  const messages = useChatStore(state => {
+    const id = state.currentId;
+    if (!id) return EMPTY_MESSAGES;
+    const thread = state.threads[id];
+    const list = thread?.messages;
+    return Array.isArray(list) ? list : EMPTY_MESSAGES;
+  });
   const addMessage = useChatStore(s => s.addMessage);
   const currentId = useChatStore(s => s.currentId);
   const [results, setResults] = useState<any[]>([]);

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -81,7 +81,7 @@ export function ChatWindow() {
     <div className="flex h-full min-h-0 flex-col">
       <div
         ref={chatRef}
-        className="flex-1 overflow-y-auto px-3 pt-3 pb-32 md:px-6 md:pt-6 md:pb-6"
+        className="flex-1 overflow-y-auto px-3 pt-4 pb-32 md:px-8 md:pt-8 md:pb-10"
         onScroll={handleScroll}
       >
         <div className="mx-auto flex w-full max-w-screen-md flex-col gap-2">
@@ -94,7 +94,7 @@ export function ChatWindow() {
               <div key={m.id} className="relative">
                 <Message message={{ ...(m as any), attachments: attachmentUrls }} />
                 {showThinkingTimer ? (
-                  <div className="mt-1 flex justify-start px-2 text-sm text-slate-400">
+                  <div className="mt-1 flex justify-start px-2 text-sm text-[#64748B] dark:text-[#CBD5F5]">
                     <AnalyzingInline active={showThinkingTimer} />
                   </div>
                 ) : null}
@@ -103,16 +103,16 @@ export function ChatWindow() {
           })}
 
           {results.length > 0 && (
-            <div className="rounded-2xl border border-slate-700/60 bg-slate-900/70 p-3 text-sm text-slate-200 md:border-slate-200/70 md:bg-white/80 md:text-slate-900">
+            <div className="rounded-2xl border border-[#1E3A5F] bg-[#13233D] p-4 text-sm text-[#E6EDF7] md:border-[#E2E8F0] md:bg-[#F8FAFC] md:text-[#0F172A]">
               <div className="mb-2 font-semibold">Nearby places</div>
               <div className="space-y-3">
                 {results.map((place) => (
-                  <div key={place.id} className="rounded-xl border border-white/5 bg-slate-950/40 p-3 md:border-slate-200/60 md:bg-white/70">
-                    <p className="font-medium">{place.name}</p>
+                  <div key={place.id} className="rounded-xl border border-[#1E3A5F] bg-[#0F1B2D] p-3 text-[#E6EDF7] md:border-[#E2E8F0] md:bg-white md:text-[#0F172A]">
+                    <p className="font-medium leading-6">{place.name}</p>
                     <p className="text-xs opacity-80">{place.address}</p>
                     <div className="mt-2 flex flex-wrap items-center gap-3 text-xs">
                       {place.phone && (
-                        <a href={`tel:${place.phone}`} className="text-blue-300 underline md:text-blue-600">
+                        <a href={`tel:${place.phone}`} className="text-[#3B82F6] underline md:text-[#2563EB]">
                           Call
                         </a>
                       )}
@@ -132,7 +132,7 @@ export function ChatWindow() {
       </div>
 
       <div className="md:hidden">
-        <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-slate-950/95 to-transparent" />
+        <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-white/95 via-white/40 to-transparent dark:from-[#0B1220]/95 dark:via-[#0B1220]/40" />
       </div>
 
       {showJump && (
@@ -144,14 +144,12 @@ export function ChatWindow() {
             el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
             setShowJump(false);
           }}
-          className="fixed bottom-24 left-1/2 z-20 -translate-x-1/2 rounded-full bg-blue-600 px-3 py-2 text-xs font-medium text-white shadow-lg md:hidden"
+          className="fixed bottom-28 right-4 z-20 inline-flex h-11 w-11 items-center justify-center rounded-full bg-[#2563EB] text-white shadow-lg transition hover:bg-[#1D4ED8] md:hidden dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+          aria-label="Jump to latest"
         >
-          <span className="inline-flex items-center gap-1">
-            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 12l6 6 6-6" />
-            </svg>
-            Jump to latest
-          </span>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 10l6 6 6-6" />
+          </svg>
         </button>
       )}
 

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -90,7 +90,7 @@ export function ChatWindow() {
     <div className="flex h-full min-h-0 flex-col">
       <div
         ref={chatRef}
-        className="flex-1 overflow-y-auto px-3 pt-4 pb-32 md:px-8 md:pt-8 md:pb-10"
+        className="flex-1 overflow-y-auto px-3 pt-3 pb-24 md:px-6 md:pt-6 md:pb-6"
         onScroll={handleScroll}
       >
         <div className="mx-auto flex w-full max-w-screen-md flex-col gap-2">
@@ -140,11 +140,11 @@ export function ChatWindow() {
         </div>
       </div>
 
-      {ENABLE_MOBILE_UI ? (
+      {ENABLE_MOBILE_UI && (
         <div className="md:hidden">
-          <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-white/95 via-white/40 to-transparent dark:from-[#0B1220]/95 dark:via-[#0B1220]/40" />
+          <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-[#FFFFFF]/95 to-transparent dark:from-[#0B1220]/95" />
         </div>
-      ) : null}
+      )}
 
       {ENABLE_MOBILE_UI && showJump && (
         <button
@@ -155,7 +155,7 @@ export function ChatWindow() {
             el.scrollTo?.({ top: el.scrollHeight, behavior: "smooth" });
             setShowJump(false);
           }}
-          className="fixed bottom-28 right-4 z-20 inline-flex h-11 w-11 items-center justify-center rounded-full bg-[#2563EB] text-white shadow-lg transition hover:bg-[#1D4ED8] md:hidden dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+          className="fixed bottom-20 right-4 z-20 md:hidden rounded-full p-2 bg-[#2563EB] text-white shadow-lg transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
           aria-label="Jump to latest"
         >
           <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,22 +1,13 @@
 "use client";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useChatStore } from "@/lib/state/chatStore";
 import { ChatInput } from "@/components/ChatInput";
 import { persistIfTemp } from "@/lib/chat/persist";
 import { AnalyzingInline } from "@/components/chat/AnalyzingInline";
 import ScrollToBottom from "@/components/ui/ScrollToBottom";
 import { getResearchFlagFromUrl } from "@/utils/researchFlag";
-import ChatMarkdown from "@/components/ChatMarkdown";
 import { LinkBadge } from "@/components/SafeLink";
-
-function MessageRow({ m }: { m: { id: string; role: string; content: string } }) {
-  return (
-    <div className="p-2 space-y-1">
-      <div className="text-xs uppercase tracking-wide text-slate-500">{m.role}</div>
-      <ChatMarkdown content={m.content} />
-    </div>
-  );
-}
+import Message from "@/components/chat/Message";
 
 export function ChatWindow() {
   const messages = useChatStore(s => s.currentId ? s.threads[s.currentId]?.messages ?? [] : []);
@@ -25,11 +16,49 @@ export function ChatWindow() {
   const [results, setResults] = useState<any[]>([]);
   const chatRef = useRef<HTMLDivElement>(null);
   const [isThinking, setIsThinking] = useState(false);
+  const [showJump, setShowJump] = useState(false);
+  const [attachments, setAttachments] = useState<Record<string, { url: string; name: string }[]>>({});
 
-  const handleSend = async (content: string, locationToken?: string) => {
+  useEffect(() => {
+    return () => {
+      Object.values(attachments).forEach(group => {
+        group.forEach(item => URL.revokeObjectURL(item.url));
+      });
+    };
+  }, [attachments]);
+
+  useEffect(() => {
+    Object.values(attachments).forEach(group => {
+      group.forEach(item => URL.revokeObjectURL(item.url));
+    });
+    setAttachments({});
+  }, [currentId]);
+
+  const handleScroll = () => {
+    const el = chatRef.current;
+    if (!el) return;
+    const distance = el.scrollHeight - (el.scrollTop + el.clientHeight);
+    setShowJump(distance > 200);
+  };
+
+  useEffect(() => {
+    handleScroll();
+  }, [messages.length]);
+
+  const handleSend = async (content: string, locationToken?: string, files?: File[], messageId?: string) => {
     // after sending user message, persist thread if needed
     await persistIfTemp();
     setIsThinking(true);
+
+    if (files?.length && messageId) {
+      const previews = files
+        .filter(file => file.type.startsWith("image/"))
+        .map(file => ({ url: URL.createObjectURL(file), name: file.name }));
+      if (previews.length) {
+        setAttachments(prev => ({ ...prev, [messageId]: previews }));
+      }
+    }
+
     if (locationToken) {
       const research = getResearchFlagFromUrl();
       const res = await fetch("/api/chat", {
@@ -49,49 +78,83 @@ export function ChatWindow() {
   };
 
   return (
-    <div className="flex flex-col h-full">
-      <div ref={chatRef} className="flex-1 overflow-auto">
-        {messages.map((m, idx) => {
-          const isLastMessage = idx === messages.length - 1;
-          const showThinkingTimer = isLastMessage && isThinking;
-          return (
-            <div key={m.id} className="space-y-2">
-              <MessageRow m={m} />
-              {showThinkingTimer ? (
-                <div className="px-2">
-                  <div className="mt-1 inline-flex items-center gap-3 text-sm text-slate-500">
-                    <span>Thinking…</span>
+    <div className="flex h-full min-h-0 flex-col">
+      <div
+        ref={chatRef}
+        className="flex-1 overflow-y-auto px-3 pt-3 pb-32 md:px-6 md:pt-6 md:pb-6"
+        onScroll={handleScroll}
+      >
+        <div className="mx-auto flex w-full max-w-screen-md flex-col gap-2">
+          {messages.map((m, idx) => {
+            const isLastMessage = idx === messages.length - 1;
+            const showThinkingTimer = isLastMessage && isThinking;
+            const attachmentUrls = attachments[m.id]?.map(item => item.url) ?? [];
+
+            return (
+              <div key={m.id} className="relative">
+                <Message message={{ ...(m as any), attachments: attachmentUrls }} />
+                {showThinkingTimer ? (
+                  <div className="mt-1 flex justify-start px-2 text-sm text-slate-400">
                     <AnalyzingInline active={showThinkingTimer} />
                   </div>
-                </div>
-              ) : null}
-            </div>
-          );
-        })}
-        {results.length > 0 && (
-          <div className="p-2 space-y-2">
-            {results.map((place) => (
-              <div key={place.id} className="result-card border p-2 rounded">
-                <p>{place.name}</p>
-                <p className="text-sm opacity-80">{place.address}</p>
-                <div className="flex flex-wrap items-center gap-3 text-sm">
-                  {place.phone && (
-                    <a href={`tel:${place.phone}`} className="underline">
-                      Call
-                    </a>
-                  )}
-                  {place.mapLink && (
-                    <LinkBadge href={place.mapLink}>
-                      Directions
-                    </LinkBadge>
-                  )}
-                  <span className="opacity-70">{place.distance_km} km</span>
-                </div>
+                ) : null}
               </div>
-            ))}
-          </div>
-        )}
+            );
+          })}
+
+          {results.length > 0 && (
+            <div className="rounded-2xl border border-slate-700/60 bg-slate-900/70 p-3 text-sm text-slate-200 md:border-slate-200/70 md:bg-white/80 md:text-slate-900">
+              <div className="mb-2 font-semibold">Nearby places</div>
+              <div className="space-y-3">
+                {results.map((place) => (
+                  <div key={place.id} className="rounded-xl border border-white/5 bg-slate-950/40 p-3 md:border-slate-200/60 md:bg-white/70">
+                    <p className="font-medium">{place.name}</p>
+                    <p className="text-xs opacity-80">{place.address}</p>
+                    <div className="mt-2 flex flex-wrap items-center gap-3 text-xs">
+                      {place.phone && (
+                        <a href={`tel:${place.phone}`} className="text-blue-300 underline md:text-blue-600">
+                          Call
+                        </a>
+                      )}
+                      {place.mapLink && (
+                        <LinkBadge href={place.mapLink}>
+                          Directions
+                        </LinkBadge>
+                      )}
+                      <span className="opacity-70">{place.distance_km} km</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
+
+      <div className="md:hidden">
+        <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-slate-950/95 to-transparent" />
+      </div>
+
+      {showJump && (
+        <button
+          type="button"
+          onClick={() => {
+            const el = chatRef.current;
+            if (!el) return;
+            el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+            setShowJump(false);
+          }}
+          className="fixed bottom-24 left-1/2 z-20 -translate-x-1/2 rounded-full bg-blue-600 px-3 py-2 text-xs font-medium text-white shadow-lg md:hidden"
+        >
+          <span className="inline-flex items-center gap-1">
+            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 12l6 6 6-6" />
+            </svg>
+            Jump to latest
+          </span>
+        </button>
+      )}
+
       <ChatInput onSend={handleSend} />
       <ScrollToBottom targetRef={chatRef} rebindKey={currentId} />
     </div>

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -89,10 +89,10 @@ export function ChatWindow() {
     <div className="flex h-full min-h-0 flex-col">
       <div
         ref={chatRef}
-        className="flex-1 overflow-y-auto px-3 pt-3 pb-24 md:px-6 md:pt-6 md:pb-6"
+        className="flex-1 overflow-y-auto px-3 pt-3 pb-24 md:px-0 md:pt-0 md:pb-0"
         onScroll={handleScroll}
       >
-        <div className="mx-auto flex w-full max-w-screen-md flex-col gap-2">
+        <div className="mx-auto flex w-full max-w-screen-md flex-col gap-2 md:max-w-none md:gap-0">
           {messages.map((m, idx) => {
             const isLastMessage = idx === messages.length - 1;
             const showThinkingTimer = isLastMessage && isThinking;
@@ -139,7 +139,7 @@ export function ChatWindow() {
         </div>
       </div>
 
-      <div className="lg:hidden">
+      <div className="md:hidden">
         <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-[#FFFFFF]/95 to-transparent dark:from-[#0B1220]/95" />
       </div>
 
@@ -152,7 +152,7 @@ export function ChatWindow() {
             el.scrollTo?.({ top: el.scrollHeight, behavior: "smooth" });
             setShowJump(false);
           }}
-          className="fixed bottom-20 right-4 z-20 lg:hidden rounded-full p-2 bg-[#2563EB] text-white shadow-lg transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+          className="fixed bottom-20 right-4 z-20 md:hidden rounded-full p-2 bg-[#2563EB] text-white shadow-lg transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
           aria-label="Jump to latest"
         >
           <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">

--- a/components/CountryGlobe.tsx
+++ b/components/CountryGlobe.tsx
@@ -25,7 +25,7 @@ export default function CountryGlobe() {
         aria-label="Choose country"
         title={`Country: ${country.name} (${country.code3}) — click to change`}
         onClick={() => setOpen(v => !v)}
-        className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/70 pl-3 pr-6 py-1.5 text-sm font-medium text-slate-900 shadow-sm transition hover:bg-white dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100 dark:hover:bg-slate-900"
+        className="inline-flex items-center gap-2 rounded-full border border-[#E2E8F0] bg-white px-3 py-1.5 text-sm font-medium text-[#0F172A] shadow-sm transition hover:border-[#2563EB] hover:text-[#2563EB] dark:border-[#1E3A5F] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:border-[#3B82F6] dark:hover:text-[#3B82F6]"
       >
         <Globe2 className="h-4 w-4" />
         <span className="tabular-nums">{country.code3}</span>
@@ -35,16 +35,16 @@ export default function CountryGlobe() {
         <div
           role="dialog"
           aria-label="Select country"
-          className="absolute right-0 top-[110%] z-50 mt-2 w-72 rounded-xl border border-black/10 bg-white/95 p-3 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-950/90"
+          className="absolute right-0 top-[110%] z-50 mt-2 w-72 rounded-xl border border-[#E2E8F0] bg-white/95 p-3 shadow-xl backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95"
         >
-          <div className="mb-2 flex items-center gap-2 rounded-lg border border-black/10 bg-white/80 px-3 py-1.5 dark:border-white/10 dark:bg-slate-900/60">
-            <Search className="h-4 w-4 text-slate-500 dark:text-slate-400" />
+          <div className="mb-2 flex items-center gap-2 rounded-lg border border-[#E2E8F0] bg-white px-3 py-1.5 dark:border-[#1E3A5F] dark:bg-[#13233D]">
+            <Search className="h-4 w-4 text-[#64748B] dark:text-[#94A3B8]" />
             <input
               autoFocus
               value={q}
               onChange={e => setQ(e.target.value)}
               placeholder="Search country or code…"
-              className="w-full bg-transparent text-sm text-slate-700 placeholder:text-slate-400 focus:outline-none dark:text-slate-100 dark:placeholder:text-slate-500"
+              className="w-full bg-transparent text-sm text-[#0F172A] placeholder:text-[#94A3B8] focus:outline-none dark:text-[#E6EDF7] dark:placeholder:text-[#64748B]"
             />
           </div>
 
@@ -56,15 +56,15 @@ export default function CountryGlobe() {
                   setCountry(c.code3);
                   setOpen(false);
                 }}
-                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition hover:bg-slate-100 dark:hover:bg-slate-800"
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition hover:bg-[#E2E8F0]/60 dark:hover:bg-[#13233D]"
               >
                 <span className="text-lg">{c.flag}</span>
                 <div className="flex flex-1 items-center justify-between gap-3">
-                  <span className="truncate text-sm">{c.name}</span>
-                  <span className="text-xs font-semibold tabular-nums text-slate-500 dark:text-slate-400">{c.code3}</span>
+                  <span className="truncate text-sm text-[#0F172A] dark:text-[#E6EDF7]">{c.name}</span>
+                  <span className="text-xs font-semibold tabular-nums text-[#64748B] dark:text-[#94A3B8]">{c.code3}</span>
                 </div>
                 {country.code3 === c.code3 && (
-                  <Check className="h-4 w-4 text-blue-500" />
+                  <Check className="h-4 w-4 text-[#2563EB] dark:text-[#3B82F6]" />
                 )}
               </button>
             ))}

--- a/components/FeatureDebug.tsx
+++ b/components/FeatureDebug.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useEffect, useState } from "react";
+import { ENABLE_MOBILE_UI } from "@/env";
+
+export default function FeatureDebug() {
+  const [size, setSize] = useState<{ width: number | null; height: number | null }>({ width: null, height: null });
+
+  useEffect(() => {
+    const update = () => {
+      setSize({ width: window.innerWidth, height: window.innerHeight });
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  const { width, height } = size;
+  const md = width !== null && width >= 768;
+  const lg = width !== null && width >= 1024;
+
+  return (
+    <div className="fixed bottom-2 left-2 z-[9999] rounded bg-black/70 px-2 py-1 text-[10px] font-medium text-white shadow-lg">
+      UI:{ENABLE_MOBILE_UI ? "ON" : "OFF"} | {width ?? "?"}×{height ?? "?"} | md≥768? {md ? "yes" : "no"} | lg≥1024? {lg ? "yes" : "no"}
+    </div>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,5 @@
 'use client';
+import type { MouseEvent } from 'react';
 import CountryGlobe from '@/components/CountryGlobe';
 import Brand from '@/components/nav/Brand';
 import ModeBar from '@/components/modes/ModeBar';
@@ -38,12 +39,40 @@ export function HeaderMobile({
   onStartNewChat,
   onOpenOverflow,
 }: HeaderMobileProps) {
+  const logError = (error: unknown) => {
+    console.error('HeaderMobile handler error', error);
+  };
+
+  const handleToggleSidebar = () => {
+    try {
+      onToggleSidebar?.();
+    } catch (error) {
+      logError(error);
+    }
+  };
+
+  const handleStartNewChat = () => {
+    try {
+      onStartNewChat?.();
+    } catch (error) {
+      logError(error);
+    }
+  };
+
+  const handleOpenOverflow = (event: MouseEvent<HTMLButtonElement>) => {
+    try {
+      onOpenOverflow?.(event.currentTarget);
+    } catch (error) {
+      logError(error);
+    }
+  };
+
   return (
     <header className="sticky top-0 z-40 bg-[#F8FAFC]/95 text-[#0F172A] backdrop-blur md:hidden dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]">
       <div className="flex items-center justify-between gap-2 px-3 pb-2 pt-[max(env(safe-area-inset-top),12px)]">
         <button
           type="button"
-          onClick={onToggleSidebar}
+          onClick={handleToggleSidebar}
           className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[#E2E8F0] bg-white text-[#0F172A] shadow-sm transition hover:bg-[#F1F5F9] dark:border-[#1E3A5F] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:bg-[#172A46]"
           aria-label="Open navigation"
         >
@@ -59,7 +88,7 @@ export function HeaderMobile({
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={onStartNewChat}
+            onClick={handleStartNewChat}
             className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-[#2563EB] text-white shadow-sm transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
             aria-label="Start new chat"
           >
@@ -70,11 +99,7 @@ export function HeaderMobile({
 
           <button
             type="button"
-            onClick={event => {
-              if (onOpenOverflow) {
-                onOpenOverflow(event.currentTarget);
-              }
-            }}
+            onClick={handleOpenOverflow}
             data-overflow-trigger
             className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[#E2E8F0] bg-white text-[#0F172A] shadow-sm transition hover:bg-[#F1F5F9] dark:border-[#1E3A5F] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:bg-[#172A46]"
             aria-label="More options"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,7 +6,7 @@ import ThemeToggle from '@/components/ThemeToggle';
 
 export default function Header() {
   return (
-    <header className="sticky top-0 z-40 hidden border-b border-black/10 bg-white/80 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/40 md:block">
+    <header className="sticky top-0 z-40 hidden border-b border-[#E2E8F0] bg-[#F8FAFC]/90 text-[#0F172A] backdrop-blur-md dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/90 dark:text-[#E6EDF7] md:block">
       <div className="mx-auto flex h-[62px] w-full max-w-screen-2xl items-center gap-4 px-6">
         <div className="flex shrink-0 items-center gap-3 text-base font-semibold md:text-lg">
           <Brand />
@@ -39,12 +39,12 @@ export function HeaderMobile({
   onOpenOverflow,
 }: HeaderMobileProps) {
   return (
-    <header className="md:hidden sticky top-0 z-40 bg-slate-950/90 backdrop-blur">
+    <header className="sticky top-0 z-40 bg-[#F8FAFC]/95 text-[#0F172A] backdrop-blur md:hidden dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]">
       <div className="flex items-center justify-between gap-2 px-3 pb-2 pt-[max(env(safe-area-inset-top),12px)]">
         <button
           type="button"
           onClick={onToggleSidebar}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-900/70 text-slate-200 shadow-sm ring-1 ring-white/5"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[#E2E8F0] bg-white text-[#0F172A] shadow-sm transition hover:bg-[#F1F5F9] dark:border-[#1E3A5F] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:bg-[#172A46]"
           aria-label="Open navigation"
         >
           <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
@@ -52,7 +52,7 @@ export function HeaderMobile({
           </svg>
         </button>
 
-        <div className="flex-1 px-1 text-center text-sm font-semibold tracking-wide text-slate-100">
+        <div className="flex-1 px-1 text-center text-sm font-semibold tracking-wide">
           {title}
         </div>
 
@@ -60,7 +60,7 @@ export function HeaderMobile({
           <button
             type="button"
             onClick={onStartNewChat}
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-blue-600/90 text-white shadow-sm ring-1 ring-blue-400/40"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-[#2563EB] text-white shadow-sm transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
             aria-label="Start new chat"
           >
             <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
@@ -76,7 +76,7 @@ export function HeaderMobile({
               }
             }}
             data-overflow-trigger
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-900/70 text-slate-200 shadow-sm ring-1 ring-white/5"
+            className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[#E2E8F0] bg-white text-[#0F172A] shadow-sm transition hover:bg-[#F1F5F9] dark:border-[#1E3A5F] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:bg-[#172A46]"
             aria-label="More options"
           >
             <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -68,7 +68,7 @@ export function HeaderMobile({
   };
 
   return (
-    <header className="lg:hidden sticky top-0 z-40 bg-[#F8FAFC]/95 text-[#0F172A] backdrop-blur dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]">
+    <header className="lg:hidden sticky top-0 z-50 bg-[#F8FAFC]/95 text-[#0F172A] backdrop-blur dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]">
       <div className="flex items-center justify-between gap-2 px-3 pb-2 pt-[max(env(safe-area-inset-top),12px)]">
         <button
           type="button"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,21 +7,19 @@ import ThemeToggle from '@/components/ThemeToggle';
 
 export default function Header() {
   return (
-    <header className="sticky top-0 z-40 hidden border-b border-[#E2E8F0] bg-[#F8FAFC]/90 text-[#0F172A] backdrop-blur-md dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/90 dark:text-[#E6EDF7] md:block">
-      <div className="mx-auto w-full max-w-screen-2xl px-6 py-3">
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex shrink-0 items-center gap-3 text-base font-semibold md:text-lg">
-            <Brand />
-          </div>
-
-          <div className="flex items-center gap-3">
-            <ThemeToggle />
-            <CountryGlobe />
-          </div>
+    <header className="sticky top-0 z-40 border-b border-black/10 bg-white/80 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/40">
+      <div className="mx-auto flex h-[62px] w-full max-w-screen-2xl items-center gap-4 px-6">
+        <div className="flex shrink-0 items-center gap-3 text-base font-semibold md:text-lg">
+          <Brand />
         </div>
 
-        <div className="mt-2">
+        <div className="flex flex-1 justify-center">
           <ModeBar />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <ThemeToggle />
+          <CountryGlobe />
         </div>
       </div>
     </header>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,7 +6,7 @@ import ThemeToggle from '@/components/ThemeToggle';
 
 export default function Header() {
   return (
-    <header className="sticky top-0 z-40 border-b border-black/10 bg-white/80 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/40">
+    <header className="sticky top-0 z-40 hidden border-b border-black/10 bg-white/80 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/40 md:block">
       <div className="mx-auto flex h-[62px] w-full max-w-screen-2xl items-center gap-4 px-6">
         <div className="flex shrink-0 items-center gap-3 text-base font-semibold md:text-lg">
           <Brand />
@@ -19,6 +19,72 @@ export default function Header() {
         <div className="flex items-center gap-3">
           <ThemeToggle />
           <CountryGlobe />
+        </div>
+      </div>
+    </header>
+  );
+}
+
+type HeaderMobileProps = {
+  title?: string;
+  onToggleSidebar?: () => void;
+  onStartNewChat?: () => void;
+  onOpenOverflow?: (anchor: HTMLElement) => void;
+};
+
+export function HeaderMobile({
+  title = "Second Opinion",
+  onToggleSidebar,
+  onStartNewChat,
+  onOpenOverflow,
+}: HeaderMobileProps) {
+  return (
+    <header className="md:hidden sticky top-0 z-40 bg-slate-950/90 backdrop-blur">
+      <div className="flex items-center justify-between gap-2 px-3 pb-2 pt-[max(env(safe-area-inset-top),12px)]">
+        <button
+          type="button"
+          onClick={onToggleSidebar}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-900/70 text-slate-200 shadow-sm ring-1 ring-white/5"
+          aria-label="Open navigation"
+        >
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+
+        <div className="flex-1 px-1 text-center text-sm font-semibold tracking-wide text-slate-100">
+          {title}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onStartNewChat}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-blue-600/90 text-white shadow-sm ring-1 ring-blue-400/40"
+            aria-label="Start new chat"
+          >
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
+            </svg>
+          </button>
+
+          <button
+            type="button"
+            onClick={event => {
+              if (onOpenOverflow) {
+                onOpenOverflow(event.currentTarget);
+              }
+            }}
+            data-overflow-trigger
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-slate-900/70 text-slate-200 shadow-sm ring-1 ring-white/5"
+            aria-label="More options"
+          >
+            <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.8">
+              <circle cx="12" cy="6" r="1.5" />
+              <circle cx="12" cy="12" r="1.5" />
+              <circle cx="12" cy="18" r="1.5" />
+            </svg>
+          </button>
         </div>
       </div>
     </header>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -68,7 +68,7 @@ export function HeaderMobile({
   };
 
   return (
-    <header className="md:hidden sticky top-0 z-40 bg-[#F8FAFC]/95 text-[#0F172A] backdrop-blur dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]">
+    <header className="lg:hidden sticky top-0 z-40 bg-[#F8FAFC]/95 text-[#0F172A] backdrop-blur dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]">
       <div className="flex items-center justify-between gap-2 px-3 pb-2 pt-[max(env(safe-area-inset-top),12px)]">
         <button
           type="button"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -68,7 +68,7 @@ export function HeaderMobile({
   };
 
   return (
-    <header className="sticky top-0 z-40 bg-[#F8FAFC]/95 text-[#0F172A] backdrop-blur md:hidden dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]">
+    <header className="md:hidden sticky top-0 z-40 bg-[#F8FAFC]/95 text-[#0F172A] backdrop-blur dark:bg-[#0F1B2D]/95 dark:text-[#E6EDF7]">
       <div className="flex items-center justify-between gap-2 px-3 pb-2 pt-[max(env(safe-area-inset-top),12px)]">
         <button
           type="button"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,18 +8,20 @@ import ThemeToggle from '@/components/ThemeToggle';
 export default function Header() {
   return (
     <header className="sticky top-0 z-40 hidden border-b border-[#E2E8F0] bg-[#F8FAFC]/90 text-[#0F172A] backdrop-blur-md dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/90 dark:text-[#E6EDF7] md:block">
-      <div className="mx-auto flex h-[62px] w-full max-w-screen-2xl items-center gap-4 px-6">
-        <div className="flex shrink-0 items-center gap-3 text-base font-semibold md:text-lg">
-          <Brand />
+      <div className="mx-auto w-full max-w-screen-2xl px-6 py-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex shrink-0 items-center gap-3 text-base font-semibold md:text-lg">
+            <Brand />
+          </div>
+
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <CountryGlobe />
+          </div>
         </div>
 
-        <div className="flex flex-1 justify-center">
+        <div className="mt-2">
           <ModeBar />
-        </div>
-
-        <div className="flex items-center gap-3">
-          <ThemeToggle />
-          <CountryGlobe />
         </div>
       </div>
     </header>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -31,11 +31,11 @@ export function SidebarDrawer({ open, onClose, children }: SidebarDrawerProps) {
         aria-hidden={!open}
       />
       <aside
-        className={`fixed inset-y-0 left-0 z-50 w-[86vw] max-w-[320px] transform border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] shadow-xl transition-transform duration-200 ease-out dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:static md:block md:translate-x-0 md:w-72 md:border-r md:border-[#E2E8F0] md:bg-[#F8FAFC] md:text-[#0F172A] md:shadow-none ${
+        className={`fixed inset-y-0 left-0 z-50 w-[86vw] max-w-[320px] transform border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] shadow-xl transition-transform duration-200 ease-out dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:static md:block md:translate-x-0 md:w-72 md:border-r md:border-black/10 md:bg-white/80 md:text-medx md:shadow-none md:backdrop-blur ${
           open ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
-        <div className="flex h-full flex-col overflow-y-auto px-4 pb-6 pt-4 md:h-auto md:overflow-visible md:px-0 md:pt-0">
+        <div className="flex h-full flex-col overflow-y-auto px-4 pb-6 pt-4 md:h-auto md:overflow-visible md:px-4 md:pb-0 md:pt-6">
           {children}
         </div>
       </aside>
@@ -80,11 +80,11 @@ export default function Sidebar() {
   };
   const filtered = threads.filter(t => (t.title ?? '').toLowerCase().includes(q.toLowerCase()));
   return (
-    <div className="sidebar-click-guard flex h-full w-full flex-col gap-4 px-4 pt-6 pb-0 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
+    <div className="sidebar-click-guard flex h-full w-full flex-col gap-4 px-4 pt-6 pb-0 text-sm text-[#0F172A] dark:text-[#E6EDF7] md:text-medx">
       <button
         type="button"
         onClick={handleNew}
-        className="w-full rounded-full bg-[#2563EB] px-4 py-2.5 text-left font-semibold text-white shadow-sm transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+        className="w-full rounded-full bg-[#2563EB] px-4 py-2.5 text-left font-semibold text-white shadow-sm transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB] md:bg-blue-600 md:hover:bg-blue-500"
       >
         + New Chat
       </button>
@@ -92,11 +92,11 @@ export default function Sidebar() {
       <div>
         <div className="relative">
           <input
-            className="h-10 w-full rounded-full border border-[#E2E8F0] bg-white pl-3 pr-8 text-sm text-[#0F172A] placeholder:text-[#64748B] transition focus:border-[#2563EB] focus:outline-none dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] dark:placeholder:text-[#94A3B8] dark:focus:border-[#3B82F6]"
+            className="h-10 w-full rounded-full border border-[#E2E8F0] bg-white pl-3 pr-8 text-sm text-[#0F172A] placeholder:text-[#64748B] transition focus:border-[#2563EB] focus:outline-none dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] dark:placeholder:text-[#94A3B8] dark:focus:border-[#3B82F6] md:border-black/10 md:bg-white/70 md:text-slate-700 md:placeholder:text-slate-500 md:backdrop-blur"
             placeholder="Search chats"
             onChange={e => handleSearch(e.target.value)}
           />
-          <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[#64748B] dark:text-[#94A3B8]" />
+          <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[#64748B] dark:text-[#94A3B8] md:text-slate-500" />
         </div>
         <Tabs />
       </div>
@@ -105,11 +105,11 @@ export default function Sidebar() {
         {filtered.map(t => (
           <div
             key={t.id}
-            className="flex items-center gap-2 rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-2.5 text-sm shadow-sm transition hover:border-[#2563EB] hover:shadow-md dark:border-[#1E3A5F] dark:bg-[#13233D] dark:hover:border-[#3B82F6]"
+            className="flex items-center gap-2 rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-2.5 text-sm shadow-sm transition hover:border-[#2563EB] hover:shadow-md dark:border-[#1E3A5F] dark:bg-[#13233D] dark:hover:border-[#3B82F6] md:border-black/5 md:bg-white/70 md:shadow-sm md:hover:border-black/5 md:hover:bg-white/80 md:hover:shadow-sm"
           >
             <button
               onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
-              className="flex-1 truncate text-left font-medium text-[#0F172A] transition hover:text-[#2563EB] dark:text-[#E6EDF7] dark:hover:text-[#3B82F6]"
+              className="flex-1 truncate text-left font-medium text-[#0F172A] transition hover:text-[#2563EB] dark:text-[#E6EDF7] dark:hover:text-[#3B82F6] md:text-slate-700 md:hover:text-blue-600"
               title={t.title}
             >
               {t.title}
@@ -131,15 +131,15 @@ export default function Sidebar() {
 
         {aidocThreads.length > 0 && (
           <div className="mt-4">
-            <div className="px-2 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">AI Doc</div>
+            <div className="px-2 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8] md:text-slate-500">AI Doc</div>
             {aidocThreads.map(t => (
               <div
                 key={t.id}
-                className="mt-2 flex items-center gap-2 rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-2.5 text-sm shadow-sm transition hover:border-[#2563EB] hover:shadow-md dark:border-[#1E3A5F] dark:bg-[#13233D] dark:hover:border-[#3B82F6]"
+                className="mt-2 flex items-center gap-2 rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-2.5 text-sm shadow-sm transition hover:border-[#2563EB] hover:shadow-md dark:border-[#1E3A5F] dark:bg-[#13233D] dark:hover:border-[#3B82F6] md:border-black/5 md:bg-white/70 md:hover:border-black/5 md:hover:bg-white/80"
               >
                 <button
                   onClick={() => router.push(`/?panel=ai-doc&threadId=${t.id}&context=profile`)}
-                  className="flex-1 truncate text-left font-medium text-[#0F172A] transition hover:text-[#2563EB] dark:text-[#E6EDF7] dark:hover:text-[#3B82F6]"
+                  className="flex-1 truncate text-left font-medium text-[#0F172A] transition hover:text-[#2563EB] dark:text-[#E6EDF7] dark:hover:text-[#3B82F6] md:text-slate-700 md:hover:text-blue-600"
                   title={t.title ?? ''}
                 >
                   {t.title ?? 'AI Doc — New Case'}
@@ -151,10 +151,10 @@ export default function Sidebar() {
       </div>
 
       <div className="mt-auto">
-        <div className="sticky bottom-0 left-0 -mx-4 border-t border-[#E2E8F0] bg-[#F8FAFC]/95 px-4 py-3 backdrop-blur-sm dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95">
+        <div className="sticky bottom-0 left-0 -mx-4 border-t border-[#E2E8F0] bg-[#F8FAFC]/95 px-4 py-3 backdrop-blur-sm dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95 md:border-black/5 md:bg-white/80">
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-[#E2E8F0] bg-white px-3 py-1.5 text-xs font-medium text-[#0F172A] shadow-sm transition hover:border-[#2563EB] hover:text-[#2563EB] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2563EB] dark:border-[#1E3A5F] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:border-[#3B82F6] dark:hover:text-[#3B82F6] dark:focus-visible:outline-[#3B82F6]"
+            className="flex items-center gap-1.5 rounded-md border border-[#E2E8F0] bg-white px-3 py-1.5 text-xs font-medium text-[#0F172A] shadow-sm transition hover:border-[#2563EB] hover:text-[#2563EB] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2563EB] dark:border-[#1E3A5F] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:border-[#3B82F6] dark:hover:text-[#3B82F6] dark:focus-visible:outline-[#3B82F6] md:border-black/10 md:bg-white md:text-slate-700 md:hover:text-blue-600"
           >
             <Settings size={14} /> Preferences
           </button>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -24,14 +24,14 @@ export function SidebarDrawer({ open, onClose, children }: SidebarDrawerProps) {
   return (
     <>
       <div
-        className={`fixed inset-0 z-40 bg-black/50 backdrop-blur-sm transition-opacity duration-200 ease-out md:hidden ${
+        className={`fixed inset-0 z-40 bg-black/40 transition-opacity duration-200 ease-out md:hidden ${
           open ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
         }`}
         onClick={handleClose}
         aria-hidden={!open}
       />
       <aside
-        className={`fixed inset-y-0 left-0 z-50 w-[86vw] max-w-[320px] transform border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] transition-transform duration-200 ease-out dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:static md:translate-x-0 md:w-72 md:border-r md:border-[#E2E8F0] md:bg-[#F8FAFC] md:text-[#0F172A] md:shadow-none ${
+        className={`fixed inset-y-0 left-0 z-50 w-[86vw] max-w-[320px] transform border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] shadow-xl transition-transform duration-200 ease-out dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:static md:block md:translate-x-0 md:w-72 md:border-r md:border-[#E2E8F0] md:bg-[#F8FAFC] md:text-[#0F172A] md:shadow-none ${
           open ? 'translate-x-0' : '-translate-x-full'
         }`}
       >

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -6,6 +6,35 @@ import { useEffect, useState } from 'react';
 import { createNewThreadId, listThreads, Thread } from '@/lib/chatThreads';
 import ThreadKebab from '@/components/chat/ThreadKebab';
 
+type SidebarDrawerProps = {
+  open: boolean;
+  onClose?: () => void;
+  children: React.ReactNode;
+};
+
+export function SidebarDrawer({ open, onClose, children }: SidebarDrawerProps) {
+  return (
+    <>
+      <div
+        className={`fixed inset-0 z-40 bg-black/40 backdrop-blur-sm transition-opacity duration-200 ease-out md:hidden ${
+          open ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+        onClick={onClose}
+        aria-hidden={!open}
+      />
+      <aside
+        className={`fixed inset-y-0 left-0 z-50 w-[86vw] max-w-[320px] transform bg-slate-950 border-r border-slate-800 transition-transform duration-200 ease-out md:static md:translate-x-0 md:w-72 md:border-r md:border-slate-200/60 md:bg-transparent md:shadow-none ${
+          open ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="flex h-full flex-col overflow-y-auto px-4 pb-6 pt-4 md:h-auto md:overflow-visible md:px-0 md:pt-0">
+          {children}
+        </div>
+      </aside>
+    </>
+  );
+}
+
 export default function Sidebar() {
   const router = useRouter();
   const [threads, setThreads] = useState<Thread[]>([]);

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -13,13 +13,21 @@ type SidebarDrawerProps = {
 };
 
 export function SidebarDrawer({ open, onClose, children }: SidebarDrawerProps) {
+  const handleClose = () => {
+    try {
+      onClose?.();
+    } catch (error) {
+      console.error('SidebarDrawer close error', error);
+    }
+  };
+
   return (
     <>
       <div
         className={`fixed inset-0 z-40 bg-black/50 backdrop-blur-sm transition-opacity duration-200 ease-out md:hidden ${
           open ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
         }`}
-        onClick={onClose}
+        onClick={handleClose}
         aria-hidden={!open}
       />
       <aside
@@ -44,6 +52,7 @@ export default function Sidebar() {
   useEffect(() => {
     const load = () => setThreads(listThreads());
     load();
+    if (typeof window === 'undefined') return;
     window.addEventListener('storage', load);
     window.addEventListener('chat-threads-updated', load);
     return () => {
@@ -65,9 +74,11 @@ export default function Sidebar() {
   };
   const handleSearch = (q: string) => {
     setQ(q);
-    window.dispatchEvent(new CustomEvent('search-chats', { detail: q }));
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('search-chats', { detail: q }));
+    }
   };
-  const filtered = threads.filter(t => t.title.toLowerCase().includes(q.toLowerCase()));
+  const filtered = threads.filter(t => (t.title ?? '').toLowerCase().includes(q.toLowerCase()));
   return (
     <div className="sidebar-click-guard flex h-full w-full flex-col gap-4 px-4 pt-6 pb-0 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
       <button
@@ -118,25 +129,25 @@ export default function Sidebar() {
           </div>
         ))}
 
-      {aidocThreads.length > 0 && (
-        <div className="mt-4">
-          <div className="px-2 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">AI Doc</div>
-          {aidocThreads.map(t => (
-            <div
-              key={t.id}
-              className="mt-2 flex items-center gap-2 rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-2.5 text-sm shadow-sm transition hover:border-[#2563EB] hover:shadow-md dark:border-[#1E3A5F] dark:bg-[#13233D] dark:hover:border-[#3B82F6]"
-            >
-              <button
-                onClick={() => router.push(`/?panel=ai-doc&threadId=${t.id}&context=profile`)}
-                className="flex-1 truncate text-left font-medium text-[#0F172A] transition hover:text-[#2563EB] dark:text-[#E6EDF7] dark:hover:text-[#3B82F6]"
-                title={t.title ?? ''}
+        {aidocThreads.length > 0 && (
+          <div className="mt-4">
+            <div className="px-2 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">AI Doc</div>
+            {aidocThreads.map(t => (
+              <div
+                key={t.id}
+                className="mt-2 flex items-center gap-2 rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-2.5 text-sm shadow-sm transition hover:border-[#2563EB] hover:shadow-md dark:border-[#1E3A5F] dark:bg-[#13233D] dark:hover:border-[#3B82F6]"
               >
-                {t.title ?? 'AI Doc — New Case'}
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
+                <button
+                  onClick={() => router.push(`/?panel=ai-doc&threadId=${t.id}&context=profile`)}
+                  className="flex-1 truncate text-left font-medium text-[#0F172A] transition hover:text-[#2563EB] dark:text-[#E6EDF7] dark:hover:text-[#3B82F6]"
+                  title={t.title ?? ''}
+                >
+                  {t.title ?? 'AI Doc — New Case'}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       <div className="mt-auto">

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -16,14 +16,14 @@ export function SidebarDrawer({ open, onClose, children }: SidebarDrawerProps) {
   return (
     <>
       <div
-        className={`fixed inset-0 z-40 bg-black/40 backdrop-blur-sm transition-opacity duration-200 ease-out md:hidden ${
+        className={`fixed inset-0 z-40 bg-black/50 backdrop-blur-sm transition-opacity duration-200 ease-out md:hidden ${
           open ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
         }`}
         onClick={onClose}
         aria-hidden={!open}
       />
       <aside
-        className={`fixed inset-y-0 left-0 z-50 w-[86vw] max-w-[320px] transform bg-slate-950 border-r border-slate-800 transition-transform duration-200 ease-out md:static md:translate-x-0 md:w-72 md:border-r md:border-slate-200/60 md:bg-transparent md:shadow-none ${
+        className={`fixed inset-y-0 left-0 z-50 w-[86vw] max-w-[320px] transform border-r border-[#E2E8F0] bg-[#F8FAFC] text-[#0F172A] transition-transform duration-200 ease-out dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] md:static md:translate-x-0 md:w-72 md:border-r md:border-[#E2E8F0] md:bg-[#F8FAFC] md:text-[#0F172A] md:shadow-none ${
           open ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
@@ -69,11 +69,11 @@ export default function Sidebar() {
   };
   const filtered = threads.filter(t => t.title.toLowerCase().includes(q.toLowerCase()));
   return (
-    <div className="sidebar-click-guard flex h-full w-full flex-col gap-4 px-4 pt-6 pb-0 text-medx">
+    <div className="sidebar-click-guard flex h-full w-full flex-col gap-4 px-4 pt-6 pb-0 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
       <button
         type="button"
         onClick={handleNew}
-        className="w-full rounded-full bg-blue-600 px-4 py-2.5 text-left text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
+        className="w-full rounded-full bg-[#2563EB] px-4 py-2.5 text-left font-semibold text-white shadow-sm transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
       >
         + New Chat
       </button>
@@ -81,11 +81,11 @@ export default function Sidebar() {
       <div>
         <div className="relative">
           <input
-            className="w-full h-10 rounded-full border border-black/10 bg-white/70 pl-3 pr-8 text-sm text-slate-700 placeholder:text-slate-500 backdrop-blur dark:border-white/10 dark:bg-slate-900/50 dark:text-slate-100 dark:placeholder:text-slate-400"
+            className="h-10 w-full rounded-full border border-[#E2E8F0] bg-white pl-3 pr-8 text-sm text-[#0F172A] placeholder:text-[#64748B] transition focus:border-[#2563EB] focus:outline-none dark:border-[#1E3A5F] dark:bg-[#0F1B2D] dark:text-[#E6EDF7] dark:placeholder:text-[#94A3B8] dark:focus:border-[#3B82F6]"
             placeholder="Search chats"
             onChange={e => handleSearch(e.target.value)}
           />
-          <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 dark:text-slate-400" />
+          <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[#64748B] dark:text-[#94A3B8]" />
         </div>
         <Tabs />
       </div>
@@ -94,11 +94,11 @@ export default function Sidebar() {
         {filtered.map(t => (
           <div
             key={t.id}
-            className="flex items-center gap-2 rounded-xl border border-black/5 bg-white/70 px-4 py-2.5 text-sm shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
+            className="flex items-center gap-2 rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-2.5 text-sm shadow-sm transition hover:border-[#2563EB] hover:shadow-md dark:border-[#1E3A5F] dark:bg-[#13233D] dark:hover:border-[#3B82F6]"
           >
             <button
               onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
-              className="flex-1 text-left truncate text-sm"
+              className="flex-1 truncate text-left font-medium text-[#0F172A] transition hover:text-[#2563EB] dark:text-[#E6EDF7] dark:hover:text-[#3B82F6]"
               title={t.title}
             >
               {t.title}
@@ -118,32 +118,32 @@ export default function Sidebar() {
           </div>
         ))}
 
-        {aidocThreads.length > 0 && (
-          <div className="mt-4">
-            <div className="px-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">AI Doc</div>
-            {aidocThreads.map(t => (
-              <div
-                key={t.id}
-                className="mt-2 flex items-center gap-2 rounded-xl border border-black/5 bg-white/70 px-4 py-2.5 text-sm shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
+      {aidocThreads.length > 0 && (
+        <div className="mt-4">
+          <div className="px-2 text-xs font-semibold uppercase tracking-wide text-[#334155] dark:text-[#94A3B8]">AI Doc</div>
+          {aidocThreads.map(t => (
+            <div
+              key={t.id}
+              className="mt-2 flex items-center gap-2 rounded-xl border border-[#E2E8F0] bg-[#F8FAFC] px-4 py-2.5 text-sm shadow-sm transition hover:border-[#2563EB] hover:shadow-md dark:border-[#1E3A5F] dark:bg-[#13233D] dark:hover:border-[#3B82F6]"
+            >
+              <button
+                onClick={() => router.push(`/?panel=ai-doc&threadId=${t.id}&context=profile`)}
+                className="flex-1 truncate text-left font-medium text-[#0F172A] transition hover:text-[#2563EB] dark:text-[#E6EDF7] dark:hover:text-[#3B82F6]"
+                title={t.title ?? ''}
               >
-                <button
-                  onClick={() => router.push(`/?panel=ai-doc&threadId=${t.id}&context=profile`)}
-                  className="flex-1 text-left truncate text-sm"
-                  title={t.title ?? ''}
-                >
-                  {t.title ?? 'AI Doc — New Case'}
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
+                {t.title ?? 'AI Doc — New Case'}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
       </div>
 
       <div className="mt-auto">
-        <div className="sticky bottom-0 left-0 -mx-4 border-t border-black/5 bg-white/80 px-4 py-3 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/50">
+        <div className="sticky bottom-0 left-0 -mx-4 border-t border-[#E2E8F0] bg-[#F8FAFC]/95 px-4 py-3 backdrop-blur-sm dark:border-[#1E3A5F] dark:bg-[#0F1B2D]/95">
           <button
             type="button"
-            className="flex items-center gap-1.5 rounded-md border border-black/10 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm transition hover:bg-white/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 dark:hover:bg-slate-900"
+            className="flex items-center gap-1.5 rounded-md border border-[#E2E8F0] bg-white px-3 py-1.5 text-xs font-medium text-[#0F172A] shadow-sm transition hover:border-[#2563EB] hover:text-[#2563EB] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2563EB] dark:border-[#1E3A5F] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:border-[#3B82F6] dark:hover:text-[#3B82F6] dark:focus-visible:outline-[#3B82F6]"
           >
             <Settings size={14} /> Preferences
           </button>

--- a/components/SidebarThreads.tsx
+++ b/components/SidebarThreads.tsx
@@ -1,8 +1,15 @@
+"use client";
+import { useMemo } from "react";
 import { useChatStore } from "@/lib/state/chatStore";
 
 export function SidebarThreads() {
-  const threads = useChatStore(s => Object.values(s.threads)
-    .sort((a,b)=>b.updatedAt - a.updatedAt));
+  const threadsMap = useChatStore(s => s.threads);
+  const threads = useMemo(() => {
+    const list = Object.values(threadsMap ?? {});
+    return list
+      .slice()
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  }, [threadsMap]);
 
   return (
     <div className="flex flex-1 flex-col gap-1 text-sm text-[#0F172A] dark:text-[#E6EDF7]">

--- a/components/SidebarThreads.tsx
+++ b/components/SidebarThreads.tsx
@@ -5,17 +5,17 @@ export function SidebarThreads() {
     .sort((a,b)=>b.updatedAt - a.updatedAt));
 
   return (
-    <div className="flex flex-1 flex-col gap-1 text-sm text-slate-100 md:text-slate-900">
+    <div className="flex flex-1 flex-col gap-1 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
       {threads.map(t => (
         <a
           key={t.id}
           href={`/chat/${t.id}`}
-          className="rounded-xl px-3 py-2 transition hover:bg-slate-800/60 md:hover:bg-muted"
+          className="rounded-xl border border-transparent px-3 py-2 transition hover:border-[#2563EB] hover:bg-[#2563EB]/10 dark:hover:border-[#3B82F6] dark:hover:bg-[#3B82F6]/10"
         >
-          <div className="truncate font-medium text-slate-50 md:text-slate-900">
+          <div className="truncate font-medium">
             {t.title || "New chat"}
           </div>
-          {t.isTemp && <div className="text-xs text-slate-300 md:text-slate-500">saving…</div>}
+          {t.isTemp && <div className="text-xs text-[#64748B] dark:text-[#94A3B8]">saving…</div>}
         </a>
       ))}
     </div>

--- a/components/SidebarThreads.tsx
+++ b/components/SidebarThreads.tsx
@@ -12,17 +12,19 @@ export function SidebarThreads() {
   }, [threadsMap]);
 
   return (
-    <div className="flex flex-1 flex-col gap-1 text-sm text-[#0F172A] dark:text-[#E6EDF7]">
+    <div className="flex flex-1 flex-col gap-1 text-sm text-[#0F172A] dark:text-[#E6EDF7] md:gap-0 md:text-base md:text-medx">
       {threads.map(t => (
         <a
           key={t.id}
           href={`/chat/${t.id}`}
-          className="rounded-xl border border-transparent px-3 py-2 transition hover:border-[#2563EB] hover:bg-[#2563EB]/10 dark:hover:border-[#3B82F6] dark:hover:bg-[#3B82F6]/10"
+          className="rounded-xl border border-transparent px-3 py-2 transition hover:border-[#2563EB] hover:bg-[#2563EB]/10 dark:hover:border-[#3B82F6] dark:hover:bg-[#3B82F6]/10 md:rounded-none md:border-0 md:px-3 md:py-2 md:hover:bg-muted md:hover:text-inherit"
         >
-          <div className="truncate font-medium">
+          <div className="truncate font-medium md:font-normal">
             {t.title || "New chat"}
           </div>
-          {t.isTemp && <div className="text-xs text-[#64748B] dark:text-[#94A3B8]">saving…</div>}
+          {t.isTemp && (
+            <div className="text-xs text-[#64748B] dark:text-[#94A3B8] md:text-[11px] md:text-slate-500">saving…</div>
+          )}
         </a>
       ))}
     </div>

--- a/components/SidebarThreads.tsx
+++ b/components/SidebarThreads.tsx
@@ -5,11 +5,17 @@ export function SidebarThreads() {
     .sort((a,b)=>b.updatedAt - a.updatedAt));
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-1 flex-col gap-1 text-sm text-slate-100 md:text-slate-900">
       {threads.map(t => (
-        <a key={t.id} href={`/chat/${t.id}`} className="px-3 py-2 hover:bg-muted">
-          <div className="truncate">{t.title || "New chat"}</div>
-          {t.isTemp && <div className="text-xs opacity-60">saving…</div>}
+        <a
+          key={t.id}
+          href={`/chat/${t.id}`}
+          className="rounded-xl px-3 py-2 transition hover:bg-slate-800/60 md:hover:bg-muted"
+        >
+          <div className="truncate font-medium text-slate-50 md:text-slate-900">
+            {t.title || "New chat"}
+          </div>
+          {t.isTemp && <div className="text-xs text-slate-300 md:text-slate-500">saving…</div>}
         </a>
       ))}
     </div>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -10,9 +10,6 @@ export default function ThemeToggle({ className }: ThemeToggleProps = {}) {
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
-  if (!mounted) return null;
-
-  const next = theme === "dark" ? "light" : "dark";
   const baseClass = useMemo(
     () =>
       [
@@ -25,6 +22,9 @@ export default function ThemeToggle({ className }: ThemeToggleProps = {}) {
         .join(" "),
     [className],
   );
+  if (!mounted) return null;
+
+  const next = theme === "dark" ? "light" : "dark";
   return (
     <button
       aria-label="Toggle theme"

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,19 +1,35 @@
 "use client";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-export default function ThemeToggle() {
+type ThemeToggleProps = {
+  className?: string;
+};
+
+export default function ThemeToggle({ className }: ThemeToggleProps = {}) {
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
   if (!mounted) return null;
 
   const next = theme === "dark" ? "light" : "dark";
+  const baseClass = useMemo(
+    () =>
+      [
+        "inline-flex h-9 items-center gap-2 rounded-full border border-[#E2E8F0] bg-white px-4 text-sm font-medium text-[#0F172A] shadow-sm transition",
+        "hover:border-[#2563EB] hover:text-[#2563EB]",
+        "dark:border-[#1E3A5F] dark:bg-[#13233D] dark:text-[#E6EDF7] dark:hover:border-[#3B82F6] dark:hover:text-[#3B82F6]",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" "),
+    [className],
+  );
   return (
     <button
       aria-label="Toggle theme"
       onClick={() => setTheme(next)}
-      className="inline-flex h-10 items-center gap-2 rounded-full border border-black/10 bg-white/70 px-4 text-sm font-medium text-slate-900 transition hover:bg-white dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100 dark:hover:bg-slate-900"
+      className={baseClass}
     >
       {theme === "dark" ? "Light" : "Dark"}
     </button>

--- a/components/chat/FeedbackControls.tsx
+++ b/components/chat/FeedbackControls.tsx
@@ -6,14 +6,14 @@ type FeedbackControlsProps = {
   className?: string;
 };
 
-const iconClasses = "transition hover:text-white md:hover:text-blue-600";
+const iconClasses = "transition hover:text-[#2563EB] dark:hover:text-[#3B82F6]";
 
 export default function FeedbackControls({ messageId, compact = false, className }: FeedbackControlsProps) {
   const size = compact ? 16 : 20;
   const spacing = compact ? "gap-2" : "gap-3";
 
   return (
-    <div className={`flex ${spacing} text-slate-300 ${className ?? ""}`}>
+    <div className={`flex ${spacing} text-[#94A3B8] dark:text-[#CBD5F5] ${className ?? ""}`}>
       <button
         type="button"
         className={`inline-flex items-center justify-center ${iconClasses}`}

--- a/components/chat/FeedbackControls.tsx
+++ b/components/chat/FeedbackControls.tsx
@@ -17,6 +17,9 @@ export default function FeedbackControls({ messageId, compact = false, className
   const classes = ["flex", spacing, "text-[#94A3B8]", "dark:text-[#CBD5F5]"];
   if (className) classes.push(className);
 
+  const onLikeSafe = onLike ?? (() => {});
+  const onDislikeSafe = onDislike ?? (() => {});
+
   const safeInvoke = (fn?: () => void) => {
     try {
       fn?.();
@@ -32,7 +35,7 @@ export default function FeedbackControls({ messageId, compact = false, className
         className={`inline-flex items-center justify-center ${iconClasses}`}
         aria-label="Thumbs up"
         data-message={dataMessage}
-        onClick={() => safeInvoke(onLike)}
+        onClick={() => safeInvoke(onLikeSafe)}
       >
         <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="1.8">
           <path strokeLinecap="round" strokeLinejoin="round" d="M6 11h2v9H6a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2zm4 9h5.4a2.6 2.6 0 0 0 2.54-2.07l1.02-5.1A2 2 0 0 0 17 11h-3.5V7.2A2.2 2.2 0 0 0 11.3 5l-1.3 6" />
@@ -43,7 +46,7 @@ export default function FeedbackControls({ messageId, compact = false, className
         className={`inline-flex items-center justify-center ${iconClasses}`}
         aria-label="Thumbs down"
         data-message={dataMessage}
-        onClick={() => safeInvoke(onDislike)}
+        onClick={() => safeInvoke(onDislikeSafe)}
       >
         <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="1.8">
           <path strokeLinecap="round" strokeLinejoin="round" d="M18 13h-2V4h2a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2zm-4-9h-5.4a2.6 2.6 0 0 0-2.54 2.07L4.6 11.17A2 2 0 0 0 7 13h3.5v3.8A2.2 2.2 0 0 0 12.7 21l1.3-6" />

--- a/components/chat/FeedbackControls.tsx
+++ b/components/chat/FeedbackControls.tsx
@@ -1,24 +1,38 @@
 'use client';
 
 type FeedbackControlsProps = {
-  messageId: string;
+  messageId?: string;
   compact?: boolean;
   className?: string;
+  onLike?: () => void;
+  onDislike?: () => void;
 };
 
 const iconClasses = "transition hover:text-[#2563EB] dark:hover:text-[#3B82F6]";
 
-export default function FeedbackControls({ messageId, compact = false, className }: FeedbackControlsProps) {
+export default function FeedbackControls({ messageId, compact = false, className, onLike, onDislike }: FeedbackControlsProps) {
   const size = compact ? 16 : 20;
   const spacing = compact ? "gap-2" : "gap-3";
+  const dataMessage = messageId ?? "";
+  const classes = ["flex", spacing, "text-[#94A3B8]", "dark:text-[#CBD5F5]"];
+  if (className) classes.push(className);
+
+  const safeInvoke = (fn?: () => void) => {
+    try {
+      fn?.();
+    } catch (error) {
+      console.error('FeedbackControls handler error', error);
+    }
+  };
 
   return (
-    <div className={`flex ${spacing} text-[#94A3B8] dark:text-[#CBD5F5] ${className ?? ""}`}>
+    <div className={classes.join(' ')}>
       <button
         type="button"
         className={`inline-flex items-center justify-center ${iconClasses}`}
         aria-label="Thumbs up"
-        data-message={messageId}
+        data-message={dataMessage}
+        onClick={() => safeInvoke(onLike)}
       >
         <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="1.8">
           <path strokeLinecap="round" strokeLinejoin="round" d="M6 11h2v9H6a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2zm4 9h5.4a2.6 2.6 0 0 0 2.54-2.07l1.02-5.1A2 2 0 0 0 17 11h-3.5V7.2A2.2 2.2 0 0 0 11.3 5l-1.3 6" />
@@ -28,7 +42,8 @@ export default function FeedbackControls({ messageId, compact = false, className
         type="button"
         className={`inline-flex items-center justify-center ${iconClasses}`}
         aria-label="Thumbs down"
-        data-message={messageId}
+        data-message={dataMessage}
+        onClick={() => safeInvoke(onDislike)}
       >
         <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="1.8">
           <path strokeLinecap="round" strokeLinejoin="round" d="M18 13h-2V4h2a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2zm-4-9h-5.4a2.6 2.6 0 0 0-2.54 2.07L4.6 11.17A2 2 0 0 0 7 13h3.5v3.8A2.2 2.2 0 0 0 12.7 21l1.3-6" />

--- a/components/chat/FeedbackControls.tsx
+++ b/components/chat/FeedbackControls.tsx
@@ -1,5 +1,39 @@
 'use client';
 
-export default function FeedbackControls({ messageId }: { messageId: string }) {
-  return null;
+type FeedbackControlsProps = {
+  messageId: string;
+  compact?: boolean;
+  className?: string;
+};
+
+const iconClasses = "transition hover:text-white md:hover:text-blue-600";
+
+export default function FeedbackControls({ messageId, compact = false, className }: FeedbackControlsProps) {
+  const size = compact ? 16 : 20;
+  const spacing = compact ? "gap-2" : "gap-3";
+
+  return (
+    <div className={`flex ${spacing} text-slate-300 ${className ?? ""}`}>
+      <button
+        type="button"
+        className={`inline-flex items-center justify-center ${iconClasses}`}
+        aria-label="Thumbs up"
+        data-message={messageId}
+      >
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="1.8">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 11h2v9H6a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2zm4 9h5.4a2.6 2.6 0 0 0 2.54-2.07l1.02-5.1A2 2 0 0 0 17 11h-3.5V7.2A2.2 2.2 0 0 0 11.3 5l-1.3 6" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        className={`inline-flex items-center justify-center ${iconClasses}`}
+        aria-label="Thumbs down"
+        data-message={messageId}
+      >
+        <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth="1.8">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M18 13h-2V4h2a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2zm-4-9h-5.4a2.6 2.6 0 0 0-2.54 2.07L4.6 11.17A2 2 0 0 0 7 13h3.5v3.8A2.2 2.2 0 0 0 12.7 21l1.3-6" />
+        </svg>
+      </button>
+    </div>
+  );
 }

--- a/components/chat/FeedbackControls.tsx
+++ b/components/chat/FeedbackControls.tsx
@@ -14,7 +14,7 @@ export default function FeedbackControls({ messageId, compact = false, className
   const size = compact ? 16 : 20;
   const spacing = compact ? "gap-2" : "gap-3";
   const dataMessage = messageId ?? "";
-  const classes = ["flex", spacing, "text-[#94A3B8]", "dark:text-[#CBD5F5]"];
+  const classes = ["flex", spacing, "text-[#94A3B8]", "dark:text-[#CBD5F5]", "md:text-slate-500", "md:dark:text-slate-400"];
   if (className) classes.push(className);
 
   const onLikeSafe = onLike ?? (() => {});

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,5 +1,6 @@
 import Markdown from "react-markdown";
 import FeedbackControls from "./FeedbackControls";
+import { Renderer } from "./Renderer";
 
 type ChatMessage = {
   id: string;
@@ -9,35 +10,63 @@ type ChatMessage = {
   imageUrl?: string;
   pending?: boolean;
   createdAt?: number;
+  attachments?: string[];
 };
 
 interface MessageProps {
   message: ChatMessage;
 }
 
+const userBubble = "ml-auto max-w-[88vw] md:max-w-[720px] rounded-2xl bg-blue-600/90 px-3 py-2 leading-6 md:leading-7 my-2 md:my-3 text-white";
+const assistantBubble = "mr-auto max-w-[88vw] md:max-w-[720px] rounded-2xl bg-slate-800/70 px-3 pt-2 pb-6 leading-6 md:leading-7 my-2 md:my-3 text-slate-100 md:pb-3";
+
 export default function Message({ message }: MessageProps) {
   if (message.kind === "image" && message.imageUrl) {
     return (
-      <div className={`my-2 flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
-        <div className="max-w-[65%] rounded-2xl overflow-hidden border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900">
+      <div className={`flex ${message.role === "user" ? "justify-end" : "justify-start"} px-1`}>
+        <div className="my-2 max-w-[88vw] overflow-hidden rounded-2xl border border-slate-700/60 bg-slate-900 md:max-w-[480px]">
           <img
             src={message.imageUrl}
             alt="Uploaded"
-            className="block max-h-[360px] w-auto object-contain sm:max-h-[240px]"
+            className="block h-auto max-h-[320px] w-full object-cover"
           />
           {message.pending && (
-            <div className="p-2 text-xs opacity-70 dark:text-gray-300 text-gray-600">Analyzing…</div>
+            <div className="px-3 py-2 text-xs text-slate-300">Analyzing…</div>
           )}
         </div>
       </div>
     );
   }
 
+  const isUser = message.role === "user";
+  const attachments = message.attachments ?? [];
+
   return (
-    <div>
-      <Markdown>{message.content ?? ""}</Markdown>
-      <div className="mt-2">
-        <FeedbackControls messageId={message.id} />
+    <div className={`relative flex ${isUser ? "justify-end" : "justify-start"} px-1`}> 
+      <div className={`relative ${isUser ? userBubble : assistantBubble}`}>
+        {attachments.length > 0 && (
+          <div className={`mb-2 flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden ${isUser ? "justify-end" : "justify-start"}`}>
+            {attachments.map((src, idx) => (
+              <img
+                key={`${message.id}-att-${idx}`}
+                src={src}
+                alt="Attachment"
+                className="h-24 w-24 flex-shrink-0 rounded-xl object-cover"
+              />
+            ))}
+          </div>
+        )}
+        {message.content ? (
+          <Markdown components={Renderer}>{message.content}</Markdown>
+        ) : null}
+
+        {!isUser && (
+          <FeedbackControls
+            messageId={message.id}
+            compact
+            className="absolute -bottom-5 right-2 flex md:static md:mt-1"
+          />
+        )}
       </div>
     </div>
   );

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -19,9 +19,9 @@ interface MessageProps {
 }
 
 const userBubble =
-  "ml-auto my-2 max-w-[88vw] rounded-2xl bg-[#2563EB] px-3 py-2 text-[15px] leading-[1.6] text-white md:my-3 md:max-w-[720px] md:px-4 md:py-3 md:text-base";
+  "ml-auto my-2 max-w-[88vw] rounded-2xl bg-[#2563EB] px-3 py-2 text-[15px] leading-[1.6] text-white md:my-2 md:ml-0 md:max-w-none md:rounded-none md:bg-transparent md:px-0 md:py-0 md:text-base md:text-inherit";
 const assistantBubble =
-  "mr-auto my-2 max-w-[88vw] rounded-2xl bg-[#13233D] px-3 pb-6 pt-2 text-[15px] leading-[1.6] text-[#E6EDF7] shadow-sm md:my-3 md:max-w-[720px] md:px-4 md:pb-4 md:pt-3 md:text-base";
+  "mr-auto my-2 max-w-[88vw] rounded-2xl bg-[#13233D] px-3 pb-6 pt-2 text-[15px] leading-[1.6] text-[#E6EDF7] shadow-sm md:my-2 md:mr-0 md:max-w-none md:rounded-none md:bg-transparent md:px-0 md:pb-0 md:pt-0 md:text-base md:text-inherit md:shadow-none";
 
 export default function Message({ message }: MessageProps) {
   const safeMessage: ChatMessage = {
@@ -51,7 +51,7 @@ export default function Message({ message }: MessageProps) {
   const content = typeof safeMessage.content === "string" ? safeMessage.content : "";
 
   return (
-    <div className={`relative flex ${isUser ? "justify-end" : "justify-start"} px-1`}>
+    <div className={`relative flex ${isUser ? "justify-end" : "justify-start"} px-1 md:block md:px-0`}>
       <div className={`relative ${isUser ? userBubble : assistantBubble}`}>
         {attachments.length > 0 && (
           <div
@@ -75,7 +75,7 @@ export default function Message({ message }: MessageProps) {
           <FeedbackControls
             messageId={safeMessage.id}
             compact
-            className="absolute -bottom-5 right-2 flex md:static md:mt-1"
+            className="absolute -bottom-5 right-2 flex md:static md:mt-2"
           />
         )}
       </div>

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -17,8 +17,8 @@ interface MessageProps {
   message: ChatMessage;
 }
 
-const userBubble = "ml-auto max-w-[88vw] md:max-w-[720px] rounded-2xl bg-blue-600/90 px-3 py-2 leading-6 md:leading-7 my-2 md:my-3 text-white";
-const assistantBubble = "mr-auto max-w-[88vw] md:max-w-[720px] rounded-2xl bg-slate-800/70 px-3 pt-2 pb-6 leading-6 md:leading-7 my-2 md:my-3 text-slate-100 md:pb-3";
+const userBubble = "ml-auto my-2 max-w-[88vw] rounded-2xl bg-[#2563EB] px-3 py-2 text-[15px] leading-[1.6] text-white md:my-3 md:max-w-[720px] md:px-4 md:py-3 md:text-base";
+const assistantBubble = "mr-auto my-2 max-w-[88vw] rounded-2xl bg-[#13233D] px-3 pb-6 pt-2 text-[15px] leading-[1.6] text-[#E6EDF7] shadow-sm md:my-3 md:max-w-[720px] md:px-4 md:pb-4 md:pt-3 md:text-base";
 
 export default function Message({ message }: MessageProps) {
   if (message.kind === "image" && message.imageUrl) {
@@ -51,7 +51,7 @@ export default function Message({ message }: MessageProps) {
                 key={`${message.id}-att-${idx}`}
                 src={src}
                 alt="Attachment"
-                className="h-24 w-24 flex-shrink-0 rounded-xl object-cover"
+                className="h-24 w-24 flex-shrink-0 rounded-xl border border-[#E2E8F0] object-cover dark:border-[#1E3A5F]"
               />
             ))}
           </div>

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,3 +1,4 @@
+'use client';
 import Markdown from "react-markdown";
 import FeedbackControls from "./FeedbackControls";
 import { Renderer } from "./Renderer";
@@ -14,41 +15,53 @@ type ChatMessage = {
 };
 
 interface MessageProps {
-  message: ChatMessage;
+  message?: ChatMessage | null;
 }
 
-const userBubble = "ml-auto my-2 max-w-[88vw] rounded-2xl bg-[#2563EB] px-3 py-2 text-[15px] leading-[1.6] text-white md:my-3 md:max-w-[720px] md:px-4 md:py-3 md:text-base";
-const assistantBubble = "mr-auto my-2 max-w-[88vw] rounded-2xl bg-[#13233D] px-3 pb-6 pt-2 text-[15px] leading-[1.6] text-[#E6EDF7] shadow-sm md:my-3 md:max-w-[720px] md:px-4 md:pb-4 md:pt-3 md:text-base";
+const userBubble =
+  "ml-auto my-2 max-w-[88vw] rounded-2xl bg-[#2563EB] px-3 py-2 text-[15px] leading-[1.6] text-white md:my-3 md:max-w-[720px] md:px-4 md:py-3 md:text-base";
+const assistantBubble =
+  "mr-auto my-2 max-w-[88vw] rounded-2xl bg-[#13233D] px-3 pb-6 pt-2 text-[15px] leading-[1.6] text-[#E6EDF7] shadow-sm md:my-3 md:max-w-[720px] md:px-4 md:pb-4 md:pt-3 md:text-base";
 
 export default function Message({ message }: MessageProps) {
-  if (message.kind === "image" && message.imageUrl) {
+  const safeMessage: ChatMessage = {
+    id: message?.id ?? "message",
+    role: message?.role ?? "assistant",
+    kind: message?.kind,
+    content: message?.content,
+    imageUrl: message?.imageUrl,
+    pending: message?.pending,
+    createdAt: message?.createdAt,
+    attachments: Array.isArray(message?.attachments) ? message.attachments : [],
+  };
+
+  if (safeMessage.kind === "image" && typeof safeMessage.imageUrl === "string" && safeMessage.imageUrl) {
     return (
-      <div className={`flex ${message.role === "user" ? "justify-end" : "justify-start"} px-1`}>
+      <div className={`flex ${safeMessage.role === "user" ? "justify-end" : "justify-start"} px-1`}>
         <div className="my-2 max-w-[88vw] overflow-hidden rounded-2xl border border-slate-700/60 bg-slate-900 md:max-w-[480px]">
-          <img
-            src={message.imageUrl}
-            alt="Uploaded"
-            className="block h-auto max-h-[320px] w-full object-cover"
-          />
-          {message.pending && (
-            <div className="px-3 py-2 text-xs text-slate-300">Analyzing…</div>
-          )}
+          <img src={safeMessage.imageUrl} alt="Uploaded" className="block h-auto max-h-[320px] w-full object-cover" />
+          {safeMessage.pending && <div className="px-3 py-2 text-xs text-slate-300">Analyzing…</div>}
         </div>
       </div>
     );
   }
 
-  const isUser = message.role === "user";
-  const attachments = message.attachments ?? [];
+  const isUser = safeMessage.role === "user";
+  const attachments = Array.isArray(safeMessage.attachments) ? safeMessage.attachments : [];
+  const content = typeof safeMessage.content === "string" ? safeMessage.content : "";
 
   return (
-    <div className={`relative flex ${isUser ? "justify-end" : "justify-start"} px-1`}> 
+    <div className={`relative flex ${isUser ? "justify-end" : "justify-start"} px-1`}>
       <div className={`relative ${isUser ? userBubble : assistantBubble}`}>
         {attachments.length > 0 && (
-          <div className={`mb-2 flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden ${isUser ? "justify-end" : "justify-start"}`}>
+          <div
+            className={`mb-2 flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden ${
+              isUser ? "justify-end" : "justify-start"
+            }`}
+          >
             {attachments.map((src, idx) => (
               <img
-                key={`${message.id}-att-${idx}`}
+                key={`${safeMessage.id}-att-${idx}`}
                 src={src}
                 alt="Attachment"
                 className="h-24 w-24 flex-shrink-0 rounded-xl border border-[#E2E8F0] object-cover dark:border-[#1E3A5F]"
@@ -56,13 +69,11 @@ export default function Message({ message }: MessageProps) {
             ))}
           </div>
         )}
-        {message.content ? (
-          <Markdown components={Renderer}>{message.content}</Markdown>
-        ) : null}
+        {content ? <Markdown components={Renderer}>{content}</Markdown> : null}
 
         {!isUser && (
           <FeedbackControls
-            messageId={message.id}
+            messageId={safeMessage.id}
             compact
             className="absolute -bottom-5 right-2 flex md:static md:mt-1"
           />
@@ -71,3 +82,4 @@ export default function Message({ message }: MessageProps) {
     </div>
   );
 }
+

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -135,7 +135,7 @@ export default function ModeBar() {
   const doctorActive = state.base === "doctor";
 
   return (
-    <div className="sticky top-[48px] z-30 -mx-3 px-3 py-2 bg-[#F8FAFC]/90 backdrop-blur md:static md:m-0 md:bg-transparent md:px-0 md:py-0 dark:bg-[#0F1B2D]/90">
+    <div className="sticky top-14 z-30 -mx-3 px-3 py-2 bg-[#F8FAFC]/90 backdrop-blur md:static md:m-0 md:bg-transparent md:px-0 md:py-0 dark:bg-[#0F1B2D]/90">
       <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] md:flex-wrap [&::-webkit-scrollbar]:hidden">
         <div className="inline-flex flex-nowrap items-center gap-2 rounded-full border border-[#E2E8F0] bg-white px-2 py-1 backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]">
           <button

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -135,49 +135,70 @@ export default function ModeBar() {
   const doctorActive = state.base === "doctor";
 
   return (
-    <div className="sticky top-14 z-30 -mx-3 px-3 py-2 bg-[#F8FAFC]/90 backdrop-blur md:static md:m-0 md:bg-transparent md:px-0 md:py-0 dark:bg-[#0F1B2D]/90">
-      <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] md:flex-wrap [&::-webkit-scrollbar]:hidden">
-        <div className="inline-flex flex-nowrap items-center gap-2 rounded-full border border-[#E2E8F0] bg-white px-2 py-1 backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]">
-          <button
-            className={btn(wellnessActive)}
-            onClick={() => apply({ type: "toggle/patient" })}
-          >
-            Wellness
-          </button>
-          <button
-            className={btn(state.therapy, aidocOn || state.base !== "patient" || therapyBusy)}
-            disabled={aidocOn || state.base !== "patient" || therapyBusy}
-            onClick={() => apply({ type: "toggle/therapy" })}
-            aria-busy={therapyBusy}
-          >
-            <span>Therapy</span>
-            {therapyBusy && !state.therapy ? (
-              <span className="ml-2 inline-flex h-3 w-3 items-center" aria-hidden="true">
-                <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              </span>
-            ) : null}
-          </button>
-          <button
-            className={btn(state.research, aidocOn)}
-            disabled={aidocOn}
-            onClick={() => apply({ type: "toggle/research" })}
-          >
-            Research
-          </button>
-          <button
-            className={btn(doctorActive)}
-            onClick={() => apply({ type: "toggle/doctor" })}
-          >
-            Clinical
-          </button>
+    <>
+      <div className="sticky top-14 z-30 -mx-3 px-3 py-2 bg-[#F8FAFC]/90 backdrop-blur dark:bg-[#0F1B2D]/90 md:hidden">
+        <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+          <div className="inline-flex flex-nowrap items-center gap-2 rounded-full border border-[#E2E8F0] bg-white px-2 py-1 backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]">
+            <button className={btn(wellnessActive)} onClick={() => apply({ type: "toggle/patient" })}>
+              Wellness
+            </button>
+            <button
+              className={btn(state.therapy, aidocOn || state.base !== "patient" || therapyBusy)}
+              disabled={aidocOn || state.base !== "patient" || therapyBusy}
+              onClick={() => apply({ type: "toggle/therapy" })}
+              aria-busy={therapyBusy}
+            >
+              <span>Therapy</span>
+              {therapyBusy && !state.therapy ? (
+                <span className="ml-2 inline-flex h-3 w-3 items-center" aria-hidden="true">
+                  <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                </span>
+              ) : null}
+            </button>
+            <button className={btn(state.research, aidocOn)} disabled={aidocOn} onClick={() => apply({ type: "toggle/research" })}>
+              Research
+            </button>
+            <button className={btn(doctorActive)} onClick={() => apply({ type: "toggle/doctor" })}>
+              Clinical
+            </button>
 
-          <div className="mx-1 hidden h-5 w-px bg-black/10 dark:bg-white/10 md:block" />
-
-          <button className={btn(aidocOn)} onClick={() => apply({ type: "toggle/aidoc" })}>
-            AI Doc
-          </button>
+            <button className={btn(aidocOn)} onClick={() => apply({ type: "toggle/aidoc" })}>
+              AI Doc
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+
+      <div className="hidden md:inline-flex md:flex-wrap md:items-center md:gap-2 md:rounded-full md:border md:border-black/10 md:bg-white/60 md:px-2 md:py-1 md:backdrop-blur dark:md:border-white/10 dark:md:bg-slate-900/40">
+        <button className={btn(wellnessActive)} onClick={() => apply({ type: "toggle/patient" })}>
+          Wellness
+        </button>
+        <button
+          className={btn(state.therapy, aidocOn || state.base !== "patient" || therapyBusy)}
+          disabled={aidocOn || state.base !== "patient" || therapyBusy}
+          onClick={() => apply({ type: "toggle/therapy" })}
+          aria-busy={therapyBusy}
+        >
+          <span>Therapy</span>
+          {therapyBusy && !state.therapy ? (
+            <span className="ml-2 inline-flex h-3 w-3 items-center" aria-hidden="true">
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            </span>
+          ) : null}
+        </button>
+        <button className={btn(state.research, aidocOn)} disabled={aidocOn} onClick={() => apply({ type: "toggle/research" })}>
+          Research
+        </button>
+        <button className={btn(doctorActive)} onClick={() => apply({ type: "toggle/doctor" })}>
+          Clinical
+        </button>
+
+        <div className="mx-1 hidden h-5 w-px bg-black/10 dark:bg-white/10 md:block" />
+
+        <button className={btn(aidocOn)} onClick={() => apply({ type: "toggle/aidoc" })}>
+          AI Doc
+        </button>
+      </div>
+    </>
   );
 }

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -131,45 +131,49 @@ export default function ModeBar() {
   const doctorActive = state.base === "doctor";
 
   return (
-    <div className="inline-flex flex-wrap items-center gap-2 rounded-full border border-black/10 bg-white/60 px-2 py-1 backdrop-blur dark:border-white/10 dark:bg-slate-900/40">
-      <button
-        className={btn(wellnessActive)}
-        onClick={() => apply({ type: "toggle/patient" })}
-      >
-        Wellness
-      </button>
-      <button
-        className={btn(state.therapy, aidocOn || state.base !== "patient" || therapyBusy)}
-        disabled={aidocOn || state.base !== "patient" || therapyBusy}
-        onClick={() => apply({ type: "toggle/therapy" })}
-        aria-busy={therapyBusy}
-      >
-        <span>Therapy</span>
-        {therapyBusy && !state.therapy ? (
-          <span className="ml-2 inline-flex h-3 w-3 items-center" aria-hidden="true">
-            <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
-          </span>
-        ) : null}
-      </button>
-      <button
-        className={btn(state.research, aidocOn)}
-        disabled={aidocOn}
-        onClick={() => apply({ type: "toggle/research" })}
-      >
-        Research
-      </button>
-      <button
-        className={btn(doctorActive)}
-        onClick={() => apply({ type: "toggle/doctor" })}
-      >
-        Clinical
-      </button>
+    <div className="sticky top-[48px] z-30 -mx-3 px-3 py-2 bg-slate-950/85 backdrop-blur md:static md:bg-transparent md:px-0 md:py-0">
+      <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] md:flex-wrap [&::-webkit-scrollbar]:hidden">
+        <div className="inline-flex flex-nowrap items-center gap-2 rounded-full border border-black/10 bg-white/60 px-2 py-1 backdrop-blur dark:border-white/10 dark:bg-slate-900/40">
+          <button
+            className={btn(wellnessActive)}
+            onClick={() => apply({ type: "toggle/patient" })}
+          >
+            Wellness
+          </button>
+          <button
+            className={btn(state.therapy, aidocOn || state.base !== "patient" || therapyBusy)}
+            disabled={aidocOn || state.base !== "patient" || therapyBusy}
+            onClick={() => apply({ type: "toggle/therapy" })}
+            aria-busy={therapyBusy}
+          >
+            <span>Therapy</span>
+            {therapyBusy && !state.therapy ? (
+              <span className="ml-2 inline-flex h-3 w-3 items-center" aria-hidden="true">
+                <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              </span>
+            ) : null}
+          </button>
+          <button
+            className={btn(state.research, aidocOn)}
+            disabled={aidocOn}
+            onClick={() => apply({ type: "toggle/research" })}
+          >
+            Research
+          </button>
+          <button
+            className={btn(doctorActive)}
+            onClick={() => apply({ type: "toggle/doctor" })}
+          >
+            Clinical
+          </button>
 
-      <div className="mx-1 h-5 w-px bg-black/10 dark:bg-white/10" />
+          <div className="mx-1 hidden h-5 w-px bg-black/10 dark:bg-white/10 md:block" />
 
-      <button className={btn(aidocOn)} onClick={() => apply({ type: "toggle/aidoc" })}>
-        AI Doc
-      </button>
+          <button className={btn(aidocOn)} onClick={() => apply({ type: "toggle/aidoc" })}>
+            AI Doc
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -121,19 +121,21 @@ export default function ModeBar() {
     [
       "h-9 rounded-full border px-4 text-sm font-medium transition",
       active
-        ? "bg-blue-600 border-blue-600 text-white shadow-sm"
-        : "bg-white/70 text-slate-900 border-slate-200 hover:bg-slate-100 dark:bg-slate-800/70 dark:text-white dark:border-slate-700 dark:hover:bg-slate-800",
-      disabled ? "opacity-60 cursor-not-allowed" : "",
-    ].filter(Boolean).join(" ");
+        ? "bg-[#2563EB] border-[#2563EB] text-white shadow-sm dark:bg-[#3B82F6] dark:border-[#3B82F6]"
+        : "bg-white text-[#334155] border-[#E2E8F0] hover:border-[#2563EB] hover:text-[#2563EB] dark:bg-[#0F1B2D] dark:text-[#94A3B8] dark:border-[#1E3A5F] dark:hover:border-[#3B82F6] dark:hover:text-[#3B82F6]",
+      disabled ? "cursor-not-allowed opacity-60" : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
 
   const aidocOn = state.base === "aidoc";
   const wellnessActive = state.base === "patient" && !state.therapy;
   const doctorActive = state.base === "doctor";
 
   return (
-    <div className="sticky top-[48px] z-30 -mx-3 px-3 py-2 bg-slate-950/85 backdrop-blur md:static md:bg-transparent md:px-0 md:py-0">
+    <div className="sticky top-[60px] z-30 -mx-3 px-3 py-2 bg-[#F8FAFC]/90 backdrop-blur md:static md:m-0 md:bg-transparent md:px-0 md:py-0 dark:bg-[#0F1B2D]/90">
       <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] md:flex-wrap [&::-webkit-scrollbar]:hidden">
-        <div className="inline-flex flex-nowrap items-center gap-2 rounded-full border border-black/10 bg-white/60 px-2 py-1 backdrop-blur dark:border-white/10 dark:bg-slate-900/40">
+        <div className="inline-flex flex-nowrap items-center gap-2 rounded-full border border-[#E2E8F0] bg-white px-2 py-1 backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]">
           <button
             className={btn(wellnessActive)}
             onClick={() => apply({ type: "toggle/patient" })}

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { reduce } from "@/lib/modes/modeMachine";
@@ -13,15 +13,17 @@ export default function ModeBar() {
   const sp = useSearchParams();
   const { theme } = useTheme();
 
+  const effectiveTheme: "light" | "dark" = theme === "dark" ? "dark" : "light";
+
   const state = useMemo(
-    () => fromSearchParams(sp, (theme as "light" | "dark") ?? "light"),
-    [sp, theme],
+    () => fromSearchParams(sp, effectiveTheme),
+    [sp, effectiveTheme],
   );
 
   const [therapyBusy, setTherapyBusy] = useState(false);
 
   // remember last non-aidoc base to exit aidoc gracefully
-  const lastNonAidoc = useRef<"patient"|"doctor">("patient");
+  const lastNonAidoc = useRef<"patient" | "doctor">("patient");
   useEffect(() => {
     if (state.base !== "aidoc") lastNonAidoc.current = state.base;
   }, [state.base]);

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -135,7 +135,7 @@ export default function ModeBar() {
   const doctorActive = state.base === "doctor";
 
   return (
-    <div className="sticky top-[60px] z-30 -mx-3 px-3 py-2 bg-[#F8FAFC]/90 backdrop-blur md:static md:m-0 md:bg-transparent md:px-0 md:py-0 dark:bg-[#0F1B2D]/90">
+    <div className="sticky top-[48px] z-30 -mx-3 px-3 py-2 bg-[#F8FAFC]/90 backdrop-blur md:static md:m-0 md:bg-transparent md:px-0 md:py-0 dark:bg-[#0F1B2D]/90">
       <div className="flex gap-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] md:flex-wrap [&::-webkit-scrollbar]:hidden">
         <div className="inline-flex flex-nowrap items-center gap-2 rounded-full border border-[#E2E8F0] bg-white px-2 py-1 backdrop-blur dark:border-[#1E3A5F] dark:bg-[#0F1B2D]">
           <button

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -648,6 +648,8 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   const [inputFocused, setInputFocused] = useState(false);
   const [proactive, setProactive] = useState<null | { kind: 'predispositions'|'medications'|'weight' }>(null);
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
+  const pendingFilesSafe = Array.isArray(pendingFiles) ? pendingFiles : [];
+  const pendingFilesCount = pendingFilesSafe.length;
   const [showJump, setShowJump] = useState(false);
   const [queueActive, setQueueActive] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -2285,7 +2287,7 @@ ${systemCommon}` + baseSys;
 
   function onFilesSelected(files: File[]) {
     if (files.length === 0) return;
-    const next = [...pendingFiles, ...files].slice(0, 10);
+    const next = [...pendingFilesSafe, ...files].slice(0, 10);
     setPendingFiles(next);
     setTimeout(() => inputRef.current?.focus(), 0);
   }
@@ -2534,10 +2536,10 @@ ${systemCommon}` + baseSys;
     try {
       const trimmed = userText.trim();
 
-      const hasPendingFiles = pendingFiles.length > 0;
+      const hasPendingFiles = pendingFilesCount > 0;
 
       if (hasPendingFiles) {
-        const files = pendingFiles;
+        const files = pendingFilesSafe;
         setPendingFiles([]);
 
         const urlsToCleanup: string[] = [];
@@ -3294,13 +3296,13 @@ ${systemCommon}` + baseSys;
                 </div>
               )}
 
-              {pendingFiles.length > 0 && (
+              {pendingFilesCount > 0 && (
                 <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200/60 bg-white/80 px-3 py-2 text-xs text-slate-600 dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200">
                   <span className="font-medium">
-                    {pendingFiles.length} file{pendingFiles.length === 1 ? '' : 's'} ready
+                    {pendingFilesCount} file{pendingFilesCount === 1 ? '' : 's'} ready
                   </span>
                   <div className="flex flex-wrap items-center gap-2">
-                    {pendingFiles.map((file, index) => (
+                    {pendingFilesSafe.map((file, index) => (
                       <span
                         key={`${file.name}-${index}`}
                         className="flex items-center gap-1 rounded-full bg-slate-100/70 px-2 py-0.5 dark:bg-slate-800/70"
@@ -3351,7 +3353,7 @@ ${systemCommon}` + baseSys;
                     rows={1}
                     className="w-full resize-none bg-transparent px-2 pr-12 text-sm leading-6 text-slate-900 outline-none placeholder:text-slate-500 dark:text-slate-100 dark:placeholder:text-slate-400"
                     placeholder={
-                      pendingFiles.length > 0
+                      pendingFilesCount > 0
                         ? 'Add a note or question for this document (optional)'
                         : 'Send a message'
                     }
@@ -3389,7 +3391,7 @@ ${systemCommon}` + baseSys;
                   <button
                     className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:opacity-50"
                     type="submit"
-                    disabled={pendingFiles.length === 0 && !userText.trim()}
+                    disabled={pendingFilesCount === 0 && !userText.trim()}
                     aria-label="Send"
                     title="Send"
                   >

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -3469,7 +3469,7 @@ ${systemCommon}` + baseSys;
       )}
 
       {ENABLE_MOBILE_UI && (
-        <div className="md:hidden">
+        <div className="lg:hidden">
           <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-[#FFFFFF]/95 to-transparent dark:from-[#0B1220]/95" />
         </div>
       )}
@@ -3483,7 +3483,7 @@ ${systemCommon}` + baseSys;
             scrollToBottom(el);
             setShowJump(false);
           }}
-          className="fixed bottom-20 right-4 md:hidden z-20 rounded-full p-2 bg-[#2563EB] text-white shadow"
+          className="fixed bottom-20 right-4 lg:hidden z-20 rounded-full p-2 bg-[#2563EB] text-white shadow"
           aria-label="Jump to latest"
         >
           <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -47,7 +47,6 @@ import { pushAssistantToChat } from "@/lib/chat/pushAssistantToChat";
 import { getUserPosition, fetchNearby, geocodeArea, type NearbyKind, type NearbyPlace } from "@/lib/nearby";
 import { formatTrialBriefMarkdown } from "@/lib/trials/brief";
 import { useIsAiDocMode } from "@/hooks/useIsAiDocMode";
-import { ENABLE_MOBILE_UI } from "@/env";
 
 const AIDOC_UI = process.env.NEXT_PUBLIC_AIDOC_UI === '1';
 const AIDOC_PREFLIGHT = process.env.NEXT_PUBLIC_AIDOC_PREFLIGHT === '1';
@@ -3468,11 +3467,9 @@ ${systemCommon}` + baseSys;
         </div>
       )}
 
-      {ENABLE_MOBILE_UI && (
-        <div className="lg:hidden">
-          <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-[#FFFFFF]/95 to-transparent dark:from-[#0B1220]/95" />
-        </div>
-      )}
+      <div className="lg:hidden">
+        <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-[#FFFFFF]/95 to-transparent dark:from-[#0B1220]/95" />
+      </div>
 
       {showJump && (
         <button

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -47,6 +47,7 @@ import { pushAssistantToChat } from "@/lib/chat/pushAssistantToChat";
 import { getUserPosition, fetchNearby, geocodeArea, type NearbyKind, type NearbyPlace } from "@/lib/nearby";
 import { formatTrialBriefMarkdown } from "@/lib/trials/brief";
 import { useIsAiDocMode } from "@/hooks/useIsAiDocMode";
+import { ENABLE_MOBILE_UI } from "@/env";
 
 const AIDOC_UI = process.env.NEXT_PUBLIC_AIDOC_UI === '1';
 const AIDOC_PREFLIGHT = process.env.NEXT_PUBLIC_AIDOC_PREFLIGHT === '1';
@@ -3467,27 +3468,27 @@ ${systemCommon}` + baseSys;
         </div>
       )}
 
-      <div className="md:hidden">
-        <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-slate-950/95 to-transparent" />
-      </div>
+      {ENABLE_MOBILE_UI && (
+        <div className="md:hidden">
+          <div className="pointer-events-none fixed inset-x-0 bottom-[64px] z-10 h-12 bg-gradient-to-t from-[#FFFFFF]/95 to-transparent dark:from-[#0B1220]/95" />
+        </div>
+      )}
 
-      {showJump && (
+      {ENABLE_MOBILE_UI && showJump && (
         <button
           type="button"
           onClick={() => {
             const el = chatRef.current;
             if (!el) return;
-            scrollToBottom(el);
+            el.scrollTo?.({ top: el.scrollHeight, behavior: "smooth" });
             setShowJump(false);
           }}
-          className="fixed bottom-24 left-1/2 z-20 -translate-x-1/2 rounded-full bg-blue-600 px-3 py-2 text-xs font-medium text-white shadow-lg md:hidden"
+          className="fixed bottom-20 right-4 z-20 md:hidden rounded-full p-2 bg-[#2563EB] text-white shadow-lg transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+          aria-label="Jump to latest"
         >
-          <span className="inline-flex items-center gap-1">
-            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 12l6 6 6-6" />
-            </svg>
-            Jump to latest
-          </span>
+          <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 10l6 6 6-6" />
+          </svg>
         </button>
       )}
 

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -3474,16 +3474,16 @@ ${systemCommon}` + baseSys;
         </div>
       )}
 
-      {ENABLE_MOBILE_UI && showJump && (
+      {showJump && (
         <button
           type="button"
           onClick={() => {
             const el = chatRef.current;
             if (!el) return;
-            el.scrollTo?.({ top: el.scrollHeight, behavior: "smooth" });
+            scrollToBottom(el);
             setShowJump(false);
           }}
-          className="fixed bottom-20 right-4 z-20 md:hidden rounded-full p-2 bg-[#2563EB] text-white shadow-lg transition hover:bg-[#1D4ED8] dark:bg-[#3B82F6] dark:hover:bg-[#2563EB]"
+          className="fixed bottom-20 right-4 md:hidden z-20 rounded-full p-2 bg-[#2563EB] text-white shadow"
           aria-label="Jump to latest"
         >
           <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -3483,7 +3483,7 @@ ${systemCommon}` + baseSys;
             scrollToBottom(el);
             setShowJump(false);
           }}
-          className="fixed bottom-20 right-4 lg:hidden z-20 rounded-full p-2 bg-[#2563EB] text-white shadow"
+          className="fixed bottom-20 right-4 lg:hidden z-50 rounded-full p-2 bg-[#2563EB] text-white shadow"
           aria-label="Jump to latest"
         >
           <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2">

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -53,7 +53,11 @@ function NavLink({
       prefetch={false}
       scroll={false}
       onClick={(e) => e.stopPropagation()}
-      className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
+      className={`block w-full rounded-lg px-3 py-2 text-sm transition ${
+        active
+          ? "bg-slate-800/80 text-white shadow-sm md:bg-muted md:text-slate-900"
+          : "text-slate-300 hover:bg-slate-800/50 md:text-slate-600 md:hover:bg-muted"
+      }`}
       data-testid={`nav-${panel}`}
       aria-current={active ? "page" : undefined}
     >

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -53,10 +53,10 @@ function NavLink({
       prefetch={false}
       scroll={false}
       onClick={(e) => e.stopPropagation()}
-      className={`block w-full rounded-lg px-3 py-2 text-sm transition ${
+      className={`block w-full rounded-lg px-3 py-2 text-sm font-medium transition ${
         active
-          ? "bg-slate-800/80 text-white shadow-sm md:bg-muted md:text-slate-900"
-          : "text-slate-300 hover:bg-slate-800/50 md:text-slate-600 md:hover:bg-muted"
+          ? "bg-[#2563EB] text-white shadow-sm dark:bg-[#3B82F6]"
+          : "text-[#334155] hover:bg-[#2563EB]/10 dark:text-[#94A3B8] dark:hover:bg-[#3B82F6]/10"
       }`}
       data-testid={`nav-${panel}`}
       aria-current={active ? "page" : undefined}

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -55,9 +55,9 @@ function NavLink({
       onClick={(e) => e.stopPropagation()}
       className={`block w-full rounded-lg px-3 py-2 text-sm font-medium transition ${
         active
-          ? "bg-[#2563EB] text-white shadow-sm dark:bg-[#3B82F6]"
-          : "text-[#334155] hover:bg-[#2563EB]/10 dark:text-[#94A3B8] dark:hover:bg-[#3B82F6]/10"
-      }`}
+          ? "bg-[#2563EB] text-white shadow-sm dark:bg-[#3B82F6] md:bg-muted md:text-inherit md:font-medium"
+          : "text-[#334155] hover:bg-[#2563EB]/10 dark:text-[#94A3B8] dark:hover:bg-[#3B82F6]/10 md:text-inherit md:hover:bg-muted"
+      } md:rounded-md`}
       data-testid={`nav-${panel}`}
       aria-current={active ? "page" : undefined}
     >

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,3 @@
+export const ENABLE_MOBILE_UI =
+  typeof process !== "undefined" &&
+  process.env.NEXT_PUBLIC_ENABLE_MOBILE_UI === "1";

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,3 +1,2 @@
 export const ENABLE_MOBILE_UI =
-  typeof process !== "undefined" &&
-  process.env.NEXT_PUBLIC_ENABLE_MOBILE_UI === "1";
+  (process.env.NEXT_PUBLIC_ENABLE_MOBILE_UI ?? "1") === "1";


### PR DESCRIPTION
## Summary
- add a dedicated mobile header with overflow menu wiring, slide-in drawer, and sticky mode chips across the chat routes
- rework chat bubbles, feedback placement, and jump-to-latest affordance for narrow screens while preserving desktop layout
- refresh the composer with fixed positioning, file previews, and updated ChatPane scroll styling to mirror ChatGPT’s mobile flow

## Testing
- `npm run lint` *(fails: interactive Next.js eslint bootstrap prompt in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c6626f88832f8429f94856ba82a9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Major client-side chat UI overhaul: responsive two-column desktop layout, mobile header/drawer, collapsible sidebar, contextual overflow menu with actions (Rename, Duplicate, Share, Delete, Settings, Theme, Country), and start-new-chat navigation.
  - Multi-file attachments with image previews, inline message attachments, Jump-to-latest button, per-message feedback controls, and improved send flow.
  - New error boundary and developer debug overlay showing mobile/layout state.

- **Style**
  - Wide visual and accessibility refinements across sidebar, tabs, country picker, mode bar, header, and theme controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->