### PR TITLE
Add mobile chat layout and controls

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -566,13 +566,46 @@ body {
     max-width: 64rem;
   }
 
-  .mobile-footer-text {
+  .mobile-footer-message {
     flex: 1;
     min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     overflow: hidden;
-    text-overflow: ellipsis;
+    position: relative;
+    line-height: 1.35;
+    padding: 0.2rem 0;
+  }
+
+  .mobile-footer-marquee-track {
+    display: inline-flex;
+    align-items: center;
+    gap: 2.75rem;
+    min-width: max-content;
     white-space: nowrap;
-    text-align: center;
+    will-change: transform;
+  }
+
+  .mobile-footer-marquee-segment {
+    white-space: nowrap;
+  }
+
+  .mobile-footer-marquee-active .mobile-footer-marquee-track {
+    animation: mobile-footer-marquee var(--mobile-footer-marquee-duration, 20s) linear infinite;
+  }
+
+  .mobile-footer-marquee-active .mobile-footer-marquee-track:hover {
+    animation-play-state: paused;
+  }
+
+  @keyframes mobile-footer-marquee {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(var(--mobile-footer-marquee-distance, -50%));
+    }
   }
 
   .mobile-footer-action {

--- a/app/globals.css
+++ b/app/globals.css
@@ -526,6 +526,10 @@ body {
     border-top: 1px solid var(--medx-outline);
   }
 
+  .mobile-composer-region {
+    padding-bottom: calc(var(--mobile-footer-height, 0px) + var(--mobile-composer-offset, 0px));
+  }
+
   .mobile-footer {
     position: fixed;
     left: 0;

--- a/app/globals.css
+++ b/app/globals.css
@@ -200,7 +200,9 @@ body {
   :root {
     --mobile-header-height: calc(3.5rem + env(safe-area-inset-top));
     --mobile-composer-height: 88px;
-    --mobile-composer-gap: 120px;
+    --mobile-composer-spacer: max(1.5rem, env(safe-area-inset-bottom) + 1rem);
+    --mobile-composer-gap: calc(var(--mobile-composer-height) + var(--mobile-composer-spacer));
+    --mobile-footer-height: 72px;
   }
 
   .mobile-header {
@@ -208,10 +210,10 @@ body {
     top: 0;
     z-index: 50;
     display: flex;
-    align-items: flex-end;
-    gap: 0.5rem;
+    align-items: center;
+    gap: 0.75rem;
     height: var(--mobile-header-height);
-    padding: calc(env(safe-area-inset-top) + 0.25rem) 0.75rem 0.5rem;
+    padding: calc(env(safe-area-inset-top) + 0.25rem) 0.75rem 0.4rem;
     background: var(--medx-panel);
     backdrop-filter: saturate(140%) blur(16px);
     border-bottom: 1px solid var(--medx-outline);
@@ -219,12 +221,12 @@ body {
 
   .mobile-header-logo {
     display: block;
-    max-height: 1.5rem;
+    max-height: 1.75rem;
     width: auto;
   }
 
   .mobile-header-logo img {
-    max-height: 1.5rem;
+    max-height: 1.75rem;
     width: auto;
     height: auto;
   }
@@ -303,7 +305,7 @@ body {
 
   .mobile-content-offset {
     padding-top: var(--mobile-header-height);
-    padding-bottom: calc(var(--mobile-composer-gap, 120px) + 0.75rem);
+    padding-bottom: calc(var(--mobile-composer-gap, 120px) + var(--mobile-footer-height, 72px));
   }
 
   .mobile-sheet-root {
@@ -466,16 +468,23 @@ body {
     right: 0;
     z-index: 40;
     padding: 0.75rem 1rem;
-    padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
     background: var(--medx-panel);
     backdrop-filter: saturate(140%) blur(16px);
     border-top: 1px solid var(--medx-outline);
     box-shadow: 0 -12px 30px rgba(15, 23, 42, 0.12);
   }
 
+  .mobile-footer {
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+  }
+
   .mobile-chat-scroll {
-    padding-bottom: calc(var(--mobile-composer-gap, 120px));
-    scroll-padding-bottom: calc(var(--mobile-composer-gap, 120px));
+    padding-bottom: var(--mobile-composer-gap, 120px);
+    scroll-padding-bottom: var(--mobile-composer-gap, 120px);
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: auto;
+    touch-action: pan-y;
   }
 
   .mobile-tappable {

--- a/app/globals.css
+++ b/app/globals.css
@@ -219,9 +219,9 @@ body {
     --mobile-header-height: calc(var(--mobile-header-base-height) + var(--mobile-header-safe-area));
     --mobile-footer-base-height: 48px;
     --mobile-footer-safe-area: env(safe-area-inset-bottom);
-    --mobile-footer-height: calc(var(--mobile-footer-base-height) + var(--mobile-footer-safe-area));
+    --mobile-footer-height: var(--mobile-footer-base-height);
     --mobile-composer-height: 88px;
-    --mobile-composer-offset: max(0.75rem, var(--mobile-footer-safe-area));
+    --mobile-composer-offset: 0.75rem;
     --mobile-composer-gap: calc(var(--mobile-composer-height) + var(--mobile-composer-offset));
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -221,7 +221,7 @@ body {
     --mobile-footer-safe-area: env(safe-area-inset-bottom);
     --mobile-footer-height: var(--mobile-footer-base-height);
     --mobile-composer-height: 88px;
-    --mobile-composer-offset: 0.75rem;
+    --mobile-composer-offset: 1rem;
     --mobile-composer-gap: calc(var(--mobile-composer-height) + var(--mobile-composer-offset));
   }
 
@@ -750,6 +750,23 @@ body {
   .dark .mobile-www-btn:not([data-state="on"]):hover,
   .dark .mobile-www-btn:not([data-state="on"]):focus-visible {
     background: rgba(15, 23, 42, 0.35);
+  }
+
+  .mobile-chat-scroll-empty {
+    padding-bottom: calc(
+      var(--mobile-footer-height, 0px) +
+        var(--mobile-footer-safe-area, 0px) +
+        var(--mobile-composer-offset, 0px)
+    );
+    scroll-padding-bottom: calc(
+      var(--mobile-footer-height, 0px) +
+        var(--mobile-footer-safe-area, 0px) +
+        var(--mobile-composer-offset, 0px)
+    );
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: contain;
+    overscroll-behavior-x: none;
+    touch-action: pan-y;
   }
 
   .mobile-chat-scroll {

--- a/app/globals.css
+++ b/app/globals.css
@@ -539,11 +539,12 @@ body {
     background: var(--medx-panel);
     backdrop-filter: saturate(140%) blur(16px);
     border-top: 1px solid var(--medx-outline);
-    box-shadow: 0 -12px 30px rgba(15, 23, 42, 0.12);
   }
 
   .mobile-footer {
-    position: sticky;
+    position: fixed;
+    left: 0;
+    right: 0;
     bottom: 0;
     z-index: 35;
     display: flex;
@@ -571,6 +572,7 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    text-align: center;
   }
 
   .mobile-footer-action {
@@ -581,6 +583,156 @@ body {
     padding: 0 0.85rem;
     border-radius: 0.75rem;
     white-space: nowrap;
+  }
+
+  .mobile-footer-icon {
+    width: 2.75rem;
+    height: 2.75rem;
+    flex-shrink: 0;
+  }
+
+  .mobile-mode-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: 0.25rem;
+    position: relative;
+    min-width: 0;
+  }
+
+  .mobile-mode-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    min-width: 0;
+    border-radius: 9999px;
+    border: 1px solid var(--medx-outline);
+    background: var(--medx-surface);
+    padding: 0.35rem 0.75rem;
+    height: 2.5rem;
+    font-size: 0.9rem;
+    color: var(--medx-text);
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+  }
+
+  .mobile-mode-trigger:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: 2px;
+  }
+
+  .mobile-mode-trigger:hover {
+    background: rgba(255, 255, 255, 0.6);
+    border-color: rgba(15, 23, 42, 0.15);
+  }
+
+  .dark .mobile-mode-trigger:hover {
+    background: rgba(8, 25, 57, 0.85);
+    border-color: rgba(255, 255, 255, 0.12);
+  }
+
+  .mobile-mode-label {
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 7.5rem;
+  }
+
+  .mobile-mode-dropdown {
+    position: absolute;
+    top: calc(100% + 0.45rem);
+    left: 0;
+    right: auto;
+    min-width: 11rem;
+    max-width: calc(100vw - 2rem);
+    padding: 0.35rem;
+    border-radius: 0.85rem;
+    background: var(--medx-panel);
+    border: 1px solid var(--medx-outline);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    z-index: 80;
+  }
+
+  .mobile-mode-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    border-radius: 0.75rem;
+    padding: 0.6rem 0.85rem;
+    background: transparent;
+    color: var(--medx-text);
+    font-size: 0.9rem;
+    transition: background-color 0.2s ease;
+  }
+
+  .mobile-mode-option:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .mobile-mode-option-active {
+    background: rgba(59, 130, 246, 0.12);
+    font-weight: 600;
+  }
+
+  .mobile-mode-option:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: 2px;
+  }
+
+  .mobile-mode-option:not(.mobile-mode-option-active):hover {
+    background: rgba(255, 255, 255, 0.45);
+  }
+
+  .dark .mobile-mode-option:not(.mobile-mode-option-active):hover {
+    background: rgba(8, 25, 57, 0.75);
+  }
+
+  .mobile-www-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 9999px;
+    border: 1px solid var(--medx-outline);
+    background: transparent;
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    color: var(--medx-text);
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  }
+
+  .mobile-www-toggle span {
+    pointer-events: none;
+  }
+
+  .mobile-www-toggle:hover,
+  .mobile-www-toggle:focus-visible {
+    background: rgba(255, 255, 255, 0.55);
+    border-color: rgba(15, 23, 42, 0.2);
+  }
+
+  .dark .mobile-www-toggle:hover,
+  .dark .mobile-www-toggle:focus-visible {
+    background: rgba(8, 25, 57, 0.85);
+    border-color: rgba(255, 255, 255, 0.16);
+  }
+
+  .mobile-www-toggle-active {
+    background: var(--medx-accent);
+    border-color: transparent;
+    color: #fff;
+  }
+
+  .mobile-www-toggle:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
   }
 
   .mobile-chat-scroll {

--- a/app/globals.css
+++ b/app/globals.css
@@ -692,47 +692,34 @@ body {
     background: rgba(8, 25, 57, 0.75);
   }
 
-  .mobile-www-toggle {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 2.5rem;
-    height: 2.5rem;
-    border-radius: 9999px;
-    border: 1px solid var(--medx-outline);
-    background: transparent;
-    font-size: 0.65rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    color: var(--medx-text);
-    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  .mobile-www-btn {
+    position: relative;
+    transition: color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
   }
 
-  .mobile-www-toggle span {
+  .mobile-www-btn svg {
     pointer-events: none;
   }
 
-  .mobile-www-toggle:hover,
-  .mobile-www-toggle:focus-visible {
-    background: rgba(255, 255, 255, 0.55);
-    border-color: rgba(15, 23, 42, 0.2);
-  }
-
-  .dark .mobile-www-toggle:hover,
-  .dark .mobile-www-toggle:focus-visible {
-    background: rgba(8, 25, 57, 0.85);
-    border-color: rgba(255, 255, 255, 0.16);
-  }
-
-  .mobile-www-toggle-active {
-    background: var(--medx-accent);
-    border-color: transparent;
-    color: #fff;
-  }
-
-  .mobile-www-toggle:disabled {
+  .mobile-www-btn[data-enabled="false"] {
     opacity: 0.45;
     cursor: not-allowed;
+  }
+
+  .mobile-www-btn[data-state="on"] {
+    color: var(--medx-accent);
+    box-shadow: inset 0 0 0 1.5px var(--medx-accent);
+  }
+
+  .mobile-www-btn:not([data-state="on"]):hover,
+  .mobile-www-btn:not([data-state="on"]):focus-visible {
+    background: rgba(255, 255, 255, 0.45);
+    border-color: var(--medx-outline);
+  }
+
+  .dark .mobile-www-btn:not([data-state="on"]):hover,
+  .dark .mobile-www-btn:not([data-state="on"]):focus-visible {
+    background: rgba(15, 23, 42, 0.35);
   }
 
   .mobile-chat-scroll {

--- a/app/globals.css
+++ b/app/globals.css
@@ -231,6 +231,7 @@ body {
     z-index: 55;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 0.75rem;
     height: var(--mobile-header-height);
     padding: var(--mobile-header-safe-area) 0.75rem 0;
@@ -238,6 +239,32 @@ body {
     backdrop-filter: saturate(140%) blur(16px);
     border-bottom: 1px solid var(--medx-outline);
     box-sizing: border-box;
+  }
+
+  .mobile-header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .mobile-header-logo {
+    display: inline-flex;
+    align-items: center;
+    max-height: 24px;
+    color: var(--medx-text);
+  }
+
+  .mobile-header-logo img {
+    height: 24px;
+    width: auto;
+  }
+
+  .mobile-header-logo span {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--medx-text);
   }
 
   .mobile-header-actions {

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,6 +197,12 @@ body {
 }
 
 @media (max-width: 768px) {
+  :root {
+    --mobile-header-height: calc(3.5rem + env(safe-area-inset-top));
+    --mobile-composer-height: 88px;
+    --mobile-composer-gap: 120px;
+  }
+
   .mobile-header {
     position: sticky;
     top: 0;
@@ -204,7 +210,7 @@ body {
     display: flex;
     align-items: flex-end;
     gap: 0.5rem;
-    height: calc(3.5rem + env(safe-area-inset-top));
+    height: var(--mobile-header-height);
     padding: calc(env(safe-area-inset-top) + 0.25rem) 0.75rem 0.5rem;
     background: var(--medx-panel);
     backdrop-filter: saturate(140%) blur(16px);
@@ -257,6 +263,7 @@ body {
     inset: 0;
     z-index: 60;
     display: flex;
+    justify-content: flex-start;
   }
 
   .mobile-sidebar-backdrop {
@@ -270,12 +277,13 @@ body {
 
   .mobile-sidebar-panel {
     position: relative;
-    margin-left: auto;
+    margin-left: 0;
+    margin-right: auto;
     height: 100%;
     width: min(20rem, 100%);
     background: var(--medx-panel);
     backdrop-filter: blur(18px);
-    border-left: 1px solid var(--medx-outline);
+    border-right: 1px solid var(--medx-outline);
     display: flex;
     flex-direction: column;
   }
@@ -294,7 +302,8 @@ body {
   }
 
   .mobile-content-offset {
-    padding-top: calc(3.5rem + env(safe-area-inset-top));
+    padding-top: var(--mobile-header-height);
+    padding-bottom: calc(var(--mobile-composer-gap, 120px) + 0.75rem);
   }
 
   .mobile-sheet-root {
@@ -462,6 +471,37 @@ body {
     backdrop-filter: saturate(140%) blur(16px);
     border-top: 1px solid var(--medx-outline);
     box-shadow: 0 -12px 30px rgba(15, 23, 42, 0.12);
+  }
+
+  .mobile-chat-scroll {
+    padding-bottom: calc(var(--mobile-composer-gap, 120px));
+    scroll-padding-bottom: calc(var(--mobile-composer-gap, 120px));
+  }
+
+  .mobile-tappable {
+    min-height: 44px;
+  }
+
+  .mobile-truncate-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .mobile-medical-profile {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.25rem 1rem 1.5rem;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    max-height: calc(100vh - var(--mobile-header-height) - var(--mobile-composer-gap, 120px));
+  }
+
+  .mobile-medical-profile section,
+  .mobile-medical-profile > * {
+    width: 100%;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -233,28 +233,6 @@ body {
     box-sizing: border-box;
   }
 
-  .mobile-header-brand {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    overflow: hidden;
-  }
-
-  .mobile-header-logo {
-    display: block;
-    flex-shrink: 0;
-    max-height: 1.5rem;
-    width: auto;
-  }
-
-  .mobile-header-logo img {
-    max-height: 1.5rem;
-    width: auto;
-    height: auto;
-  }
-
   .mobile-header-actions {
     display: flex;
     align-items: center;
@@ -530,10 +508,10 @@ body {
   }
 
   .mobile-composer {
-    position: sticky;
-    bottom: calc(var(--mobile-footer-height, 0px) + var(--mobile-composer-offset, 0px));
+    position: fixed;
     left: 0;
     right: 0;
+    bottom: calc(var(--mobile-footer-height, 0px) + var(--mobile-composer-offset, 0px));
     z-index: 45;
     padding: 0.75rem 1rem;
     background: var(--medx-panel);
@@ -625,19 +603,22 @@ body {
   }
 
   .mobile-mode-controls {
+    flex: 1;
+    min-width: 0;
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: 0.5rem;
-    margin-left: 0.25rem;
     position: relative;
-    min-width: 0;
   }
 
   .mobile-mode-trigger {
-    display: inline-flex;
+    display: flex;
     align-items: center;
+    justify-content: center;
     gap: 0.35rem;
     min-width: 0;
+    max-width: 100%;
     border-radius: 9999px;
     border: 1px solid var(--medx-outline);
     background: var(--medx-surface);
@@ -664,11 +645,14 @@ body {
   }
 
   .mobile-mode-label {
+    flex: 1;
+    min-width: 0;
     font-weight: 600;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 7.5rem;
+    max-width: 100%;
+    text-align: center;
   }
 
   .mobile-mode-dropdown {

--- a/app/globals.css
+++ b/app/globals.css
@@ -221,7 +221,7 @@ body {
   .mobile-header {
     position: sticky;
     top: 0;
-    z-index: 50;
+    z-index: 55;
     display: flex;
     align-items: center;
     gap: 0.75rem;
@@ -534,7 +534,7 @@ body {
     bottom: calc(var(--mobile-footer-height, 0px) + var(--mobile-composer-offset, 0px));
     left: 0;
     right: 0;
-    z-index: 40;
+    z-index: 45;
     padding: 0.75rem 1rem;
     background: var(--medx-panel);
     backdrop-filter: saturate(140%) blur(16px);
@@ -546,7 +546,7 @@ body {
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 35;
+    z-index: 40;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -727,7 +727,7 @@ body {
 
   .mobile-www-btn {
     position: relative;
-    transition: color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+    transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
   }
 
   .mobile-www-btn svg {
@@ -737,11 +737,17 @@ body {
   .mobile-www-btn[data-enabled="false"] {
     opacity: 0.45;
     cursor: not-allowed;
+    color: var(--medx-subtext);
   }
 
   .mobile-www-btn[data-state="on"] {
     color: var(--medx-accent);
-    box-shadow: inset 0 0 0 1.5px var(--medx-accent);
+    border-color: currentColor;
+    background: rgba(255, 255, 255, 0.4);
+  }
+
+  .dark .mobile-www-btn[data-state="on"] {
+    background: rgba(15, 23, 42, 0.35);
   }
 
   .mobile-www-btn:not([data-state="on"]):hover,

--- a/app/globals.css
+++ b/app/globals.css
@@ -192,7 +192,276 @@ body,
 }
 
 html,
-body {
+body { 
   overflow: hidden;
+}
+
+@media (max-width: 768px) {
+  .mobile-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    display: flex;
+    align-items: flex-end;
+    gap: 0.5rem;
+    height: calc(3.5rem + env(safe-area-inset-top));
+    padding: calc(env(safe-area-inset-top) + 0.25rem) 0.75rem 0.5rem;
+    background: var(--medx-panel);
+    backdrop-filter: saturate(140%) blur(16px);
+    border-bottom: 1px solid var(--medx-outline);
+  }
+
+  .mobile-header-logo {
+    display: block;
+    max-height: 1.5rem;
+    width: auto;
+  }
+
+  .mobile-header-logo img {
+    max-height: 1.5rem;
+    width: auto;
+    height: auto;
+  }
+
+  .mobile-icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 9999px;
+    color: var(--medx-text);
+    background: transparent;
+    border: 1px solid transparent;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+  }
+
+  .mobile-icon-btn:hover,
+  .mobile-icon-btn:focus-visible {
+    background: rgba(255, 255, 255, 0.4);
+    border-color: var(--medx-outline);
+  }
+
+  .dark .mobile-icon-btn:hover,
+  .dark .mobile-icon-btn:focus-visible {
+    background: rgba(15, 23, 42, 0.35);
+  }
+
+  .mobile-icon-btn:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: 2px;
+  }
+
+  .mobile-sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    display: flex;
+  }
+
+  .mobile-sidebar-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    border: none;
+    padding: 0;
+    cursor: pointer;
+  }
+
+  .mobile-sidebar-panel {
+    position: relative;
+    margin-left: auto;
+    height: 100%;
+    width: min(20rem, 100%);
+    background: var(--medx-panel);
+    backdrop-filter: blur(18px);
+    border-left: 1px solid var(--medx-outline);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .mobile-sidebar-header {
+    display: flex;
+    justify-content: flex-end;
+    padding: 0.75rem;
+    border-bottom: 1px solid var(--medx-outline);
+  }
+
+  .mobile-sidebar-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem 1rem 2rem;
+  }
+
+  .mobile-content-offset {
+    padding-top: calc(3.5rem + env(safe-area-inset-top));
+  }
+
+  .mobile-sheet-root {
+    position: fixed;
+    inset: 0;
+    z-index: 70;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+  }
+
+  .mobile-sheet-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    border: none;
+    padding: 0;
+    cursor: pointer;
+  }
+
+  .mobile-sheet-panel {
+    position: relative;
+    width: 100%;
+    max-width: 32rem;
+    border-top-left-radius: 1rem;
+    border-top-right-radius: 1rem;
+    background: var(--medx-panel);
+    backdrop-filter: blur(18px);
+    border-top: 1px solid var(--medx-outline);
+    box-shadow: 0 -12px 36px rgba(15, 23, 42, 0.25);
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+  }
+
+  .mobile-sheet-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .mobile-sheet-handle {
+    display: inline-block;
+    width: 2.5rem;
+    height: 0.35rem;
+    border-radius: 9999px;
+    background: var(--medx-outline);
+  }
+
+  .mobile-sheet-title {
+    flex: 1;
+    text-align: center;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--medx-text);
+  }
+
+  .mobile-sheet-section {
+    display: flex;
+    flex-direction: column;
+    padding: 0.25rem 0.5rem;
+    gap: 0.25rem;
+  }
+
+  .mobile-sheet-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    width: 100%;
+    min-height: 2.75rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.9rem;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--medx-text);
+    font-size: 0.95rem;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+  }
+
+  .mobile-sheet-item:hover,
+  .mobile-sheet-item:focus-visible {
+    background: rgba(255, 255, 255, 0.45);
+    border-color: var(--medx-outline);
+  }
+
+  .dark .mobile-sheet-item:hover,
+  .dark .mobile-sheet-item:focus-visible {
+    background: rgba(15, 23, 42, 0.4);
+  }
+
+  .mobile-sheet-item:focus-visible {
+    outline: 2px solid #3b82f6;
+    outline-offset: 2px;
+  }
+
+  .mobile-sheet-item-label {
+    font-weight: 500;
+  }
+
+  .mobile-sheet-item-value {
+    font-size: 0.9rem;
+    color: var(--medx-subtext);
+  }
+
+  .mobile-sheet-item-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--medx-subtext);
+  }
+
+  .mobile-sheet-search {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0.5rem 0.75rem;
+    padding: 0.6rem 0.75rem;
+    border-radius: 0.85rem;
+    border: 1px solid var(--medx-outline);
+    background: rgba(255, 255, 255, 0.6);
+  }
+
+  .dark .mobile-sheet-search {
+    background: rgba(8, 25, 57, 0.85);
+  }
+
+  .mobile-sheet-search input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    font-size: 0.9rem;
+    color: var(--medx-text);
+  }
+
+  .mobile-sheet-search input:focus {
+    outline: none;
+  }
+
+  .mobile-sheet-list {
+    max-height: 16rem;
+    overflow-y: auto;
+    padding: 0.25rem 0.5rem 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .mobile-sheet-country {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 0.95rem;
+  }
+
+  .mobile-composer {
+    position: sticky;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 40;
+    padding: 0.75rem 1rem;
+    padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+    background: var(--medx-panel);
+    backdrop-filter: saturate(140%) blur(16px);
+    border-top: 1px solid var(--medx-outline);
+    box-shadow: 0 -12px 30px rgba(15, 23, 42, 0.12);
+  }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,13 @@
 /* smooth theme transitions */
 * { transition: background-color .15s ease, color .15s ease, border-color .15s ease; }
 
+@layer base {
+  html,
+  body {
+    font-family: "Proxima Nova", "proxima-nova", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  }
+}
+
 .btn-secondary{
   @apply inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm transition
          bg-white text-slate-700 border-slate-200 hover:bg-slate-50

--- a/app/globals.css
+++ b/app/globals.css
@@ -221,7 +221,7 @@ body {
     --mobile-footer-safe-area: env(safe-area-inset-bottom);
     --mobile-footer-height: var(--mobile-footer-base-height);
     --mobile-composer-height: 88px;
-    --mobile-composer-offset: 1rem;
+    --mobile-composer-offset: 1.75rem;
     --mobile-composer-gap: calc(var(--mobile-composer-height) + var(--mobile-composer-offset));
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -202,15 +202,20 @@ body {
     overflow-x: hidden;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
-    overscroll-behavior-y: auto;
+    overscroll-behavior-y: none;
+    touch-action: pan-y;
   }
 
   :root {
-    --mobile-header-height: calc(3.5rem + env(safe-area-inset-top));
+    --mobile-header-base-height: 52px;
+    --mobile-header-safe-area: env(safe-area-inset-top);
+    --mobile-header-height: calc(var(--mobile-header-base-height) + var(--mobile-header-safe-area));
+    --mobile-footer-base-height: 48px;
+    --mobile-footer-safe-area: env(safe-area-inset-bottom);
+    --mobile-footer-height: calc(var(--mobile-footer-base-height) + var(--mobile-footer-safe-area));
     --mobile-composer-height: 88px;
-    --mobile-composer-offset: max(0.75rem, env(safe-area-inset-bottom) * 0.6);
+    --mobile-composer-offset: max(0.75rem, var(--mobile-footer-safe-area));
     --mobile-composer-gap: calc(var(--mobile-composer-height) + var(--mobile-composer-offset));
-    --mobile-footer-height: 48px;
   }
 
   .mobile-header {
@@ -221,22 +226,40 @@ body {
     align-items: center;
     gap: 0.75rem;
     height: var(--mobile-header-height);
-    padding: calc(env(safe-area-inset-top) + 0.25rem) 0.75rem 0.4rem;
+    padding: var(--mobile-header-safe-area) 0.75rem 0;
     background: var(--medx-panel);
     backdrop-filter: saturate(140%) blur(16px);
     border-bottom: 1px solid var(--medx-outline);
+    box-sizing: border-box;
+  }
+
+  .mobile-header-brand {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    overflow: hidden;
   }
 
   .mobile-header-logo {
     display: block;
-    max-height: 1.75rem;
+    flex-shrink: 0;
+    max-height: 1.5rem;
     width: auto;
   }
 
   .mobile-header-logo img {
-    max-height: 1.75rem;
+    max-height: 1.5rem;
     width: auto;
     height: auto;
+  }
+
+  .mobile-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
   }
 
   .mobile-icon-btn {
@@ -523,15 +546,49 @@ body {
     position: sticky;
     bottom: 0;
     z-index: 35;
-    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: var(--mobile-footer-base-height);
+    padding: 0 1rem;
+    padding-bottom: var(--mobile-footer-safe-area);
+    background: var(--medx-panel);
+    border-top: 1px solid var(--medx-outline);
     backdrop-filter: saturate(140%) blur(16px);
+  }
+
+  .mobile-footer-inner {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    width: 100%;
+    max-width: 64rem;
+  }
+
+  .mobile-footer-text {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mobile-footer-action {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 0.85rem;
+    border-radius: 0.75rem;
+    white-space: nowrap;
   }
 
   .mobile-chat-scroll {
     padding-bottom: calc(var(--mobile-composer-gap, 120px) + var(--mobile-footer-height, 0px));
     scroll-padding-bottom: calc(var(--mobile-composer-gap, 120px) + var(--mobile-footer-height, 0px));
     -webkit-overflow-scrolling: touch;
-    overscroll-behavior-y: auto;
+    overscroll-behavior-y: contain;
+    overscroll-behavior-x: none;
     touch-action: pan-y;
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -197,12 +197,20 @@ body {
 }
 
 @media (max-width: 768px) {
+  html,
+  body {
+    overflow-x: hidden;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: auto;
+  }
+
   :root {
     --mobile-header-height: calc(3.5rem + env(safe-area-inset-top));
     --mobile-composer-height: 88px;
-    --mobile-composer-spacer: max(1.5rem, env(safe-area-inset-bottom) + 1rem);
-    --mobile-composer-gap: calc(var(--mobile-composer-height) + var(--mobile-composer-spacer));
-    --mobile-footer-height: 72px;
+    --mobile-composer-offset: max(0.75rem, env(safe-area-inset-bottom) * 0.6);
+    --mobile-composer-gap: calc(var(--mobile-composer-height) + var(--mobile-composer-offset));
+    --mobile-footer-height: 48px;
   }
 
   .mobile-header {
@@ -242,6 +250,7 @@ body {
     background: transparent;
     border: 1px solid transparent;
     transition: background-color 0.2s ease, border-color 0.2s ease;
+    touch-action: manipulation;
   }
 
   .mobile-icon-btn:hover,
@@ -253,6 +262,15 @@ body {
   .dark .mobile-icon-btn:hover,
   .dark .mobile-icon-btn:focus-visible {
     background: rgba(15, 23, 42, 0.35);
+  }
+
+  .mobile-icon-btn:active {
+    background: rgba(255, 255, 255, 0.55);
+    border-color: var(--medx-outline);
+  }
+
+  .dark .mobile-icon-btn:active {
+    background: rgba(15, 23, 42, 0.5);
   }
 
   .mobile-icon-btn:focus-visible {
@@ -301,11 +319,13 @@ body {
     flex: 1;
     overflow-y: auto;
     padding: 0.5rem 1rem 2rem;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: contain;
   }
 
   .mobile-content-offset {
-    padding-top: var(--mobile-header-height);
-    padding-bottom: calc(var(--mobile-composer-gap, 120px) + var(--mobile-footer-height, 72px));
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   .mobile-sheet-root {
@@ -330,13 +350,27 @@ body {
     position: relative;
     width: 100%;
     max-width: 32rem;
+    max-height: min(88vh, 640px);
     border-top-left-radius: 1rem;
     border-top-right-radius: 1rem;
     background: var(--medx-panel);
     backdrop-filter: blur(18px);
     border-top: 1px solid var(--medx-outline);
     box-shadow: 0 -12px 36px rgba(15, 23, 42, 0.25);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    touch-action: pan-y;
+    will-change: transform;
+    transition: transform 0.24s ease;
+  }
+
+  .mobile-sheet-content {
+    flex: 1;
+    overflow-y: auto;
     padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-y: contain;
   }
 
   .mobile-sheet-header {
@@ -345,6 +379,7 @@ body {
     justify-content: space-between;
     gap: 0.75rem;
     padding: 0.75rem 1rem;
+    flex-shrink: 0;
   }
 
   .mobile-sheet-handle {
@@ -384,6 +419,7 @@ body {
     color: var(--medx-text);
     font-size: 0.95rem;
     transition: background-color 0.2s ease, border-color 0.2s ease;
+    touch-action: manipulation;
   }
 
   .mobile-sheet-item:hover,
@@ -395,6 +431,15 @@ body {
   .dark .mobile-sheet-item:hover,
   .dark .mobile-sheet-item:focus-visible {
     background: rgba(15, 23, 42, 0.4);
+  }
+
+  .mobile-sheet-item:active {
+    background: rgba(255, 255, 255, 0.55);
+    border-color: var(--medx-outline);
+  }
+
+  .dark .mobile-sheet-item:active {
+    background: rgba(15, 23, 42, 0.5);
   }
 
   .mobile-sheet-item:focus-visible {
@@ -463,12 +508,11 @@ body {
 
   .mobile-composer {
     position: sticky;
-    bottom: 0;
+    bottom: calc(var(--mobile-footer-height, 0px) + var(--mobile-composer-offset, 0px));
     left: 0;
     right: 0;
     z-index: 40;
     padding: 0.75rem 1rem;
-    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
     background: var(--medx-panel);
     backdrop-filter: saturate(140%) blur(16px);
     border-top: 1px solid var(--medx-outline);
@@ -476,12 +520,16 @@ body {
   }
 
   .mobile-footer {
+    position: sticky;
+    bottom: 0;
+    z-index: 35;
     padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+    backdrop-filter: saturate(140%) blur(16px);
   }
 
   .mobile-chat-scroll {
-    padding-bottom: var(--mobile-composer-gap, 120px);
-    scroll-padding-bottom: var(--mobile-composer-gap, 120px);
+    padding-bottom: calc(var(--mobile-composer-gap, 120px) + var(--mobile-footer-height, 0px));
+    scroll-padding-bottom: calc(var(--mobile-composer-gap, 120px) + var(--mobile-footer-height, 0px));
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-y: auto;
     touch-action: pan-y;
@@ -489,6 +537,10 @@ body {
 
   .mobile-tappable {
     min-height: 44px;
+  }
+
+  .mobile-scroll-safe {
+    padding-bottom: calc(var(--mobile-footer-height, 0px) + var(--mobile-composer-offset, 0px));
   }
 
   .mobile-truncate-2 {

--- a/app/globals.css
+++ b/app/globals.css
@@ -828,10 +828,15 @@ body {
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    padding: 1.25rem 1rem 1.5rem;
+    padding: 1.25rem 1rem 2.75rem;
     overflow-y: auto;
     overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
     max-height: calc(100vh - var(--mobile-header-height) - var(--mobile-composer-gap, 120px));
+    padding-bottom: calc(
+      2.75rem + var(--mobile-footer-height, 0px) + var(--mobile-composer-offset, 0px)
+    );
   }
 
   .mobile-medical-profile section,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,11 @@ import MemorySnackbar from "@/components/memory/Snackbar";
 import UndoToast from "@/components/memory/UndoToast";
 import AppToastHost from "@/components/ui/AppToastHost";
 import { Roboto } from "next/font/google";
+import dynamic from "next/dynamic";
+
+const MobileHeader = dynamic(() => import("@/components/mobile/MobileHeader"), { ssr: false });
+const MobileSidebarOverlay = dynamic(() => import("@/components/mobile/MobileSidebarOverlay"), { ssr: false });
+const MobileActionsSheet = dynamic(() => import("@/components/mobile/MobileActionsSheet"), { ssr: false });
 
 export const metadata = { title: BRAND_NAME, description: "Global medical AI" };
 
@@ -32,9 +37,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <TopicProvider>
                 <div className="flex h-full min-h-screen flex-col medx-gradient">
                   <Suspense fallback={<div className="h-[62px]" />}>
-                    <Header />
+                    <div className="hidden md:block">
+                      <Header />
+                    </div>
                   </Suspense>
-                  <div className="grid grow min-h-0 grid-cols-12">
+                  <MobileHeader />
+                  <div className="grid grow min-h-0 grid-cols-12 mobile-content-offset md:pt-0">
                     <aside className="hidden min-h-0 overflow-y-auto border-r border-black/5 bg-white/70 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/40 md:col-span-3 md:flex lg:col-span-2">
                       <Suspense fallback={null}>
                         <Sidebar />
@@ -52,6 +60,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <MemorySnackbar />
                   <UndoToast />
                   <AppToastHost />
+                  <MobileSidebarOverlay />
+                  <MobileActionsSheet />
                 </div>
               </TopicProvider>
             </ContextProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,6 @@ import { Suspense } from "react";
 import MemorySnackbar from "@/components/memory/Snackbar";
 import UndoToast from "@/components/memory/UndoToast";
 import AppToastHost from "@/components/ui/AppToastHost";
-import { Inter } from "next/font/google";
 import dynamic from "next/dynamic";
 
 const MobileHeader = dynamic(() => import("@/components/mobile/MobileHeader"), { ssr: false });
@@ -20,16 +19,9 @@ const MobileActionsSheet = dynamic(() => import("@/components/mobile/MobileActio
 
 export const metadata = { title: BRAND_NAME, description: "Global medical AI" };
 
-const inter = Inter({
-  subsets: ["latin"],
-  weight: ["300", "400", "500", "600", "700", "800", "900"],
-  variable: "--font-inter",
-  display: "swap",
-});
-
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={inter.variable} suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <body className="h-full bg-slate-100 text-slate-900 dark:bg-transparent dark:text-slate-100 font-sans antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <CountryProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ import { Suspense } from "react";
 import MemorySnackbar from "@/components/memory/Snackbar";
 import UndoToast from "@/components/memory/UndoToast";
 import AppToastHost from "@/components/ui/AppToastHost";
-import { Roboto } from "next/font/google";
+import { Inter } from "next/font/google";
 import dynamic from "next/dynamic";
 
 const MobileHeader = dynamic(() => import("@/components/mobile/MobileHeader"), { ssr: false });
@@ -20,16 +20,16 @@ const MobileActionsSheet = dynamic(() => import("@/components/mobile/MobileActio
 
 export const metadata = { title: BRAND_NAME, description: "Global medical AI" };
 
-const roboto = Roboto({
+const inter = Inter({
   subsets: ["latin"],
-  weight: ["300", "400", "500", "700", "900"],
-  variable: "--font-roboto",
+  weight: ["300", "400", "500", "600", "700", "800", "900"],
+  variable: "--font-inter",
   display: "swap",
 });
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={roboto.variable} suppressHydrationWarning>
+    <html lang="en" className={inter.variable} suppressHydrationWarning>
       <body className="h-full bg-slate-100 text-slate-900 dark:bg-transparent dark:text-slate-100 font-sans antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <CountryProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,7 +44,7 @@ export default function Page({ searchParams }: { searchParams: Search }) {
           <ChatPane inputRef={chatInputRef} />
         </ResearchFiltersProvider>
       ) : (
-        <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="flex-1 min-h-0 overflow-y-auto mobile-scroll-safe">
           <div className="m-6 rounded-2xl p-6 ring-1 ring-black/5 bg-white/80 dark:bg-slate-900/60 dark:ring-white/10">
             {renderPane()}
           </div>

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -26,6 +26,7 @@ export function ChatWindow() {
   const chatRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<HTMLDivElement>(null);
   const [isThinking, setIsThinking] = useState(false);
+  const hasScrollableContent = messages.length > 0 || results.length > 0;
 
   useLayoutEffect(() => {
     if (typeof window === "undefined") return;
@@ -105,7 +106,11 @@ export function ChatWindow() {
     <div className="flex h-full flex-col">
       <div
         ref={chatRef}
-        className="flex-1 overflow-y-auto px-4 pb-32 pt-4 md:px-0 md:pb-0 md:pt-0 mobile-chat-scroll"
+        className={`flex-1 px-4 pt-4 md:px-0 md:pt-0 ${
+          hasScrollableContent
+            ? "overflow-y-auto mobile-chat-scroll"
+            : "overflow-hidden mobile-chat-scroll-empty"
+        } md:pb-0 md:overflow-y-auto`}
       >
         {messages.map((m, idx) => {
           const isLastMessage = idx === messages.length - 1;

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -49,8 +49,11 @@ export function ChatWindow() {
   };
 
   return (
-    <div className="flex flex-col h-full">
-      <div ref={chatRef} className="flex-1 overflow-auto">
+    <div className="flex h-full flex-col">
+      <div
+        ref={chatRef}
+        className="flex-1 overflow-y-auto px-4 pb-32 pt-4 md:px-0 md:pb-0 md:pt-0"
+      >
         {messages.map((m, idx) => {
           const isLastMessage = idx === messages.length - 1;
           const showThinkingTimer = isLastMessage && isThinking;
@@ -92,7 +95,9 @@ export function ChatWindow() {
           </div>
         )}
       </div>
-      <ChatInput onSend={handleSend} />
+      <div className="mobile-composer md:static md:bg-transparent md:p-0 md:shadow-none">
+        <ChatInput onSend={handleSend} />
+      </div>
       <ScrollToBottom targetRef={chatRef} rebindKey={currentId} />
     </div>
   );

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -106,52 +106,54 @@ export function ChatWindow() {
     <div className="flex h-full flex-col">
       <div
         ref={chatRef}
-        className={`flex-1 px-4 pt-4 md:px-0 md:pt-0 ${
+        className={`flex-1 pt-4 md:px-0 md:pt-0 ${
           hasScrollableContent
             ? "overflow-y-auto mobile-chat-scroll"
             : "overflow-hidden mobile-chat-scroll-empty"
         } md:pb-0 md:overflow-y-auto`}
       >
-        {messages.map((m, idx) => {
-          const isLastMessage = idx === messages.length - 1;
-          const showThinkingTimer = isLastMessage && isThinking;
-          return (
-            <div key={m.id} className="space-y-2">
-              <MessageRow m={m} />
-              {showThinkingTimer ? (
-                <div className="px-2">
-                  <div className="mt-1 inline-flex items-center gap-3 text-sm text-slate-500">
-                    <span>Thinking…</span>
-                    <AnalyzingInline active={showThinkingTimer} />
+        <div className="px-4">
+          {messages.map((m, idx) => {
+            const isLastMessage = idx === messages.length - 1;
+            const showThinkingTimer = isLastMessage && isThinking;
+            return (
+              <div key={m.id} className="space-y-2">
+                <MessageRow m={m} />
+                {showThinkingTimer ? (
+                  <div className="px-2">
+                    <div className="mt-1 inline-flex items-center gap-3 text-sm text-slate-500">
+                      <span>Thinking…</span>
+                      <AnalyzingInline active={showThinkingTimer} />
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+          {results.length > 0 && (
+            <div className="p-2 space-y-2">
+              {results.map((place) => (
+                <div key={place.id} className="result-card border p-2 rounded">
+                  <p>{place.name}</p>
+                  <p className="text-sm opacity-80">{place.address}</p>
+                  <div className="flex flex-wrap items-center gap-3 text-sm">
+                    {place.phone && (
+                      <a href={`tel:${place.phone}`} className="underline">
+                        Call
+                      </a>
+                    )}
+                    {place.mapLink && (
+                      <LinkBadge href={place.mapLink}>
+                        Directions
+                      </LinkBadge>
+                    )}
+                    <span className="opacity-70">{place.distance_km} km</span>
                   </div>
                 </div>
-              ) : null}
+              ))}
             </div>
-          );
-        })}
-        {results.length > 0 && (
-          <div className="p-2 space-y-2">
-            {results.map((place) => (
-              <div key={place.id} className="result-card border p-2 rounded">
-                <p>{place.name}</p>
-                <p className="text-sm opacity-80">{place.address}</p>
-                <div className="flex flex-wrap items-center gap-3 text-sm">
-                  {place.phone && (
-                    <a href={`tel:${place.phone}`} className="underline">
-                      Call
-                    </a>
-                  )}
-                  {place.mapLink && (
-                    <LinkBadge href={place.mapLink}>
-                      Directions
-                    </LinkBadge>
-                  )}
-                  <span className="opacity-70">{place.distance_km} km</span>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+          )}
+        </div>
       </div>
       <div ref={composerRef} className="mobile-composer md:static md:bg-transparent md:p-0 md:shadow-none">
         <ChatInput onSend={handleSend} />

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -51,8 +51,19 @@ export function ChatWindow() {
 
     updateMetrics();
 
+    const handleFooterMetrics = () => {
+      updateMetrics();
+    };
+
+    window.addEventListener("mobile-footer-height-change", handleFooterMetrics);
+    window.addEventListener("resize", updateMetrics);
+
     if (typeof ResizeObserver === "undefined") {
-      return restore;
+      return () => {
+        window.removeEventListener("mobile-footer-height-change", handleFooterMetrics);
+        window.removeEventListener("resize", updateMetrics);
+        restore();
+      };
     }
 
     const observer = new ResizeObserver(() => {
@@ -62,6 +73,8 @@ export function ChatWindow() {
 
     return () => {
       observer.disconnect();
+      window.removeEventListener("mobile-footer-height-change", handleFooterMetrics);
+      window.removeEventListener("resize", updateMetrics);
       restore();
     };
   }, []);

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -33,29 +33,20 @@ export function ChatWindow() {
     if (!composer) return;
     const root = document.documentElement;
     const previousHeight = root.style.getPropertyValue("--mobile-composer-height");
-    const previousGap = root.style.getPropertyValue("--mobile-composer-gap");
-
-    const minGap = 104; // ensures space for footer and last message on first load
+    const hadPreviousHeight = previousHeight.trim().length > 0;
 
     const restore = () => {
-      if (previousHeight) {
+      if (hadPreviousHeight) {
         root.style.setProperty("--mobile-composer-height", previousHeight);
       } else {
         root.style.removeProperty("--mobile-composer-height");
-      }
-      if (previousGap) {
-        root.style.setProperty("--mobile-composer-gap", previousGap);
-      } else {
-        root.style.removeProperty("--mobile-composer-gap");
       }
     };
 
     const updateMetrics = () => {
       const rect = composer.getBoundingClientRect();
-      const height = rect.height;
-      const gap = Math.max(height + 24, minGap);
+      const height = Math.max(64, Math.round(rect.height));
       root.style.setProperty("--mobile-composer-height", `${height}px`);
-      root.style.setProperty("--mobile-composer-gap", `${gap}px`);
     };
 
     updateMetrics();

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { useChatStore } from "@/lib/state/chatStore";
 import { ChatInput } from "@/components/ChatInput";
 import { persistIfTemp } from "@/lib/chat/persist";
@@ -27,7 +27,7 @@ export function ChatWindow() {
   const composerRef = useRef<HTMLDivElement>(null);
   const [isThinking, setIsThinking] = useState(false);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (typeof window === "undefined") return;
     const composer = composerRef.current;
     if (!composer) return;

--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Scale } from "lucide-react";
 
@@ -20,6 +21,8 @@ const PRIVACY_EMAIL =
   process.env.NEXT_PUBLIC_PRIVACY_EMAIL ?? "privacy@secondopinion.ai";
 const GOVERNING_LAW =
   process.env.NEXT_PUBLIC_GOVERNING_LAW ?? "Delaware, USA";
+
+const LEGAL_NOTICE = "Second Opinion can make mistakes… Always consult a clinician.";
 
 const DEFAULT_PREFS: CookiePrefs = {
   essential: true,
@@ -128,6 +131,9 @@ export default function LegalPrivacyFooter() {
   const [agreeChecked, setAgreeChecked] = useState(false);
   const [cookiePrefs, setCookiePrefs] = useState<CookiePrefs>(DEFAULT_PREFS);
   const footerRef = useRef<HTMLElement | null>(null);
+  const marqueeContainerRef = useRef<HTMLDivElement | null>(null);
+  const marqueeTextRef = useRef<HTMLSpanElement | null>(null);
+  const [marqueeVars, setMarqueeVars] = useState<{ duration: number; distance: number } | null>(null);
 
   useLayoutEffect(() => {
     if (typeof window === "undefined") return;
@@ -200,6 +206,55 @@ export default function LegalPrivacyFooter() {
     };
   }, [isOpen]);
 
+  useLayoutEffect(() => {
+    const container = marqueeContainerRef.current;
+    const text = marqueeTextRef.current;
+    if (!container || !text) return;
+
+    const gap = 48;
+    let frame = 0;
+
+    const measure = () => {
+      const containerWidth = container.clientWidth;
+      const textWidth = text.scrollWidth;
+      if (textWidth > containerWidth && containerWidth > 0) {
+        const distance = textWidth + gap;
+        const duration = Math.min(32, Math.max(16, distance / 18));
+        setMarqueeVars(current => {
+          if (current && current.distance === distance && current.duration === duration) {
+            return current;
+          }
+          return { distance, duration };
+        });
+      } else {
+        setMarqueeVars(current => (current ? null : current));
+      }
+    };
+
+    const schedule = () => {
+      cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(measure);
+    };
+
+    schedule();
+
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(schedule);
+      observer.observe(container);
+      observer.observe(text);
+      return () => {
+        cancelAnimationFrame(frame);
+        observer.disconnect();
+      };
+    }
+
+    window.addEventListener("resize", schedule);
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("resize", schedule);
+    };
+  }, []);
+
   const toggleCookie = (key: ToggleableCookie) => {
     setCookiePrefs(prev => ({
       ...prev,
@@ -259,9 +314,29 @@ export default function LegalPrivacyFooter() {
         className="mobile-footer flex-shrink-0 border-t border-black/10 bg-white/80 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/60"
       >
         <div className="mobile-footer-inner mx-auto flex w-full max-w-screen-2xl items-center justify-center gap-1.5 px-6 text-center text-[11px] text-slate-600 dark:text-slate-300 md:gap-3 md:py-1.5 md:text-xs">
-          <p className="mobile-footer-text leading-5 text-center">
-            Second Opinion can make mistakes… Always consult a clinician.
-          </p>
+          <div
+            ref={marqueeContainerRef}
+            className={`mobile-footer-message${marqueeVars ? " mobile-footer-marquee-active" : ""}`}
+            style={
+              marqueeVars
+                ? ({
+                    ["--mobile-footer-marquee-duration" as const]: `${marqueeVars.duration}s`,
+                    ["--mobile-footer-marquee-distance" as const]: `-${marqueeVars.distance}px`,
+                  } as CSSProperties)
+                : undefined
+            }
+          >
+            <div className="mobile-footer-marquee-track">
+              <span ref={marqueeTextRef} className="mobile-footer-marquee-segment">
+                {LEGAL_NOTICE}
+              </span>
+              {marqueeVars ? (
+                <span aria-hidden="true" className="mobile-footer-marquee-segment">
+                  {LEGAL_NOTICE}
+                </span>
+              ) : null}
+            </div>
+          </div>
           <button
             type="button"
             onClick={openModal}

--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -140,12 +140,18 @@ export default function LegalPrivacyFooter() {
     const footer = footerRef.current;
     if (!footer) return;
     const root = document.documentElement;
+    const computed = window.getComputedStyle(root);
+    const baseHeightRaw = computed.getPropertyValue("--mobile-footer-base-height");
+    const parsedBase = Number.parseFloat(baseHeightRaw || "");
+    const fallbackBase = Number.isFinite(parsedBase) ? parsedBase : 48;
     const previous = root.style.getPropertyValue("--mobile-footer-height");
     const hadPrevious = previous.trim().length > 0;
 
     const updateHeight = () => {
       const rect = footer.getBoundingClientRect();
-      root.style.setProperty("--mobile-footer-height", `${Math.round(rect.height)}px`);
+      const measured = Math.max(Math.round(rect.height), 0);
+      const next = Math.max(fallbackBase, measured);
+      root.style.setProperty("--mobile-footer-height", `${next}px`);
     };
 
     updateHeight();

--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 type CookiePrefs = {
   essential: true;
@@ -144,7 +144,7 @@ export default function LegalPrivacyFooter() {
     }
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (typeof window === "undefined") return;
     const footer = footerRef.current;
     if (!footer) return;

--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type CookiePrefs = {
   essential: true;
@@ -126,6 +126,7 @@ export default function LegalPrivacyFooter() {
   const [consentValue, setConsentValue] = useState<"true" | "false" | null>(null);
   const [agreeChecked, setAgreeChecked] = useState(false);
   const [cookiePrefs, setCookiePrefs] = useState<CookiePrefs>(DEFAULT_PREFS);
+  const footerRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -141,6 +142,47 @@ export default function LegalPrivacyFooter() {
     if (parsedConsent === null) {
       setIsOpen(true);
     }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const footer = footerRef.current;
+    if (!footer) return;
+
+    const root = document.documentElement;
+    const previous = root.style.getPropertyValue("--mobile-footer-height");
+    const hadPrevious = previous.trim().length > 0;
+
+    const update = () => {
+      const rect = footer.getBoundingClientRect();
+      if (rect.height > 0) {
+        root.style.setProperty("--mobile-footer-height", `${Math.round(rect.height)}px`);
+      }
+    };
+
+    update();
+
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        if (hadPrevious) {
+          root.style.setProperty("--mobile-footer-height", previous);
+        } else {
+          root.style.removeProperty("--mobile-footer-height");
+        }
+      };
+    }
+
+    const observer = new ResizeObserver(() => update());
+    observer.observe(footer);
+
+    return () => {
+      observer.disconnect();
+      if (hadPrevious) {
+        root.style.setProperty("--mobile-footer-height", previous);
+      } else {
+        root.style.removeProperty("--mobile-footer-height");
+      }
+    };
   }, []);
 
   useEffect(() => {
@@ -216,7 +258,10 @@ export default function LegalPrivacyFooter() {
 
   return (
     <>
-      <footer className="flex-shrink-0 border-t border-black/10 bg-white/80 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/60">
+      <footer
+        ref={footerRef}
+        className="mobile-footer flex-shrink-0 border-t border-black/10 bg-white/80 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/60"
+      >
         <div className="mx-auto flex w-full max-w-screen-2xl flex-col items-center justify-center gap-1.5 px-6 py-1.5 text-center text-[11px] text-slate-600 dark:text-slate-300 sm:flex-row sm:gap-3 sm:text-xs">
           <p className="leading-4 sm:ml-[17rem] sm:max-w-3xl">
             {BRAND} can make mistakes. This is not medical advice. Always consult a clinician.

--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type CookiePrefs = {
   essential: true;
@@ -126,8 +126,6 @@ export default function LegalPrivacyFooter() {
   const [consentValue, setConsentValue] = useState<"true" | "false" | null>(null);
   const [agreeChecked, setAgreeChecked] = useState(false);
   const [cookiePrefs, setCookiePrefs] = useState<CookiePrefs>(DEFAULT_PREFS);
-  const footerRef = useRef<HTMLElement | null>(null);
-
   useEffect(() => {
     if (typeof window === "undefined") return;
 
@@ -142,47 +140,6 @@ export default function LegalPrivacyFooter() {
     if (parsedConsent === null) {
       setIsOpen(true);
     }
-  }, []);
-
-  useLayoutEffect(() => {
-    if (typeof window === "undefined") return;
-    const footer = footerRef.current;
-    if (!footer) return;
-
-    const root = document.documentElement;
-    const previous = root.style.getPropertyValue("--mobile-footer-height");
-    const hadPrevious = previous.trim().length > 0;
-
-    const update = () => {
-      const rect = footer.getBoundingClientRect();
-      if (rect.height > 0) {
-        root.style.setProperty("--mobile-footer-height", `${Math.round(rect.height)}px`);
-      }
-    };
-
-    update();
-
-    if (typeof ResizeObserver === "undefined") {
-      return () => {
-        if (hadPrevious) {
-          root.style.setProperty("--mobile-footer-height", previous);
-        } else {
-          root.style.removeProperty("--mobile-footer-height");
-        }
-      };
-    }
-
-    const observer = new ResizeObserver(() => update());
-    observer.observe(footer);
-
-    return () => {
-      observer.disconnect();
-      if (hadPrevious) {
-        root.style.setProperty("--mobile-footer-height", previous);
-      } else {
-        root.style.removeProperty("--mobile-footer-height");
-      }
-    };
   }, []);
 
   useEffect(() => {
@@ -253,23 +210,22 @@ export default function LegalPrivacyFooter() {
     setCookiePrefs({ ...DEFAULT_PREFS });
     setConsentValue("false");
     setAgreeChecked(false);
-    setIsOpen(false);
+      setIsOpen(false);
   };
 
   return (
     <>
       <footer
-        ref={footerRef}
         className="mobile-footer flex-shrink-0 border-t border-black/10 bg-white/80 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/60"
       >
-        <div className="mx-auto flex w-full max-w-screen-2xl flex-col items-center justify-center gap-1.5 px-6 py-1.5 text-center text-[11px] text-slate-600 dark:text-slate-300 sm:flex-row sm:gap-3 sm:text-xs">
-          <p className="leading-4 sm:ml-[17rem] sm:max-w-3xl">
+        <div className="mobile-footer-inner mx-auto flex w-full max-w-screen-2xl items-center justify-center gap-1.5 px-6 text-center text-[11px] text-slate-600 dark:text-slate-300 md:gap-3 md:py-1.5 md:text-xs">
+          <p className="mobile-footer-text leading-5">
             {BRAND} can make mistakes. This is not medical advice. Always consult a clinician.
           </p>
           <button
             type="button"
             onClick={openModal}
-            className="rounded-md px-2.5 py-1 text-xs font-medium text-primary transition hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white sm:ml-2 sm:text-xs dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
+            className="mobile-footer-action rounded-md px-2.5 py-1 text-xs font-medium text-primary transition hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:hover:bg-slate-800 dark:focus-visible:ring-offset-slate-900"
           >
             Legal &amp; Privacy
           </button>

--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -161,7 +161,7 @@ export default function LegalPrivacyFooter() {
       const footerStyles = window.getComputedStyle(footer);
       const safeInsetRaw = footerStyles.paddingBottom;
       const safeInset = Number.parseFloat(safeInsetRaw || "") || 0;
-      const offset = Math.max(fontSize, safeInset + 8);
+      const offset = Math.max(Math.round(fontSize * 1.5), safeInset + 24);
       root.style.setProperty("--mobile-footer-height", `${next}px`);
       root.style.setProperty("--mobile-footer-safe-area", `${safeInset}px`);
       root.style.setProperty("--mobile-composer-offset", `${offset}px`);

--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -146,12 +146,30 @@ export default function LegalPrivacyFooter() {
     const fallbackBase = Number.isFinite(parsedBase) ? parsedBase : 48;
     const previous = root.style.getPropertyValue("--mobile-footer-height");
     const hadPrevious = previous.trim().length > 0;
+    const previousOffset = root.style.getPropertyValue("--mobile-composer-offset");
+    const hadPreviousOffset = previousOffset.trim().length > 0;
+    const previousSafeArea = root.style.getPropertyValue("--mobile-footer-safe-area");
+    const hadPreviousSafeArea = previousSafeArea.trim().length > 0;
 
     const updateHeight = () => {
       const rect = footer.getBoundingClientRect();
       const measured = Math.max(Math.round(rect.height), 0);
       const next = Math.max(fallbackBase, measured);
+      const rootStyles = window.getComputedStyle(root);
+      const fontSizeRaw = rootStyles.fontSize;
+      const fontSize = Number.parseFloat(fontSizeRaw || "") || 16;
+      const footerStyles = window.getComputedStyle(footer);
+      const safeInsetRaw = footerStyles.paddingBottom;
+      const safeInset = Number.parseFloat(safeInsetRaw || "") || 0;
+      const offset = Math.max(fontSize * 0.75, safeInset);
       root.style.setProperty("--mobile-footer-height", `${next}px`);
+      root.style.setProperty("--mobile-footer-safe-area", `${safeInset}px`);
+      root.style.setProperty("--mobile-composer-offset", `${offset}px`);
+      window.dispatchEvent(
+        new CustomEvent("mobile-footer-height-change", {
+          detail: { height: next, offset },
+        }),
+      );
     };
 
     updateHeight();
@@ -175,6 +193,10 @@ export default function LegalPrivacyFooter() {
       if (observer) observer.disconnect();
       if (hadPrevious) root.style.setProperty("--mobile-footer-height", previous);
       else root.style.removeProperty("--mobile-footer-height");
+      if (hadPreviousSafeArea) root.style.setProperty("--mobile-footer-safe-area", previousSafeArea);
+      else root.style.removeProperty("--mobile-footer-safe-area");
+      if (hadPreviousOffset) root.style.setProperty("--mobile-composer-offset", previousOffset);
+      else root.style.removeProperty("--mobile-composer-offset");
     };
   }, []);
   useEffect(() => {

--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -161,7 +161,7 @@ export default function LegalPrivacyFooter() {
       const footerStyles = window.getComputedStyle(footer);
       const safeInsetRaw = footerStyles.paddingBottom;
       const safeInset = Number.parseFloat(safeInsetRaw || "") || 0;
-      const offset = Math.max(fontSize * 0.75, safeInset);
+      const offset = Math.max(fontSize, safeInset + 8);
       root.style.setProperty("--mobile-footer-height", `${next}px`);
       root.style.setProperty("--mobile-footer-safe-area", `${safeInset}px`);
       root.style.setProperty("--mobile-composer-offset", `${offset}px`);

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -5,12 +5,14 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { createNewThreadId, listThreads, Thread } from '@/lib/chatThreads';
 import ThreadKebab from '@/components/chat/ThreadKebab';
+import { useMobileUiStore } from '@/lib/state/mobileUiStore';
 
 export default function Sidebar() {
   const router = useRouter();
   const [threads, setThreads] = useState<Thread[]>([]);
   const [aidocThreads, setAidocThreads] = useState<{ id: string; title: string | null }[]>([]);
   const [q, setQ] = useState('');
+  const closeSidebar = useMobileUiStore(state => state.closeSidebar);
 
   useEffect(() => {
     const load = () => setThreads(listThreads());
@@ -32,6 +34,7 @@ export default function Sidebar() {
 
   const handleNew = () => {
     const id = createNewThreadId();
+    closeSidebar();
     router.push(`/?panel=chat&threadId=${id}`);
   };
   const handleSearch = (q: string) => {
@@ -68,7 +71,10 @@ export default function Sidebar() {
             className="flex items-center gap-2 rounded-xl border border-black/5 bg-white/70 px-4 py-2.5 text-sm shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
           >
             <button
-              onClick={() => router.push(`/?panel=chat&threadId=${t.id}`)}
+              onClick={() => {
+                closeSidebar();
+                router.push(`/?panel=chat&threadId=${t.id}`);
+              }}
               className="flex-1 text-left truncate text-sm"
               title={t.title}
             >
@@ -98,7 +104,10 @@ export default function Sidebar() {
                 className="mt-2 flex items-center gap-2 rounded-xl border border-black/5 bg-white/70 px-4 py-2.5 text-sm shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
               >
                 <button
-                  onClick={() => router.push(`/?panel=ai-doc&threadId=${t.id}&context=profile`)}
+                  onClick={() => {
+                    closeSidebar();
+                    router.push(`/?panel=ai-doc&threadId=${t.id}&context=profile`);
+                  }}
                   className="flex-1 text-left truncate text-sm"
                   title={t.title ?? ''}
                 >

--- a/components/brand/Logo.tsx
+++ b/components/brand/Logo.tsx
@@ -4,7 +4,13 @@
 import Image from "next/image";
 import Link from "next/link";
 import * as React from "react";
-import { BRAND_NAME, LOGO_SRC, LOGO_FALLBACKS } from "@/lib/brand";
+import {
+  BRAND_NAME,
+  LOGO_SRC,
+  LOGO_FALLBACKS,
+  LOGO_WHITE_SRC,
+  LOGO_WHITE_FALLBACKS,
+} from "@/lib/brand";
 
 /**
  * Robust Logo component:
@@ -12,18 +18,32 @@ import { BRAND_NAME, LOGO_SRC, LOGO_FALLBACKS } from "@/lib/brand";
  * - On 404/error, walks through LOGO_FALLBACKS automatically
  * - If all fail, shows brand name text (so you never see a broken image)
  */
+type LogoVariant = "default" | "white";
+
 export default function Logo({
   width = 160,
   height = 48,
   className = "",
+  variant = "default",
 }: {
   width?: number;
   height?: number;
   className?: string;
+  variant?: LogoVariant;
 }) {
-  const sources = React.useMemo(() => [LOGO_SRC, ...LOGO_FALLBACKS], []);
+  const defaultSources = React.useMemo(() => [LOGO_SRC, ...LOGO_FALLBACKS], []);
+  const whiteSources = React.useMemo(
+    () => [LOGO_WHITE_SRC, ...LOGO_WHITE_FALLBACKS, ...defaultSources],
+    [defaultSources],
+  );
+  const sources = variant === "white" ? whiteSources : defaultSources;
   const [idx, setIdx] = React.useState(0);
   const [showText, setShowText] = React.useState(false);
+
+  React.useEffect(() => {
+    setIdx(0);
+    setShowText(false);
+  }, [sources]);
 
   const src = sources[idx] ?? null;
 

--- a/components/icons/WwwGlobe.tsx
+++ b/components/icons/WwwGlobe.tsx
@@ -1,0 +1,41 @@
+import type { SVGProps } from "react";
+
+export default function WwwGlobeIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      role="img"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <circle cx="12" cy="12" r="8.25" fill="none" stroke="currentColor" strokeWidth="1.5" />
+      <path
+        d="M6.75 9.5a8.7 8.7 0 0 1 10.5 0"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.25"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity="0.65"
+      />
+      <path
+        d="M5.5 12h13"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.1"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity="0.65"
+      />
+      <path
+        d="M7.4 14.7l1.02-3.1h.86l.97 2.65.95-2.65h.86l.98 2.67.95-2.67h.86l1.02 3.1"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/components/icons/WwwGlobe.tsx
+++ b/components/icons/WwwGlobe.tsx
@@ -9,32 +9,56 @@ export default function WwwGlobeIcon(props: SVGProps<SVGSVGElement>) {
       focusable="false"
       {...props}
     >
-      <circle cx="12" cy="12" r="8.25" fill="none" stroke="currentColor" strokeWidth="1.5" />
-      <path
-        d="M6.75 9.5a8.7 8.7 0 0 1 10.5 0"
+      <circle
+        cx="12"
+        cy="12"
+        r="8.25"
         fill="none"
         stroke="currentColor"
-        strokeWidth="1.25"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        opacity="0.65"
+        strokeWidth="1.5"
       />
       <path
-        d="M5.5 12h13"
+        d="M12 3.75c-2.34 2.18-3.78 5.62-3.78 8.25s1.44 6.07 3.78 8.25"
         fill="none"
         stroke="currentColor"
-        strokeWidth="1.1"
+        strokeWidth="1.35"
         strokeLinecap="round"
         strokeLinejoin="round"
-        opacity="0.65"
       />
       <path
-        d="M7.4 14.7l1.02-3.1h.86l.97 2.65.95-2.65h.86l.98 2.67.95-2.67h.86l1.02 3.1"
+        d="M12 3.75c2.34 2.18 3.78 5.62 3.78 8.25s-1.44 6.07-3.78 8.25"
         fill="none"
         stroke="currentColor"
-        strokeWidth="1.3"
+        strokeWidth="1.35"
         strokeLinecap="round"
         strokeLinejoin="round"
+      />
+      <path
+        d="M4.75 9.2c2.2-1.72 4.98-2.7 7.25-2.7s5.05.98 7.25 2.7"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeOpacity="0.7"
+      />
+      <path
+        d="M4.75 14.8c2.2 1.72 4.98 2.7 7.25 2.7s5.05-.98 7.25-2.7"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeOpacity="0.7"
+      />
+      <path
+        d="M3.75 12h16.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeOpacity="0.7"
       />
     </svg>
   );

--- a/components/mobile/MobileActionsSheet.tsx
+++ b/components/mobile/MobileActionsSheet.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useEffect, useId, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ArrowLeft, Check, Globe2, Moon, Search, Settings, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useMobileUiStore } from "@/lib/state/mobileUiStore";
+import { useCountry } from "@/lib/country";
+import { COUNTRIES } from "@/data/countries";
+import { fromSearchParams, toQuery } from "@/lib/modes/url";
+import { canonicalize } from "@/lib/modes/modeMachine";
+import type { ModeState } from "@/lib/modes/types";
+
+const MODE_OPTIONS = [
+  { key: "wellness", label: "Wellness" },
+  { key: "wellness-research", label: "Wellness + Research" },
+  { key: "doctor", label: "Doctor" },
+  { key: "doctor-research", label: "Doctor + Research" },
+  { key: "aidoc", label: "AI Doc" },
+] as const;
+
+type ModeKey = typeof MODE_OPTIONS[number]["key"];
+
+function deriveModeLabel(state: ModeState): string {
+  if (state.base === "aidoc") return "AI Doc";
+  if (state.base === "doctor") {
+    return state.research ? "Doctor + Research" : "Doctor";
+  }
+  if (state.research) return "Wellness + Research";
+  return "Wellness";
+}
+
+function nextStateForMode(current: ModeState, mode: ModeKey): ModeState {
+  const base: ModeState = { ...current };
+  switch (mode) {
+    case "wellness":
+      return canonicalize({ ...base, base: "patient", therapy: false, research: false });
+    case "wellness-research":
+      return canonicalize({ ...base, base: "patient", therapy: false, research: true });
+    case "doctor":
+      return canonicalize({ ...base, base: "doctor", therapy: false, research: false });
+    case "doctor-research":
+      return canonicalize({ ...base, base: "doctor", therapy: false, research: true });
+    case "aidoc":
+      return canonicalize({ ...base, base: "aidoc", therapy: false, research: false });
+    default:
+      return base;
+  }
+}
+
+export default function MobileActionsSheet() {
+  const { sheetOpen, sheetView, closeSheet, setSheetView } = useMobileUiStore();
+  const { theme, setTheme } = useTheme();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { country, setCountry } = useCountry();
+  const [query, setQuery] = useState("");
+  const titleId = useId();
+
+  useEffect(() => {
+    if (sheetOpen) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = prev;
+      };
+    }
+    return undefined;
+  }, [sheetOpen]);
+
+  useEffect(() => {
+    if (!sheetOpen) {
+      setQuery("");
+    }
+  }, [sheetOpen]);
+
+  const modeState = useMemo(() => {
+    const currentTheme = (theme as "light" | "dark") ?? "light";
+    return fromSearchParams(searchParams, currentTheme);
+  }, [searchParams, theme]);
+
+  const modeLabel = deriveModeLabel(modeState);
+
+  const filteredCountries = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return COUNTRIES;
+    return COUNTRIES.filter(c =>
+      c.name.toLowerCase().includes(q) ||
+      c.code3.toLowerCase().includes(q),
+    );
+  }, [query]);
+
+  if (!sheetOpen) return null;
+
+  const toggleTheme = () => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  };
+
+  const goToSettings = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("panel", "settings");
+    router.push(`/?${params.toString()}`);
+    closeSheet();
+  };
+
+  const renderHeader = (title: string, onBack?: () => void) => (
+    <div className="mobile-sheet-header">
+      {onBack ? (
+        <button type="button" className="mobile-icon-btn" onClick={onBack} aria-label="Back">
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+      ) : (
+        <span className="mobile-sheet-handle" aria-hidden="true" />
+      )}
+      <div className="mobile-sheet-title" id={titleId}>{title}</div>
+      <button type="button" className="mobile-icon-btn" onClick={closeSheet} aria-label="Close sheet">
+        <XIcon />
+      </button>
+    </div>
+  );
+
+  const sheetLabel = sheetView === "mode"
+    ? "Mode options"
+    : sheetView === "country"
+      ? "Country selector"
+      : "Menu";
+
+  return (
+    <div className="mobile-sheet-root md:hidden">
+      <div className="mobile-sheet-backdrop" aria-hidden="true" onClick={closeSheet} />
+      <div className="mobile-sheet-panel" role="dialog" aria-modal="true" aria-label={sheetLabel} aria-labelledby={titleId}>
+        {sheetView === "main" ? (
+          <>
+            {renderHeader("Menu")}
+            <div className="mobile-sheet-section">
+              <button
+                type="button"
+                className="mobile-sheet-item"
+                onClick={() => setSheetView("mode")}
+              >
+                <div className="mobile-sheet-item-label">Mode</div>
+                <div className="mobile-sheet-item-value">{modeLabel}</div>
+              </button>
+              <button
+                type="button"
+                className="mobile-sheet-item"
+                onClick={goToSettings}
+              >
+                <div className="mobile-sheet-item-label">Settings</div>
+                <div className="mobile-sheet-item-icon"><Settings className="h-4 w-4" /></div>
+              </button>
+              <button
+                type="button"
+                className="mobile-sheet-item"
+                onClick={() => {
+                  toggleTheme();
+                  closeSheet();
+                }}
+              >
+                <div className="mobile-sheet-item-label">{theme === "dark" ? "Light Mode" : "Dark Mode"}</div>
+                <div className="mobile-sheet-item-icon">
+                  {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+                </div>
+              </button>
+              <button
+                type="button"
+                className="mobile-sheet-item"
+                onClick={() => setSheetView("country")}
+              >
+                <div className="mobile-sheet-item-label">Country</div>
+                <div className="mobile-sheet-item-value inline-flex items-center gap-2">
+                  <Globe2 className="h-4 w-4" />
+                  <span className="font-medium">{country.code3}</span>
+                </div>
+              </button>
+            </div>
+          </>
+        ) : null}
+
+        {sheetView === "mode" ? (
+          <>
+            {renderHeader("Mode", () => setSheetView("main"))}
+            <div className="mobile-sheet-section">
+              {MODE_OPTIONS.map(option => {
+                const next = nextStateForMode(modeState, option.key);
+                const isActive = deriveModeLabel(modeState) === option.label;
+                return (
+                  <button
+                    key={option.key}
+                    type="button"
+                    className="mobile-sheet-item"
+                    onClick={() => {
+                      router.push(toQuery(next, searchParams));
+                      closeSheet();
+                    }}
+                  >
+                    <div className="mobile-sheet-item-label">{option.label}</div>
+                    <div className="mobile-sheet-item-icon">
+                      {isActive ? (
+                        <Check className="h-4 w-4" />
+                      ) : null}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        ) : null}
+
+        {sheetView === "country" ? (
+          <>
+            {renderHeader("Country", () => setSheetView("main"))}
+            <div className="mobile-sheet-section">
+              <div className="mobile-sheet-search">
+                <Search className="h-4 w-4" />
+                <input
+                  value={query}
+                  onChange={event => setQuery(event.target.value)}
+                  placeholder="Search country or code"
+                />
+              </div>
+              <div className="mobile-sheet-list">
+                {filteredCountries.map(c => (
+                  <button
+                    key={c.code3}
+                    type="button"
+                    className="mobile-sheet-item"
+                    onClick={() => {
+                      setCountry(c.code3);
+                      closeSheet();
+                    }}
+                  >
+                    <div className="mobile-sheet-country">
+                      <span className="text-xl">{c.flag}</span>
+                      <span className="truncate">{c.name}</span>
+                    </div>
+                    <div className="mobile-sheet-item-icon">
+                      {country.code3 === c.code3 ? <Check className="h-4 w-4" /> : null}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false">
+      <path
+        d="M6 6l12 12M18 6l-12 12"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/components/mobile/MobileActionsSheet.tsx
+++ b/components/mobile/MobileActionsSheet.tsx
@@ -68,11 +68,9 @@ export default function MobileActionsSheet() {
 
   const modeSummary = useMemo(() => {
     if (state.therapy) return "Therapy";
-    const base = state.base === "aidoc" ? "AI Doc" : state.base === "doctor" ? "Clinical" : "Wellness";
-    if (state.research && (state.base === "patient" || state.base === "doctor")) {
-      return `${base} · Research`;
-    }
-    return base;
+    if (state.base === "aidoc") return "AI Doc";
+    const baseLabel = state.base === "doctor" ? "Clinical" : "Wellness";
+    return state.research ? `${baseLabel} + Research` : baseLabel;
   }, [state.base, state.research, state.therapy]);
 
   const filteredCountries = useMemo(() => {
@@ -121,10 +119,37 @@ export default function MobileActionsSheet() {
   switch (sheetView) {
     case "mode": {
       const options = [
-        { key: "wellness" as const, label: "Wellness", active: !state.therapy && state.base === "patient" },
-        { key: "therapy" as const, label: "Therapy", active: state.therapy, disabled: therapyBusy },
-        { key: "doctor" as const, label: "Clinical", active: !state.therapy && state.base === "doctor" },
-        { key: "aidoc" as const, label: "AI Doc", active: state.base === "aidoc" },
+        {
+          key: "wellness" as const,
+          label: "Wellness",
+          active: state.base === "patient" && !state.therapy && !state.research,
+        },
+        {
+          key: "wellness-research" as const,
+          label: "Wellness + Research",
+          active: state.base === "patient" && state.research,
+        },
+        {
+          key: "therapy" as const,
+          label: "Therapy",
+          active: state.therapy,
+          disabled: therapyBusy,
+        },
+        {
+          key: "doctor" as const,
+          label: "Clinical",
+          active: state.base === "doctor" && !state.research,
+        },
+        {
+          key: "doctor-research" as const,
+          label: "Clinical + Research",
+          active: state.base === "doctor" && state.research,
+        },
+        {
+          key: "aidoc" as const,
+          label: "AI Doc",
+          active: state.base === "aidoc",
+        },
       ];
 
       header = buildHeader("Mode", () => setSheetView("main"));

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Menu, MoreHorizontal, Sparkles } from "lucide-react";
+import Logo from "@/components/brand/Logo";
+import { useMobileUiStore } from "@/lib/state/mobileUiStore";
+import { useRouter } from "next/navigation";
+import { useChatStore } from "@/lib/state/chatStore";
+
+export default function MobileHeader() {
+  const openSidebar = useMobileUiStore(state => state.openSidebar);
+  const openSheet = useMobileUiStore(state => state.openSheet);
+  const startNewThread = useChatStore(state => state.startNewThread);
+  const router = useRouter();
+
+  const handleNewChat = () => {
+    const id = startNewThread();
+    router.push(`/chat/${id}`);
+  };
+
+  return (
+    <header className="mobile-header md:hidden">
+      <button
+        type="button"
+        aria-label="Open menu"
+        className="mobile-icon-btn"
+        onClick={openSidebar}
+      >
+        <Menu className="h-5 w-5" />
+      </button>
+
+      <div className="flex flex-1 items-center overflow-hidden">
+        <Logo width={120} height={32} className="mobile-header-logo" />
+      </div>
+
+      <div className="ml-auto flex items-center gap-1.5">
+        <button
+          type="button"
+          aria-label="New chat"
+          className="mobile-icon-btn"
+          onClick={handleNewChat}
+        >
+          <Sparkles className="h-5 w-5" />
+        </button>
+        <button
+          type="button"
+          aria-label="Open options"
+          className="mobile-icon-btn"
+          onClick={() => openSheet("main")}
+        >
+          <MoreHorizontal className="h-5 w-5" />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -61,14 +61,14 @@ export default function MobileHeader() {
   const modeLabel = useMemo(() => {
     if (state.base === "aidoc") return "AI Doc";
     if (state.therapy) return "Therapy";
-    if (state.base === "doctor") return "Doctor";
+    if (state.base === "doctor") return "Clinical";
     return "Wellness";
   }, [state.base, state.therapy]);
 
   const modeOptions = [
     { key: "wellness" as const, label: "Wellness" },
     { key: "therapy" as const, label: "Therapy", disabled: therapyBusy },
-    { key: "doctor" as const, label: "Doctor" },
+    { key: "doctor" as const, label: "Clinical" },
     { key: "aidoc" as const, label: "AI Doc" },
   ];
 

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -1,21 +1,58 @@
 "use client";
 
-import { Menu, MoreHorizontal, PlusCircle } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, Menu, MoreHorizontal, PlusCircle } from "lucide-react";
 import Logo from "@/components/brand/Logo";
 import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 import { useRouter } from "next/navigation";
 import { useChatStore } from "@/lib/state/chatStore";
+import { useModeController } from "@/hooks/useModeController";
 
 export default function MobileHeader() {
   const openSidebar = useMobileUiStore(state => state.openSidebar);
   const openSheet = useMobileUiStore(state => state.openSheet);
   const startNewThread = useChatStore(state => state.startNewThread);
   const router = useRouter();
+  const { state, selectMode, toggleResearch, researchEnabled, therapyBusy } = useModeController();
+  const [modeOpen, setModeOpen] = useState(false);
+  const modeRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!modeOpen) return;
+    const handlePointer = (event: MouseEvent | TouchEvent) => {
+      if (!modeRef.current) return;
+      const target = event.target as Node | null;
+      if (target && modeRef.current.contains(target)) return;
+      setModeOpen(false);
+    };
+    document.addEventListener("pointerdown", handlePointer);
+    return () => document.removeEventListener("pointerdown", handlePointer);
+  }, [modeOpen]);
+
+  useEffect(() => {
+    setModeOpen(false);
+  }, [state.base, state.therapy]);
 
   const handleNewChat = () => {
     const id = startNewThread();
     router.push(`/chat/${id}`);
   };
+
+  const modeLabel = useMemo(() => {
+    if (state.base === "aidoc") return "AI Doc";
+    if (state.therapy) return "Therapy";
+    if (state.base === "doctor") return "Doctor";
+    return "Wellness";
+  }, [state.base, state.therapy]);
+
+  const modeOptions = [
+    { key: "wellness" as const, label: "Wellness" },
+    { key: "therapy" as const, label: "Therapy", disabled: therapyBusy },
+    { key: "doctor" as const, label: "Doctor" },
+    { key: "aidoc" as const, label: "AI Doc" },
+  ];
+
+  const researchActive = researchEnabled && state.research;
 
   return (
     <header className="mobile-header md:hidden">
@@ -30,6 +67,68 @@ export default function MobileHeader() {
 
       <div className="mobile-header-brand">
         <Logo width={132} height={36} className="mobile-header-logo" variant="white" />
+        <div className="mobile-mode-controls" ref={modeRef}>
+          <button
+            type="button"
+            aria-label="Select mode"
+            className="mobile-mode-trigger"
+            onClick={() => setModeOpen(prev => !prev)}
+            aria-haspopup="menu"
+            aria-expanded={modeOpen}
+          >
+            <span className="mobile-mode-label" aria-live="polite">{modeLabel}</span>
+            <ChevronDown className="h-4 w-4 flex-shrink-0" />
+          </button>
+          <button
+            type="button"
+            aria-label={researchActive ? "Disable research mode" : "Enable research mode"}
+            className={`mobile-www-toggle${researchActive ? " mobile-www-toggle-active" : ""}`}
+            onClick={() => {
+              if (researchEnabled) toggleResearch();
+            }}
+            disabled={!researchEnabled}
+            aria-pressed={researchActive}
+            title={
+              researchEnabled
+                ? researchActive
+                  ? "Research mode on"
+                  : "Research mode off"
+                : "Research mode unavailable"
+            }
+          >
+            <span>WWW</span>
+          </button>
+          {modeOpen ? (
+            <div className="mobile-mode-dropdown" role="menu">
+              {modeOptions.map(option => {
+                const isActive = modeLabel === option.label;
+                return (
+                  <button
+                    key={option.key}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={isActive}
+                    className={`mobile-mode-option${isActive ? " mobile-mode-option-active" : ""}`}
+                    onClick={() => {
+                      selectMode(option.key);
+                      setModeOpen(false);
+                    }}
+                    disabled={option.disabled}
+                  >
+                    <span>{option.label}</span>
+                    {option.key === "therapy" && therapyBusy && !state.therapy ? (
+                      <span className="inline-flex h-3 w-3 items-center justify-center" aria-hidden="true">
+                        <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                      </span>
+                    ) : isActive ? (
+                      <span aria-hidden="true">•</span>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
       </div>
 
       <div className="mobile-header-actions">

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -118,7 +118,7 @@ export default function MobileHeader() {
                 : "Research mode unavailable"
             }
           >
-            <WwwGlobeIcon className="h-5 w-5" />
+            <WwwGlobeIcon className="h-[21px] w-[21px]" />
           </button>
           {modeOpen ? (
             <div className="mobile-mode-dropdown" role="menu">

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, Menu, MoreHorizontal, PlusCircle } from "lucide-react";
-import Logo from "@/components/brand/Logo";
 import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useModeController } from "@/hooks/useModeController";
@@ -85,72 +84,69 @@ export default function MobileHeader() {
         <Menu className="h-5 w-5" />
       </button>
 
-      <div className="mobile-header-brand">
-        <Logo width={132} height={36} className="mobile-header-logo" variant="white" />
-        <div className="mobile-mode-controls" ref={modeRef}>
-          <button
-            type="button"
-            aria-label="Select mode"
-            className="mobile-mode-trigger"
-            onClick={() => setModeOpen(prev => !prev)}
-            aria-haspopup="menu"
-            aria-expanded={modeOpen}
-          >
-            <span className="mobile-mode-label" aria-live="polite">{modeLabel}</span>
-            <ChevronDown className="h-4 w-4 flex-shrink-0" />
-          </button>
-          <button
-            type="button"
-            aria-label={researchActive ? "Disable research mode" : "Enable research mode"}
-            className="mobile-icon-btn mobile-www-btn"
-            data-state={researchActive ? "on" : "off"}
-            data-enabled={researchEnabled ? "true" : "false"}
-            onClick={() => {
-              if (researchEnabled) toggleResearch();
-            }}
-            disabled={!researchEnabled}
-            aria-pressed={researchActive}
-            title={
-              researchEnabled
-                ? researchActive
-                  ? "Research mode on"
-                  : "Research mode off"
-                : "Research mode unavailable"
-            }
-          >
-            <WwwGlobeIcon className="h-[21px] w-[21px]" />
-          </button>
-          {modeOpen ? (
-            <div className="mobile-mode-dropdown" role="menu">
-              {modeOptions.map(option => {
-                const isActive = modeLabel === option.label;
-                return (
-                  <button
-                    key={option.key}
-                    type="button"
-                    role="menuitemradio"
-                    aria-checked={isActive}
-                    className={`mobile-mode-option${isActive ? " mobile-mode-option-active" : ""}`}
-                    onClick={() => {
-                      selectMode(option.key);
-                      setModeOpen(false);
-                    }}
-                    disabled={option.disabled}
-                  >
-                    <span>{option.label}</span>
-                    {option.key === "therapy" && therapyBusy && !state.therapy ? (
-                      <span className="inline-flex h-3 w-3 items-center justify-center" aria-hidden="true">
-                        <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                      </span>
-                    ) : isActive ? (
-                      <span aria-hidden="true">•</span>
-                    ) : null}
-                  </button>
-                );
-              })}
-            </div>
-          ) : null}
-        </div>
+      <div className="mobile-mode-controls" ref={modeRef}>
+        <button
+          type="button"
+          aria-label="Select mode"
+          className="mobile-mode-trigger"
+          onClick={() => setModeOpen(prev => !prev)}
+          aria-haspopup="menu"
+          aria-expanded={modeOpen}
+        >
+          <span className="mobile-mode-label" aria-live="polite">{modeLabel}</span>
+          <ChevronDown className="h-4 w-4 flex-shrink-0" />
+        </button>
+        <button
+          type="button"
+          aria-label={researchActive ? "Disable research mode" : "Enable research mode"}
+          className="mobile-icon-btn mobile-www-btn"
+          data-state={researchActive ? "on" : "off"}
+          data-enabled={researchEnabled ? "true" : "false"}
+          onClick={() => {
+            if (researchEnabled) toggleResearch();
+          }}
+          disabled={!researchEnabled}
+          aria-pressed={researchActive}
+          title={
+            researchEnabled
+              ? researchActive
+                ? "Research mode on"
+                : "Research mode off"
+              : "Research mode unavailable"
+          }
+        >
+          <WwwGlobeIcon className="h-[21px] w-[21px]" />
+        </button>
+        {modeOpen ? (
+          <div className="mobile-mode-dropdown" role="menu">
+            {modeOptions.map(option => {
+              const isActive = modeLabel === option.label;
+              return (
+                <button
+                  key={option.key}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={isActive}
+                  className={`mobile-mode-option${isActive ? " mobile-mode-option-active" : ""}`}
+                  onClick={() => {
+                    selectMode(option.key);
+                    setModeOpen(false);
+                  }}
+                  disabled={option.disabled}
+                >
+                  <span>{option.label}</span>
+                  {option.key === "therapy" && therapyBusy && !state.therapy ? (
+                    <span className="inline-flex h-3 w-3 items-center justify-center" aria-hidden="true">
+                      <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                    </span>
+                  ) : isActive ? (
+                    <span aria-hidden="true">•</span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
       </div>
 
       <div className="mobile-header-actions">

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -1,50 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, Menu, MoreHorizontal, PlusCircle } from "lucide-react";
+import { useCallback } from "react";
+import { Menu, MoreHorizontal, PlusCircle } from "lucide-react";
 import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useModeController } from "@/hooks/useModeController";
 import { createNewThreadId } from "@/lib/chatThreads";
-import WwwGlobeIcon from "@/components/icons/WwwGlobe";
+import Logo from "@/components/brand/Logo";
 
 export default function MobileHeader() {
   const openSidebar = useMobileUiStore(state => state.openSidebar);
   const openSheet = useMobileUiStore(state => state.openSheet);
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { state, selectMode, toggleResearch, researchEnabled, therapyBusy } = useModeController();
-  const [modeOpen, setModeOpen] = useState(false);
-  const modeRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!modeOpen) return;
-    const handlePointer = (event: Event) => {
-      if (!modeRef.current) return;
-      const target = event.target as Node | null;
-      if (target && modeRef.current.contains(target)) return;
-      setModeOpen(false);
-    };
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setModeOpen(false);
-      }
-    };
-    document.addEventListener("pointerdown", handlePointer);
-    document.addEventListener("mousedown", handlePointer);
-    document.addEventListener("touchstart", handlePointer);
-    document.addEventListener("keydown", handleKey);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointer);
-      document.removeEventListener("mousedown", handlePointer);
-      document.removeEventListener("touchstart", handlePointer);
-      document.removeEventListener("keydown", handleKey);
-    };
-  }, [modeOpen]);
-
-  useEffect(() => {
-    setModeOpen(false);
-  }, [state.base, state.therapy]);
 
   const handleNewChat = useCallback(() => {
     const id = createNewThreadId();
@@ -57,98 +24,19 @@ export default function MobileHeader() {
     }, 150);
   }, [router, searchParams]);
 
-  const modeLabel = useMemo(() => {
-    if (state.base === "aidoc") return "AI Doc";
-    if (state.therapy) return "Therapy";
-    if (state.base === "doctor") return "Clinical";
-    return "Wellness";
-  }, [state.base, state.therapy]);
-
-  const modeOptions = [
-    { key: "wellness" as const, label: "Wellness" },
-    { key: "therapy" as const, label: "Therapy", disabled: therapyBusy },
-    { key: "doctor" as const, label: "Clinical" },
-    { key: "aidoc" as const, label: "AI Doc" },
-  ];
-
-  const researchActive = researchEnabled && state.research;
-
   return (
     <header className="mobile-header md:hidden">
-      <button
-        type="button"
-        aria-label="Open menu"
-        className="mobile-icon-btn"
-        onClick={openSidebar}
-      >
-        <Menu className="h-5 w-5" />
-      </button>
-
-      <div className="mobile-mode-controls" ref={modeRef}>
+      <div className="mobile-header-left">
         <button
           type="button"
-          aria-label="Select mode"
-          className="mobile-mode-trigger"
-          onClick={() => setModeOpen(prev => !prev)}
-          aria-haspopup="menu"
-          aria-expanded={modeOpen}
+          aria-label="Open menu"
+          className="mobile-icon-btn"
+          onClick={openSidebar}
         >
-          <span className="mobile-mode-label" aria-live="polite">{modeLabel}</span>
-          <ChevronDown className="h-4 w-4 flex-shrink-0" />
+          <Menu className="h-5 w-5" />
         </button>
-        <button
-          type="button"
-          aria-label={researchActive ? "Disable research mode" : "Enable research mode"}
-          className="mobile-icon-btn mobile-www-btn"
-          data-state={researchActive ? "on" : "off"}
-          data-enabled={researchEnabled ? "true" : "false"}
-          onClick={() => {
-            if (researchEnabled) toggleResearch();
-          }}
-          disabled={!researchEnabled}
-          aria-pressed={researchActive}
-          title={
-            researchEnabled
-              ? researchActive
-                ? "Research mode on"
-                : "Research mode off"
-              : "Research mode unavailable"
-          }
-        >
-          <WwwGlobeIcon className="h-[21px] w-[21px]" />
-        </button>
-        {modeOpen ? (
-          <div className="mobile-mode-dropdown" role="menu">
-            {modeOptions.map(option => {
-              const isActive = modeLabel === option.label;
-              return (
-                <button
-                  key={option.key}
-                  type="button"
-                  role="menuitemradio"
-                  aria-checked={isActive}
-                  className={`mobile-mode-option${isActive ? " mobile-mode-option-active" : ""}`}
-                  onClick={() => {
-                    selectMode(option.key);
-                    setModeOpen(false);
-                  }}
-                  disabled={option.disabled}
-                >
-                  <span>{option.label}</span>
-                  {option.key === "therapy" && therapyBusy && !state.therapy ? (
-                    <span className="inline-flex h-3 w-3 items-center justify-center" aria-hidden="true">
-                      <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                    </span>
-                  ) : isActive ? (
-                    <span aria-hidden="true">•</span>
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
-        ) : null}
+        <Logo variant="white" width={120} height={28} className="mobile-header-logo" />
       </div>
-
       <div className="mobile-header-actions">
         <button
           type="button"

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -29,10 +29,10 @@ export default function MobileHeader() {
       </button>
 
       <div className="flex flex-1 items-center overflow-hidden">
-        <Logo width={116} height={32} className="mobile-header-logo" variant="white" />
+        <Logo width={132} height={36} className="mobile-header-logo" variant="white" />
       </div>
 
-      <div className="ml-auto flex items-center gap-1.5">
+      <div className="ml-auto flex items-center gap-2">
         <button
           type="button"
           aria-label="New chat"

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -28,11 +28,11 @@ export default function MobileHeader() {
         <Menu className="h-5 w-5" />
       </button>
 
-      <div className="flex flex-1 items-center overflow-hidden">
+      <div className="mobile-header-brand">
         <Logo width={132} height={36} className="mobile-header-logo" variant="white" />
       </div>
 
-      <div className="ml-auto flex items-center gap-2">
+      <div className="mobile-header-actions">
         <button
           type="button"
           aria-label="New chat"

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -1,17 +1,28 @@
 "use client";
 
-import { useCallback } from "react";
-import { Menu, MoreHorizontal, PlusCircle } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown, Menu, MoreHorizontal, PlusCircle } from "lucide-react";
 import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createNewThreadId } from "@/lib/chatThreads";
-import Logo from "@/components/brand/Logo";
+import { useModeController } from "@/hooks/useModeController";
+import WwwGlobeIcon from "@/components/icons/WwwGlobe";
 
 export default function MobileHeader() {
   const openSidebar = useMobileUiStore(state => state.openSidebar);
   const openSheet = useMobileUiStore(state => state.openSheet);
   const router = useRouter();
   const searchParams = useSearchParams();
+  const {
+    state,
+    therapyBusy,
+    selectMode,
+    toggleResearch,
+    researchEnabled,
+  } = useModeController();
+
+  const [modeOpen, setModeOpen] = useState(false);
+  const modeRef = useRef<HTMLDivElement | null>(null);
 
   const handleNewChat = useCallback(() => {
     const id = createNewThreadId();
@@ -24,6 +35,81 @@ export default function MobileHeader() {
     }, 150);
   }, [router, searchParams]);
 
+  const modeLabel = useMemo(() => {
+    if (state.therapy) return "Therapy";
+    if (state.base === "aidoc") return "AI Doc";
+    if (state.base === "doctor") return "Clinical";
+    return "Wellness";
+  }, [state.base, state.therapy]);
+
+  useEffect(() => {
+    if (!modeOpen) return;
+
+    const handlePointer = (event: MouseEvent | TouchEvent) => {
+      if (!modeRef.current) return;
+      const target = event.target as Node | null;
+      if (target && modeRef.current.contains(target)) return;
+      setModeOpen(false);
+    };
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setModeOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointer);
+    document.addEventListener("touchstart", handlePointer, { passive: true });
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handlePointer);
+      document.removeEventListener("touchstart", handlePointer);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [modeOpen]);
+
+  useEffect(() => {
+    setModeOpen(false);
+  }, [state.base, state.therapy, state.research]);
+
+  type HeaderModeChoice = "wellness" | "therapy" | "doctor" | "aidoc";
+
+  const modeOptions = useMemo(
+    () =>
+      [
+        {
+          key: "wellness" as HeaderModeChoice,
+          label: "Wellness",
+          active: state.base === "patient" && !state.therapy,
+          disabled: false,
+        },
+        {
+          key: "therapy" as HeaderModeChoice,
+          label: "Therapy",
+          active: state.therapy,
+          disabled: therapyBusy && !state.therapy,
+        },
+        {
+          key: "doctor" as HeaderModeChoice,
+          label: "Clinical",
+          active: state.base === "doctor" && !state.therapy,
+          disabled: false,
+        },
+        {
+          key: "aidoc" as HeaderModeChoice,
+          label: "AI Doc",
+          active: state.base === "aidoc",
+          disabled: false,
+        },
+      ] satisfies Array<{
+        key: HeaderModeChoice;
+        label: string;
+        active: boolean;
+        disabled: boolean;
+      }>,
+    [state.base, state.therapy, therapyBusy],
+  );
+
   return (
     <header className="mobile-header md:hidden">
       <div className="mobile-header-left">
@@ -35,7 +121,66 @@ export default function MobileHeader() {
         >
           <Menu className="h-5 w-5" />
         </button>
-        <Logo variant="white" width={120} height={28} className="mobile-header-logo" />
+        <div ref={modeRef} className="mobile-mode-controls">
+          <button
+            type="button"
+            className="mobile-mode-trigger"
+            aria-haspopup="menu"
+            aria-expanded={modeOpen}
+            onClick={() => setModeOpen(open => !open)}
+          >
+            <span className="mobile-mode-label">{modeLabel}</span>
+            <ChevronDown className="h-4 w-4" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="mobile-icon-btn mobile-www-btn"
+            aria-label={state.research ? "Disable research mode" : "Enable research mode"}
+            aria-pressed={state.research}
+            data-state={state.research ? "on" : "off"}
+            data-enabled={researchEnabled}
+            onClick={() => {
+              if (!researchEnabled) return;
+              toggleResearch();
+            }}
+            disabled={!researchEnabled}
+          >
+            <WwwGlobeIcon className="h-5 w-5" />
+          </button>
+          {modeOpen ? (
+            <div className="mobile-mode-dropdown" role="menu">
+              {modeOptions.map(option => (
+                <button
+                  key={option.key}
+                  type="button"
+                  className={[
+                    "mobile-mode-option",
+                    option.active ? "mobile-mode-option-active" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                  onClick={() => {
+                    selectMode(option.key);
+                    setModeOpen(false);
+                  }}
+                  disabled={option.disabled}
+                  role="menuitemradio"
+                  aria-checked={option.active}
+                >
+                  <span>{option.label}</span>
+                  <span className="flex items-center gap-2">
+                    {option.key === "therapy" && therapyBusy && !state.therapy ? (
+                      <span className="inline-flex h-3 w-3 items-center" aria-hidden="true">
+                        <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                      </span>
+                    ) : null}
+                    {option.active ? <Check className="h-4 w-4" /> : null}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
       </div>
       <div className="mobile-header-actions">
         <button

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Menu, MoreHorizontal, Sparkles } from "lucide-react";
+import { Menu, MoreHorizontal, PlusCircle } from "lucide-react";
 import Logo from "@/components/brand/Logo";
 import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 import { useRouter } from "next/navigation";
@@ -29,7 +29,7 @@ export default function MobileHeader() {
       </button>
 
       <div className="flex flex-1 items-center overflow-hidden">
-        <Logo width={120} height={32} className="mobile-header-logo" />
+        <Logo width={116} height={32} className="mobile-header-logo" variant="white" />
       </div>
 
       <div className="ml-auto flex items-center gap-1.5">
@@ -39,7 +39,7 @@ export default function MobileHeader() {
           className="mobile-icon-btn"
           onClick={handleNewChat}
         >
-          <Sparkles className="h-5 w-5" />
+          <PlusCircle className="h-5 w-5" />
         </button>
         <button
           type="button"

--- a/components/mobile/MobileSidebarOverlay.tsx
+++ b/components/mobile/MobileSidebarOverlay.tsx
@@ -40,7 +40,7 @@ export default function MobileSidebarOverlay() {
     const touch = event.touches[0];
     const deltaX = touch.clientX - swipeOrigin.current.x;
     const deltaY = touch.clientY - swipeOrigin.current.y;
-    if (Math.abs(deltaX) > Math.abs(deltaY) && deltaX < -40) {
+    if (Math.abs(deltaX) > Math.abs(deltaY) && deltaX < -80) {
       swipeOrigin.current = null;
       close();
     }

--- a/components/mobile/MobileSidebarOverlay.tsx
+++ b/components/mobile/MobileSidebarOverlay.tsx
@@ -8,7 +8,13 @@ import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 export default function MobileSidebarOverlay() {
   const open = useMobileUiStore(state => state.sidebarOpen);
   const close = useMobileUiStore(state => state.closeSidebar);
-  const swipeOrigin = useRef<{ x: number; y: number } | null>(null);
+  const swipeOrigin = useRef<{ x: number; y: number; time: number } | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const draggingRef = useRef(false);
+  const translateRef = useRef(0);
+  const velocityRef = useRef(0);
+  const lastMoveRef = useRef<{ x: number; time: number } | null>(null);
+  const closeTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (open) {
@@ -28,26 +34,104 @@ export default function MobileSidebarOverlay() {
     return undefined;
   }, [open, close]);
 
+  useEffect(() => {
+    if (!open && closeTimeoutRef.current !== null) {
+      window.clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    panel.style.transform = "translateX(0px)";
+    panel.style.transition = "transform 0.24s ease";
+    const id = window.requestAnimationFrame(() => {
+      if (panel) {
+        panel.style.transition = "";
+      }
+    });
+    return () => window.cancelAnimationFrame(id);
+  }, [open]);
+
   if (!open) return null;
 
   const handleTouchStart = (event: ReactTouchEvent<HTMLDivElement>) => {
     const touch = event.touches[0];
-    swipeOrigin.current = { x: touch.clientX, y: touch.clientY };
+    swipeOrigin.current = { x: touch.clientX, y: touch.clientY, time: event.timeStamp };
+    lastMoveRef.current = { x: touch.clientX, time: event.timeStamp };
+    velocityRef.current = 0;
+    translateRef.current = 0;
+    draggingRef.current = false;
   };
 
   const handleTouchMove = (event: ReactTouchEvent<HTMLDivElement>) => {
     if (!swipeOrigin.current) return;
+    const panel = panelRef.current;
+    if (!panel) return;
     const touch = event.touches[0];
     const deltaX = touch.clientX - swipeOrigin.current.x;
     const deltaY = touch.clientY - swipeOrigin.current.y;
-    if (Math.abs(deltaX) > Math.abs(deltaY) && deltaX < -80) {
-      swipeOrigin.current = null;
-      close();
+    if (!draggingRef.current) {
+      if (Math.abs(deltaX) < 24) return;
+      if (Math.abs(deltaX) <= Math.abs(deltaY)) return;
+      if (deltaX >= 0) {
+        swipeOrigin.current = null;
+        return;
+      }
+      draggingRef.current = true;
+      panel.style.transition = "none";
     }
+
+    if (!draggingRef.current) return;
+
+    event.preventDefault();
+    const clamped = Math.max(deltaX, -panel.offsetWidth);
+    translateRef.current = clamped;
+    panel.style.transform = `translateX(${clamped}px)`;
+
+    const last = lastMoveRef.current;
+    if (last && event.timeStamp > last.time) {
+      const dx = touch.clientX - last.x;
+      const dt = event.timeStamp - last.time;
+      velocityRef.current = (dx / dt) * 1000;
+    }
+    lastMoveRef.current = { x: touch.clientX, time: event.timeStamp };
   };
 
   const handleTouchEnd = () => {
+    const panel = panelRef.current;
+    if (!panel) {
+      swipeOrigin.current = null;
+      draggingRef.current = false;
+      return;
+    }
+
+    const width = panel.offsetWidth || 1;
+    const travelled = Math.abs(translateRef.current);
+    const velocity = velocityRef.current;
+    const shouldClose = travelled > width * 0.5 || velocity < -650;
+
+    panel.style.transition = "transform 0.24s ease";
+
+    if (shouldClose) {
+      panel.style.transform = `translateX(-${width}px)`;
+      if (closeTimeoutRef.current !== null) {
+        window.clearTimeout(closeTimeoutRef.current);
+      }
+      closeTimeoutRef.current = window.setTimeout(() => {
+        close();
+      }, 180);
+    } else {
+      panel.style.transform = "translateX(0px)";
+    }
+
     swipeOrigin.current = null;
+    draggingRef.current = false;
+    translateRef.current = 0;
+    velocityRef.current = 0;
+    lastMoveRef.current = null;
   };
 
   return (
@@ -64,7 +148,13 @@ export default function MobileSidebarOverlay() {
         aria-label="Close menu"
         onClick={close}
       />
-      <div className="mobile-sidebar-panel" role="dialog" aria-modal="true" aria-label="Navigation menu">
+      <div
+        ref={panelRef}
+        className="mobile-sidebar-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation menu"
+      >
         <div className="mobile-sidebar-header">
           <button
             type="button"

--- a/components/mobile/MobileSidebarOverlay.tsx
+++ b/components/mobile/MobileSidebarOverlay.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { X } from "lucide-react";
+import { useEffect } from "react";
+import Sidebar from "@/components/Sidebar";
+import { useMobileUiStore } from "@/lib/state/mobileUiStore";
+
+export default function MobileSidebarOverlay() {
+  const open = useMobileUiStore(state => state.sidebarOpen);
+  const close = useMobileUiStore(state => state.closeSidebar);
+
+  useEffect(() => {
+    if (open) {
+      const prev = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = prev;
+      };
+    }
+    return undefined;
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="mobile-sidebar-overlay md:hidden">
+      <button
+        type="button"
+        className="mobile-sidebar-backdrop"
+        aria-label="Close menu"
+        onClick={close}
+      />
+      <div className="mobile-sidebar-panel" role="dialog" aria-modal="true" aria-label="Navigation menu">
+        <div className="mobile-sidebar-header">
+          <button
+            type="button"
+            className="mobile-icon-btn"
+            aria-label="Close menu"
+            onClick={close}
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="mobile-sidebar-content">
+          <Sidebar />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/mobile/PanelLoader.tsx
+++ b/components/mobile/PanelLoader.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function PanelLoader({ label }: { label: string }) {
+  const [showHint, setShowHint] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setShowHint(true), 3200);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return (
+    <div className="flex min-h-[240px] flex-col items-center justify-center gap-3 py-12 text-center">
+      <div className="flex flex-col items-center gap-2" role="status" aria-live="polite">
+        <span className="inline-flex h-12 w-12 items-center justify-center text-primary">
+          <span className="h-12 w-12 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+        </span>
+        <span className="text-sm font-medium text-[color:var(--medx-text)] dark:text-[color:var(--medx-text)]">
+          {label}
+        </span>
+      </div>
+      {showHint ? (
+        <p className="max-w-[220px] text-xs text-slate-500 dark:text-slate-400">
+          Fetching your data securely…
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -1,121 +1,16 @@
 "use client";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { reduce } from "@/lib/modes/modeMachine";
-import { fromSearchParams, toQuery } from "@/lib/modes/url";
-import { useTheme } from "next-themes";
-import type { ModeState } from "@/lib/modes/types";
-import { createThread } from "@/lib/chatThreads";
-import { pushToast } from "@/lib/ui/toast";
+import { useModeController } from "@/hooks/useModeController";
 
 export default function ModeBar() {
-  const router = useRouter();
-  const sp = useSearchParams();
-  const { theme } = useTheme();
-
-  const state = useMemo(
-    () => fromSearchParams(sp, (theme as "light" | "dark") ?? "light"),
-    [sp, theme],
-  );
-
-  const [therapyBusy, setTherapyBusy] = useState(false);
-
-  // remember last non-aidoc base to exit aidoc gracefully
-  const lastNonAidoc = useRef<"patient"|"doctor">("patient");
-  useEffect(() => {
-    if (state.base !== "aidoc") lastNonAidoc.current = state.base;
-  }, [state.base]);
-
-  const lastPatientThread = useRef<string | null>(null);
-  useEffect(() => {
-    if (state.therapy) return;
-    lastPatientThread.current = sp.get("threadId");
-  }, [sp, state.therapy]);
-
-  const startTherapy = useCallback(
-    async (nextState: ModeState, currentThread: string | null) => {
-      if (therapyBusy) return;
-      if (currentThread) lastPatientThread.current = currentThread;
-      setTherapyBusy(true);
-      try {
-        const { id } = await createThread({
-          title: "Therapy session",
-          mode: "patient",
-          therapy: true,
-        });
-        const params = new URLSearchParams(sp.toString());
-        params.set("threadId", id);
-        params.delete("context");
-        router.push(toQuery(nextState, params));
-      } catch (err) {
-        console.error("Failed to start therapy session", err);
-        pushToast({
-          title: "Couldn’t start Therapy chat",
-          description: "Please check your connection and try again.",
-          variant: "destructive",
-        });
-      } finally {
-        setTherapyBusy(false);
-      }
-    },
-    [router, sp, therapyBusy],
-  );
-
-  const exitTherapy = useCallback(
-    async (nextState: ModeState) => {
-      const params = new URLSearchParams(sp.toString());
-      params.delete("therapy");
-      params.delete("context");
-
-      const fallback = lastPatientThread.current;
-      if (fallback) {
-        params.set("threadId", fallback);
-        router.push(toQuery(nextState, params));
-        return;
-      }
-
-      try {
-        const { id } = await createThread({
-          title: "New chat",
-          mode: nextState.base === "doctor" ? "doctor" : "patient",
-        });
-        params.set("threadId", id);
-      } catch (err) {
-        console.error("Failed to create fallback chat after therapy", err);
-        params.delete("threadId");
-      }
-
-      router.push(toQuery(nextState, params));
-    },
-    [router, sp],
-  );
-
-  const apply = (action: Parameters<typeof reduce>[1]) => {
-    if (action.type === "toggle/aidoc" && state.base === "aidoc") {
-      const q = toQuery(
-        { ...state, base: lastNonAidoc.current, therapy: false, research: false },
-        sp,
-      );
-      router.push(q);
-      return;
-    }
-
-    const next = reduce(state, action);
-
-    if (!state.therapy && next.therapy) {
-      if (therapyBusy) return;
-      const currentThread = sp.get("threadId");
-      void startTherapy(next, currentThread);
-      return;
-    }
-
-    if (state.therapy && !next.therapy) {
-      void exitTherapy(next);
-      return;
-    }
-
-    router.push(toQuery(next, sp));
-  };
+  const {
+    state,
+    therapyBusy,
+    togglePatient,
+    toggleDoctor,
+    toggleAidoc,
+    toggleTherapy,
+    toggleResearch,
+  } = useModeController();
 
   const btn = (active: boolean, disabled?: boolean) =>
     [
@@ -134,14 +29,14 @@ export default function ModeBar() {
     <div className="inline-flex flex-wrap items-center gap-2 rounded-full border border-black/10 bg-white/60 px-2 py-1 backdrop-blur dark:border-white/10 dark:bg-slate-900/40">
       <button
         className={btn(wellnessActive)}
-        onClick={() => apply({ type: "toggle/patient" })}
+        onClick={() => togglePatient()}
       >
         Wellness
       </button>
       <button
         className={btn(state.therapy, aidocOn || state.base !== "patient" || therapyBusy)}
         disabled={aidocOn || state.base !== "patient" || therapyBusy}
-        onClick={() => apply({ type: "toggle/therapy" })}
+        onClick={() => toggleTherapy()}
         aria-busy={therapyBusy}
       >
         <span>Therapy</span>
@@ -154,20 +49,20 @@ export default function ModeBar() {
       <button
         className={btn(state.research, aidocOn)}
         disabled={aidocOn}
-        onClick={() => apply({ type: "toggle/research" })}
+        onClick={() => toggleResearch()}
       >
         Research
       </button>
       <button
         className={btn(doctorActive)}
-        onClick={() => apply({ type: "toggle/doctor" })}
+        onClick={() => toggleDoctor()}
       >
         Clinical
       </button>
 
       <div className="mx-1 h-5 w-px bg-black/10 dark:bg-white/10" />
 
-      <button className={btn(aidocOn)} onClick={() => apply({ type: "toggle/aidoc" })}>
+      <button className={btn(aidocOn)} onClick={() => toggleAidoc()}>
         AI Doc
       </button>
     </div>

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -3057,6 +3057,13 @@ ${systemCommon}` + baseSys;
     return () => window.removeEventListener('keydown', handleKey);
   }, [busy]);
 
+  const hasScrollableContent =
+    visibleMessages.length > 0 ||
+    showWelcomeCard ||
+    summary != null ||
+    trialRows.length > 0 ||
+    Boolean(aidoc);
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {showWelcomeCard && welcomeContent ? (
@@ -3074,7 +3081,11 @@ ${systemCommon}` + baseSys;
       <div
         ref={chatRef}
         id="chat-scroll-container"
-        className={`flex-1 min-h-0 overflow-y-auto${showWelcomeCard ? ' mt-4' : ''}`}
+        className={`flex-1 min-h-0 ${
+          hasScrollableContent
+            ? 'overflow-y-auto mobile-chat-scroll'
+            : 'overflow-hidden mobile-chat-scroll-empty'
+        }${showWelcomeCard ? ' mt-4' : ''} md:overflow-y-auto`}
       >
         <div className={`flex min-h-full flex-col justify-end px-6${showWelcomeCard ? '' : ' pt-6'}`}>
           {mode === "doctor" && researchMode && (
@@ -3329,8 +3340,8 @@ ${systemCommon}` + baseSys;
         </div>
       </div>
 
-      <div className="mt-auto">
-        <div className="px-6 pb-[max(16px,env(safe-area-inset-bottom))]">
+      <div className="mt-auto mobile-composer-region">
+        <div className="px-6 pb-4 md:pb-6">
           <div className="mx-auto max-w-3xl space-y-3 px-4 py-4">
               {mode === 'doctor' && AIDOC_UI && (
                 <button

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -165,15 +165,15 @@ export default function MedicalProfile() {
   };
 
   return (
-    <div className="p-4 space-y-4 relative z-0">
+    <div className="p-4 space-y-4 relative z-0 mobile-medical-profile">
       <section className="rounded-xl border p-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h2 className="font-semibold">Wellness Info</h2>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             {/* Reset (sidebar-safe) */}
             <button
               type="button"
-              className="text-sm rounded-md border px-3 py-1.5 hover:bg-muted"
+              className="text-sm rounded-md border px-3 py-1.5 hover:bg-muted mobile-tappable md:min-h-0"
               onClick={async () => {
                 const pick = window.prompt(
                   "Reset:\n1 = Clear observations\n2 = Clear everything (obs+pred+alerts)\n3 = Zero demo values\n\nEnter 1/2/3 or Cancel"
@@ -210,7 +210,7 @@ export default function MedicalProfile() {
             {/* Save (sidebar-safe) */}
             <button
               type="button"
-              className="text-sm rounded-md border px-3 py-1.5 hover:bg-muted disabled:opacity-50"
+              className="text-sm rounded-md border px-3 py-1.5 hover:bg-muted disabled:opacity-50 mobile-tappable md:min-h-0"
               disabled={saving}
               onClick={async () => {
                 setSaving(true);
@@ -402,17 +402,17 @@ export default function MedicalProfile() {
               return (
                 <div key={key}>
                   <div className="mb-2 text-sm font-medium">{TITLES[key]}</div>
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-3 text-sm">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 text-sm">
                     {items.slice(0, 6).map(it => (
                       <div key={it.key} className="flex items-start justify-between rounded-md bg-muted/40 px-3 py-2">
-                        <div className="pr-2">
-                          <div>{it.label}</div>
-                          <div className="text-xs text-muted-foreground">
+                        <div className="pr-2 mobile-truncate-2">
+                          <div className="font-medium">{it.label}</div>
+                          <div className="text-xs text-muted-foreground mobile-truncate-2">
                             {new Date(it.observedAt).toLocaleDateString()}
                             {it.source ? ` • ${it.source}` : ""}
                           </div>
                         </div>
-                        <div className="font-medium text-right">
+                        <div className="font-medium text-right mobile-truncate-2">
                           {it.value ?? "—"}{it.unit ? ` ${it.unit}` : ""}
                         </div>
                       </div>
@@ -430,9 +430,9 @@ export default function MedicalProfile() {
 
       {/* --- AI Summary & Reasons --- */}
       <div className="mt-6 rounded-xl border p-4">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h3 className="font-semibold">AI Summary</h3>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <button
               onClick={async () => {
                 try {
@@ -463,12 +463,12 @@ export default function MedicalProfile() {
                   );
                 }
               }}
-              className="text-xs px-2 py-1 rounded-md border"
+              className="text-xs px-2 py-1 rounded-md border mobile-tappable md:min-h-0"
             >Discuss & Correct in Chat</button>
             <button
               id="recompute-risk-btn"
               onClick={onRecomputeRisk}
-              className="text-xs px-2 py-1 rounded-md border"
+              className="text-xs px-2 py-1 rounded-md border mobile-tappable md:min-h-0"
             >Recompute Risk</button>
           </div>
         </div>

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -166,7 +166,7 @@ export default function MedicalProfile() {
   };
 
   return (
-    <div className="p-4 space-y-4 relative z-0 mobile-medical-profile">
+    <div className="relative z-0 space-y-4 p-4 mobile-medical-profile md:p-6">
       <section className="rounded-xl border p-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <h2 className="font-semibold">Wellness Info</h2>
@@ -246,7 +246,7 @@ export default function MedicalProfile() {
           </div>
         </div>
 
-        <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+        <div className="mt-3 grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
           <label className="flex flex-col gap-1">
             <span>Name</span>
             <input
@@ -321,14 +321,18 @@ export default function MedicalProfile() {
                 <option key={c} value={c} />
               ))}
             </datalist>
-            <div className="flex flex-wrap gap-2 mt-1">
+            <div className="mt-1 flex flex-wrap gap-2">
               {predis.map(c => (
-                <span key={c} className="text-xs border rounded-full px-2 py-0.5">
-                  {c}
-                  <button type="button" className="ml-1" onClick={() => setPredis(predis.filter(x => x !== c))}>
-                    ×
-                  </button>
-                </span>
+                <button
+                  key={c}
+                  type="button"
+                  className="mobile-tappable inline-flex max-w-full items-center gap-1.5 truncate rounded-full border px-3 py-1 text-xs transition hover:bg-muted md:min-h-0 md:px-2.5 md:py-1"
+                  onClick={() => setPredis(predis.filter(x => x !== c))}
+                  aria-label={`Remove ${c} predisposition`}
+                >
+                  <span className="truncate">{c}</span>
+                  <span aria-hidden="true">×</span>
+                </button>
               ))}
             </div>
           </label>
@@ -348,14 +352,18 @@ export default function MedicalProfile() {
               }}
               list="condlist"
             />
-            <div className="flex flex-wrap gap-2 mt-1">
+            <div className="mt-1 flex flex-wrap gap-2">
               {chronic.map(c => (
-                <span key={c} className="text-xs border rounded-full px-2 py-0.5">
-                  {c}
-                  <button type="button" className="ml-1" onClick={() => setChronic(chronic.filter(x => x !== c))}>
-                    ×
-                  </button>
-                </span>
+                <button
+                  key={c}
+                  type="button"
+                  className="mobile-tappable inline-flex max-w-full items-center gap-1.5 truncate rounded-full border px-3 py-1 text-xs transition hover:bg-muted md:min-h-0 md:px-2.5 md:py-1"
+                  onClick={() => setChronic(chronic.filter(x => x !== c))}
+                  aria-label={`Remove ${c} chronic condition`}
+                >
+                  <span className="truncate">{c}</span>
+                  <span aria-hidden="true">×</span>
+                </button>
               ))}
             </div>
           </label>
@@ -403,18 +411,24 @@ export default function MedicalProfile() {
               return (
                 <div key={key}>
                   <div className="mb-2 text-sm font-medium">{TITLES[key]}</div>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 text-sm">
+                  <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2 md:grid-cols-3">
                     {items.slice(0, 6).map(it => (
-                      <div key={it.key} className="flex items-start justify-between rounded-md bg-muted/40 px-3 py-2">
-                        <div className="pr-2 mobile-truncate-2">
-                          <div className="font-medium">{it.label}</div>
+                      <div
+                        key={it.key}
+                        className="flex min-w-0 flex-col gap-2 rounded-lg bg-muted/40 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <div className="min-w-0 pr-2">
+                          <div className="truncate font-medium">{it.label}</div>
                           <div className="text-xs text-muted-foreground mobile-truncate-2">
                             {new Date(it.observedAt).toLocaleDateString()}
                             {it.source ? ` • ${it.source}` : ""}
                           </div>
                         </div>
-                        <div className="font-medium text-right mobile-truncate-2">
-                          {it.value ?? "—"}{it.unit ? ` ${it.unit}` : ""}
+                        <div className="min-w-0 text-sm font-medium sm:text-right">
+                          <span className="block truncate">
+                            {it.value ?? "—"}
+                            {it.unit ? ` ${it.unit}` : ""}
+                          </span>
                         </div>
                       </div>
                     ))}

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { safeJson } from "@/lib/safeJson";
 import { useProfile } from "@/lib/hooks/useAppData";
+import PanelLoader from "@/components/mobile/PanelLoader";
 
 const SEXES = ["male", "female", "other"] as const;
 const BLOOD_GROUPS = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
@@ -143,7 +144,7 @@ export default function MedicalProfile() {
     setBootstrapped(true);
   }, [prof, bootstrapped]);
 
-  if (isLoading) return <div className="p-6 text-sm text-muted-foreground">Loading profile…</div>;
+  if (isLoading) return <PanelLoader label="Medical Profile" />;
   if (error)     return <div className="p-6 text-sm text-red-500">Couldn’t load profile. Retrying in background…</div>;
   if (!data)     return <div className="p-6 text-sm text-muted-foreground">No profile yet.</div>;
 

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useTimeline } from "@/lib/hooks/useAppData";
 import { useIsAiDocMode } from "@/hooks/useIsAiDocMode";
+import PanelLoader from "@/components/mobile/PanelLoader";
 
 type Cat = "ALL"|"LABS"|"VITALS"|"IMAGING"|"AI"|"NOTES";
 const catOf = (it:any):Cat => {
@@ -71,7 +72,7 @@ export default function Timeline(){
 
   if (!isAiDoc) return null;
 
-  if (isLoading) return <div className="p-6 text-sm text-muted-foreground">Loading timeline…</div>;
+  if (isLoading) return <PanelLoader label="Timeline" />;
   if (error)     return <div className="p-6 text-sm text-red-500">Couldn’t load timeline. Retrying in background…</div>;
 
   if (!items.length) return <div className="p-6 text-sm text-muted-foreground">No events yet.</div>;

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 
 type Tab = {
   key: string;
@@ -37,6 +38,7 @@ function NavLink({
   context?: string;
 }) {
   const params = useSearchParams();
+  const closeSidebar = useMobileUiStore(state => state.closeSidebar);
 
   const threadId = threadIdProp;
   const href = `/?panel=${panel}${threadId ? `&threadId=${encodeURIComponent(threadId)}` : ""}${
@@ -52,7 +54,10 @@ function NavLink({
       href={href}
       prefetch={false}
       scroll={false}
-      onClick={(e) => e.stopPropagation()}
+      onClick={event => {
+        closeSidebar();
+        event.stopPropagation();
+      }}
       className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
       data-testid={`nav-${panel}`}
       aria-current={active ? "page" : undefined}

--- a/hooks/useModeController.ts
+++ b/hooks/useModeController.ts
@@ -1,0 +1,179 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTheme } from "next-themes";
+import { fromSearchParams, toQuery } from "@/lib/modes/url";
+import { reduce, type Action } from "@/lib/modes/modeMachine";
+import type { ModeState } from "@/lib/modes/types";
+import { createThread } from "@/lib/chatThreads";
+import { pushToast } from "@/lib/ui/toast";
+
+type ModeChoice = "wellness" | "doctor" | "aidoc" | "therapy";
+
+type Controller = {
+  state: ModeState;
+  therapyBusy: boolean;
+  selectMode: (choice: ModeChoice) => void;
+  togglePatient: () => void;
+  toggleDoctor: () => void;
+  toggleAidoc: () => void;
+  toggleTherapy: () => void;
+  toggleResearch: () => void;
+  toggleTheme: () => void;
+  researchEnabled: boolean;
+};
+
+export function useModeController(): Controller {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { theme } = useTheme();
+
+  const state = useMemo(
+    () => fromSearchParams(searchParams, (theme as "light" | "dark") ?? "light"),
+    [searchParams, theme],
+  );
+
+  const [therapyBusy, setTherapyBusy] = useState(false);
+  const lastNonAidoc = useRef<"patient" | "doctor">("patient");
+  useEffect(() => {
+    if (state.base !== "aidoc") lastNonAidoc.current = state.base;
+  }, [state.base]);
+
+  const lastPatientThread = useRef<string | null>(null);
+  useEffect(() => {
+    if (state.therapy) return;
+    lastPatientThread.current = searchParams.get("threadId");
+  }, [state.therapy, searchParams]);
+
+  const startTherapy = useCallback(
+    async (nextState: ModeState) => {
+      if (therapyBusy) return;
+      const currentThread = searchParams.get("threadId");
+      if (currentThread) lastPatientThread.current = currentThread;
+      setTherapyBusy(true);
+      try {
+        const { id } = await createThread({
+          title: "Therapy session",
+          mode: "patient",
+          therapy: true,
+        });
+        const params = new URLSearchParams(searchParams.toString());
+        params.set("threadId", id);
+        params.delete("context");
+        router.push(toQuery(nextState, params));
+      } catch (err) {
+        console.error("Failed to start therapy session", err);
+        pushToast({
+          title: "Couldn’t start Therapy chat",
+          description: "Please check your connection and try again.",
+          variant: "destructive",
+        });
+      } finally {
+        setTherapyBusy(false);
+      }
+    },
+    [router, searchParams, therapyBusy],
+  );
+
+  const exitTherapy = useCallback(
+    async (nextState: ModeState) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("therapy");
+      params.delete("context");
+      const fallback = lastPatientThread.current;
+      if (fallback) {
+        params.set("threadId", fallback);
+        router.push(toQuery(nextState, params));
+        return;
+      }
+      try {
+        const { id } = await createThread({
+          title: "New chat",
+          mode: nextState.base === "doctor" ? "doctor" : "patient",
+        });
+        params.set("threadId", id);
+      } catch (err) {
+        console.error("Failed to create fallback chat after therapy", err);
+        params.delete("threadId");
+      }
+      router.push(toQuery(nextState, params));
+    },
+    [router, searchParams],
+  );
+
+  const applyAction = useCallback(
+    (action: Action) => {
+      if (action.type === "toggle/aidoc" && state.base === "aidoc") {
+        const params = new URLSearchParams(searchParams.toString());
+        const restored = {
+          ...state,
+          base: lastNonAidoc.current,
+          therapy: false,
+          research: false,
+        } as ModeState;
+        router.push(toQuery(restored, params));
+        return;
+      }
+
+      const next = reduce(state, action);
+
+      if (!state.therapy && next.therapy) {
+        void startTherapy(next);
+        return;
+      }
+
+      if (state.therapy && !next.therapy) {
+        void exitTherapy(next);
+        return;
+      }
+
+      router.push(toQuery(next, searchParams));
+    },
+    [exitTherapy, router, searchParams, startTherapy, state],
+  );
+
+  const togglePatient = useCallback(() => applyAction({ type: "toggle/patient" }), [applyAction]);
+  const toggleDoctor = useCallback(() => applyAction({ type: "toggle/doctor" }), [applyAction]);
+  const toggleAidoc = useCallback(() => applyAction({ type: "toggle/aidoc" }), [applyAction]);
+  const toggleTherapy = useCallback(() => applyAction({ type: "toggle/therapy" }), [applyAction]);
+  const toggleResearch = useCallback(() => applyAction({ type: "toggle/research" }), [applyAction]);
+  const toggleTheme = useCallback(() => applyAction({ type: "toggle/theme" }), [applyAction]);
+
+  const selectMode = useCallback(
+    (choice: ModeChoice) => {
+      switch (choice) {
+        case "wellness":
+          togglePatient();
+          break;
+        case "doctor":
+          toggleDoctor();
+          break;
+        case "aidoc":
+          toggleAidoc();
+          break;
+        case "therapy":
+          if (!state.therapy) toggleTherapy();
+          break;
+        default:
+          break;
+      }
+    },
+    [state.therapy, toggleAidoc, toggleDoctor, togglePatient, toggleTherapy],
+  );
+
+  const researchEnabled = !state.therapy && (state.base === "patient" || state.base === "doctor");
+
+  return {
+    state,
+    therapyBusy,
+    selectMode,
+    togglePatient,
+    toggleDoctor,
+    toggleAidoc,
+    toggleTherapy,
+    toggleResearch,
+    toggleTheme,
+    researchEnabled,
+  };
+}

--- a/lib/brand.ts
+++ b/lib/brand.ts
@@ -9,6 +9,14 @@ export const BRAND_NAME = "Second Opinion";
 // Canonical path you want to converge on (case-sensitive, recommended):
 export const LOGO_SRC = "/brand/second-opinion.png";
 
+// White variant used for dark or glass backgrounds on mobile.
+export const LOGO_WHITE_SRC = "/Second-Opieee23423nion.png";
+export const LOGO_WHITE_FALLBACKS: string[] = [
+  "/brand/second-opinion-white.png",
+  "/second-opinion-white.png",
+  LOGO_SRC,
+];
+
 // Optional: alternate places/names you might currently have in /public.
 // The Logo component will try these on onError in order.
 export const LOGO_FALLBACKS: string[] = [

--- a/lib/state/mobileUiStore.ts
+++ b/lib/state/mobileUiStore.ts
@@ -1,0 +1,26 @@
+"use client";
+import { create } from "zustand";
+
+type SheetView = "main" | "mode" | "country";
+
+type MobileUIState = {
+  sidebarOpen: boolean;
+  sheetOpen: boolean;
+  sheetView: SheetView;
+  openSidebar: () => void;
+  closeSidebar: () => void;
+  openSheet: (view?: SheetView) => void;
+  closeSheet: () => void;
+  setSheetView: (view: SheetView) => void;
+};
+
+export const useMobileUiStore = create<MobileUIState>((set) => ({
+  sidebarOpen: false,
+  sheetOpen: false,
+  sheetView: "main",
+  openSidebar: () => set({ sidebarOpen: true }),
+  closeSidebar: () => set({ sidebarOpen: false }),
+  openSheet: (view = "main") => set({ sheetOpen: true, sheetView: view }),
+  closeSheet: () => set({ sheetOpen: false, sheetView: "main" }),
+  setSheetView: (view) => set({ sheetView: view }),
+}));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,7 @@ module.exports = {
       },
       fontFamily: {
         // Use with className="font-sans"
-        sans: ["var(--font-roboto)", "system-ui", "sans-serif"],
+        sans: ["var(--font-inter)", "system-ui", "sans-serif"],
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,14 @@ module.exports = {
       },
       fontFamily: {
         // Use with className="font-sans"
-        sans: ["var(--font-inter)", "system-ui", "sans-serif"],
+        sans: [
+          "Proxima Nova",
+          "proxima-nova",
+          "Helvetica Neue",
+          "Helvetica",
+          "Arial",
+          "sans-serif",
+        ],
       },
     },
   },


### PR DESCRIPTION
## Summary
- add a dedicated mobile header, sidebar overlay, and bottom-sheet menu wired through a small Zustand store
- restyle the chat window and input so the composer is safe-area aware and sticks above the scrolling messages on handheld breakpoints
- layer in mobile-specific CSS tokens and offsets to preserve theme parity while matching the ChatGPT-inspired layout

## Testing
- npm run lint *(fails: prompts for eslint configuration and cannot be completed non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d43ca48440832f856232ce8926b491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-first UI: mobile header, sidebar overlay, draggable bottom actions sheet, mobile composer/footer with dynamic sizing, and centralized mobile UI state.
  * Chat UX: auto-resizing composer, Enter-to-send, file upload, disabled send when empty, auto-create thread, composer height sync.
  * Mode & branding: centralized mode controls, white logo variant, new globe icon, and a lightweight mobile loader.

* **Bug Fixes**
  * Improved safe-area handling, scrolling/overflow, marquee sizing, and auto-closing sidebar on navigation.

* **Style**
  * Updated default sans font stack and mobile footer/marquee presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->