### PR TITLE
Use Proxima Nova font across application

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,9 +1,15 @@
+@import url("https://fonts.cdnfonts.com/css/proxima-nova-2");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 /* smooth theme transitions */
 * { transition: background-color .15s ease, color .15s ease, border-color .15s ease; }
+
+html, body {
+  font-family: var(--font-proxima-nova);
+}
 
 .btn-secondary{
   @apply inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm transition
@@ -99,6 +105,7 @@
 
 /* === MedX Theme Tokens (Light & Dark) === */
 :root {
+  --font-proxima-nova: "Proxima Nova", "Proxima Nova Rg", "ProximaNova", "Helvetica Neue", "Arial", sans-serif;
   --medx-bg-a: #e9efff;   /* light indigo */
   --medx-bg-b: #d0f3ff;   /* light cyan */
   --medx-bg-c: #ffffff;   /* fallback third stop */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,20 +11,17 @@ import { Suspense } from "react";
 import MemorySnackbar from "@/components/memory/Snackbar";
 import UndoToast from "@/components/memory/UndoToast";
 import AppToastHost from "@/components/ui/AppToastHost";
-import { Roboto } from "next/font/google";
-
 export const metadata = { title: BRAND_NAME, description: "Global medical AI" };
-
-const roboto = Roboto({
-  subsets: ["latin"],
-  weight: ["300", "400", "500", "700", "900"],
-  variable: "--font-roboto",
-  display: "swap",
-});
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={roboto.variable} suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <link
+          rel="stylesheet"
+          href="https://fonts.cdnfonts.com/css/proxima-nova-2"
+        />
+      </head>
       <body className="h-full bg-slate-100 text-slate-900 dark:bg-transparent dark:text-slate-100 font-sans antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <CountryProvider>

--- a/app/styles.css
+++ b/app/styles.css
@@ -16,7 +16,7 @@ body[data-role="doctor"] { --accent:#7c3aed; }
 html,body{ height:100%; margin:0; padding:0 }
 body{
   background:var(--bg); color:var(--fg);
-  font:16px/1.55 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  font:16px/1.55 "Proxima Nova", "Proxima Nova Rg", ProximaNova, "Helvetica Neue", Helvetica, Arial, sans-serif;
   -webkit-font-smoothing:antialiased; -moz-osx-font-smoothing:grayscale;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,7 +14,14 @@ module.exports = {
       },
       fontFamily: {
         // Use with className="font-sans"
-        sans: ["var(--font-roboto)", "system-ui", "sans-serif"],
+        sans: [
+          "Proxima Nova",
+          "Proxima Nova Rg",
+          "ProximaNova",
+          "Helvetica Neue",
+          "Arial",
+          "sans-serif",
+        ],
       },
     },
   },


### PR DESCRIPTION
## Summary
- import the Proxima Nova webfont globally and default the app typography to it
- update Tailwind's sans-serif stack and legacy styles to rely on the new font family
- remove the Roboto font dependency from the root layout to ensure every surface uses Proxima Nova

## Testing
- npm run lint *(fails: prompts for ESLint configuration and does not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68d4cbf5dee4832f93a9469911312023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Style
  - Updated global typography to use Proxima Nova for a cleaner, more modern look.
  - Unified the sans-serif font stack across the app for consistent rendering.

- Chores
  - Replaced previous font loading setup with an external Proxima Nova stylesheet.
  - Adjusted styling configuration to align with the new font across all pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->