### PR TITLE
Revamp medical profile UI with vitals and meds flows

### DIFF
--- a/components/meds/MedicationInput.tsx
+++ b/components/meds/MedicationInput.tsx
@@ -27,6 +27,8 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
 
   const name = lockedName ?? query.trim();
   const showSave = name.length >= 2;
+  const trimmedDose = dose.trim();
+  const shouldShowDoseInput = needsDose || !!lockedName || trimmedDose.length > 0 || showSave;
 
   useEffect(() => {
     if (!query.trim() || lockedName) {
@@ -63,7 +65,7 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
       setError("Enter a medication name.");
       return;
     }
-    const finalDose = dose.trim();
+    const finalDose = trimmedDose;
     if (!finalDose && !needsDose) {
       setNeedsDose(true);
       return;
@@ -89,8 +91,8 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
   };
 
   return (
-    <div className="space-y-2">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+    <div className="space-y-3">
+      <div className="flex flex-col gap-3">
         <div className="flex-1">
           <label className="flex flex-col gap-1 text-sm">
             <span className="text-xs font-medium text-muted-foreground">Medication name</span>
@@ -135,12 +137,12 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
             </div>
           ) : null}
         </div>
-        {needsDose ? (
-          <label className="flex flex-col gap-1 text-sm sm:w-48">
-            <span className="text-xs font-medium text-muted-foreground">Dose</span>
+        {shouldShowDoseInput ? (
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-xs font-medium text-muted-foreground">Dose (enter 0 if not applicable)</span>
             <input
               className="rounded-md border px-3 py-2"
-              placeholder="e.g. 500 mg"
+              placeholder="e.g. 500 mg or 0"
               value={dose}
               onChange={e => setDose(e.target.value)}
             />
@@ -149,7 +151,7 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
         {showSave ? (
           <button
             type="button"
-            className="inline-flex items-center justify-center rounded-md border bg-primary px-3 py-2 text-sm text-primary-foreground shadow disabled:opacity-60"
+            className="inline-flex items-center justify-center self-start rounded-md border bg-primary px-3 py-2 text-sm text-primary-foreground shadow disabled:opacity-60"
             onClick={handleSave}
             disabled={loading}
           >
@@ -157,8 +159,8 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
           </button>
         ) : null}
       </div>
-      {needsDose && !dose.trim() ? (
-        <p className="text-xs text-muted-foreground">Add a dose before saving.</p>
+      {needsDose && !trimmedDose ? (
+        <p className="text-xs text-muted-foreground">Add a dose (enter 0 if not applicable) before saving.</p>
       ) : null}
     </div>
   );

--- a/components/meds/MedicationInput.tsx
+++ b/components/meds/MedicationInput.tsx
@@ -10,13 +10,14 @@ type Suggestion = {
 };
 
 export type MedicationInputProps = {
-  onSave: (med: { name: string; dose?: string | null }) => Promise<void> | void;
+  onSave: (med: { name: string; dose?: string | null; rxnormId?: string | null }) => Promise<void> | void;
   placeholder?: string;
 };
 
 export default function MedicationInput({ onSave, placeholder = "Add a medication" }: MedicationInputProps) {
   const [query, setQuery] = useState("");
   const [lockedName, setLockedName] = useState<string | null>(null);
+  const [lockedSuggestion, setLockedSuggestion] = useState<Suggestion | null>(null);
   const [dose, setDose] = useState("");
   const [needsDose, setNeedsDose] = useState(false);
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
@@ -68,9 +69,10 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
       return;
     }
     try {
-      await onSave({ name, dose: finalDose || null });
+      await onSave({ name, dose: finalDose || null, rxnormId: lockedSuggestion?.rxnormId ?? null });
       setQuery("");
       setLockedName(null);
+      setLockedSuggestion(null);
       setDose("");
       setNeedsDose(false);
       setSuggestions([]);
@@ -98,6 +100,7 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
               value={lockedName ?? query}
               onChange={e => {
                 setLockedName(null);
+                setLockedSuggestion(null);
                 setQuery(e.target.value);
               }}
             />
@@ -118,7 +121,11 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
                     <button
                       type="button"
                       className="rounded-full border px-3 py-1 hover:bg-muted"
-                      onClick={() => setLockedName(s.name)}
+                      onClick={() => {
+                        setLockedName(s.name);
+                        setLockedSuggestion(s);
+                        setQuery(s.name);
+                      }}
                     >
                       {s.name}
                     </button>

--- a/components/meds/MedicationInput.tsx
+++ b/components/meds/MedicationInput.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { pushToast } from "@/lib/ui/toast";
+
+type Suggestion = {
+  name: string;
+  rxnormId?: string | null;
+};
+
+export type MedicationInputProps = {
+  onSave: (med: { name: string; dose?: string | null }) => Promise<void> | void;
+  placeholder?: string;
+};
+
+export default function MedicationInput({ onSave, placeholder = "Add a medication" }: MedicationInputProps) {
+  const [query, setQuery] = useState("");
+  const [lockedName, setLockedName] = useState<string | null>(null);
+  const [dose, setDose] = useState("");
+  const [needsDose, setNeedsDose] = useState(false);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const name = lockedName ?? query.trim();
+  const showSave = name.length >= 2;
+
+  useEffect(() => {
+    if (!query.trim() || lockedName) {
+      setSuggestions([]);
+      setError(null);
+      abortRef.current?.abort();
+      return;
+    }
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const handle = window.setTimeout(() => {
+      void fetchSuggestions(query.trim(), controller.signal)
+        .then(list => {
+          setSuggestions(list);
+          setError(null);
+        })
+        .catch(err => {
+          if (err.name === "AbortError") return;
+          console.warn("Medication search failed", err);
+          setError("Couldn’t fetch suggestions.");
+          setSuggestions([]);
+        })
+        .finally(() => setLoading(false));
+    }, 300);
+    setLoading(true);
+    return () => {
+      window.clearTimeout(handle);
+      controller.abort();
+    };
+  }, [lockedName, query]);
+
+  const handleSave = async () => {
+    if (!name) {
+      setError("Enter a medication name.");
+      return;
+    }
+    const finalDose = dose.trim();
+    if (!finalDose && !needsDose) {
+      setNeedsDose(true);
+      return;
+    }
+    try {
+      await onSave({ name, dose: finalDose || null });
+      setQuery("");
+      setLockedName(null);
+      setDose("");
+      setNeedsDose(false);
+      setSuggestions([]);
+      setError(null);
+      pushToast({ title: "Medication saved" });
+    } catch (err: any) {
+      console.error("Failed to save medication", err);
+      pushToast({
+        title: "Couldn’t save medication",
+        description: err?.message || "Please try again.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+        <div className="flex-1">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-xs font-medium text-muted-foreground">Medication name</span>
+            <input
+              className="rounded-md border px-3 py-2"
+              placeholder={placeholder}
+              value={lockedName ?? query}
+              onChange={e => {
+                setLockedName(null);
+                setQuery(e.target.value);
+              }}
+            />
+          </label>
+          {loading ? (
+            <p className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              Searching suggestions…
+            </p>
+          ) : null}
+          {error ? <p className="mt-1 text-xs text-destructive">{error}</p> : null}
+          {!loading && !lockedName && suggestions.length > 0 ? (
+            <div className="mt-2 space-y-1 text-xs">
+              <p className="font-medium text-muted-foreground">Did you mean…</p>
+              <ul className="flex flex-wrap gap-1">
+                {suggestions.slice(0, 5).map(s => (
+                  <li key={`${s.rxnormId || s.name}`}>
+                    <button
+                      type="button"
+                      className="rounded-full border px-3 py-1 hover:bg-muted"
+                      onClick={() => setLockedName(s.name)}
+                    >
+                      {s.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+        {needsDose ? (
+          <label className="flex flex-col gap-1 text-sm sm:w-48">
+            <span className="text-xs font-medium text-muted-foreground">Dose</span>
+            <input
+              className="rounded-md border px-3 py-2"
+              placeholder="e.g. 500 mg"
+              value={dose}
+              onChange={e => setDose(e.target.value)}
+            />
+          </label>
+        ) : null}
+        {showSave ? (
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-md border bg-primary px-3 py-2 text-sm text-primary-foreground shadow disabled:opacity-60"
+            onClick={handleSave}
+            disabled={loading}
+          >
+            Save
+          </button>
+        ) : null}
+      </div>
+      {needsDose && !dose.trim() ? (
+        <p className="text-xs text-muted-foreground">Add a dose before saving.</p>
+      ) : null}
+    </div>
+  );
+}
+
+async function fetchSuggestions(term: string, signal: AbortSignal): Promise<Suggestion[]> {
+  const suggestions: Suggestion[] = [];
+  try {
+    const searchRes = await fetch(`/api/meds/search?q=${encodeURIComponent(term)}`, { signal });
+    if (searchRes.ok) {
+      const json = await searchRes.json();
+      const meds = Array.isArray(json?.meds) ? json.meds : [];
+      for (const med of meds) {
+        if (!med?.name) continue;
+        suggestions.push({ name: String(med.name), rxnormId: med.rxnormId ?? null });
+      }
+      return dedupeSuggestions(suggestions);
+    }
+    if (searchRes.status !== 404) {
+      throw new Error(`HTTP ${searchRes.status}`);
+    }
+  } catch (err) {
+    if ((err as any)?.name === "AbortError") throw err;
+    // fall through to normalization fallback
+  }
+
+  try {
+    const normalizeUrl = `/api/rxnorm/normalize?name=${encodeURIComponent(term)}`;
+    let normalizeRes = await fetch(normalizeUrl, { signal });
+    if (normalizeRes.status === 405) {
+      normalizeRes = await fetch("/api/rxnorm/normalize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: term }),
+        signal,
+      });
+    }
+    if (!normalizeRes.ok) return [];
+    const json = await normalizeRes.json();
+    const meds = Array.isArray(json?.meds)
+      ? json.meds
+      : Array.isArray(json?.tokens)
+      ? json.tokens
+      : [];
+    for (const med of meds) {
+      if (typeof med === "string") {
+        suggestions.push({ name: med });
+      } else if (med?.name) {
+        suggestions.push({ name: String(med.name), rxnormId: med.rxnormId ?? med.rxcui ?? null });
+      } else if (med?.token) {
+        suggestions.push({ name: String(med.token), rxnormId: med.rxcui ?? null });
+      }
+    }
+    return dedupeSuggestions(suggestions);
+  } catch (err) {
+    if ((err as any)?.name === "AbortError") throw err;
+    return [];
+  }
+}
+
+function dedupeSuggestions(input: Suggestion[]): Suggestion[] {
+  const map = new Map<string, Suggestion>();
+  for (const item of input) {
+    const key = item.name.toLowerCase();
+    if (!map.has(key)) {
+      map.set(key, item);
+    }
+  }
+  return Array.from(map.values());
+}

--- a/components/meds/MedicationTag.tsx
+++ b/components/meds/MedicationTag.tsx
@@ -18,12 +18,12 @@ export default function MedicationTag({ label, onRemove, disabled = false }: Med
       {onRemove ? (
         <button
           type="button"
-          className="ml-1 flex h-6 w-6 items-center justify-center rounded-full transition hover:bg-muted"
+          className="ml-1 flex h-8 w-8 items-center justify-center rounded-full transition hover:bg-muted"
           onClick={onRemove}
           disabled={disabled}
           aria-label="Remove medication"
         >
-          <X className="h-3.5 w-3.5" aria-hidden="true" />
+          <X className="h-4 w-4" aria-hidden="true" />
         </button>
       ) : null}
     </span>

--- a/components/meds/MedicationTag.tsx
+++ b/components/meds/MedicationTag.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { X } from "lucide-react";
+import type { ReactNode } from "react";
+
+export type MedicationTagProps = {
+  label: ReactNode;
+  onRemove?: () => void;
+  disabled?: boolean;
+};
+
+export default function MedicationTag({ label, onRemove, disabled = false }: MedicationTagProps) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted/50 px-3 py-1 text-sm text-foreground">
+      <span className="max-w-[10rem] truncate" title={typeof label === "string" ? label : undefined}>
+        {label}
+      </span>
+      {onRemove ? (
+        <button
+          type="button"
+          className="ml-1 flex h-6 w-6 items-center justify-center rounded-full transition hover:bg-muted"
+          onClick={onRemove}
+          disabled={disabled}
+          aria-label="Remove medication"
+        >
+          <X className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      ) : null}
+    </span>
+  );
+}

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -142,6 +142,8 @@ export default function MedicalProfile() {
   const [nextStepsDraft, setNextStepsDraft] = useState("");
   const [savingNextSteps, setSavingNextSteps] = useState(false);
 
+  const extractedMedications = useMemo(() => extractMedicationEntries(data), [data]);
+
   const latestMap: ObservationMap = (data?.latest as ObservationMap) || {};
 
   useEffect(() => {
@@ -242,7 +244,6 @@ export default function MedicalProfile() {
     },
   ];
 
-  const extractedMedications = useMemo(() => extractMedicationEntries(data), [data]);
   const labs = data?.groups?.labs ?? [];
   const medsEmpty = medications.length === 0;
 

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -440,8 +440,8 @@ export default function MedicalProfile() {
     }
   };
 
-  const showWellnessSections = panelMode !== "clinical" || panelMode === "ai-doc";
-  const showClinicalSections = panelMode !== "wellness" || panelMode === "ai-doc";
+  const showWellnessSections = panelMode !== "clinical";
+  const showClinicalSections = panelMode !== "wellness";
 
   if (isLoading) return <PanelLoader label="Medical Profile" />;
   if (error) {

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -927,16 +927,8 @@ export default function MedicalProfile() {
             <div className="rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
               ⚠️ This is AI-generated support, not a medical diagnosis. Always consult a clinician.
             </div>
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4">
-              <div>
-                <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Chronic conditions
-                </h4>
-                <p className="mt-1 text-sm">
-                  {chronic.length ? chronic.join(", ") : "—"}
-                </p>
-              </div>
-              <div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <div className="space-y-2">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                   Active medications
                 </h4>
@@ -946,7 +938,7 @@ export default function MedicalProfile() {
                       <MedicationTag
                         key={`summary-${med.key}`}
                         label={formatMedicationLabel(med)}
-                        onRemove={summaryMedsEditing ? () => handleRemoveMedication(med) : undefined}
+                        onRemove={() => handleRemoveMedication(med)}
                       />
                     ))}
                   </div>
@@ -954,7 +946,7 @@ export default function MedicalProfile() {
                   <p className="mt-1 text-sm text-muted-foreground">No medications recorded yet.</p>
                 )}
                 {summaryMedsEditing ? (
-                  <div className="mt-3 space-y-2">
+                  <div className="space-y-3">
                     <MedicationInput onSave={handleAddMedication} placeholder="Add a medication" />
                     <button
                       type="button"
@@ -967,14 +959,14 @@ export default function MedicalProfile() {
                 ) : (
                   <button
                     type="button"
-                    className="mt-2 inline-flex items-center rounded-md border px-3 py-1.5 text-xs"
+                    className="inline-flex items-center rounded-md border px-3 py-1.5 text-xs"
                     onClick={() => setSummaryMedsEditing(true)}
                   >
-                    Edit medications
+                    Add medication
                   </button>
                 )}
               </div>
-              <div>
+              <div className="space-y-2">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                   Symptoms / notes
                 </h4>
@@ -1032,7 +1024,7 @@ export default function MedicalProfile() {
                   </button>
                 )}
               </div>
-              <div>
+              <div className="space-y-2">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                   Next steps
                 </h4>

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -1,9 +1,16 @@
 "use client";
-import { useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { safeJson } from "@/lib/safeJson";
-import { useProfile } from "@/lib/hooks/useAppData";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams, type ReadonlyURLSearchParams } from "next/navigation";
+import { useTheme } from "next-themes";
 import PanelLoader from "@/components/mobile/PanelLoader";
+import ProfileSection from "@/components/profile/ProfileSection";
+import VitalsEditor, { type VitalsEditorValues } from "@/components/profile/VitalsEditor";
+import MedicationInput from "@/components/meds/MedicationInput";
+import MedicationTag from "@/components/meds/MedicationTag";
+import { useProfile } from "@/lib/hooks/useAppData";
+import { pushToast } from "@/lib/ui/toast";
+import { fromSearchParams } from "@/lib/modes/url";
 
 const SEXES = ["male", "female", "other"] as const;
 const BLOOD_GROUPS = ["A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-"];
@@ -24,229 +31,453 @@ const PRESET_CONDITIONS = [
   "Dyslipidemia",
 ];
 
+type MedicationEntry = {
+  name: string;
+  dose?: string | null;
+  since?: string | null;
+};
+
+type ObservationMap = Record<string, { value: any; unit: string | null; observedAt: string } | undefined>;
+
+type PanelMode = "wellness" | "clinical" | "ai-doc";
+
 function ageFromDob(dob?: string | null) {
   if (!dob) return "";
   const d = new Date(dob);
-  if (isNaN(d.getTime())) return "";
+  if (Number.isNaN(d.getTime())) return "";
   const diff = Date.now() - d.getTime();
   return String(Math.floor(diff / (365.25 * 24 * 3600 * 1000)));
 }
 
-type Observation = { kind: string; value: any; observedAt: string };
+function dedupeStrings(values: string[]) {
+  return Array.from(new Set(values.map(v => v.trim()).filter(Boolean)));
+}
 
-type Item = {
-  key: string;
-  label: string;
-  value: string | number | null;
-  unit: string | null;
-  observedAt: string;
-  source?: string | null;
-};
-type Groups = Record<
-  "vitals" | "labs" | "imaging" | "medications" | "diagnoses" | "procedures" | "immunizations" | "notes" | "other",
-  Item[]
->;
+function parseNumber(raw: any): number | null {
+  if (raw == null) return null;
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+  if (typeof raw === "string") {
+    const cleaned = raw.replace(/[^0-9.,-]+/g, "").replace(/,/g, "");
+    const parsed = Number(cleaned);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function parseBp(value: any): { systolic?: number; diastolic?: number } {
+  if (typeof value === "string" && value.includes("/")) {
+    const [s, d] = value.split("/").map(part => parseNumber(part));
+    return { systolic: s ?? undefined, diastolic: d ?? undefined };
+  }
+  return {};
+}
+
+function heightToMeters(value: any, unit?: string | null): number | null {
+  const numeric = parseNumber(value);
+  if (numeric == null) return null;
+  const u = (unit || "").toLowerCase();
+  if (u.includes("cm")) return numeric / 100;
+  if (u.includes("meter")) return numeric;
+  if (u.includes("inch") || u.includes("in")) return numeric * 0.0254;
+  return numeric > 3 ? numeric / 100 : numeric; // assume cm if large number
+}
+
+function weightToKg(value: any, unit?: string | null): number | null {
+  const numeric = parseNumber(value);
+  if (numeric == null) return null;
+  const u = (unit || "").toLowerCase();
+  if (u.includes("lb")) return numeric * 0.453592;
+  if (u.includes("kg")) return numeric;
+  return numeric;
+}
+
+function pickObservation(map: ObservationMap, keys: string[]): { value: any; unit: string | null } | null {
+  for (const key of keys) {
+    const entry = map?.[key];
+    if (entry && entry.value != null) {
+      return { value: entry.value, unit: entry.unit ?? null };
+    }
+  }
+  return null;
+}
+
+function derivePanelMode(searchParams: ReadonlyURLSearchParams, theme: string | undefined): PanelMode {
+  const serialized = searchParams?.toString?.() ?? "";
+  const state = fromSearchParams(new URLSearchParams(serialized), (theme as "light" | "dark") ?? "light");
+  if (state.base === "aidoc") return "ai-doc";
+  if (state.base === "doctor") return "clinical";
+  return "wellness";
+}
+
 export default function MedicalProfile() {
-  const { data, error, isLoading, mutate } = useProfile();
-  const [obs, setObs] = useState<Observation[]>([]);
-  const [saving, setSaving] = useState(false);
-  const [resetting, setResetting] = useState<null | "obs" | "all" | "zero">(null);
-
   const router = useRouter();
   const params = useSearchParams();
-  const _threadId = params.get("threadId") || "default";
+  const { theme } = useTheme();
+  const panelMode = useMemo(() => derivePanelMode(params, theme), [params, theme]);
 
-  const [summary, setSummary] = useState<string>("");
-  const [reasons, setReasons] = useState<string>("");
+  const { data, error, isLoading, mutate } = useProfile();
 
-  const loadSummary = async () => {
-    try {
-      const r = await fetch("/api/profile/summary", { cache: "no-store" });
-      const j = await r.json();
-      if (j?.text) setSummary(j.text);
-      else if (j?.summary) setSummary(j.summary);
-      if (j?.reasons) setReasons(j.reasons);
-    } catch {}
-  };
-  useEffect(() => { loadSummary(); }, []);
-
-  const onRecomputeRisk = async () => {
-    const btn = document.getElementById("recompute-risk-btn") as HTMLButtonElement | null;
-    if (btn) btn.disabled = true;
-    try {
-      const threadId = "med-profile";
-      const url = new URL(window.location.href);
-      url.searchParams.set("panel", "ai-doc");
-      url.searchParams.set("threadId", threadId);
-      url.searchParams.set("context", "ai-doc-med-profile");
-      history.replaceState(null, "", url.toString());
-
-      const res = await fetch("/api/predictions/compute", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ threadId })
-      });
-      const body = await res.json().catch(() => ({}));
-      if (!res.ok || body?.ok === false) {
-        throw new Error(body?.error || `HTTP ${res.status}`);
-      }
-      await loadSummary();
-
-      fetch("/api/aidoc/chat", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          mode: "doctor",
-          threadId,
-          messages: [
-            {
-              role: "user",
-              content:
-                "Recompute risk based on my latest profile and timeline. Summarize key risks & next steps.",
-            },
-          ],
-          context: "ai-doc-med-profile",
-          clientRequestId: `recompute-${Date.now()}`,
-        }),
-      }).catch(() => {});
-    } catch (err: any) {
-      console.error("Recompute failed:", err?.message || err);
-      alert(`Recompute failed: ${err?.message || String(err)}`);
-    } finally {
-      if (btn) btn.disabled = false;
-    }
-  };
-
-  const prof = data?.profile ?? null;
-  const [bootstrapped, setBootstrapped] = useState(false);
   const [fullName, setFullName] = useState("");
   const [dob, setDob] = useState("");
   const [sex, setSex] = useState("");
   const [bloodGroup, setBloodGroup] = useState("");
   const [predis, setPredis] = useState<string[]>([]);
   const [chronic, setChronic] = useState<string[]>([]);
+  const [medications, setMedications] = useState<MedicationEntry[]>([]);
+  const [summaryText, setSummaryText] = useState("No summary yet.");
+  const [predictionText, setPredictionText] = useState("—");
+  const [summaryNotes, setSummaryNotes] = useState("—");
+  const [summaryNextSteps, setSummaryNextSteps] = useState("—");
+
+  const [bootstrapped, setBootstrapped] = useState(false);
+  const [savingProfile, setSavingProfile] = useState(false);
+  const [editingVitals, setEditingVitals] = useState(false);
+  const [savingVitals, setSavingVitals] = useState(false);
+  const [recomputeBusy, setRecomputeBusy] = useState(false);
+  const [notesEditing, setNotesEditing] = useState(false);
+  const [notesDraft, setNotesDraft] = useState("");
+  const [savingNotes, setSavingNotes] = useState(false);
+  const [nextStepsEditing, setNextStepsEditing] = useState(false);
+  const [nextStepsDraft, setNextStepsDraft] = useState("");
+  const [savingNextSteps, setSavingNextSteps] = useState(false);
+
+  const latestMap: ObservationMap = (data?.latest as ObservationMap) || {};
 
   useEffect(() => {
-    safeJson(fetch("/api/observations")).then(setObs).catch(() => setObs([]));
-    const h = () => mutate();
-    window.addEventListener("observations-updated", h);
-    return () => window.removeEventListener("observations-updated", h);
-  }, [mutate]);
-
-  useEffect(() => {
+    const prof = data?.profile ?? null;
     if (!prof || bootstrapped) return;
     setFullName(prof.full_name || "");
     setDob(prof.dob || "");
     setSex(prof.sex || "");
     setBloodGroup(prof.blood_group || "");
-    setPredis(prof.conditions_predisposition || []);
-    setChronic(prof.chronic_conditions || []);
+    setPredis(Array.isArray(prof.conditions_predisposition) ? prof.conditions_predisposition : []);
+    setChronic(Array.isArray(prof.chronic_conditions) ? prof.chronic_conditions : []);
+    if (Array.isArray((prof as any).medications)) {
+      setMedications((prof as any).medications as MedicationEntry[]);
+    }
     setBootstrapped(true);
-  }, [prof, bootstrapped]);
+  }, [bootstrapped, data?.profile]);
 
-  if (isLoading) return <PanelLoader label="Medical Profile" />;
-  if (error)     return <div className="p-6 text-sm text-red-500">Couldn’t load profile. Retrying in background…</div>;
-  if (!data)     return <div className="p-6 text-sm text-muted-foreground">No profile yet.</div>;
+  useEffect(() => {
+    if (!data?.profile) return;
+    if (Array.isArray((data.profile as any).medications)) {
+      setMedications((data.profile as any).medications as MedicationEntry[]);
+    }
+  }, [data?.profile]);
 
-  const latestObs = (k: string) => obs.find(o => o.kind === k);
+  const parseSummary = useCallback((text: string) => {
+    const lines = text
+      .split(/\n+/)
+      .map(line => line.trim())
+      .filter(Boolean);
+    const findValue = (label: string) => {
+      const line = lines.find(l => l.toLowerCase().startsWith(label.toLowerCase()));
+      if (!line) return "—";
+      return line.slice(label.length).replace(/^[:\s]+/, "").trim() || "—";
+    };
+    setSummaryText(text || "No summary yet.");
+    setPredictionText(findValue("AI Prediction"));
+    setSummaryNotes(findValue("Symptoms/Notes"));
+    setSummaryNextSteps(findValue("Next Steps"));
+  }, []);
 
-  const ORDER: Array<keyof Groups> = [
-    "vitals","labs","imaging","medications","diagnoses","procedures","immunizations","notes","other",
+  const loadSummary = useCallback(async () => {
+    try {
+      const res = await fetch("/api/profile/summary", { cache: "no-store" });
+      const body = await res.json().catch(() => ({}));
+      const text = body?.text || body?.summary || "";
+      if (text) parseSummary(text);
+      const reasons = body?.reasons || "";
+      if (typeof reasons === "string" && !text) {
+        setSummaryText(reasons);
+      }
+    } catch (err) {
+      console.warn("Failed to load profile summary", err);
+    }
+  }, [parseSummary]);
+
+  useEffect(() => {
+    void loadSummary();
+  }, [loadSummary]);
+
+  const profileVitals = useMemo(() => {
+    const bpEntry = pickObservation(latestMap, [
+      "bp_systolic",
+      "sbp",
+      "bp",
+      "systolic_bp",
+      "blood_pressure",
+    ]);
+    const dpEntry = pickObservation(latestMap, ["bp_diastolic", "dbp", "diastolic_bp"]);
+    const heartEntry = pickObservation(latestMap, ["heart_rate", "hr", "pulse", "heart_rate_bpm"]);
+    const heightEntry = pickObservation(latestMap, ["height", "height_cm", "height_m"]);
+    const weightEntry = pickObservation(latestMap, ["weight", "weight_kg", "body_weight"]);
+
+    const bpPair = bpEntry ? parseBp(bpEntry.value) : {};
+
+    const systolic = bpPair.systolic ?? parseNumber(bpEntry?.value);
+    const diastolic = bpPair.diastolic ?? parseNumber(dpEntry?.value);
+    const heartRate = parseNumber(heartEntry?.value);
+
+    const heightMeters = heightToMeters(heightEntry?.value, heightEntry?.unit);
+    const weightKg = weightToKg(weightEntry?.value, weightEntry?.unit);
+    const bmi =
+      heightMeters && weightKg ? Number((weightKg / (heightMeters * heightMeters)).toFixed(1)) : null;
+
+    return { systolic, diastolic, heartRate, bmi, weightKg, heightMeters };
+  }, [latestMap]);
+
+  const vitalsDisplay = [
+    {
+      label: "Blood pressure",
+      value:
+        profileVitals.systolic != null && profileVitals.diastolic != null
+          ? `${profileVitals.systolic}/${profileVitals.diastolic} mmHg`
+          : "—",
+    },
+    {
+      label: "Heart rate",
+      value: profileVitals.heartRate != null ? `${profileVitals.heartRate} bpm` : "—",
+    },
+    {
+      label: "BMI",
+      value: profileVitals.bmi != null ? `${profileVitals.bmi}` : "—",
+    },
   ];
-  const TITLES: Record<keyof Groups, string> = {
-    vitals: "Vitals",
-    labs: "Labs",
-    imaging: "Imaging",
-    medications: "Medications",
-    diagnoses: "Diagnoses",
-    procedures: "Procedures",
-    immunizations: "Immunizations",
-    notes: "Notes",
-    other: "Other Findings",
+
+  const labs = data?.groups?.labs ?? [];
+  const medsEmpty = medications.length === 0;
+
+  const handleProfileSave = async () => {
+    setSavingProfile(true);
+    try {
+      const payload = {
+        full_name: fullName || null,
+        dob: dob || null,
+        sex: sex || null,
+        blood_group: bloodGroup || null,
+        conditions_predisposition: predis,
+        chronic_conditions: chronic,
+      } as Record<string, unknown>;
+      const res = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      pushToast({ title: "Profile saved" });
+      await mutate();
+      await loadSummary();
+    } catch (err: any) {
+      pushToast({
+        title: "Couldn’t save profile",
+        description: err?.message || "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setSavingProfile(false);
+    }
   };
 
-  return (
-    <div className="relative z-0 space-y-4 p-4 mobile-medical-profile md:p-6">
-      <section className="rounded-xl border p-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <h2 className="font-semibold">Wellness Info</h2>
-          <div className="flex flex-wrap items-center gap-2">
-            {/* Reset (sidebar-safe) */}
-            <button
-              type="button"
-              className="text-sm rounded-md border px-3 py-1.5 hover:bg-muted mobile-tappable md:min-h-0"
-              onClick={async () => {
-                const pick = window.prompt(
-                  "Reset:\n1 = Clear observations\n2 = Clear everything (obs+pred+alerts)\n3 = Zero demo values\n\nEnter 1/2/3 or Cancel"
-                );
-                const map: any = { "1": "obs", "2": "all", "3": "zero" };
-                const sel = map[pick || ""];
-                if (!sel) return;
-                setResetting(sel);
-                try {
-                  const body =
-                    sel === "obs"
-                      ? { scope: "observations", mode: "clear" }
-                      : sel === "all"
-                      ? { scope: "all", mode: "clear" }
-                      : { scope: "observations", mode: "zero" };
-                  const r = await fetch("/api/admin/reset", {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify(body),
-                  });
-                  if (!r.ok) throw new Error(await r.text());
-                  window.dispatchEvent(new Event("observations-updated"));
-                  await mutate();
-                } catch (e: any) {
-                  alert(e.message || "Reset failed");
-                } finally {
-                  setResetting(null);
-                }
-              }}
-            >
-              {resetting ? "Resetting…" : "Reset"}
-            </button>
+  const saveVitals = async (values: VitalsEditorValues) => {
+    setSavingVitals(true);
+    try {
+      const observations = [
+        values.systolic != null
+          ? { kind: "bp_systolic", value_num: values.systolic, unit: "mmHg" }
+          : null,
+        values.diastolic != null
+          ? { kind: "bp_diastolic", value_num: values.diastolic, unit: "mmHg" }
+          : null,
+        values.heartRate != null
+          ? { kind: "heart_rate", value_num: values.heartRate, unit: "bpm" }
+          : null,
+      ].filter(Boolean);
+      if (!observations.length) {
+        throw new Error("Enter at least one vital to save.");
+      }
+      const res = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ observations }),
+      });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      pushToast({ title: "Vitals updated" });
+      setEditingVitals(false);
+      await mutate();
+      await loadSummary();
+    } catch (err: any) {
+      pushToast({
+        title: "Couldn’t update vitals",
+        description: err?.message || "Please try again.",
+        variant: "destructive",
+      });
+      throw err;
+    } finally {
+      setSavingVitals(false);
+    }
+  };
 
-            {/* Save (sidebar-safe) */}
+  const saveMedications = async (next: MedicationEntry[]) => {
+    const payload = { medications: next } as Record<string, unknown>;
+    const res = await fetch("/api/profile", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) throw new Error(await res.text());
+    setMedications(next);
+    await mutate();
+    await loadSummary();
+  };
+
+  const handleAddMedication = async (med: { name: string; dose?: string | null }) => {
+    const name = med.name.trim();
+    if (!name) throw new Error("Medication name required");
+    const dose = med.dose ? med.dose.trim() : null;
+    const next = dedupeMedicationList([...medications, { name, dose }]);
+    await saveMedications(next);
+  };
+
+  const handleRemoveMedication = async (med: MedicationEntry) => {
+    const next = medications.filter(
+      item => item.name !== med.name || (item.dose || "") !== (med.dose || ""),
+    );
+    try {
+      await saveMedications(next);
+      pushToast({ title: "Medication removed" });
+    } catch (err: any) {
+      pushToast({
+        title: "Couldn’t remove medication",
+        description: err?.message || "Please try again.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleSaveNotes = async () => {
+    setSavingNotes(true);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: notesDraft.trim() || null }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      pushToast({ title: "Notes saved" });
+      setNotesEditing(false);
+      await loadSummary();
+    } catch (err: any) {
+      pushToast({
+        title: "Couldn’t save notes",
+        description: err?.message || "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setSavingNotes(false);
+    }
+  };
+
+  const handleSaveNextSteps = async () => {
+    setSavingNextSteps(true);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ next_steps: nextStepsDraft.trim() || null }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      pushToast({ title: "Next steps saved" });
+      setNextStepsEditing(false);
+      await loadSummary();
+    } catch (err: any) {
+      pushToast({
+        title: "Couldn’t save next steps",
+        description: err?.message || "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setSavingNextSteps(false);
+    }
+  };
+
+  const onRecomputeRisk = async () => {
+    setRecomputeBusy(true);
+    try {
+      const res = await fetch("/api/predictions/compute", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ threadId: "med-profile" }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok || body?.ok === false) {
+        throw new Error(body?.error || `HTTP ${res.status}`);
+      }
+      const summary = body?.summary as string | undefined;
+      if (summary) {
+        parseSummary(summary);
+        setSummaryText(summary);
+        if (/insufficient data/i.test(summary)) {
+          setPredictionText("Not enough data to compute risk yet.");
+        }
+      } else {
+        setPredictionText("Not enough data to compute risk yet.");
+      }
+      pushToast({ title: "Risk recomputed" });
+      await loadSummary();
+    } catch (err: any) {
+      pushToast({
+        title: "Recompute failed",
+        description: err?.message || "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setRecomputeBusy(false);
+    }
+  };
+
+  const showWellnessSections = panelMode !== "clinical" || panelMode === "ai-doc";
+  const showClinicalSections = panelMode !== "wellness" || panelMode === "ai-doc";
+
+  if (isLoading) return <PanelLoader label="Medical Profile" />;
+  if (error) {
+    return (
+      <div className="p-6 text-sm text-red-500">Couldn’t load profile. Retrying in background…</div>
+    );
+  }
+  if (!data) {
+    return <div className="p-6 text-sm text-muted-foreground">No profile yet.</div>;
+  }
+
+  return (
+    <div className="space-y-4 p-4 md:p-6">
+      <ProfileSection
+        title="Personal details"
+        actions={
+          <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              className="text-sm rounded-md border px-3 py-1.5 hover:bg-muted disabled:opacity-50 mobile-tappable md:min-h-0"
-              disabled={saving}
-              onClick={async () => {
-                setSaving(true);
-                try {
-                  const r = await fetch("/api/profile", {
-                    method: "PUT",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                      full_name: fullName || null,
-                      dob: dob || null,
-                      sex: sex || null,
-                      blood_group: bloodGroup || null,
-                      conditions_predisposition: predis,
-                      chronic_conditions: chronic,
-                    }),
-                  });
-                  if (!r.ok) throw new Error(await r.text());
-                  await mutate();
-                  await loadSummary(); // ensure visible summary reflects just-saved arrays
-                  if (typeof window !== "undefined") {
-                    window.dispatchEvent(new Event("profile-updated"));
-                  }
-                } catch (e: any) {
-                  alert(e.message || "Save failed");
-                } finally {
-                  setSaving(false);
-                }
-              }}
+              className="rounded-md border px-3 py-1.5 text-sm"
+              onClick={() => router.push("/?panel=chat&threadId=med-profile&context=profile")}
             >
-              {saving ? "Saving…" : "Save"}
+              Open in chat
+            </button>
+            <button
+              type="button"
+              className="rounded-md border bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow disabled:opacity-60"
+              onClick={handleProfileSave}
+              disabled={savingProfile}
+            >
+              {savingProfile ? "Saving…" : "Save"}
             </button>
           </div>
-        </div>
-
-        <div className="mt-3 grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+        }
+      >
+        <div className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
           <label className="flex flex-col gap-1">
             <span>Name</span>
             <input
@@ -256,19 +487,17 @@ export default function MedicalProfile() {
               placeholder="Full name"
             />
           </label>
-
           <label className="flex flex-col gap-1">
             <span>DOB</span>
             <input
               type="date"
               className="rounded-md border px-3 py-2"
               value={/^\d{4}-\d{2}-\d{2}$/.test(dob) ? dob : ""}
-              max={new Date().toISOString().slice(0,10)}
+              max={new Date().toISOString().slice(0, 10)}
               onChange={e => setDob(e.target.value)}
             />
-            <span className="text-xs text-muted-foreground">Age: {ageFromDob(dob)}</span>
+            <span className="text-xs text-muted-foreground">Age: {ageFromDob(dob) || "—"}</span>
           </label>
-
           <label className="flex flex-col gap-1">
             <span>Sex</span>
             <select
@@ -284,9 +513,8 @@ export default function MedicalProfile() {
               ))}
             </select>
           </label>
-
           <label className="flex flex-col gap-1">
-            <span>Blood Group</span>
+            <span>Blood group</span>
             <select
               className="rounded-md border px-3 py-2"
               value={bloodGroup || ""}
@@ -300,17 +528,16 @@ export default function MedicalProfile() {
               ))}
             </select>
           </label>
-
           <label className="flex flex-col gap-1 md:col-span-1">
             <span>Predispositions</span>
             <input
               className="rounded-md border px-3 py-2"
               placeholder="Type to add (Enter)…"
               onKeyDown={e => {
-                const v = (e.target as HTMLInputElement).value.trim();
-                if (e.key === "Enter" && v) {
+                const value = (e.target as HTMLInputElement).value.trim();
+                if (e.key === "Enter" && value) {
                   e.preventDefault();
-                  setPredis(Array.from(new Set([...predis, v])));
+                  setPredis(dedupeStrings([...predis, value]));
                   (e.target as HTMLInputElement).value = "";
                 }
               }}
@@ -326,27 +553,25 @@ export default function MedicalProfile() {
                 <button
                   key={c}
                   type="button"
-                  className="mobile-tappable inline-flex max-w-full items-center gap-1.5 truncate rounded-full border px-3 py-1 text-xs transition hover:bg-muted md:min-h-0 md:px-2.5 md:py-1"
+                  className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs"
                   onClick={() => setPredis(predis.filter(x => x !== c))}
-                  aria-label={`Remove ${c} predisposition`}
                 >
                   <span className="truncate">{c}</span>
-                  <span aria-hidden="true">×</span>
+                  <span aria-hidden>×</span>
                 </button>
               ))}
             </div>
           </label>
-
           <label className="flex flex-col gap-1 md:col-span-1">
             <span>Chronic conditions</span>
             <input
               className="rounded-md border px-3 py-2"
               placeholder="Type to add (Enter)…"
               onKeyDown={e => {
-                const v = (e.target as HTMLInputElement).value.trim();
-                if (e.key === "Enter" && v) {
+                const value = (e.target as HTMLInputElement).value.trim();
+                if (e.key === "Enter" && value) {
                   e.preventDefault();
-                  setChronic(Array.from(new Set([...chronic, v])));
+                  setChronic(dedupeStrings([...chronic, value]));
                   (e.target as HTMLInputElement).value = "";
                 }
               }}
@@ -357,142 +582,289 @@ export default function MedicalProfile() {
                 <button
                   key={c}
                   type="button"
-                  className="mobile-tappable inline-flex max-w-full items-center gap-1.5 truncate rounded-full border px-3 py-1 text-xs transition hover:bg-muted md:min-h-0 md:px-2.5 md:py-1"
+                  className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs"
                   onClick={() => setChronic(chronic.filter(x => x !== c))}
-                  aria-label={`Remove ${c} chronic condition`}
                 >
                   <span className="truncate">{c}</span>
-                  <span aria-hidden="true">×</span>
+                  <span aria-hidden>×</span>
                 </button>
               ))}
             </div>
           </label>
         </div>
-      </section>
+      </ProfileSection>
 
-      {/* Existing fixed sections (unchanged) */}
-      <section className="rounded-xl border p-4">
-        <h2 className="font-semibold mb-2">Vitals</h2>
-        <ul className="text-sm space-y-1">
-          {["bp","hr","bmi"].map(k => {
-            const o = latestObs(k);
-            return <li key={k}>{k.toUpperCase()}: {o ? JSON.stringify(o.value) : "—"}</li>;
-          })}
-        </ul>
-      </section>
-
-      <section className="rounded-xl border p-4">
-        <h2 className="font-semibold mb-2">Labs</h2>
-        <ul className="text-sm space-y-1">
-          {["HbA1c","FPG","eGFR"].map(k => {
-            const o = latestObs(k);
-            return <li key={k}>{k}: {o ? JSON.stringify(o.value) : "—"}</li>;
-          })}
-        </ul>
-      </section>
-
-      <section className="rounded-xl border p-4">
-        <h2 className="font-semibold mb-2">Symptoms/notes</h2>
-        <ul className="text-sm space-y-1">
-          {obs.filter(o => typeof o.value === "string").slice(0, 5).map(o => (
-            <li key={o.observedAt}>{o.value}</li>
-          ))}
-        </ul>
-      </section>
-
-      {/* NEW: Dynamic renderer for ALL categories from /api/profile */}
-      {data?.groups && (
-        <section className="rounded-xl border p-4">
-          <h2 className="font-semibold mb-2">From uploads (all categories)</h2>
-          <div className="space-y-6">
-            {ORDER.map(key => {
-              const items = data.groups[key] || [];
-              if (!items.length) return null;
-              return (
-                <div key={key}>
-                  <div className="mb-2 text-sm font-medium">{TITLES[key]}</div>
-                  <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2 md:grid-cols-3">
-                    {items.slice(0, 6).map(it => (
-                      <div
-                        key={it.key}
-                        className="flex min-w-0 flex-col gap-2 rounded-lg bg-muted/40 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
-                      >
-                        <div className="min-w-0 pr-2">
-                          <div className="truncate font-medium">{it.label}</div>
-                          <div className="text-xs text-muted-foreground mobile-truncate-2">
-                            {new Date(it.observedAt).toLocaleDateString()}
-                            {it.source ? ` • ${it.source}` : ""}
-                          </div>
-                        </div>
-                        <div className="min-w-0 text-sm font-medium sm:text-right">
-                          <span className="block truncate">
-                            {it.value ?? "—"}
-                            {it.unit ? ` ${it.unit}` : ""}
-                          </span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-          <div className="mt-2 text-xs text-muted-foreground">
-            Shows the latest item per finding from your uploads. Use Timeline for full history.
-          </div>
-        </section>
-      )}
-
-      {/* --- AI Summary & Reasons --- */}
-      <div className="mt-6 rounded-xl border p-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <h3 className="font-semibold">AI Summary</h3>
-          <div className="flex flex-wrap gap-2">
+      {showWellnessSections ? (
+        <ProfileSection
+          title="Vitals"
+          actions={
             <button
-              onClick={async () => {
-                try {
-                  const prof = await fetch("/api/profile", { cache: "no-store" })
-                    .then(r => r.json())
-                    .catch(() => null);
-                  const packet = await fetch("/api/profile/packet", { cache: "no-store" })
-                    .then(r => r.json())
-                    .catch(() => ({ text: "" }));
-                  const prefill = encodeURIComponent(
-                    JSON.stringify({
-                      kind: "profileSummary",
-                      summary,
-                      reasons,
-                      profile: prof?.profile || prof || null,
-                      packet: packet?.text || "",
-                    })
-                  );
-                  router.push(
-                    `/?panel=chat&threadId=med-profile&context=profile&prefill=${prefill}`
-                  );
-                } catch {
-                  const prefill = encodeURIComponent(
-                    JSON.stringify({ kind: "profileSummary", summary, reasons })
-                  );
-                  router.push(
-                    `/?panel=chat&threadId=med-profile&context=profile&prefill=${prefill}`
-                  );
-                }
+              type="button"
+              className="rounded-md border px-3 py-1.5 text-sm"
+              onClick={() => setEditingVitals(open => !open)}
+            >
+              {editingVitals ? "Close" : "Edit"}
+            </button>
+          }
+        >
+          {editingVitals ? (
+            <VitalsEditor
+              initialValues={{
+                systolic: profileVitals.systolic ?? null,
+                diastolic: profileVitals.diastolic ?? null,
+                heartRate: profileVitals.heartRate ?? null,
               }}
-              className="text-xs px-2 py-1 rounded-md border mobile-tappable md:min-h-0"
-            >Discuss & Correct in Chat</button>
-            <button
-              id="recompute-risk-btn"
-              onClick={onRecomputeRisk}
-              className="text-xs px-2 py-1 rounded-md border mobile-tappable md:min-h-0"
-            >Recompute Risk</button>
+              onSave={saveVitals}
+              onCancel={() => setEditingVitals(false)}
+              isSaving={savingVitals}
+            />
+          ) : (
+            <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
+              {vitalsDisplay.map(item => (
+                <div key={item.label}>
+                  <dt className="text-xs uppercase tracking-wide text-muted-foreground">{item.label}</dt>
+                  <dd className="text-base font-medium">{item.value}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+        </ProfileSection>
+      ) : null}
+
+      <ProfileSection
+        title="Labs"
+        isEmpty={labs.length === 0}
+        emptyMessage="No labs yet—upload a report or add data in chat."
+      >
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-border text-sm">
+            <thead className="bg-muted/40">
+              <tr>
+                <th className="px-3 py-2 text-left font-semibold">Test</th>
+                <th className="px-3 py-2 text-left font-semibold">Value</th>
+                <th className="px-3 py-2 text-left font-semibold">Observed</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {labs.map(item => (
+                <tr key={`${item.key}-${item.observedAt}`}>
+                  <td className="px-3 py-2 font-medium">{item.label}</td>
+                  <td className="px-3 py-2">
+                    {item.value ?? "—"}
+                    {item.unit ? ` ${item.unit}` : ""}
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    {new Date(item.observedAt).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </ProfileSection>
+
+      {showWellnessSections || showClinicalSections ? (
+        <ProfileSection
+          title="AI Summary"
+          actions={
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                className="rounded-md border px-3 py-1.5 text-sm"
+                onClick={() => router.push("/?panel=chat&threadId=med-profile&context=profile")}
+              >
+                Discuss in chat
+              </button>
+              <button
+                type="button"
+                className="inline-flex items-center gap-2 rounded-md border bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow disabled:opacity-60"
+                onClick={onRecomputeRisk}
+                disabled={recomputeBusy}
+              >
+                {recomputeBusy ? "Computing…" : "Recompute risk"}
+              </button>
+            </div>
+          }
+        >
+          <div className="space-y-3 text-sm">
+            <p className="whitespace-pre-wrap leading-relaxed">{summaryText}</p>
+            <div className="rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground">
+              ⚠️ This is AI-generated support, not a medical diagnosis. Always consult a clinician.
+            </div>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <div>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Chronic conditions
+                </h4>
+                <p className="mt-1 text-sm">
+                  {chronic.length ? chronic.join(", ") : "—"}
+                </p>
+              </div>
+              <div>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Symptoms / notes
+                </h4>
+                {summaryNotes !== "—" && !notesEditing ? (
+                  <p className="mt-1 text-sm whitespace-pre-wrap">{summaryNotes}</p>
+                ) : null}
+                {notesEditing ? (
+                  <div className="mt-2 space-y-2">
+                    <textarea
+                      className="w-full rounded-md border px-3 py-2 text-sm"
+                      rows={3}
+                      value={notesDraft}
+                      onChange={e => setNotesDraft(e.target.value)}
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        className="rounded-md border bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow disabled:opacity-60"
+                        onClick={handleSaveNotes}
+                        disabled={savingNotes}
+                      >
+                        {savingNotes ? "Saving…" : "Save"}
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-md border px-3 py-1.5 text-sm"
+                        onClick={() => setNotesEditing(false)}
+                        disabled={savingNotes}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : summaryNotes === "—" ? (
+                  <button
+                    type="button"
+                    className="mt-2 rounded-md border px-3 py-1.5 text-sm"
+                    onClick={() => {
+                      setNotesDraft("");
+                      setNotesEditing(true);
+                    }}
+                  >
+                    Add notes
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="mt-2 rounded-md border px-3 py-1.5 text-xs"
+                    onClick={() => {
+                      setNotesDraft(summaryNotes === "—" ? "" : summaryNotes);
+                      setNotesEditing(true);
+                    }}
+                  >
+                    Edit
+                  </button>
+                )}
+              </div>
+              <div>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Next steps
+                </h4>
+                {summaryNextSteps !== "—" && !nextStepsEditing ? (
+                  <p className="mt-1 text-sm whitespace-pre-wrap">{summaryNextSteps}</p>
+                ) : null}
+                {nextStepsEditing ? (
+                  <div className="mt-2 space-y-2">
+                    <textarea
+                      className="w-full rounded-md border px-3 py-2 text-sm"
+                      rows={3}
+                      value={nextStepsDraft}
+                      onChange={e => setNextStepsDraft(e.target.value)}
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        className="rounded-md border bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow disabled:opacity-60"
+                        onClick={handleSaveNextSteps}
+                        disabled={savingNextSteps}
+                      >
+                        {savingNextSteps ? "Saving…" : "Save"}
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-md border px-3 py-1.5 text-sm"
+                        onClick={() => setNextStepsEditing(false)}
+                        disabled={savingNextSteps}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : summaryNextSteps === "—" ? (
+                  <button
+                    type="button"
+                    className="mt-2 rounded-md border px-3 py-1.5 text-sm"
+                    onClick={() => {
+                      setNextStepsDraft("");
+                      setNextStepsEditing(true);
+                    }}
+                  >
+                    Add next steps
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="mt-2 rounded-md border px-3 py-1.5 text-xs"
+                    onClick={() => {
+                      setNextStepsDraft(summaryNextSteps === "—" ? "" : summaryNextSteps);
+                      setNextStepsEditing(true);
+                    }}
+                  >
+                    Edit
+                  </button>
+                )}
+              </div>
+            </div>
+            {showClinicalSections ? (
+              <div className="rounded-lg border bg-muted/20 p-3 text-sm">
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">AI prediction</div>
+                <div className="mt-1 text-base font-medium whitespace-pre-wrap">
+                  {predictionText && predictionText !== "—"
+                    ? predictionText
+                    : "No prediction yet — add vitals, labs, or medications to compute risk."}
+                </div>
+              </div>
+            ) : null}
           </div>
-        </div>
-        <p className="mt-2 text-sm whitespace-pre-wrap">{summary || "No summary yet."}</p>
-        <div className="mt-3 text-[11px] text-muted-foreground">
-          ⚠️ This is AI-generated support, not a medical diagnosis. Always consult a qualified clinician.
-        </div>
-      </div>
+        </ProfileSection>
+      ) : null}
+
+      {showClinicalSections ? (
+        <ProfileSection
+          title="Active medications"
+          isEmpty={medsEmpty}
+          emptyMessage="No medications recorded yet."
+        >
+          {medications.length ? (
+            <div className="flex flex-wrap gap-2">
+              {medications.map(med => (
+                <MedicationTag
+                  key={`${med.name}-${med.dose || ""}`}
+                  label={`${med.name}${med.dose ? ` ${med.dose}` : ""}`}
+                  onRemove={() => handleRemoveMedication(med)}
+                />
+              ))}
+            </div>
+          ) : null}
+          <div className="mt-3">
+            <MedicationInput onSave={handleAddMedication} />
+          </div>
+        </ProfileSection>
+      ) : null}
     </div>
   );
 }
 
+function dedupeMedicationList(input: MedicationEntry[]): MedicationEntry[] {
+  const map = new Map<string, MedicationEntry>();
+  for (const med of input) {
+    if (!med.name) continue;
+    const key = `${med.name.toLowerCase()}::${(med.dose || "").toLowerCase()}`;
+    if (!map.has(key)) {
+      map.set(key, med);
+    }
+  }
+  return Array.from(map.values());
+}

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -1123,34 +1123,25 @@ function extractMedicationEntries(data: any): MedicationEntry[] {
   if (!data) return [];
 
   const entries: MedicationEntry[] = [];
-  const groups = (data as any)?.groups ?? (data?.profile as any)?.groups;
+  const profile = (data?.profile as any) ?? data ?? {};
+  const groups = (profile?.groups as any) ?? {};
   const groupMeds = Array.isArray(groups?.medications) ? groups.medications : [];
   for (const item of groupMeds) {
     const med = normalizeMedicationItem(item);
     if (med) entries.push(med);
   }
 
-  const profileMeds = Array.isArray((data?.profile as any)?.medications)
-    ? (data.profile as any).medications
-    : [];
+  const profileMeds = Array.isArray(profile?.medications) ? profile.medications : [];
   for (const item of profileMeds) {
     const med = normalizeMedicationItem(item);
     if (med) entries.push(med);
   }
 
-  const observationMeds = Array.isArray((data?.profile as any)?.observations)
-    ? (data.profile as any).observations
-    : [];
+  const observationMeds = Array.isArray(profile?.observations) ? profile.observations : [];
   for (const item of observationMeds) {
     if (typeof item?.kind === "string" && item.kind.toLowerCase() !== "medication") {
       continue;
     }
-    const med = normalizeMedicationItem(item);
-    if (med) entries.push(med);
-  }
-
-  const summaryMeds = Array.isArray((data?.summary as any)?.medications) ? data.summary.medications : [];
-  for (const item of summaryMeds) {
     const med = normalizeMedicationItem(item);
     if (med) entries.push(med);
   }

--- a/components/profile/ProfileSection.tsx
+++ b/components/profile/ProfileSection.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { ReactNode, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+export type ProfileSectionProps = {
+  title: string;
+  children?: ReactNode;
+  actions?: ReactNode;
+  isLoading?: boolean;
+  hasError?: boolean;
+  errorMessage?: string;
+  isEmpty?: boolean;
+  emptyMessage?: string;
+  defaultOpen?: boolean;
+  className?: string;
+};
+
+export default function ProfileSection({
+  title,
+  children,
+  actions,
+  isLoading = false,
+  hasError = false,
+  errorMessage,
+  isEmpty = false,
+  emptyMessage = "No data yet.",
+  defaultOpen = true,
+  className = "",
+}: ProfileSectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <section className={`rounded-xl border bg-background p-4 shadow-sm ${className}`}>
+      <header className="flex items-start justify-between gap-3">
+        <button
+          type="button"
+          className="flex flex-1 items-center gap-2 text-left font-semibold"
+          onClick={() => setOpen(v => !v)}
+          aria-expanded={open}
+          aria-controls={sectionId(title)}
+        >
+          {open ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          )}
+          <span>{title}</span>
+        </button>
+        {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+      </header>
+      <div id={sectionId(title)} className={open ? "mt-3" : "mt-3 hidden"}>
+        {isLoading ? (
+          <div className="space-y-2">
+            <SkeletonLine />
+            <SkeletonLine className="w-3/4" />
+          </div>
+        ) : hasError ? (
+          <p className="text-sm text-destructive">
+            {errorMessage || "Couldn’t load this section."}
+          </p>
+        ) : isEmpty ? (
+          <p className="text-sm text-muted-foreground">{emptyMessage}</p>
+        ) : (
+          children
+        )}
+      </div>
+    </section>
+  );
+}
+
+function sectionId(title: string) {
+  return `profile-section-${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+}
+
+function SkeletonLine({ className = "" }: { className?: string }) {
+  return (
+    <div
+      className={`h-3 animate-pulse rounded bg-muted/70 dark:bg-muted/40 ${className}`}
+      aria-hidden="true"
+    />
+  );
+}

--- a/components/profile/VitalsEditor.tsx
+++ b/components/profile/VitalsEditor.tsx
@@ -121,10 +121,10 @@ export default function VitalsEditor({
     setIsSaving(true);
     setError(null);
     try {
-      const res = await fetch("/api/observations/bulk", {
-        method: "POST",
+      const res = await fetch("/api/profile", {
+        method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ items: observations }),
+        body: JSON.stringify({ observations }),
       });
 
       if (!res.ok) {

--- a/components/profile/VitalsEditor.tsx
+++ b/components/profile/VitalsEditor.tsx
@@ -68,6 +68,8 @@ export default function VitalsEditor({
 
     const observedAt = new Date().toISOString();
 
+    const metaBase = { source: "manual", category: "vital", committed: true } as const;
+
     const observations = [
       systolicValue != null
         ? {
@@ -76,7 +78,7 @@ export default function VitalsEditor({
             value_text: String(systolicValue),
             unit: "mmHg",
             observed_at: observedAt,
-            meta: { source: "manual", category: "vital" },
+            meta: metaBase,
           }
         : null,
       diastolicValue != null
@@ -86,7 +88,7 @@ export default function VitalsEditor({
             value_text: String(diastolicValue),
             unit: "mmHg",
             observed_at: observedAt,
-            meta: { source: "manual", category: "vital" },
+            meta: metaBase,
           }
         : null,
       heartRateValue != null
@@ -96,7 +98,7 @@ export default function VitalsEditor({
             value_text: String(heartRateValue),
             unit: "bpm",
             observed_at: observedAt,
-            meta: { source: "manual", category: "vital" },
+            meta: metaBase,
           }
         : null,
       bmiValue != null
@@ -106,7 +108,7 @@ export default function VitalsEditor({
             value_text: String(bmiValue),
             unit: "kg/m2",
             observed_at: observedAt,
-            meta: { source: "manual", category: "vital" },
+            meta: metaBase,
           }
         : null,
     ].filter(Boolean);

--- a/components/profile/VitalsEditor.tsx
+++ b/components/profile/VitalsEditor.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+
+export type VitalsEditorValues = {
+  systolic?: number | null;
+  diastolic?: number | null;
+  heartRate?: number | null;
+};
+
+export type VitalsEditorProps = {
+  initialValues: VitalsEditorValues;
+  onSave: (values: VitalsEditorValues) => Promise<void> | void;
+  onCancel: () => void;
+  isSaving?: boolean;
+};
+
+export default function VitalsEditor({
+  initialValues,
+  onSave,
+  onCancel,
+  isSaving = false,
+}: VitalsEditorProps) {
+  const [systolic, setSystolic] = useState(valueToString(initialValues.systolic));
+  const [diastolic, setDiastolic] = useState(valueToString(initialValues.diastolic));
+  const [heartRate, setHeartRate] = useState(valueToString(initialValues.heartRate));
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setError(null);
+    const next = {
+      systolic: stringToNumber(systolic),
+      diastolic: stringToNumber(diastolic),
+      heartRate: stringToNumber(heartRate),
+    } satisfies VitalsEditorValues;
+    if (Object.values(next).every(v => v == null)) {
+      setError("Enter at least one vital to save.");
+      return;
+    }
+    try {
+      await onSave(next);
+    } catch (err: any) {
+      setError(err?.message || "Couldn’t save vitals.");
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium text-muted-foreground">Systolic (mmHg)</span>
+          <input
+            type="number"
+            min={0}
+            inputMode="numeric"
+            className="rounded-md border px-3 py-2"
+            placeholder="120"
+            value={systolic}
+            onChange={e => setSystolic(e.target.value)}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium text-muted-foreground">Diastolic (mmHg)</span>
+          <input
+            type="number"
+            min={0}
+            inputMode="numeric"
+            className="rounded-md border px-3 py-2"
+            placeholder="80"
+            value={diastolic}
+            onChange={e => setDiastolic(e.target.value)}
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-xs font-medium text-muted-foreground">Heart rate (BPM)</span>
+          <input
+            type="number"
+            min={0}
+            inputMode="numeric"
+            className="rounded-md border px-3 py-2"
+            placeholder="72"
+            value={heartRate}
+            onChange={e => setHeartRate(e.target.value)}
+          />
+        </label>
+      </div>
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="inline-flex items-center rounded-md border bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow disabled:opacity-60"
+          onClick={handleSave}
+          disabled={isSaving}
+        >
+          {isSaving ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center rounded-md border px-3 py-1.5 text-sm"
+          onClick={onCancel}
+          disabled={isSaving}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function valueToString(value?: number | null) {
+  return value == null || Number.isNaN(value) ? "" : String(value);
+}
+
+function stringToNumber(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return null;
+  return parsed;
+}


### PR DESCRIPTION
## Summary
- add reusable ProfileSection wrapper plus VitalsEditor for inline vitals updates
- create medication input/tag components with suggestion fallback and delete actions
- overhaul MedicalProfile panel to compute BMI, wire risk recompute, handle AI summary edits, and use new UI states

## Testing
- `npx tsc --noEmit` *(fails: placeholder test files contain non-TypeScript content)*


------
https://chatgpt.com/codex/tasks/task_e_68d560f9a244832f9aeb4f7be15ba95d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Medication input with live, debounced suggestions, keyboard navigation, dedupe, optional dose prompt, save flow and success/error toasts.
  - Removable medication tags for active meds.
  - Vitals editor: edit systolic/diastolic, heart rate, computed/manual BMI with validation, save/cancel and feedback.
  - Collapsible profile sections: accessible loading, empty, and error states with keyboard toggle.
  - Editable AI summaries with one‑click risk recompute and feedback.

- Refactor
  - Medical profile reorganized into panel-driven modes with improved parsing, loading, and consistent toasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->