### PR TITLE
Add assistant actions row with refresh and share support

### DIFF
--- a/app/api/share/route.ts
+++ b/app/api/share/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { createShare } from "@/lib/share/store";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const content = typeof body?.content === "string" ? body.content.trim() : "";
+    const mode = typeof body?.mode === "string" ? body.mode : undefined;
+
+    if (!content) {
+      return NextResponse.json({ ok: false, error: "empty" }, { status: 400 });
+    }
+
+    if (content.length > 20000) {
+      return NextResponse.json({ ok: false, error: "too_long" }, { status: 400 });
+    }
+
+    const record = createShare(content, mode);
+    return NextResponse.json({ ok: true, id: record.id, url: `/s/${record.id}` });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: "invalid" }, { status: 400 });
+  }
+}

--- a/app/s/[id]/page.tsx
+++ b/app/s/[id]/page.tsx
@@ -1,0 +1,32 @@
+import ChatMarkdown from "@/components/ChatMarkdown";
+import { BRAND_NAME } from "@/lib/brand";
+import { getShare } from "@/lib/share/store";
+import { notFound } from "next/navigation";
+
+interface SharePageProps {
+  params: { id: string };
+}
+
+export default function SharePage({ params }: SharePageProps) {
+  const data = getShare(params.id);
+  if (!data) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-100 py-16 px-4 dark:bg-slate-950">
+      <div className="mx-auto max-w-3xl rounded-3xl border border-slate-200/80 bg-white/95 p-8 shadow-xl dark:border-slate-800/70 dark:bg-slate-900/80">
+        <header className="mb-6 flex items-center justify-between">
+          <h1 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Shared answer</h1>
+          <span className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">{BRAND_NAME}</span>
+        </header>
+        <div className="rounded-2xl bg-slate-50/80 p-6 text-slate-900 shadow-inner dark:bg-slate-950/40 dark:text-slate-100">
+          <ChatMarkdown content={data.content} />
+        </div>
+        <footer className="mt-6 text-xs text-slate-500 dark:text-slate-500">
+          Shared on {new Date(data.createdAt).toLocaleString()}
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/components/chat/MessageActions.tsx
+++ b/components/chat/MessageActions.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { Copy, RefreshCcw, Share2, ThumbsDown, ThumbsUp } from "lucide-react";
+import { useMemo } from "react";
+
+const baseButtonClasses =
+  "inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-500 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 hover:bg-slate-200/70 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-700/70 dark:hover:text-slate-100";
+
+const disabledClasses = "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-inherit";
+
+type MessageActionsProps = {
+  conversationId: string;
+  messageId: string;
+  onCopy: () => Promise<void> | void;
+  onRefresh?: () => Promise<void> | void;
+  onShare: () => void;
+  isRefreshing?: boolean;
+  disableRefresh?: boolean;
+  allowFeedback: boolean;
+  feedbackState: {
+    submittedFor: Record<string, 1 | -1>;
+    loading: string | null;
+  };
+  onFeedback: (rating: 1 | -1) => void;
+};
+
+function ActionButton({
+  label,
+  onClick,
+  children,
+  disabled,
+  active,
+  spinning,
+}: {
+  label: string;
+  onClick?: () => void;
+  children: React.ReactNode;
+  disabled?: boolean;
+  active?: boolean;
+  spinning?: boolean;
+}) {
+  const classes = [
+    baseButtonClasses,
+    disabled ? disabledClasses : "",
+    active ? "!text-indigo-500 dark:!text-indigo-400" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      className={classes}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      aria-pressed={active ? "true" : undefined}
+    >
+      <span className={`inline-flex items-center ${spinning ? "animate-spin" : ""}`}>{children}</span>
+    </button>
+  );
+}
+
+export default function MessageActions({
+  conversationId,
+  messageId,
+  onCopy,
+  onRefresh,
+  onShare,
+  isRefreshing = false,
+  disableRefresh = false,
+  allowFeedback,
+  feedbackState,
+  onFeedback,
+}: MessageActionsProps) {
+  const key = useMemo(() => `${conversationId}:${messageId}`, [conversationId, messageId]);
+  const submitted = feedbackState.submittedFor[key];
+  const loading = feedbackState.loading === key;
+
+  const refreshDisabled = disableRefresh || isRefreshing || loading;
+  const feedbackDisabled = loading || isRefreshing;
+
+  const desktopRow = (
+    <div className="absolute right-3 top-3 hidden gap-2 rounded-full bg-white/80 px-2 py-1 text-slate-500 shadow-sm ring-1 ring-slate-200 transition md:flex md:opacity-0 md:group-hover:opacity-80 md:group-focus-within:opacity-100 dark:bg-slate-900/80 dark:text-slate-300 dark:ring-slate-700">
+      <ActionButton label="Copy full answer" onClick={() => void onCopy()}>
+        <Copy size={14} />
+      </ActionButton>
+      {onRefresh ? (
+        <ActionButton
+          label="Refresh this answer"
+          onClick={() => onRefresh?.()}
+          disabled={refreshDisabled}
+          spinning={isRefreshing}
+        >
+          <RefreshCcw size={14} />
+        </ActionButton>
+      ) : null}
+      <ActionButton label="Share" onClick={() => onShare()}>
+        <Share2 size={14} />
+      </ActionButton>
+      {allowFeedback && (
+        <>
+          <ActionButton
+            label="Good answer"
+            onClick={() => {
+              if (submitted === 1) return;
+              onFeedback(1);
+            }}
+            disabled={feedbackDisabled}
+            active={submitted === 1}
+          >
+            <ThumbsUp size={14} />
+          </ActionButton>
+          <ActionButton
+            label="Needs work"
+            onClick={() => {
+              if (submitted === -1) return;
+              onFeedback(-1);
+            }}
+            disabled={feedbackDisabled}
+            active={submitted === -1}
+          >
+            <ThumbsDown size={14} />
+          </ActionButton>
+        </>
+      )}
+    </div>
+  );
+
+  const mobileRow = (
+    <div className="mt-3 flex justify-end gap-2 md:hidden">
+      <ActionButton label="Copy full answer" onClick={() => void onCopy()}>
+        <Copy size={14} />
+      </ActionButton>
+      {onRefresh ? (
+        <ActionButton
+          label="Refresh this answer"
+          onClick={() => onRefresh?.()}
+          disabled={refreshDisabled}
+          spinning={isRefreshing}
+        >
+          <RefreshCcw size={14} />
+        </ActionButton>
+      ) : null}
+      <ActionButton label="Share" onClick={() => onShare()}>
+        <Share2 size={14} />
+      </ActionButton>
+      {allowFeedback && (
+        <>
+          <ActionButton
+            label="Good answer"
+            onClick={() => {
+              if (submitted === 1) return;
+              onFeedback(1);
+            }}
+            disabled={feedbackDisabled}
+            active={submitted === 1}
+          >
+            <ThumbsUp size={14} />
+          </ActionButton>
+          <ActionButton
+            label="Needs work"
+            onClick={() => {
+              if (submitted === -1) return;
+              onFeedback(-1);
+            }}
+            disabled={feedbackDisabled}
+            active={submitted === -1}
+          >
+            <ThumbsDown size={14} />
+          </ActionButton>
+        </>
+      )}
+    </div>
+  );
+
+  return (
+    <>
+      {desktopRow}
+      {mobileRow}
+    </>
+  );
+}

--- a/components/panels/SharePanel.tsx
+++ b/components/panels/SharePanel.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect } from "react";
+import { X, Link as LinkIcon, Download, Share2, Share as ShareIcon, Copy } from "lucide-react";
+import { BRAND_NAME } from "@/lib/brand";
+import { trackAnalyticsEvent } from "@/lib/analytics";
+
+type SharePanelProps = {
+  open: boolean;
+  onClose: () => void;
+  onCopyLink?: () => Promise<void>;
+  onDownloadImage: () => Promise<void>;
+  onShareX: () => Promise<void> | void;
+  onShareFacebook: () => Promise<void> | void;
+  onSystemShare?: () => Promise<void>;
+  onCopyCaption: () => Promise<void>;
+  busyAction?: "link" | "download" | "system" | null;
+  canCopyLink: boolean;
+  canSystemShare: boolean;
+};
+
+export default function SharePanel({
+  open,
+  onClose,
+  onCopyLink,
+  onDownloadImage,
+  onShareFacebook,
+  onShareX,
+  onSystemShare,
+  onCopyCaption,
+  busyAction = null,
+  canCopyLink,
+  canSystemShare,
+}: SharePanelProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const makeActionClass = (disabled?: boolean) =>
+    `flex w-full items-center gap-3 rounded-lg border border-slate-200/80 px-3 py-2 text-sm transition dark:border-slate-700/70 ${
+      disabled
+        ? "opacity-60"
+        : "hover:border-slate-300 hover:bg-slate-100/70 dark:hover:border-slate-600 dark:hover:bg-slate-800/60"
+    }`;
+
+  const handleClick = async (cb?: () => Promise<void> | void, eventName?: string) => {
+    if (!cb) return;
+    if (eventName) trackAnalyticsEvent(eventName);
+    await cb();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-slate-900/40 px-4 pb-6 pt-10 sm:items-center sm:bg-slate-900/60">
+      <div className="w-full max-w-md rounded-3xl bg-white p-5 shadow-xl ring-1 ring-slate-200 transition dark:bg-slate-950 dark:ring-slate-800 sm:p-6">
+        <div className="mb-4 flex items-start">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Share safely</div>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Privacy check</h2>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+              Make sure this doesn’t include personal info before sharing.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-auto rounded-full p-1 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          {canCopyLink && (
+            <button
+              type="button"
+              className={makeActionClass(busyAction === "link")}
+              onClick={() => handleClick(onCopyLink, "share_copy_link")}
+              disabled={busyAction === "link"}
+            >
+              <LinkIcon size={16} />
+              <span>Copy link</span>
+            </button>
+          )}
+
+          <button
+            type="button"
+            className={makeActionClass(busyAction === "download")}
+            onClick={() => handleClick(onDownloadImage, "share_download_image")}
+            disabled={busyAction === "download"}
+          >
+            <Download size={16} />
+            <span>Download image</span>
+          </button>
+
+          <button
+            type="button"
+            className={makeActionClass(false)}
+            onClick={() => handleClick(async () => onShareX(), "share_x")}
+          >
+            <Share2 size={16} />
+            <span>Share to X</span>
+          </button>
+
+          <button
+            type="button"
+            className={makeActionClass(false)}
+            onClick={() => handleClick(async () => onShareFacebook(), "share_facebook")}
+          >
+            <ShareIcon size={16} />
+            <span>Share to Facebook</span>
+          </button>
+
+          {canSystemShare && onSystemShare && (
+            <button
+              type="button"
+              className={makeActionClass(busyAction === "system")}
+              onClick={() => handleClick(onSystemShare, "share_system")}
+              disabled={busyAction === "system"}
+            >
+              <ShareIcon size={16} />
+              <span>Share via device</span>
+            </button>
+          )}
+
+          <button
+            type="button"
+            className={makeActionClass(false)}
+            onClick={() => handleClick(onCopyCaption)}
+          >
+            <Copy size={16} />
+            <span>Copy caption for Instagram</span>
+          </button>
+        </div>
+
+        <p className="mt-5 text-center text-xs text-slate-500 dark:text-slate-500">
+          Sharing from {BRAND_NAME}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,34 @@
+export type AnalyticsEventDetail = {
+  event: string;
+  payload?: Record<string, unknown>;
+};
+
+const ANALYTICS_EVENT_NAME = "medx:analytics";
+
+declare global {
+  interface Window {
+    medxAnalytics?: (event: string, payload?: Record<string, unknown>) => void;
+  }
+}
+
+export function trackAnalyticsEvent(event: string, payload?: Record<string, unknown>) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.dispatchEvent(new CustomEvent<AnalyticsEventDetail>(ANALYTICS_EVENT_NAME, {
+      detail: { event, payload },
+    }));
+  } catch (error) {
+    // Silent no-op; avoid breaking UX if analytics bridge is unavailable
+  }
+
+  try {
+    if (typeof window.medxAnalytics === "function") {
+      window.medxAnalytics(event, payload);
+    }
+  } catch (error) {
+    // Ignore downstream analytics errors
+  }
+}

--- a/lib/share/snapshot.ts
+++ b/lib/share/snapshot.ts
@@ -1,0 +1,76 @@
+import { toPng } from "html-to-image";
+import { BRAND_NAME } from "@/lib/brand";
+
+function buildWrapper(element: HTMLElement) {
+  const wrapper = document.createElement("div");
+  wrapper.style.position = "fixed";
+  wrapper.style.top = "0";
+  wrapper.style.left = "0";
+  wrapper.style.width = "100%";
+  wrapper.style.padding = "32px";
+  wrapper.style.background = "linear-gradient(180deg, rgba(226,232,240,0.9), rgba(255,255,255,1))";
+  wrapper.style.color = "#0f172a";
+  wrapper.style.fontFamily = getComputedStyle(document.documentElement).fontFamily || "Inter, sans-serif";
+  wrapper.style.zIndex = "-1";
+
+  const container = document.createElement("div");
+  container.style.margin = "0 auto";
+  container.style.maxWidth = "720px";
+  container.style.background = "rgba(255,255,255,0.94)";
+  container.style.borderRadius = "20px";
+  container.style.boxShadow = "0 24px 48px rgba(15,23,42,0.12)";
+  container.style.padding = "24px";
+  container.style.border = "1px solid rgba(148,163,184,0.2)";
+
+  const cloned = element.cloneNode(true) as HTMLElement;
+  cloned.style.margin = "0";
+  cloned.style.padding = "0";
+  cloned.style.background = "transparent";
+  cloned.style.boxShadow = "none";
+  cloned.style.maxWidth = "100%";
+
+  const footer = document.createElement("div");
+  footer.style.display = "flex";
+  footer.style.alignItems = "center";
+  footer.style.justifyContent = "space-between";
+  footer.style.fontSize = "12px";
+  footer.style.marginTop = "24px";
+  footer.style.opacity = "0.7";
+
+  const brand = document.createElement("span");
+  brand.textContent = BRAND_NAME;
+  brand.style.fontWeight = "600";
+  brand.style.letterSpacing = "0.04em";
+  brand.style.textTransform = "uppercase";
+
+  const time = document.createElement("span");
+  time.textContent = new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date());
+
+  footer.appendChild(brand);
+  footer.appendChild(time);
+
+  container.appendChild(cloned);
+  container.appendChild(footer);
+
+  wrapper.appendChild(container);
+  document.body.appendChild(wrapper);
+  return wrapper;
+}
+
+export async function exportMessageToPng(element: HTMLElement) {
+  const wrapper = buildWrapper(element);
+  try {
+    const dataUrl = await toPng(wrapper, {
+      cacheBust: true,
+      pixelRatio: window.devicePixelRatio || 2,
+      backgroundColor: "#f8fafc",
+      quality: 0.95,
+    });
+    return dataUrl;
+  } finally {
+    document.body.removeChild(wrapper);
+  }
+}

--- a/lib/share/store.ts
+++ b/lib/share/store.ts
@@ -1,0 +1,38 @@
+export type ShareRecord = {
+  id: string;
+  content: string;
+  mode?: string;
+  createdAt: number;
+};
+
+type ShareStore = Map<string, ShareRecord>;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __medxShareStore: ShareStore | undefined;
+}
+
+function getStore(): ShareStore {
+  if (!globalThis.__medxShareStore) {
+    globalThis.__medxShareStore = new Map();
+  }
+  return globalThis.__medxShareStore;
+}
+
+export function createShare(content: string, mode?: string): ShareRecord {
+  const store = getStore();
+  const id = crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+  const record: ShareRecord = {
+    id,
+    content,
+    mode,
+    createdAt: Date.now(),
+  };
+  store.set(id, record);
+  return record;
+}
+
+export function getShare(id: string): ShareRecord | null {
+  const store = getStore();
+  return store.get(id) ?? null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@supabase/supabase-js": "^2.57.0",
         "@tanstack/react-query": "^5.89.0",
         "framer-motion": "^12.23.12",
+        "html-to-image": "^1.11.11",
         "isomorphic-dompurify": "2.13.0",
         "katex": "^0.16.22",
         "lucide-react": "0.441.0",
@@ -4114,6 +4115,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.11",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.11.tgz",
+      "integrity": "sha512-9gux8QhvjRO/erSnDPv28noDZcPZmYE7e1vFsBLKLlRlKDSqNJYebj6Qz1TGd5lsRV+X+xYyjCKjuZdABinWjA==",
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@supabase/supabase-js": "^2.57.0",
     "@tanstack/react-query": "^5.89.0",
     "framer-motion": "^12.23.12",
+    "html-to-image": "^1.11.11",
     "isomorphic-dompurify": "2.13.0",
     "katex": "^0.16.22",
     "lucide-react": "0.441.0",

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -7,4 +7,8 @@ export type ChatMessage = {
   // followUps may be legacy string arrays or Suggestion objects; normalize before use
   followUps?: unknown;
   citations?: Citation[];
+  originUserText?: string;
+  replacedByNewer?: boolean;
+  replacedByMessageId?: string;
+  refreshOf?: string;
 };


### PR DESCRIPTION
## Summary
- add a MessageActions control bar on assistant messages with copy, refresh, share, and feedback hooks
- implement SharePanel UI, sharing helpers, and in-memory share endpoints to support link, PNG, and social sharing
- expand ChatPane logic for refresh handling, sharing flows, analytics events, and update chat types and dependencies

## Testing
- CI=1 npm run lint *(fails: Next.js prompts for ESLint config in interactive mode)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c7b5aa7c832f81bda0c2cd60182f