### PR TITLE
Remove artificial chat response delay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,5 +109,5 @@ OPENAI_FINAL_SAY=true
 
 # ===== Calculators & Behavior =====
 CALC_AI_DISABLE=0                # 0 (default) = include local calc prelude
-MIN_OUTPUT_DELAY_SECONDS=10       # server-enforced floor before any output
+MIN_OUTPUT_DELAY_SECONDS=0        # server-enforced floor before any output (0 = immediate)
 SYMPTOM_TRIAGE_ENABLED=true

--- a/lib/utils/ensureMinDelay.ts
+++ b/lib/utils/ensureMinDelay.ts
@@ -1,13 +1,21 @@
+function getConfiguredDelayMs(): number {
+  const envSeconds = Number.parseInt(process.env.MIN_OUTPUT_DELAY_SECONDS ?? "", 10);
+  if (Number.isFinite(envSeconds)) {
+    return Math.max(0, envSeconds * 1000);
+  }
+  return 0;
+}
+
 export async function ensureMinDelay<T>(work: Promise<T>, minMs?: number): Promise<T> {
   const floor =
     typeof minMs === "number" && Number.isFinite(minMs)
       ? Math.max(0, Math.floor(minMs))
-      : Math.max(0, (parseInt(process.env.MIN_OUTPUT_DELAY_SECONDS || "", 10) || 10) * 1000);
+      : getConfiguredDelayMs();
   const sleeper = new Promise<void>((r) => setTimeout(r, floor));
   const [result] = await Promise.all([work, sleeper]);
   return result;
 }
 
 export function minDelayMs(): number {
-  return Math.max(0, (parseInt(process.env.MIN_OUTPUT_DELAY_SECONDS || "", 10) || 10) * 1000);
+  return getConfiguredDelayMs();
 }


### PR DESCRIPTION
## Summary
- default the chat response delay to zero so streaming starts immediately
- document the zero-second delay in the example environment configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f0ede014832f9ae98dc51e7caf9b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Output now appears immediately by default (previous 10s enforced delay removed). You can still configure a custom delay via MIN_OUTPUT_DELAY_SECONDS.

- Documentation
  - Updated environment variable example to clarify that 0 means immediate output.

- Refactor
  - Centralized delay configuration logic to ensure consistent and predictable behavior across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->