### PR TITLE
Ensure medical profile meds persist and clean summary

### DIFF
--- a/app/api/meds/search/route.ts
+++ b/app/api/meds/search/route.ts
@@ -12,12 +12,19 @@ export async function GET(req: NextRequest) {
   }
   const { searchParams } = new URL(req.url);
   const q = String(searchParams.get("q") || "").trim();
+  const countryParam = (searchParams.get("country") || "").trim();
+  const country = countryParam || undefined;
   if (!q) {
     return NextResponse.json({ error: "q_required" }, { status: 400 });
   }
   try {
-    const url = `https://rxnav.nlm.nih.gov/REST/approximateTerm.json?term=${encodeURIComponent(q)}&maxEntries=5`;
-    const r = await fetch(url, { headers: { Accept: "application/json" } });
+    const url = new URL("https://rxnav.nlm.nih.gov/REST/approximateTerm.json");
+    url.searchParams.set("term", q);
+    url.searchParams.set("maxEntries", "5");
+    if (country) {
+      url.searchParams.set("country", country);
+    }
+    const r = await fetch(url.toString(), { headers: { Accept: "application/json" } });
     let meds: { name: string | null; rxnormId: string | null; score: number | null }[] = [];
     if (r.ok) {
       const j = await r.json();
@@ -33,7 +40,7 @@ export async function GET(req: NextRequest) {
         version: VERSION,
         sourceVersion: SOURCE_VERSION,
         slug: null,
-        country: null,
+        country: country ?? null,
         cached: false,
       };
     }

--- a/app/api/profile/summary/route.ts
+++ b/app/api/profile/summary/route.ts
@@ -215,10 +215,6 @@ function formatLabDate(iso?: string | null) {
   return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
 }
 
-function formatUploadsDate(date: Date) {
-  return date.toLocaleDateString("en-US", { day: "2-digit", month: "short", year: "numeric" });
-}
-
 function formatListLine(label: string, values: string[]) {
   return `${label}: ${values.length ? values.join(", ") : NO_DATA}`;
 }
@@ -386,22 +382,6 @@ export async function GET() {
   const nextStepsValue = nextStepsArr.length ? nextStepsArr.slice(0, 2).join("; ") : NO_DATA;
   const nextStepsLine = `Next Steps: ${nextStepsValue}`;
 
-  const uploadDates = obs
-    .map(row => resolveDate(row))
-    .map(iso => {
-      if (!iso) return null;
-      const d = new Date(iso);
-      return Number.isNaN(d.getTime()) ? null : d;
-    })
-    .filter((d): d is Date => Boolean(d))
-    .sort((a, b) => b.getTime() - a.getTime());
-  const latestUploadDate = uploadDates[0] ?? null;
-  const uploadsCount = obs.length;
-  const uploadsLine =
-    uploadsCount > 0
-      ? `Uploads: ${uploadsCount}${latestUploadDate ? ` (Last: ${formatUploadsDate(latestUploadDate)})` : ""}`
-      : `Uploads: ${NO_DATA}`;
-
   const summaryLines = [
     "AI Summary",
     patientLine,
@@ -412,7 +392,6 @@ export async function GET() {
     predLine,
     notesLine,
     nextStepsLine,
-    uploadsLine,
     "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
   ];
   const text = summaryLines.join("\n");

--- a/app/api/profile/summary/route.ts
+++ b/app/api/profile/summary/route.ts
@@ -6,63 +6,228 @@ import { supabaseAdmin } from "@/lib/supabase/admin";
 import { getUserId } from "@/lib/getUserId";
 
 const noStore = { "Cache-Control": "no-store, max-age=0" };
+const NO_DATA = "No data available";
 
-const STOPWORDS = [
-  "PHYSICAL EXAMINATION",
-  "VISUAL EXAMINATION",
-  "QUANTITY",
-  "SPECIMEN",
-  "DEPARTMENT",
-  "INVESTIGATION",
-  "REMARK",
-  "REFERENCE INTERVAL",
-  "OBSERVED VALUE",
-  "UNIT",
-  "BIOLOGICAL",
+type ObservationRow = {
+  id?: string | number | null;
+  kind?: string | null;
+  value_num?: number | null;
+  value_text?: string | null;
+  unit?: string | null;
+  observed_at?: string | null;
+  created_at?: string | null;
+  meta?: any;
+  details?: any;
+  name?: string | null;
+};
+
+type PanelDescriptor = {
+  id: string;
+  label: string;
+  synonyms: string[];
+  defaultUnit?: string;
+};
+
+type PanelSummary = {
+  id: string;
+  label: string;
+  name: string;
+  latest?: { value: number; unit: string | null; date?: string | null };
+  previous?: { value: number };
+};
+
+type SanitizeResult =
+  | { ok: true; v: number; unit: string | null }
+  | { ok: false };
+
+const LAB_PANELS: PanelDescriptor[] = [
+  { id: "hba1c", label: "HbA1c", synonyms: ["hba1c", "hb_a1c", "hb-a1c", "a1c"], defaultUnit: "%" },
+  { id: "ldl", label: "LDL", synonyms: ["ldl", "ldl_c", "ldl-c", "ldl_cholesterol"], defaultUnit: "mg/dL" },
+  { id: "alt", label: "ALT", synonyms: ["alt", "sgpt"], defaultUnit: "U/L" },
+  { id: "egfr", label: "eGFR", synonyms: ["egfr"], defaultUnit: "mL/min/1.73m²" },
+  {
+    id: "vitamin_d",
+    label: "Vitamin D",
+    synonyms: ["vitamin_d", "vitamin_d3", "25_oh_vitamin_d", "25-oh-vitamin-d"],
+    defaultUnit: "ng/mL",
+  },
 ];
-const cues = /(mg|mcg|µg|g|iu|ml|tablet|tab|capsule|cap|syrup|injection|drop|ointment|cream|patch)\b/i;
-const looksLikeMed = (s: string) =>
-  /[A-Za-z]/.test(s) &&
-  /\d/.test(s) &&
-  cues.test(s) &&
-  !STOPWORDS.some((w) => s.toUpperCase().includes(w));
-const sanitizeMeds = (list: any[]): string[] =>
-  Array.from(
-    new Map(
-      (list || [])
-        .map((s: any) => String(s).replace(/\s+/g, " ").trim())
-        .filter(looksLikeMed)
-        .map((m: string) => [m.toLowerCase().replace(/[^a-z0-9]+/g, ""), m])
-    ).values()
-  );
 
-const toTitle = (s: string) =>
-  s
-    .toLowerCase()
-    .replace(/\b\w/g, (c) => c.toUpperCase());
-
-function when(r: any) {
-  return new Date(
-    r.observed_at ||
-      r.meta?.report_date ||
-      r.details?.report_date ||
-      r.meta?.observed_at ||
-      r.details?.observed_at ||
-      r.created_at ||
-      0
-  ).getTime();
+function toTitle(s: string) {
+  return s.toLowerCase().replace(/\b\w/g, c => c.toUpperCase());
 }
 
-function vStr(r: any) {
-  const val = r.value ?? r.value_num ?? r.meta?.value ?? r.details?.value ?? r.meta?.value_num;
-  const unit = r.unit ?? r.meta?.unit ?? r.details?.unit;
-  return `${val ?? "?"}${unit ? ` ${unit}` : ""}`;
+function normalize(value: any): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_")
+    .replace(/[^a-z0-9_]/g, "")
+    .replace(/^_+|_+$/g, "");
+}
+
+function firstDefined<T>(...values: T[]): T | undefined {
+  for (const value of values) {
+    if (value !== undefined && value !== null) return value;
+  }
+  return undefined;
+}
+
+function parseValue(row: ObservationRow): any {
+  const meta = row.meta ?? row.details ?? {};
+  const candidates = [
+    row.value_num,
+    row.value_text,
+    meta.value_num,
+    meta.value,
+    meta.result,
+    meta.score,
+    meta.reading,
+  ];
+  return firstDefined(...candidates);
+}
+
+function resolveUnit(row: ObservationRow): any {
+  const meta = row.meta ?? row.details ?? {};
+  return firstDefined(row.unit, meta.unit, meta.units, meta.value_unit);
+}
+
+function resolveDate(row: ObservationRow): string | undefined {
+  const meta = row.meta ?? row.details ?? {};
+  return firstDefined(row.observed_at, meta.observed_at, meta.takenAt, meta.taken_at, row.created_at);
+}
+
+function isDeleted(row: ObservationRow) {
+  const meta = row.meta ?? row.details ?? {};
+  if (meta?.deleted || meta?.cleared) return true;
+  const unit = typeof row.unit === "string" ? row.unit.trim().toLowerCase() : "";
+  return unit === "__deleted__";
+}
+
+function sanitize(value: any, unit: any, fallbackUnit?: string): SanitizeResult {
+  const numeric =
+    typeof value === "string"
+      ? Number(value.replace(/[^0-9.+-]+/g, ""))
+      : Number(value);
+  if (!Number.isFinite(numeric)) {
+    return { ok: false };
+  }
+  const rawUnit = typeof unit === "string" ? unit.trim() : "";
+  const lower = rawUnit.toLowerCase();
+  let cleanUnit: string | undefined;
+  if (lower.includes("mg/dl")) cleanUnit = "mg/dL";
+  else if (lower.includes("%")) cleanUnit = "%";
+  else if (lower.includes("u/l") || lower.includes("iu/l")) cleanUnit = "U/L";
+  else if (lower.includes("ng/ml")) cleanUnit = "ng/mL";
+  else if (lower.includes("ml/min")) cleanUnit = "mL/min/1.73m²";
+  else if (rawUnit) cleanUnit = rawUnit;
+  if (!cleanUnit && fallbackUnit) cleanUnit = fallbackUnit;
+  return { ok: true, v: numeric, unit: cleanUnit ?? null };
+}
+
+function trend(latest: number, prev?: number) {
+  if (prev == null || !Number.isFinite(prev)) return "→";
+  if (latest > prev) return "↑";
+  if (latest < prev) return "↓";
+  return "→";
+}
+
+function matchesPanel(row: ObservationRow, panel: PanelDescriptor) {
+  if (!row) return false;
+  const normalizedKind = normalize(row.kind);
+  if (panel.synonyms.includes(normalizedKind)) return true;
+  const meta = row.meta ?? row.details ?? {};
+  const metaKind = normalize(meta.kind);
+  if (metaKind && panel.synonyms.includes(metaKind)) return true;
+  const nameCandidates = [
+    meta.normalizedName,
+    meta.label,
+    meta.name,
+    meta.metric,
+    row.name,
+    (row as any).label,
+  ];
+  for (const candidate of nameCandidates) {
+    const norm = normalize(candidate);
+    if (norm && panel.synonyms.includes(norm)) return true;
+  }
+  return false;
+}
+
+function computePanels(rows: ObservationRow[]): PanelSummary[] {
+  return LAB_PANELS.map(panel => {
+    const series = rows
+      .filter(row => matchesPanel(row, panel))
+      .map(row => ({
+        rawValue: parseValue(row),
+        rawUnit: resolveUnit(row),
+        date: resolveDate(row),
+      }))
+      .filter(item => item.rawValue != null || item.rawUnit)
+      .sort((a, b) => {
+        const da = a.date ? new Date(a.date).getTime() : 0;
+        const db = b.date ? new Date(b.date).getTime() : 0;
+        return db - da;
+      });
+
+    const latestEntry = series.find(item => sanitize(item.rawValue, item.rawUnit, panel.defaultUnit).ok);
+    if (!latestEntry) {
+      return { id: panel.id, label: panel.label, name: panel.label };
+    }
+
+    const previousEntry = series.find(item => {
+      if (item === latestEntry) return false;
+      return sanitize(item.rawValue, item.rawUnit, panel.defaultUnit).ok;
+    });
+
+    const latestSan = sanitize(latestEntry.rawValue, latestEntry.rawUnit, panel.defaultUnit) as Extract<
+      SanitizeResult,
+      { ok: true }
+    >;
+    const previousSan = previousEntry
+      ? (sanitize(previousEntry.rawValue, previousEntry.rawUnit, panel.defaultUnit) as SanitizeResult)
+      : { ok: false };
+
+    return {
+      id: panel.id,
+      label: panel.label,
+      name: panel.label,
+      latest: {
+        value: latestSan.v,
+        unit: latestSan.unit ?? panel.defaultUnit ?? null,
+        date: latestEntry.date ?? null,
+      },
+      previous: previousSan.ok ? { value: previousSan.v } : undefined,
+    };
+  });
+}
+
+function formatLabValue(value: number) {
+  if (!Number.isFinite(value)) return "";
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+function formatLabDate(iso?: string | null) {
+  if (!iso) return "No date recorded";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "No date recorded";
+  return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+function formatUploadsDate(date: Date) {
+  return date.toLocaleDateString("en-US", { day: "2-digit", month: "short", year: "numeric" });
+}
+
+function formatListLine(label: string, values: string[]) {
+  return `${label}: ${values.length ? values.join(", ") : NO_DATA}`;
 }
 
 export async function GET() {
   const userId = await getUserId();
-  if (!userId)
+  if (!userId) {
     return NextResponse.json({ text: "", reasons: "" }, { headers: noStore });
+  }
 
   const db = supabaseAdmin();
   const [pRes, oRes, prRes] = await Promise.all([
@@ -75,7 +240,7 @@ export async function GET() {
       .from("observations")
       .select("*")
       .eq("user_id", userId)
-      .eq('meta->>committed','true'),
+      .eq("meta->>committed", "true"),
     db
       .from("predictions")
       .select("*")
@@ -84,126 +249,183 @@ export async function GET() {
       .limit(1),
   ]);
 
-  const asArray = (x: any) => Array.isArray(x) ? x : (typeof x === 'string' ? (()=>{ try { const p = JSON.parse(x); return Array.isArray(p) ? p : [] } catch { return [] } })() : []);
+  const asArray = (value: any): string[] => {
+    if (Array.isArray(value)) return value;
+    if (typeof value === "string") {
+      try {
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  };
+
   const prof: any = pRes.data || {};
   prof.conditions_predisposition = asArray(prof.conditions_predisposition);
-  prof.chronic_conditions        = asArray(prof.chronic_conditions);
-  const obs: any[] = oRes.data || [];
+  prof.chronic_conditions = asArray(prof.chronic_conditions);
+
+  const rawObs: ObservationRow[] = (oRes.data as ObservationRow[]) || [];
+  const obs = rawObs.filter(row => !isDeleted(row));
   const pred = prRes.data?.[0];
 
   const age = prof.dob
     ? Math.floor((Date.now() - new Date(prof.dob).getTime()) / (365.25 * 864e5))
     : null;
-  const patientName = prof.full_name ? toTitle(prof.full_name) : '—';
-  const patientLine = `Patient: ${patientName} (${prof.sex || 'Unknown'}${
-    age ? `, ${age} y` : ''
-  }${prof.blood_group ? `, ${prof.blood_group}` : ''})`;
 
-  const chronicArr = prof.chronic_conditions || [];
-  const chronicLine = `Chronic Conditions: ${chronicArr.length ? chronicArr.join(', ') : '—'}`;
+  const patientName = prof.full_name ? toTitle(prof.full_name) : NO_DATA;
+  const patientDetails = [prof.sex || null, age ? `${age} y` : null, prof.blood_group || null].filter(Boolean);
+  const patientLine =
+    patientName === NO_DATA
+      ? `Patient: ${patientDetails.length ? patientDetails.join(", ") : NO_DATA}`
+      : patientDetails.length
+      ? `Patient: ${patientName} (${patientDetails.join(", ")})`
+      : `Patient: ${patientName}`;
 
-  const predisArr = prof.conditions_predisposition || [];
-  const predisLine = `Predispositions: ${predisArr.length ? predisArr.join(', ') : '—'}`;
+  const chronicLine = formatListLine("Chronic Conditions", prof.chronic_conditions || []);
+  const predisLine = formatListLine("Predispositions", prof.conditions_predisposition || []);
 
-  const medsRaw = obs.flatMap((r: any) => {
-    const m = r.meta || r.details || {};
-    const list = m.meds || m.medicines || m.medications || [];
-    return Array.isArray(list) ? list : typeof list === 'string' ? [list] : [];
+  const committedMeds = obs.filter(row => {
+    const kind = normalize(row.kind);
+    if (!kind) return false;
+    const meta = row.meta ?? row.details ?? {};
+    const category = normalize(meta.category);
+    const group = normalize(meta.group);
+    const committedFlag = meta?.committed;
+    const committed =
+      committedFlag === true ||
+      committedFlag === "true" ||
+      committedFlag === undefined;
+    if (!committed) return false;
+    const isMedKind = kind.startsWith("medication");
+    const isMedCategory = category === "medication";
+    const isMedGroup = group === "medications";
+    return isMedKind || isMedCategory || isMedGroup;
   });
-  const medsClean = sanitizeMeds(medsRaw);
-  const medsLine = `Active Meds: ${
-    medsClean.length
-      ? medsClean.slice(0, 4).join('; ') +
-        (medsClean.length > 4 ? `, +${medsClean.length - 4}` : '')
-      : '—'
-  }`;
 
-  const textOf = (r: any) =>
-    `${(r.name || '').toLowerCase()} ${JSON.stringify(r.meta || {}).toLowerCase()} ${JSON.stringify(
-      r.details || {}
-    ).toLowerCase()}`;
-  const pickLatest = (rx: RegExp) =>
-    obs.filter((r) => rx.test(textOf(r))).sort((a, b) => when(b) - when(a))[0];
-  const reasons: string[] = [];
-  const labsParts: string[] = [];
-  const hb = pickLatest(/\bhba1c\b/i);
-  if (hb) {
-    const val = parseFloat(hb.value ?? hb.value_num ?? hb.meta?.value ?? hb.details?.value);
-    labsParts.push(`HbA1c ${vStr(hb)}${val > 7 ? ' ↑' : ''}`);
-    reasons.push(`HbA1c ${vStr(hb)}`);
+  const medsSet = new Set<string>();
+  const activeMeds: string[] = [];
+  for (const row of committedMeds) {
+    const meta = row.meta ?? row.details ?? {};
+    const nameCandidate = [meta.normalizedName, row.value_text, meta.label, row.name]
+      .map(value => (typeof value === "string" ? value.trim() : ""))
+      .find(Boolean);
+    if (!nameCandidate) continue;
+    const doseCandidate = [meta.doseLabel, meta.dose, meta.sig]
+      .map(value => (typeof value === "string" ? value.trim() : ""))
+      .find(Boolean);
+    const display = [nameCandidate, doseCandidate].filter(Boolean).join(" ");
+    const dedupeKey = `${nameCandidate.toLowerCase()}|${(doseCandidate || "").toLowerCase()}`;
+    if (display && !medsSet.has(dedupeKey)) {
+      medsSet.add(dedupeKey);
+      activeMeds.push(display);
+    }
   }
-  const ldl = pickLatest(/\bldl\b/i);
-  if (ldl) {
-    const val = parseFloat(ldl.value ?? ldl.value_num ?? ldl.meta?.value ?? ldl.details?.value);
-    labsParts.push(`LDL ${vStr(ldl)}${val > 100 ? ' ↑' : ''}`);
-    reasons.push(`LDL ${vStr(ldl)}`);
-  }
-  const egfr = pickLatest(/\begfr\b/i);
-  if (egfr) {
-    const val = parseFloat(egfr.value ?? egfr.value_num ?? egfr.meta?.value ?? egfr.details?.value);
-    labsParts.push(`eGFR ${vStr(egfr)}${val < 90 ? ' ↓' : ''}`);
-    reasons.push(`eGFR ${vStr(egfr)}`);
-  }
-  const labsLine = `Recent Labs (latest): ${labsParts.length ? labsParts.join(', ') : '—'}`;
+  const medsLine = `Active Meds: ${activeMeds.length ? activeMeds.join(", ") : NO_DATA}`;
 
-  let predLine = 'AI Prediction: —';
+  const panels = computePanels(obs);
+  const highlights = panels.map(panel => {
+    if (!panel.latest) {
+      return { label: panel.label, text: NO_DATA };
+    }
+    const arrow = trend(panel.latest.value, panel.previous?.value);
+    const valueText = formatLabValue(panel.latest.value);
+    const unitText = panel.latest.unit ? ` ${panel.latest.unit}` : "";
+    const dt = formatLabDate(panel.latest.date);
+    return { label: panel.label, text: `${panel.name} ${valueText}${unitText} ${arrow} (Last: ${dt})` };
+  });
+
+  const labsLines = [
+    "Recent Labs:",
+    ...highlights.map(item =>
+      item.text === NO_DATA ? `- ${item.label}: ${NO_DATA}` : `- ${item.text}`
+    ),
+  ];
+
+  let predLine = `AI Prediction: ${NO_DATA}`;
   if (pred) {
     const d = pred.details ?? pred.meta ?? {};
-    const label = pred.name || d.label || d.name || 'Prediction';
+    const label = pred.name || d.label || d.name || "Prediction";
     const prob =
-      typeof pred.probability === 'number'
+      typeof pred.probability === "number"
         ? pred.probability
-        : typeof d.probability === 'number'
+        : typeof d.probability === "number"
         ? d.probability
         : null;
     const pct = prob != null ? Math.round(prob * 100) : null;
-    const bucket = pct == null ? '—' : pct < 20 ? 'Low' : pct <= 60 ? 'Moderate' : 'High';
-    predLine = `AI Prediction: ${label}: ${bucket}${pct != null ? ` (${pct}%)` : ''}`;
-    reasons.push(`Prediction signal: ${label}`);
+    const bucket = pct == null ? NO_DATA : pct < 20 ? "Low" : pct <= 60 ? "Moderate" : "High";
+    const suffix = pct != null ? ` (${pct}%)` : "";
+    predLine = `AI Prediction: ${label}: ${bucket}${suffix}`;
   }
 
   const notes = obs
-    .filter((r) => /(note|symptom)/i.test(r.kind || r.name || ''))
-    .sort((a, b) => when(b) - when(a))
+    .filter(row => /(note|symptom)/i.test(String(row.kind || row.name || "")))
+    .sort((a, b) => {
+      const da = resolveDate(a);
+      const db = resolveDate(b);
+      const ta = da ? new Date(da).getTime() : 0;
+      const tb = db ? new Date(db).getTime() : 0;
+      return tb - ta;
+    })
     .slice(0, 2)
-    .map((r) => (r.value_text || r.meta?.summary || r.meta?.text || '').toString().trim())
+    .map(row => {
+      const meta = row.meta ?? row.details ?? {};
+      const text = firstDefined(row.value_text, meta.summary, meta.text);
+      return typeof text === "string" ? text.trim() : "";
+    })
     .filter(Boolean);
 
-  const nextSteps = (() => {
-    const arr = Array.isArray(pred?.details?.next_steps)
-      ? pred.details.next_steps
-      : Array.isArray(pred?.meta?.next_steps)
-      ? pred.meta.next_steps
-      : null;
-    return arr && arr.length ? arr.slice(0, 2).join('; ') : '—';
+  const notesLine = `Symptoms/Notes: ${notes.length ? notes.join("; ") : NO_DATA}`;
+
+  const nextStepsArr = (() => {
+    const details = pred?.details ?? pred?.meta ?? {};
+    const arr = Array.isArray(details.next_steps) ? details.next_steps : [];
+    return arr.filter((value: any) => typeof value === "string" && value.trim());
   })();
+  const nextStepsValue = nextStepsArr.length ? nextStepsArr.slice(0, 2).join("; ") : NO_DATA;
+  const nextStepsLine = `Next Steps: ${nextStepsValue}`;
 
+  const uploadDates = obs
+    .map(row => resolveDate(row))
+    .map(iso => {
+      if (!iso) return null;
+      const d = new Date(iso);
+      return Number.isNaN(d.getTime()) ? null : d;
+    })
+    .filter((d): d is Date => Boolean(d))
+    .sort((a, b) => b.getTime() - a.getTime());
+  const latestUploadDate = uploadDates[0] ?? null;
   const uploadsCount = obs.length;
-  const latestUpload = obs.map(when).sort((a, b) => b - a)[0];
-  const latestDate = latestUpload
-    ? new Date(latestUpload).toLocaleDateString('en-GB', {
-        day: '2-digit',
-        month: 'short',
-        year: 'numeric',
-      })
-    : '—';
-  const uploadsLine = `Uploads: ${uploadsCount} (latest: ${latestDate})`;
+  const uploadsLine =
+    uploadsCount > 0
+      ? `Uploads: ${uploadsCount}${latestUploadDate ? ` (Last: ${formatUploadsDate(latestUploadDate)})` : ""}`
+      : `Uploads: ${NO_DATA}`;
 
-  const lines = [
+  const summaryLines = [
+    "AI Summary",
     patientLine,
     chronicLine,
     predisLine,
     medsLine,
-    labsLine,
+    ...labsLines,
     predLine,
-    `Symptoms/Notes: ${notes.length ? notes.join('; ') : '—'}`,
-    `Next Steps: ${nextSteps}`,
+    notesLine,
+    nextStepsLine,
     uploadsLine,
-    'AI assistance only — not a medical diagnosis. Confirm with a clinician.',
-  ].join('\n');
+    "AI assistance only — not a medical diagnosis. Confirm with a clinician.",
+  ];
+  const text = summaryLines.join("\n");
+
+  const reasons: string[] = [];
+  highlights
+    .filter(item => item.text !== NO_DATA)
+    .forEach(item => reasons.push(item.text));
+  if (predLine !== `AI Prediction: ${NO_DATA}`) reasons.push(predLine);
+  if (activeMeds.length) reasons.push(`Active Meds: ${activeMeds.join(", ")}`);
 
   return NextResponse.json(
-    { text: lines, summary: lines, reasons: reasons.join('; ') },
+    { text, summary: text, reasons: reasons.join("; ") },
     { headers: noStore }
   );
 }

--- a/app/api/profile/summary/route.ts
+++ b/app/api/profile/summary/route.ts
@@ -184,8 +184,8 @@ function computePanels(rows: ObservationRow[]): PanelSummary[] {
       SanitizeResult,
       { ok: true }
     >;
-    const previousSan = previousEntry
-      ? (sanitize(previousEntry.rawValue, previousEntry.rawUnit, panel.defaultUnit) as SanitizeResult)
+    const previousSan: SanitizeResult = previousEntry
+      ? sanitize(previousEntry.rawValue, previousEntry.rawUnit, panel.defaultUnit)
       : { ok: false };
 
     return {
@@ -197,7 +197,7 @@ function computePanels(rows: ObservationRow[]): PanelSummary[] {
         unit: latestSan.unit ?? panel.defaultUnit ?? null,
         date: latestEntry.date ?? null,
       },
-      previous: previousSan.ok ? { value: previousSan.v } : undefined,
+      previous: previousSan.ok === true ? { value: previousSan.v } : undefined,
     };
   });
 }

--- a/app/api/rxnorm/normalize/route.ts
+++ b/app/api/rxnorm/normalize/route.ts
@@ -1,16 +1,16 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from "next/server";
 
 async function rxcuiForName(name: string): Promise<string | null> {
   const url = `https://rxnav.nlm.nih.gov/REST/rxcui.json?name=${encodeURIComponent(name)}&search=2`;
   let res: Response;
   try {
-    res = await fetch(url, { headers: { Accept: 'application/json' } });
+    res = await fetch(url, { headers: { Accept: "application/json" } });
   } catch {
     return null;
   }
   if (!res.ok) return null;
-  const ct = res.headers.get('content-type') || '';
-  if (!ct.includes('application/json')) return null;
+  const ct = res.headers.get("content-type") || "";
+  if (!ct.includes("application/json")) return null;
   try {
     const j = await res.json();
     return j?.idGroup?.rxnormId?.[0] || null;
@@ -19,12 +19,58 @@ async function rxcuiForName(name: string): Promise<string | null> {
   }
 }
 
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const name = (url.searchParams.get("name") || "").trim();
+  if (!name) {
+    return NextResponse.json({ meds: [] });
+  }
+  const rxcui = await rxcuiForName(name);
+  return NextResponse.json({ meds: rxcui ? [{ name, rxcui }] : [] });
+}
+
 export async function POST(req: NextRequest) {
-  const { text } = await req.json();
-  if (!text) return NextResponse.json({ meds: [] });
-  const tokens = Array.from(new Set(String(text).split(/[^A-Za-z0-9-]+/).filter(t => t.length > 2))).slice(0, 120);
-  const meds: { token: string; rxcui: string }[] = [];
-  for (const token of tokens) { try { const rxcui = await rxcuiForName(token); if (rxcui) meds.push({ token, rxcui }); } catch {} }
-  const dedup = Object.values(meds.reduce((acc: any, m) => (acc[m.rxcui] = m, acc), {}));
+  const body = await req.json().catch(() => ({} as any));
+  const nameInput = typeof body?.name === "string" ? body.name.trim() : "";
+  if (nameInput) {
+    const rxcui = await rxcuiForName(nameInput);
+    return NextResponse.json({ meds: rxcui ? [{ name: nameInput, rxcui }] : [] });
+  }
+
+  const text = typeof body?.text === "string" ? body.text : "";
+  if (!text) {
+    return NextResponse.json({ meds: [] });
+  }
+
+  const tokens = Array.from(
+    new Set(
+      String(text)
+        .split(/[^A-Za-z0-9-]+/)
+        .map(token => token.trim())
+        .filter(token => token.length > 2)
+    )
+  ).slice(0, 120);
+
+  const meds: { name: string; rxcui: string }[] = [];
+  for (const token of tokens) {
+    try {
+      const rxcui = await rxcuiForName(token);
+      if (rxcui) {
+        meds.push({ name: token, rxcui });
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  const dedup = Array.from(
+    meds.reduce((acc, item) => {
+      if (!acc.has(item.rxcui)) {
+        acc.set(item.rxcui, item);
+      }
+      return acc;
+    }, new Map<string, { name: string; rxcui: string }>()).values()
+  );
+
   return NextResponse.json({ meds: dedup });
 }

--- a/components/meds/MedicationInput.tsx
+++ b/components/meds/MedicationInput.tsx
@@ -42,7 +42,8 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
     (normalizedSuggestion && normalizedSuggestion.name.toLowerCase() === name.toLowerCase()
       ? normalizedSuggestion
       : null);
-  const showSave = Boolean(confirmedSuggestion);
+  const canSaveName = (confirmedSuggestion?.name ?? name).trim().length > 0;
+  const showSave = canSaveName;
   const shouldShowDoseInput = needsDose || !!lockedName || trimmedDose.length > 0 || showSave;
   const listOpen = useMemo(() => !lockedName && suggestions.length > 0, [lockedName, suggestions.length]);
   const displaySuggestions = useMemo(() => suggestions.slice(0, 5), [suggestions]);
@@ -114,10 +115,6 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
       return;
     }
     const source = confirmedSuggestion;
-    if (!source) {
-      setError("Select a suggestion to confirm the medication name.");
-      return;
-    }
     const finalDose = trimmedDose;
     const isZeroDose = /^0+(\.0+)?$/.test(finalDose);
     if (!finalDose && !isZeroDose && !needsDose) {
@@ -125,7 +122,12 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
       return;
     }
     try {
-      await onSave({ name: source.name, dose: finalDose || null, rxnormId: source.rxnormId ?? null });
+      const finalName = (source?.name ?? name).trim();
+      if (!finalName) {
+        setError("Enter a medication name.");
+        return;
+      }
+      await onSave({ name: finalName, dose: finalDose || null, rxnormId: source?.rxnormId ?? null });
       setQuery("");
       setLockedName(null);
       setLockedSuggestion(null);
@@ -160,6 +162,7 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
                 setLockedSuggestion(null);
                 setNormalizedSuggestion(null);
                 setQuery(e.target.value);
+                setError(null);
               }}
               onKeyDown={event => {
                 if (!listOpen || displaySuggestions.length === 0) {

--- a/components/meds/MedicationInput.tsx
+++ b/components/meds/MedicationInput.tsx
@@ -119,7 +119,8 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
       return;
     }
     const finalDose = trimmedDose;
-    if (!finalDose && !needsDose) {
+    const isZeroDose = /^0+(\.0+)?$/.test(finalDose);
+    if (!finalDose && !isZeroDose && !needsDose) {
       setNeedsDose(true);
       return;
     }


### PR DESCRIPTION
## Summary
- persist manual medication additions and removals through `/api/observations`, storing observation ids for tags and refreshing profile data immediately
- accept zero-dose inputs in the medication form and show consistent "No data available" fallbacks in the AI summary panels
- rebuild the profile summary API to gather active meds from committed observations, format lab highlights with units, trends, and empty states, add RxNorm GET/name support, and pass the optional country flag through medication search

## Testing
- `npm run lint` *(fails: Next.js prompts for initial ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d792739170832f937dace4201d1b5c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Optional country filter for medication search.
  * New GET endpoint to normalize medications by name; POST now returns name–rxcui pairs.
  * Enhanced lab panel summaries with units, trends, and dates; uploads show last upload date.

* Bug Fixes
  * Zero-dose entries no longer trigger a dose prompt.

* Refactor
  * Overhauled profile summary for consistent formatting, robust data handling, and clearer AI highlights.
  * Updated medications save/remove workflow for reliability and faster refresh.
  * Unified "No data" placeholder and updated labels (Active Meds, Symptoms & Notes, Next Steps).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->