### PR TITLE
Add care directory feature

### DIFF
--- a/app/api/directory/flag/route.ts
+++ b/app/api/directory/flag/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+const FEATURE_ENABLED =
+  process.env.FEATURE_DIRECTORY === "1" || process.env.NEXT_PUBLIC_FEATURE_DIRECTORY === "1";
+
+type FlagBody = {
+  placeId?: string;
+  reason?: string;
+};
+
+export async function POST(request: Request) {
+  if (!FEATURE_ENABLED) {
+    return NextResponse.json({ error: "disabled" }, { status: 404 });
+  }
+
+  let body: FlagBody = {};
+  try {
+    body = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+
+  if (!body.placeId) {
+    return NextResponse.json({ error: "missing_place" }, { status: 400 });
+  }
+
+  console.info("directory_flag", {
+    placeId: body.placeId,
+    reason: body.reason ?? "",
+    ts: new Date().toISOString(),
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/directory/place/[id]/route.ts
+++ b/app/api/directory/place/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { fetchOsmPlaceById } from "@/lib/directory/osm";
+
+const FEATURE_ENABLED =
+  process.env.FEATURE_DIRECTORY === "1" || process.env.NEXT_PUBLIC_FEATURE_DIRECTORY === "1";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } },
+) {
+  if (!FEATURE_ENABLED) {
+    return NextResponse.json({ error: "disabled" }, { status: 404 });
+  }
+
+  const { id } = params;
+  if (!id) {
+    return NextResponse.json({ error: "missing_id" }, { status: 400 });
+  }
+
+  const place = await fetchOsmPlaceById(id);
+  if (!place) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ place, attribution: "© OpenStreetMap contributors" });
+}

--- a/app/api/directory/search/route.ts
+++ b/app/api/directory/search/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { searchOsmPlaces } from "@/lib/directory/osm";
+import type { DirectoryPlaceType } from "@/lib/directory/types";
+
+const FEATURE_ENABLED =
+  process.env.FEATURE_DIRECTORY === "1" || process.env.NEXT_PUBLIC_FEATURE_DIRECTORY === "1";
+
+function parseType(value: string | null): DirectoryPlaceType {
+  if (value === "pharmacy" || value === "lab") return value;
+  return "doctor";
+}
+
+function parseNumber(value: string | null, fallback: number): number {
+  if (!value) return fallback;
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return num;
+}
+
+export async function GET(request: Request) {
+  if (!FEATURE_ENABLED) {
+    return NextResponse.json({ error: "disabled" }, { status: 404 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const lat = Number(searchParams.get("lat"));
+  const lng = Number(searchParams.get("lng"));
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    return NextResponse.json({ error: "missing_location" }, { status: 400 });
+  }
+
+  const type = parseType(searchParams.get("type"));
+  const radius = parseNumber(searchParams.get("radius"), 4000);
+  const query = searchParams.get("q")?.trim() || undefined;
+  const minRating = parseNumber(searchParams.get("min_rating"), 0);
+  const maxKmParam = searchParams.get("max_km");
+  const maxKm = maxKmParam ? parseNumber(maxKmParam, 0) : 0;
+  const openNow = searchParams.get("open_now") === "1";
+
+  try {
+    const results = await searchOsmPlaces({ type, lat, lng, radius, query });
+    const filtered = results.filter(place => {
+      if (minRating > 0 && (place.rating ?? 0) < minRating) return false;
+      if (maxKm > 0 && (place.distance_m ?? Number.POSITIVE_INFINITY) > maxKm * 1000) return false;
+      if (openNow && place.open_now === false) return false;
+      return true;
+    });
+
+    return NextResponse.json({
+      results: filtered,
+      attribution: "© OpenStreetMap contributors",
+      updated_at: new Date().toISOString(),
+    });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error?.message ?? "unknown_error", results: [], attribution: "© OpenStreetMap contributors" },
+      { status: 502 },
+    );
+  }
+}

--- a/app/directory/loading.tsx
+++ b/app/directory/loading.tsx
@@ -1,0 +1,13 @@
+export default function DirectoryLoading() {
+  return (
+    <div className="flex flex-1 flex-col gap-4 bg-slate-50/60 p-6">
+      <div className="h-10 w-48 animate-pulse rounded-full bg-slate-200" />
+      <div className="h-12 animate-pulse rounded-3xl bg-slate-200" />
+      <div className="space-y-3">
+        {[1, 2, 3].map(item => (
+          <div key={item} className="h-32 animate-pulse rounded-3xl border border-slate-200 bg-white/60" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -1,0 +1,28 @@
+import dynamic from "next/dynamic";
+import { notFound } from "next/navigation";
+import { BRAND_NAME } from "@/lib/brand";
+import type { Metadata } from "next";
+
+const FEATURE_ENABLED =
+  process.env.FEATURE_DIRECTORY === "1" || process.env.NEXT_PUBLIC_FEATURE_DIRECTORY === "1";
+
+const DirectoryView = dynamic(() => import("@/components/directory/DirectoryView"), {
+  ssr: false,
+  loading: () => <div className="flex flex-1 items-center justify-center">Loading directory…</div>,
+});
+
+export const metadata: Metadata = {
+  title: `Directory | ${BRAND_NAME}`,
+};
+
+export default function DirectoryPage() {
+  if (!FEATURE_ENABLED) {
+    notFound();
+  }
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <DirectoryView />
+    </div>
+  );
+}

--- a/components/directory/DirectoryHeader.tsx
+++ b/components/directory/DirectoryHeader.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { MapPin, Search, SlidersHorizontal } from "lucide-react";
+import type { DirectoryPlaceType } from "@/lib/directory/types";
+
+export type DirectoryFilters = {
+  openNow: boolean;
+  minRating: boolean;
+  withinThreeKm: boolean;
+  twentyFourSeven: boolean;
+  cashless: boolean;
+  wheelchair: boolean;
+};
+
+type DirectoryHeaderProps = {
+  locationLabel: string;
+  approximate: boolean;
+  search: string;
+  onSearchChange: (value: string) => void;
+  type: DirectoryPlaceType;
+  onTypeChange: (value: DirectoryPlaceType) => void;
+  filters: DirectoryFilters;
+  onToggleFilter: (key: keyof DirectoryFilters) => void;
+  resultsCount: number;
+  updatedAt: Date | null;
+  showMapToggle: boolean;
+  mapVisible: boolean;
+  onToggleMap: () => void;
+};
+
+function timeAgo(date: Date | null): string {
+  if (!date) return "just now";
+  const diffSeconds = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000));
+  if (diffSeconds < 60) return "just now";
+  if (diffSeconds < 3600) return `${Math.floor(diffSeconds / 60)}m ago`;
+  if (diffSeconds < 86400) return `${Math.floor(diffSeconds / 3600)}h ago`;
+  return `${Math.floor(diffSeconds / 86400)}d ago`;
+}
+
+const TYPE_CHIPS: Array<{ key: DirectoryPlaceType; label: string }> = [
+  { key: "doctor", label: "Doctors" },
+  { key: "pharmacy", label: "Pharmacies" },
+  { key: "lab", label: "Labs" },
+];
+
+export default function DirectoryHeader({
+  locationLabel,
+  approximate,
+  search,
+  onSearchChange,
+  type,
+  onTypeChange,
+  filters,
+  onToggleFilter,
+  resultsCount,
+  updatedAt,
+  showMapToggle,
+  mapVisible,
+  onToggleMap,
+}: DirectoryHeaderProps) {
+  return (
+    <header className="sticky top-[56px] z-20 border-b border-slate-200/80 bg-white/80 backdrop-blur md:top-0">
+      <div className="px-4 py-3 space-y-3">
+        <div className="text-xs uppercase tracking-wide text-slate-500">
+          {approximate ? "Using approximate location" : "Using your location"} • {locationLabel || "Locating…"}
+        </div>
+
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <input
+            className="w-full rounded-full border border-slate-200 bg-white py-2 pl-9 pr-4 text-sm text-slate-700 shadow-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+            placeholder="Search near me"
+            value={search}
+            onChange={event => onSearchChange(event.target.value)}
+          />
+        </div>
+
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {TYPE_CHIPS.map(chip => (
+            <button
+              key={chip.key}
+              type="button"
+              onClick={() => onTypeChange(chip.key)}
+              className={`flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium transition ${
+                type === chip.key
+                  ? "border-blue-500 bg-blue-50 text-blue-700"
+                  : "border-slate-200 bg-white text-slate-600 hover:border-blue-200"
+              }`}
+            >
+              <MapPin className="h-4 w-4" />
+              {chip.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 text-xs font-medium text-slate-600">
+          <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-slate-500">
+            <SlidersHorizontal className="h-3.5 w-3.5" /> Filters
+          </span>
+          <FilterChip label="Open now" active={filters.openNow} onClick={() => onToggleFilter("openNow")} />
+          <FilterChip label="★ 4.0+" active={filters.minRating} onClick={() => onToggleFilter("minRating")} />
+          <FilterChip label="&lt; 3 km" active={filters.withinThreeKm} onClick={() => onToggleFilter("withinThreeKm")} />
+          <FilterChip label="24×7" active={filters.twentyFourSeven} onClick={() => onToggleFilter("twentyFourSeven")} />
+          <FilterChip label="Cashless" active={filters.cashless} onClick={() => onToggleFilter("cashless")} />
+          <FilterChip label="Wheelchair" active={filters.wheelchair} onClick={() => onToggleFilter("wheelchair")} />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-3 border-t border-slate-200/60 px-4 py-2 text-xs text-slate-500">
+        <div>
+          <span className="font-medium text-slate-700">{resultsCount}</span> results • updated {timeAgo(updatedAt)}
+        </div>
+        {showMapToggle ? (
+          <button
+            type="button"
+            onClick={onToggleMap}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+              mapVisible
+                ? "border-blue-500 bg-blue-50 text-blue-700"
+                : "border-slate-200 bg-white text-slate-600 hover:border-blue-200"
+            }`}
+            aria-pressed={mapVisible}
+          >
+            <MapPin className="h-4 w-4" /> {mapVisible ? "Hide map" : "Map"}
+          </button>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
+type FilterChipProps = {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+};
+
+function FilterChip({ label, active, onClick }: FilterChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full border px-3 py-1 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+        active
+          ? "border-blue-500 bg-blue-50 text-blue-700"
+          : "border-slate-200 bg-white text-slate-600 hover:border-blue-200"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/components/directory/DirectoryList.tsx
+++ b/components/directory/DirectoryList.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useMemo } from "react";
+import type { MouseEvent, ReactNode } from "react";
+import { Copy, ExternalLink, MapPin, Phone, Send, Star, Tag } from "lucide-react";
+import type { DirectoryPlace } from "@/lib/directory/types";
+
+type DirectoryListProps = {
+  places: DirectoryPlace[];
+  loading: boolean;
+  error: string | null;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+};
+
+export default function DirectoryList({ places, loading, error, selectedId, onSelect }: DirectoryListProps) {
+  if (loading) {
+    return (
+      <div className="space-y-3 px-4 py-4">
+        {[1, 2, 3].map(item => (
+          <div
+            key={item}
+            className="animate-pulse rounded-2xl border border-slate-200 bg-white/60 p-4 shadow-sm"
+          >
+            <div className="h-4 w-1/2 rounded bg-slate-200" />
+            <div className="mt-2 h-3 w-1/3 rounded bg-slate-100" />
+            <div className="mt-4 h-3 w-2/3 rounded bg-slate-100" />
+            <div className="mt-6 flex gap-2">
+              <div className="h-8 w-16 rounded-full bg-slate-100" />
+              <div className="h-8 w-16 rounded-full bg-slate-100" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-4 py-6 text-sm text-red-600">
+        {error}
+      </div>
+    );
+  }
+
+  if (!places.length) {
+    return (
+      <div className="px-4 py-12 text-center text-sm text-slate-500">
+        No results found nearby. Try broadening your filters or search.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 px-4 py-4">
+      {places.map(place => (
+        <Card key={place.id} place={place} selected={place.id === selectedId} onSelect={onSelect} />
+      ))}
+    </div>
+  );
+}
+
+type CardProps = {
+  place: DirectoryPlace;
+  selected: boolean;
+  onSelect: (id: string) => void;
+};
+
+function Card({ place, selected, onSelect }: CardProps) {
+  const directionsHref = place.geo
+    ? `https://www.google.com/maps/dir/?api=1&destination=${place.geo.lat},${place.geo.lng}`
+    : null;
+  const whatsappNumber = place.whatsapp || (place.phones[0] ?? "");
+  const whatsappHref = whatsappNumber ? `https://wa.me/${whatsappNumber.replace(/[^0-9]/g, "")}` : null;
+
+  const meta = useMemo(() => {
+    const parts: string[] = [];
+    if (place.rating) parts.push(`★ ${place.rating.toFixed(1)}`);
+    if (place.distance_m != null) parts.push(`${(place.distance_m / 1000).toFixed(1)} km`);
+    if (place.open_now) parts.push("Open now");
+    if (place.price_level) parts.push("₹".repeat(Math.min(3, place.price_level)));
+    return parts.join(" • ");
+  }, [place.rating, place.distance_m, place.open_now, place.price_level]);
+
+  const badges = [...place.services.slice(0, 2), ...place.amenities.slice(0, 2)];
+
+  return (
+    <article
+      className={`cursor-pointer rounded-2xl border p-4 shadow-sm transition ${
+        selected
+          ? "border-blue-500 bg-blue-50/70"
+          : "border-slate-200 bg-white/80 hover:border-blue-200 hover:shadow"
+      }`}
+      onClick={() => onSelect(place.id)}
+      tabIndex={0}
+      onKeyDown={event => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSelect(place.id);
+        }
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-semibold text-slate-900">{place.name}</h3>
+            {place.specialties[0] ? (
+              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
+                {place.specialties[0]}
+              </span>
+            ) : null}
+          </div>
+          <div className="mt-1 text-xs text-slate-500">
+            {meta || "No rating available"}
+          </div>
+        </div>
+        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-500">{place.type}</span>
+      </div>
+
+      <div className="mt-3 flex items-center gap-2 text-sm text-slate-600">
+        <MapPin className="h-4 w-4 text-slate-400" />
+        <span>{place.address_short || "Address unavailable"}</span>
+        {place.address_short ? (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded-full border border-slate-200 px-2 py-0.5 text-xs text-slate-500 transition hover:border-blue-200 hover:text-blue-600"
+            onClick={event => {
+              event.stopPropagation();
+              if (place.address_short && navigator.clipboard?.writeText) {
+                navigator.clipboard.writeText(place.address_short).catch(() => {});
+              }
+            }}
+          >
+            <Copy className="h-3.5 w-3.5" /> Copy
+          </button>
+        ) : null}
+      </div>
+
+      {badges.length ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {badges.map(badge => (
+            <span key={badge} className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
+              <Tag className="h-3.5 w-3.5" />
+              {badge}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="mt-4 grid grid-cols-2 gap-2 text-sm font-medium text-slate-700 sm:grid-cols-4">
+        <ActionButton
+          icon={<Phone className="h-4 w-4" />}
+          label="Call"
+          href={place.phones[0] ? `tel:${place.phones[0]}` : undefined}
+          disabled={!place.phones.length}
+          onClick={event => event.stopPropagation()}
+        />
+        <ActionButton
+          icon={<ExternalLink className="h-4 w-4" />}
+          label="Directions"
+          href={directionsHref || undefined}
+          disabled={!directionsHref}
+          onClick={event => event.stopPropagation()}
+        />
+        <ActionButton
+          icon={<Send className="h-4 w-4" />}
+          label="WhatsApp"
+          href={whatsappHref || undefined}
+          disabled={!whatsappHref}
+          onClick={event => event.stopPropagation()}
+        />
+        <ActionButton
+          icon={<Star className="h-4 w-4" />}
+          label="Book"
+          disabled
+          onClick={event => event.stopPropagation()}
+        />
+      </div>
+    </article>
+  );
+}
+
+type ActionButtonProps = {
+  icon: ReactNode;
+  label: string;
+  href?: string;
+  disabled?: boolean;
+  onClick?: (event: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+};
+
+function ActionButton({ icon, label, href, disabled, onClick }: ActionButtonProps) {
+  const className = `inline-flex items-center justify-center gap-2 rounded-full border px-3 py-2 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${
+    disabled
+      ? "cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400"
+      : "border-slate-200 bg-white text-slate-600 hover:border-blue-200 hover:text-blue-600"
+  }`;
+
+  if (href && !disabled) {
+    return (
+      <a className={className} href={href} target="_blank" rel="noreferrer" onClick={event => onClick?.(event)}>
+        {icon}
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" className={className} disabled={disabled} onClick={event => onClick?.(event)}>
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/components/directory/DirectoryMap.tsx
+++ b/components/directory/DirectoryMap.tsx
@@ -31,10 +31,10 @@ export default function DirectoryMap({ places, selectedId, onSelect, userLocatio
       style: MAP_STYLE,
       center,
       zoom: 13,
-      attributionControl: true,
     });
 
     map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "top-right");
+    map.addControl(new maplibregl.AttributionControl({ compact: true }), "bottom-right");
     mapRef.current = map;
 
     return () => {

--- a/components/directory/DirectoryMap.tsx
+++ b/components/directory/DirectoryMap.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import maplibregl, { Marker } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+import type { DirectoryPlace } from "@/lib/directory/types";
+
+interface DirectoryMapProps {
+  places: DirectoryPlace[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  userLocation: { lat: number; lng: number } | null;
+}
+
+const MAP_STYLE = "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json";
+
+export default function DirectoryMap({ places, selectedId, onSelect, userLocation }: DirectoryMapProps) {
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const markersRef = useRef<Marker[]>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (mapRef.current || !containerRef.current) return;
+
+    const center = userLocation ? [userLocation.lng, userLocation.lat] : [77.209, 28.6139];
+    const map = new maplibregl.Map({
+      container: containerRef.current,
+      style: MAP_STYLE,
+      center,
+      zoom: 13,
+      attributionControl: true,
+    });
+
+    map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "top-right");
+    mapRef.current = map;
+
+    return () => {
+      markersRef.current.forEach(marker => marker.remove());
+      markersRef.current = [];
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [userLocation]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (!userLocation) return;
+    map.flyTo({ center: [userLocation.lng, userLocation.lat], zoom: Math.max(map.getZoom(), 12), speed: 0.6 });
+  }, [userLocation]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    markersRef.current.forEach(marker => marker.remove());
+    markersRef.current = [];
+
+    if (places.length === 0) return;
+
+    const bounds = new maplibregl.LngLatBounds();
+
+    places.forEach(place => {
+      if (!place.geo) return;
+      const marker = new maplibregl.Marker({ color: place.id === selectedId ? "#2563eb" : "#1f2937" })
+        .setLngLat([place.geo.lng, place.geo.lat])
+        .addTo(map);
+      marker.getElement().addEventListener("click", event => {
+        event.stopPropagation();
+        onSelect(place.id);
+      });
+      markersRef.current.push(marker);
+      bounds.extend([place.geo.lng, place.geo.lat]);
+    });
+
+    if (userLocation) {
+      const userMarker = new maplibregl.Marker({ color: "#059669" })
+        .setLngLat([userLocation.lng, userLocation.lat])
+        .addTo(map);
+      markersRef.current.push(userMarker);
+      bounds.extend([userLocation.lng, userLocation.lat]);
+    }
+
+    if (!bounds.isEmpty()) {
+      map.fitBounds(bounds, { padding: 60, maxZoom: 16, duration: 600 });
+    }
+  }, [places, selectedId, onSelect, userLocation]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !selectedId) return;
+    const place = places.find(item => item.id === selectedId);
+    if (place?.geo) {
+      map.flyTo({ center: [place.geo.lng, place.geo.lat], zoom: Math.max(map.getZoom(), 14), speed: 0.6 });
+    }
+  }, [selectedId, places]);
+
+  const attribution = useMemo(
+    () => (
+      <div className="pointer-events-none absolute bottom-2 right-2 rounded-full bg-white/80 px-2 py-0.5 text-[10px] text-slate-500 shadow">
+        © OpenStreetMap contributors
+      </div>
+    ),
+    [],
+  );
+
+  return (
+    <div className="relative h-full w-full">
+      <div ref={containerRef} className="h-full w-full rounded-3xl border border-slate-200" />
+      {attribution}
+    </div>
+  );
+}

--- a/components/directory/DirectoryMap.tsx
+++ b/components/directory/DirectoryMap.tsx
@@ -23,7 +23,9 @@ export default function DirectoryMap({ places, selectedId, onSelect, userLocatio
     if (typeof window === "undefined") return;
     if (mapRef.current || !containerRef.current) return;
 
-    const center = userLocation ? [userLocation.lng, userLocation.lat] : [77.209, 28.6139];
+    const center: [number, number] = userLocation
+      ? [userLocation.lng, userLocation.lat]
+      : [77.209, 28.6139];
     const map = new maplibregl.Map({
       container: containerRef.current,
       style: MAP_STYLE,

--- a/components/directory/DirectorySheet.tsx
+++ b/components/directory/DirectorySheet.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { X, Phone, ExternalLink, Send, Star, MapPin, Clock, Building2 } from "lucide-react";
+import type { ReactNode } from "react";
+import type { DirectoryPlace } from "@/lib/directory/types";
+
+interface DirectorySheetProps {
+  place: DirectoryPlace;
+  onClose: () => void;
+}
+
+export default function DirectorySheet({ place, onClose }: DirectorySheetProps) {
+  const directionsHref = place.geo
+    ? `https://www.google.com/maps/dir/?api=1&destination=${place.geo.lat},${place.geo.lng}`
+    : null;
+  const whatsappNumber = place.whatsapp || (place.phones[0] ?? "");
+  const whatsappHref = whatsappNumber ? `https://wa.me/${whatsappNumber.replace(/[^0-9]/g, "")}` : null;
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 rounded-t-3xl border border-slate-200 bg-white p-5 shadow-2xl">
+      <div className="mx-auto h-1.5 w-12 rounded-full bg-slate-200" />
+      <button
+        type="button"
+        className="absolute right-4 top-4 inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500"
+        aria-label="Close"
+        onClick={onClose}
+      >
+        <X className="h-4 w-4" />
+      </button>
+
+      <div className="mt-4 space-y-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h3 className="text-lg font-semibold text-slate-900">{place.name}</h3>
+            {place.specialties[0] ? (
+              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
+                {place.specialties[0]}
+              </span>
+            ) : null}
+          </div>
+          <div className="text-sm text-slate-500">
+            {place.rating ? `★ ${place.rating.toFixed(1)}` : "No rating"}
+            {place.distance_m != null ? ` • ${(place.distance_m / 1000).toFixed(1)} km away` : ""}
+          </div>
+        </div>
+
+        <InfoRow icon={<MapPin className="h-4 w-4" />} label="Address" value={place.address_short || "Not available"} />
+        <InfoRow icon={<Phone className="h-4 w-4" />} label="Phone" value={place.phones.join(", ") || "Not available"} />
+        <InfoRow
+          icon={<Building2 className="h-4 w-4" />}
+          label="Services"
+          value={place.services.length ? place.services.join(", ") : "Not listed"}
+        />
+        <InfoRow
+          icon={<Building2 className="h-4 w-4" />}
+          label="Amenities"
+          value={place.amenities.length ? place.amenities.join(", ") : "Not listed"}
+        />
+        <InfoRow
+          icon={<Clock className="h-4 w-4" />}
+          label="Hours"
+          value={
+            place.hours && Object.keys(place.hours).length
+              ? Object.values(place.hours).join(" • ")
+              : "Not provided"
+          }
+        />
+
+        <div className="grid grid-cols-2 gap-2 text-sm font-medium text-slate-700">
+          <SheetButton label="Call" icon={<Phone className="h-4 w-4" />} href={place.phones[0] ? `tel:${place.phones[0]}` : undefined} />
+          <SheetButton label="Directions" icon={<ExternalLink className="h-4 w-4" />} href={directionsHref || undefined} />
+          <SheetButton label="WhatsApp" icon={<Send className="h-4 w-4" />} href={whatsappHref || undefined} />
+          <SheetButton label="Book" icon={<Star className="h-4 w-4" />} disabled />
+        </div>
+
+        <p className="text-xs text-slate-400">
+          Data source: {place.source.toUpperCase()} • Last checked 2d ago
+        </p>
+      </div>
+    </div>
+  );
+}
+
+type InfoRowProps = {
+  icon: ReactNode;
+  label: string;
+  value: string;
+};
+
+function InfoRow({ icon, label, value }: InfoRowProps) {
+  return (
+    <div className="flex items-start gap-3 rounded-xl bg-slate-50 px-3 py-2 text-sm text-slate-600">
+      <span className="mt-0.5 text-slate-400">{icon}</span>
+      <div>
+        <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">{label}</div>
+        <div className="mt-0.5 text-sm text-slate-700">{value}</div>
+      </div>
+    </div>
+  );
+}
+
+type SheetButtonProps = {
+  icon: ReactNode;
+  label: string;
+  href?: string;
+  disabled?: boolean;
+};
+
+function SheetButton({ icon, label, href, disabled }: SheetButtonProps) {
+  const className = `inline-flex items-center justify-center gap-2 rounded-full border px-3 py-2 transition ${
+    disabled
+      ? "cursor-not-allowed border-slate-200 bg-slate-100 text-slate-400"
+      : "border-slate-200 bg-white text-slate-600 hover:border-blue-200 hover:text-blue-600"
+  }`;
+
+  if (href && !disabled) {
+    return (
+      <a className={className} href={href} target="_blank" rel="noreferrer">
+        {icon}
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" className={className} disabled={disabled}>
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/components/directory/DirectoryView.tsx
+++ b/components/directory/DirectoryView.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
+import type { DirectoryPlace, DirectoryPlaceType } from "@/lib/directory/types";
+import DirectoryHeader, { DirectoryFilters } from "./DirectoryHeader";
+import DirectoryList from "./DirectoryList";
+import DirectorySheet from "./DirectorySheet";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+
+const DirectoryMap = dynamic(() => import("./DirectoryMap"), {
+  ssr: false,
+  loading: () => <div className="h-full w-full rounded-3xl border border-slate-200 bg-slate-100" />,
+});
+
+type Coords = { lat: number; lng: number };
+
+const FALLBACK_LOCATION: Coords = { lat: 28.5355, lng: 77.196 }; // South Delhi
+
+const FEATURE_ENABLED =
+  process.env.NEXT_PUBLIC_FEATURE_DIRECTORY === "1" || process.env.FEATURE_DIRECTORY === "1";
+
+export default function DirectoryView() {
+  const isDesktop = useMediaQuery("(min-width: 1024px)");
+  const [search, setSearch] = useState("");
+  const [type, setType] = useState<DirectoryPlaceType>("doctor");
+  const [filters, setFilters] = useState<DirectoryFilters>({
+    openNow: false,
+    minRating: false,
+    withinThreeKm: false,
+    twentyFourSeven: false,
+    cashless: false,
+    wheelchair: false,
+  });
+  const [activeCoords, setActiveCoords] = useState<Coords>(FALLBACK_LOCATION);
+  const [locationStatus, setLocationStatus] = useState<"pending" | "granted" | "denied">("pending");
+  const [approximate, setApproximate] = useState(true);
+  const [locationLabel, setLocationLabel] = useState("South Delhi");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [places, setPlaces] = useState<DirectoryPlace[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [updatedAt, setUpdatedAt] = useState<Date | null>(null);
+  const [showMap, setShowMap] = useState(false);
+
+  const debouncedSearch = useDebouncedValue(search, 350);
+
+  useEffect(() => {
+    if (!FEATURE_ENABLED) return;
+    if (!("geolocation" in navigator)) {
+      setLocationStatus("denied");
+      setApproximate(true);
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      position => {
+        const coords = { lat: Number(position.coords.latitude), lng: Number(position.coords.longitude) };
+        setActiveCoords(coords);
+        setLocationStatus("granted");
+        setApproximate(false);
+      },
+      () => {
+        setLocationStatus("denied");
+        setApproximate(true);
+        setActiveCoords(FALLBACK_LOCATION);
+      },
+      { enableHighAccuracy: true, timeout: 8000 },
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!FEATURE_ENABLED) return;
+    const controller = new AbortController();
+    const { lat, lng } = activeCoords;
+    const url = new URL("https://nominatim.openstreetmap.org/reverse");
+    url.searchParams.set("format", "jsonv2");
+    url.searchParams.set("lat", String(lat));
+    url.searchParams.set("lon", String(lng));
+
+    fetch(url.toString(), {
+      headers: { "accept-language": "en", "user-agent": "MedxDirectory/1.0" },
+      signal: controller.signal,
+    })
+      .then(response => response.json())
+      .then(data => {
+        if (data && typeof data === "object") {
+          const locality = data.address?.suburb || data.address?.city || data.address?.state || "Nearby";
+          setLocationLabel(locality);
+        }
+      })
+      .catch(() => {
+        setLocationLabel("Nearby");
+      });
+
+    return () => controller.abort();
+  }, [activeCoords.lat, activeCoords.lng]);
+
+  useEffect(() => {
+    if (!FEATURE_ENABLED) return;
+    setShowMap(isDesktop);
+  }, [isDesktop]);
+
+  useEffect(() => {
+    if (!FEATURE_ENABLED) return;
+    setLoading(true);
+    setError(null);
+
+    const radius = filters.withinThreeKm ? 3000 : 5000;
+    const minRatingValue = filters.minRating ? 4 : 0;
+    const maxKmValue = filters.withinThreeKm ? 3 : 0;
+
+    const url = new URL("/api/directory/search", window.location.origin);
+    url.searchParams.set("type", type);
+    url.searchParams.set("lat", String(activeCoords.lat));
+    url.searchParams.set("lng", String(activeCoords.lng));
+    url.searchParams.set("radius", String(radius));
+    if (debouncedSearch) url.searchParams.set("q", debouncedSearch);
+    if (filters.openNow) url.searchParams.set("open_now", "1");
+    if (minRatingValue > 0) url.searchParams.set("min_rating", String(minRatingValue));
+    if (maxKmValue > 0) url.searchParams.set("max_km", String(maxKmValue));
+
+    fetch(url.toString())
+      .then(res => {
+        if (!res.ok) throw new Error("Could not load directory");
+        return res.json();
+      })
+      .then(data => {
+        setPlaces(Array.isArray(data.results) ? data.results : []);
+        setUpdatedAt(data.updated_at ? new Date(data.updated_at) : new Date());
+        setLoading(false);
+      })
+      .catch(err => {
+        setError(err instanceof Error ? err.message : "Failed to load directory");
+        setPlaces([]);
+        setLoading(false);
+      });
+  }, [type, activeCoords, debouncedSearch, filters.openNow, filters.minRating, filters.withinThreeKm]);
+
+  const filteredPlaces = useMemo(() => {
+    let list = places.slice();
+    if (filters.openNow) {
+      list = list.filter(place => place.open_now !== false);
+    }
+    if (filters.twentyFourSeven) {
+      list = list.filter(place => {
+        if (place.open_now) return true;
+        if (!place.hours) return false;
+        return Object.values(place.hours).some(value => value.includes("24"));
+      });
+    }
+    if (filters.cashless) {
+      list = list.filter(place => place.amenities.some(amenity => amenity.toLowerCase().includes("cash")));
+    }
+    if (filters.wheelchair) {
+      list = list.filter(place => place.amenities.some(amenity => amenity.toLowerCase().includes("wheelchair")));
+    }
+    return list;
+  }, [places, filters.openNow, filters.twentyFourSeven, filters.cashless, filters.wheelchair]);
+
+  useEffect(() => {
+    if (!filteredPlaces.length) {
+      setSelectedId(null);
+      return;
+    }
+    if (!selectedId || !filteredPlaces.some(place => place.id === selectedId)) {
+      setSelectedId(filteredPlaces[0].id);
+    }
+  }, [filteredPlaces, selectedId]);
+
+  const selectedPlace = filteredPlaces.find(place => place.id === selectedId) ?? null;
+
+  const toggleFilter = (key: keyof DirectoryFilters) => {
+    setFilters(prev => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleSelect = (id: string) => {
+    setSelectedId(id);
+  };
+
+  return (
+    <div className="flex w-full flex-1 flex-col bg-slate-50/60">
+      {locationStatus === "denied" ? (
+        <div className="bg-amber-100 px-4 py-2 text-xs text-amber-700">
+          Allow location access to see the closest care providers. Showing approximate distances for {locationLabel}.
+        </div>
+      ) : null}
+
+      <DirectoryHeader
+        locationLabel={locationLabel}
+        approximate={approximate}
+        search={search}
+        onSearchChange={setSearch}
+        type={type}
+        onTypeChange={setType}
+        filters={filters}
+        onToggleFilter={toggleFilter}
+        resultsCount={filteredPlaces.length}
+        updatedAt={updatedAt}
+        showMapToggle={!isDesktop}
+        mapVisible={showMap}
+        onToggleMap={() => setShowMap(value => !value)}
+      />
+
+      <div className={`flex min-h-0 flex-1 flex-col gap-4 px-0 py-4 md:flex-row md:px-4`}>
+        <div className={`flex-1 overflow-y-auto md:pr-4 ${isDesktop ? "max-h-[calc(100vh-180px)]" : ""}`}>
+          <DirectoryList
+            places={filteredPlaces}
+            loading={loading}
+            error={error}
+            selectedId={selectedId}
+            onSelect={handleSelect}
+          />
+        </div>
+        {showMap ? (
+          <div className="hidden min-h-[400px] flex-1 overflow-hidden rounded-3xl border border-slate-200 bg-white/60 shadow-md md:block">
+            <DirectoryMap places={filteredPlaces} selectedId={selectedId} onSelect={handleSelect} userLocation={activeCoords} />
+          </div>
+        ) : null}
+      </div>
+
+      {!isDesktop && showMap ? (
+        <div className="px-4 pb-6">
+          <div className="h-72 overflow-hidden rounded-3xl border border-slate-200">
+            <DirectoryMap places={filteredPlaces} selectedId={selectedId} onSelect={handleSelect} userLocation={activeCoords} />
+          </div>
+        </div>
+      ) : null}
+
+      {!isDesktop && selectedPlace ? (
+        <DirectorySheet place={selectedPlace} onClose={() => setSelectedId(null)} />
+      ) : null}
+    </div>
+  );
+}

--- a/hooks/useDebouncedValue.ts
+++ b/hooks/useDebouncedValue.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const getMatches = () => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(query).matches;
+  };
+
+  const [matches, setMatches] = useState<boolean>(getMatches);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mediaQuery = window.matchMedia(query);
+    const handler = (event: MediaQueryListEvent) => setMatches(event.matches);
+    setMatches(mediaQuery.matches);
+    mediaQuery.addEventListener("change", handler);
+    return () => mediaQuery.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}

--- a/lib/directory/osm.ts
+++ b/lib/directory/osm.ts
@@ -1,0 +1,202 @@
+import { rankPlace } from "./rank";
+import type { DirectoryPlace, DirectorySearchParams, DirectoryPlaceType } from "./types";
+import {
+  distanceMeters,
+  extractAmenities,
+  extractServices,
+  sanitizePhone,
+  setCache,
+  getCache,
+  shortAddressFrom,
+} from "./utils";
+
+const OVERPASS_URL = process.env.OVERPASS_URL || "https://overpass-api.de/api/interpreter";
+const CACHE_TTL_MS = (Number(process.env.NEARBY_CACHE_TTL_SEC || 3600) || 3600) * 1000;
+
+const searchCache = new Map<string, { expiresAt: number; value: DirectoryPlace[] }>();
+const detailCache = new Map<string, { expiresAt: number; value: DirectoryPlace | null }>();
+
+const TYPE_SELECTORS: Record<DirectoryPlaceType, string[]> = {
+  doctor: [
+    'node["amenity"="doctors"]',
+    'way["amenity"="doctors"]',
+    'node["healthcare"="doctor"]',
+    'way["healthcare"="doctor"]',
+    'node["amenity"="clinic"]',
+    'way["amenity"="clinic"]',
+  ],
+  pharmacy: [
+    'node["amenity"="pharmacy"]',
+    'way["amenity"="pharmacy"]',
+    'relation["amenity"="pharmacy"]',
+  ],
+  lab: [
+    'node["healthcare"="laboratory"]',
+    'way["healthcare"="laboratory"]',
+    'relation["healthcare"="laboratory"]',
+    'node["amenity"="laboratory"]',
+    'way["amenity"="laboratory"]',
+    'relation["amenity"="laboratory"]',
+  ],
+};
+
+function normalizeType(element: any, requested: DirectoryPlaceType): DirectoryPlaceType {
+  if (requested !== "doctor") return requested;
+  const speciality = element.tags?.["healthcare:speciality"] || "";
+  if (speciality.toLowerCase().includes("lab")) return "lab";
+  return requested;
+}
+
+function parseHours(opening: string | undefined): Record<string, string> | null {
+  if (!opening) return null;
+  const parts = opening.split(";").map(s => s.trim()).filter(Boolean);
+  if (!parts.length) return null;
+  const hours: Record<string, string> = {};
+  parts.forEach((part, index) => {
+    hours[`slot${index + 1}`] = part;
+  });
+  return hours;
+}
+
+function parseSpecialties(tags: Record<string, string | undefined>): string[] {
+  const value = tags["healthcare:speciality"] || tags["speciality"] || tags["specialty"];
+  if (!value) return [];
+  return Array.from(new Set(
+    value
+      .split(";")
+      .map(v => v.trim())
+      .filter(Boolean)
+      .map(v => v.charAt(0).toUpperCase() + v.slice(1)),
+  ));
+}
+
+function buildPlace(
+  element: any,
+  origin: { lat: number; lng: number },
+  requestedType: DirectoryPlaceType,
+): DirectoryPlace {
+  const tags: Record<string, string | undefined> = element.tags ?? {};
+  const lat = Number(element.lat ?? element.center?.lat);
+  const lng = Number(element.lon ?? element.center?.lon);
+  const geo = Number.isFinite(lat) && Number.isFinite(lng) ? { lat, lng } : null;
+
+  const distance = geo ? Math.round(distanceMeters(origin, geo)) : null;
+  const phoneCandidates = [
+    sanitizePhone(tags.phone),
+    sanitizePhone(tags["contact:phone"]),
+    sanitizePhone(tags["contact:mobile"]),
+    sanitizePhone(tags["mobile"]),
+  ].filter((value): value is string => Boolean(value));
+  const phones = Array.from(new Set(phoneCandidates));
+  const whatsapp = sanitizePhone(tags["contact:whatsapp"] || tags["whatsapp"] || null);
+
+  const source: DirectoryPlace["source"] = "osm";
+  const place: DirectoryPlace = {
+    id: `osm:${element.type}/${element.id}`,
+    name: tags.name || tags["name:en"] || "(Unnamed)",
+    type: normalizeType(element, requestedType),
+    specialties: parseSpecialties(tags),
+    rating: null,
+    reviews_count: null,
+    price_level: null,
+    distance_m: distance,
+    open_now: tags.opening_hours?.includes("24/7") || tags["opening_hours:signed"] === "yes" ? true : null,
+    hours: parseHours(tags.opening_hours),
+    phones,
+    whatsapp,
+    address_short: shortAddressFrom(tags),
+    geo,
+    amenities: extractAmenities(tags),
+    services: extractServices(tags),
+    images: [],
+    source,
+    last_checked: new Date().toISOString(),
+    rank_score: 0,
+    raw: undefined,
+  };
+
+  place.rank_score = rankPlace(place);
+  return place;
+}
+
+async function fetchOverpass(query: string) {
+  const response = await fetch(OVERPASS_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+      "user-agent": "MedxDirectory/1.0",
+    },
+    body: new URLSearchParams({ data: query }).toString(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`overpass_${response.status}`);
+  }
+
+  const payload = await response.json();
+  if (!payload || !Array.isArray(payload.elements)) return [];
+  return payload.elements;
+}
+
+export async function searchOsmPlaces(params: DirectorySearchParams): Promise<DirectoryPlace[]> {
+  const key = JSON.stringify(params);
+  const cached = getCache(searchCache, key);
+  if (cached !== undefined) return cached;
+
+  const selectors = TYPE_SELECTORS[params.type] ?? TYPE_SELECTORS.pharmacy;
+  const query = `
+    [out:json][timeout:30];
+    (
+      ${selectors.map(sel => `${sel}(around:${Math.round(params.radius)},${params.lat},${params.lng});`).join("\n")}
+    );
+    out center tags;
+  `;
+
+  const elements = await fetchOverpass(query.trim());
+  const origin = { lat: params.lat, lng: params.lng };
+  const places = elements
+    .map((element: any) => buildPlace(element, origin, params.type))
+    .filter((place: DirectoryPlace) => place.geo !== null);
+
+  const results = params.query
+    ? places.filter(place =>
+        place.name.toLowerCase().includes(params.query!.toLowerCase()) ||
+        place.specialties.some(spec => spec.toLowerCase().includes(params.query!.toLowerCase())),
+      )
+    : places;
+
+  const sorted = results.sort((a, b) => b.rank_score - a.rank_score);
+  setCache(searchCache, key, sorted, CACHE_TTL_MS);
+  return sorted;
+}
+
+export async function fetchOsmPlaceById(id: string): Promise<DirectoryPlace | null> {
+  const cached = getCache(detailCache, id);
+  if (cached !== undefined) return cached;
+
+  if (!id.startsWith("osm:")) return null;
+  const [, rest] = id.split(":", 2);
+  if (!rest) return null;
+  const [type, osmId] = rest.split("/");
+  if (!type || !osmId) return null;
+
+  const query = `
+    [out:json][timeout:25];
+    ${type}(id:${osmId});
+    out center tags;
+  `;
+
+  const elements = await fetchOverpass(query.trim());
+  const element = Array.isArray(elements) && elements.length > 0 ? elements[0] : null;
+  if (!element) {
+    setCache(detailCache, id, null, CACHE_TTL_MS);
+    return null;
+  }
+
+  const lat = Number(element.lat ?? element.center?.lat);
+  const lng = Number(element.lon ?? element.center?.lon);
+  const place = buildPlace(element, { lat, lng }, "doctor");
+  setCache(detailCache, id, place, CACHE_TTL_MS);
+  return place;
+}

--- a/lib/directory/rank.ts
+++ b/lib/directory/rank.ts
@@ -1,0 +1,44 @@
+import type { DirectoryPlace } from "./types";
+
+const METERS_FOR_FULL_DISTANCE_SCORE = 1000;
+const METERS_FOR_ZERO_DISTANCE_SCORE = 5000;
+
+function distanceScore(distance: number | null): number {
+  if (distance == null || !Number.isFinite(distance)) return 0;
+  if (distance <= METERS_FOR_FULL_DISTANCE_SCORE) return 1;
+  if (distance >= METERS_FOR_ZERO_DISTANCE_SCORE) return 0;
+  const range = METERS_FOR_ZERO_DISTANCE_SCORE - METERS_FOR_FULL_DISTANCE_SCORE;
+  return 1 - (distance - METERS_FOR_FULL_DISTANCE_SCORE) / range;
+}
+
+function profileCompleteness(place: DirectoryPlace): number {
+  let score = 0;
+  if (place.phones.length > 0) score += 1;
+  if (place.hours && Object.keys(place.hours).length > 0) score += 1;
+  if (place.services.length > 0) score += 1;
+  if (place.images.length > 0) score += 1;
+  return score / 4;
+}
+
+export function rankPlace(place: DirectoryPlace): number {
+  const ratingScore = place.rating ? Math.min(Math.max(place.rating / 5, 0), 1) : 0;
+  const distanceComponent = distanceScore(place.distance_m);
+  const openNowScore = place.open_now ? 1 : 0;
+  const completeness = profileCompleteness(place);
+  const reviewFreshness = place.last_checked ? 1 : 0;
+
+  const w1 = 0.35;
+  const w2 = 0.25;
+  const w3 = 0.15;
+  const w4 = 0.15;
+  const w5 = 0.1;
+
+  const score =
+    w1 * distanceComponent +
+    w2 * ratingScore +
+    w3 * openNowScore +
+    w4 * completeness +
+    w5 * reviewFreshness;
+
+  return Number(score.toFixed(4));
+}

--- a/lib/directory/types.ts
+++ b/lib/directory/types.ts
@@ -1,0 +1,38 @@
+export type DirectoryPlaceType = "doctor" | "pharmacy" | "lab";
+
+export type DirectoryPlace = {
+  id: string;
+  name: string;
+  type: DirectoryPlaceType;
+  specialties: string[];
+  rating: number | null;
+  reviews_count: number | null;
+  price_level: number | null;
+  distance_m: number | null;
+  open_now: boolean | null;
+  hours: Record<string, string> | null;
+  phones: string[];
+  whatsapp: string | null;
+  address_short: string | null;
+  geo: { lat: number; lng: number } | null;
+  amenities: string[];
+  services: string[];
+  images: string[];
+  source: "osm" | "google";
+  last_checked: string | null;
+  rank_score: number;
+  raw?: Record<string, unknown>;
+};
+
+export type DirectorySearchParams = {
+  type: DirectoryPlaceType;
+  lat: number;
+  lng: number;
+  radius: number;
+  query?: string;
+};
+
+export type DirectorySearchResponse = {
+  results: DirectoryPlace[];
+  attribution: string;
+};

--- a/lib/directory/utils.ts
+++ b/lib/directory/utils.ts
@@ -1,0 +1,93 @@
+export function distanceMeters(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number },
+): number {
+  const R = 6371000;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const sinLat = Math.sin(dLat / 2);
+  const sinLng = Math.sin(dLng / 2);
+  const c = sinLat * sinLat + Math.cos(lat1) * Math.cos(lat2) * sinLng * sinLng;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(c)));
+}
+
+export function sanitizePhone(phone: string | null | undefined): string | null {
+  if (!phone) return null;
+  return phone.replace(/[^0-9+]/g, "").trim() || null;
+}
+
+export function shortAddressFrom(tags: Record<string, string | undefined>): string | null {
+  const parts = [
+    tags["addr:housenumber"],
+    tags["addr:street"],
+    tags["addr:suburb"],
+    tags["addr:city"],
+  ].filter(Boolean);
+  if (!parts.length) return null;
+  return parts.join(", ");
+}
+
+export function extractAmenities(tags: Record<string, string | undefined>): string[] {
+  const list: string[] = [];
+  if (tags["wheelchair"] === "yes") list.push("Wheelchair access");
+  if (tags["cash_withdrawal"] === "yes" || tags["payment:cash"] === "yes") list.push("Cashless");
+  if (tags["payment:credit_cards"] === "yes") list.push("Cards accepted");
+  if (tags["drive_through"] === "yes") list.push("Drive-through");
+  if (tags["air_conditioning"] === "yes") list.push("Air conditioning");
+  return Array.from(new Set(list));
+}
+
+export function extractServices(tags: Record<string, string | undefined>): string[] {
+  const services: string[] = [];
+  const raw =
+    tags["services"] ||
+    tags["healthcare:speciality"] ||
+    tags["amenity"] ||
+    tags["healthcare"];
+
+  if (raw) {
+    raw
+      .split(";")
+      .map(s => s.trim())
+      .filter(Boolean)
+      .forEach(s => services.push(capitalize(s)));
+  }
+
+  const extra = tags["service"];
+  if (extra) {
+    extra
+      .split(";")
+      .map(s => s.trim())
+      .filter(Boolean)
+      .forEach(s => services.push(capitalize(s)));
+  }
+
+  return Array.from(new Set(services));
+}
+
+export function capitalize(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+export type CacheEntry<T> = {
+  expiresAt: number;
+  value: T;
+};
+
+export function getCache<T>(cache: Map<string, CacheEntry<T>>, key: string): T | undefined {
+  const entry = cache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key);
+    return undefined;
+  }
+  return entry.value;
+}
+
+export function setCache<T>(cache: Map<string, CacheEntry<T>>, key: string, value: T, ttlMs: number) {
+  cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "isomorphic-dompurify": "2.13.0",
         "katex": "^0.16.22",
         "lucide-react": "0.441.0",
+        "maplibre-gl": "^5.7.3",
         "marked": "12.0.2",
         "mathjs": "^14.7.0",
         "next": "14.2.4",
@@ -400,6 +401,112 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "license": "ISC",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.1.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.1.1.tgz",
+      "integrity": "sha512-xErR4lvMdzPNTxmglGEhSZxeyG55OusHjGhcPSrdZUnskBMPliVBQBxuzevmkQkb8gnl/UGDCYR+Byy3rkAgYQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.0.3.tgz",
+      "integrity": "sha512-YsW99BwnT+ukJRkseBcLuZHfITB4puJoxnqPVjo72rhW/TaawVYsgQHcqWLzTxqknttYoDpgyERzWSa/XrETdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@types/geojson-vt": "3.2.5",
+        "@types/supercluster": "^7.1.3",
+        "geojson-vt": "^4.0.2",
+        "pbf": "^4.0.1",
+        "supercluster": "^8.0.1"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -898,6 +1005,21 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "license": "MIT",
@@ -968,6 +1090,15 @@
     "node_modules/@types/scheduler": {
       "version": "0.26.0",
       "license": "MIT"
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -2323,6 +2454,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3681,6 +3818,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
+      "license": "ISC"
+    },
     "node_modules/get-func-name": {
       "version": "2.0.2",
       "dev": true,
@@ -3759,6 +3902,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.3.10",
@@ -4851,6 +5000,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "1.0.2",
       "dev": true,
@@ -4889,6 +5044,12 @@
       "bin": {
         "katex": "cli.js"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -5029,6 +5190,43 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/maplibre-gl": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.7.3.tgz",
+      "integrity": "sha512-T6XsjwcSfOr0vtAt4GTzx4m/vD6nrbR0+61MgMzZ9REQwILSEnhqwNpFuFbDedX6LC3ZWjZWnxN7fN/I66WoDQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.7",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.1.1",
+        "@maplibre/vt-pbf": "^4.0.3",
+        "@types/geojson": "^7946.0.16",
+        "@types/geojson-vt": "3.2.5",
+        "@types/supercluster": "^7.1.3",
+        "earcut": "^3.0.2",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
     "node_modules/markdown-table": {
@@ -5945,7 +6143,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5992,6 +6189,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "license": "MIT"
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -6751,6 +6954,18 @@
         "node": "*"
       }
     },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/pdf-lib": {
       "version": "1.17.1",
       "license": "MIT",
@@ -6961,6 +7176,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/preact": {
       "version": "10.27.2",
       "license": "MIT",
@@ -7009,6 +7230,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "license": "MIT",
@@ -7048,6 +7275,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/react": {
       "version": "18.2.0",
@@ -7289,6 +7522,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/reusify": {
@@ -7692,6 +7934,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -8294,6 +8542,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -8524,6 +8781,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyspy": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "isomorphic-dompurify": "2.13.0",
     "katex": "^0.16.22",
     "lucide-react": "0.441.0",
+    "maplibre-gl": "^5.7.3",
     "marked": "12.0.2",
     "mathjs": "^14.7.0",
     "next": "14.2.4",


### PR DESCRIPTION
## Summary
- gate a new Directory navigation entry behind FEATURE_DIRECTORY and remove the legacy Chat tab
- add the /directory route with list, map, sheet, and filtering components for the nearby care experience
- implement directory API endpoints backed by OpenStreetMap with simple caching and ranking utilities
- bring in maplibre-gl plus client hooks to support responsive layouts and debounced search

## Testing
- npx tsc --noEmit *(fails: repository contains placeholder test content that breaks type-checking)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c1683f20832f963ffdd9d7d07e32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds a feature-flagged Directory to find nearby doctors, pharmacies, and labs with search, filters, debounced queries, and OSM attribution.
  - Rich results: ratings, distance, open status, price, quick actions (Call, Directions, WhatsApp, Book) and a place detail bottom sheet.
  - Interactive map with markers, user location, synchronized list selection, and a Directory tab when enabled.
  - Ability to flag/report a place.
- **Chores**
  - Added MapLibre runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->