### PR TITLE
Improve timeline observation metadata and deletion

### DIFF
--- a/app/api/observations/[id]/route.ts
+++ b/app/api/observations/[id]/route.ts
@@ -1,0 +1,50 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { getUserId } from "@/lib/getUserId";
+
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const userId = await getUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const id = params?.id;
+  if (!id) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const sb = supabaseAdmin();
+  const { data, error } = await sb
+    .from("observations")
+    .select("id, user_id, meta")
+    .eq("id", id)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (error || !data) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  const meta = (data as any)?.meta ?? {};
+  const bucket = meta?.bucket ?? meta?.file_bucket ?? null;
+  const path = meta?.storage_path ?? meta?.file_path ?? meta?.path ?? null;
+
+  if (bucket && path) {
+    try {
+      await sb.storage.from(bucket).remove([path]);
+    } catch (err) {
+      console.warn("[observations/delete] storage cleanup failed", err);
+    }
+  }
+
+  const { error: delError } = await sb
+    .from("observations")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", userId);
+
+  if (delError) {
+    return NextResponse.json({ error: "Delete failed" }, { status: 500 });
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/app/api/observations/bulk/route.ts
+++ b/app/api/observations/bulk/route.ts
@@ -9,34 +9,53 @@ type InObs = {
   value_num?: number | null;
   value_text?: string | null;
   unit?: string | null;
-  observed_at?: string | null;   // ISO
+  observed_at?: string | null; // ISO
   thread_id?: string | null;
-  meta?: any;                    // jsonb
+  meta?: any; // jsonb
 };
 
 export async function POST(req: NextRequest) {
   const userId = await getUserId();
   if (!userId) return new NextResponse("Unauthorized", { status: 401 });
 
-  const { items } = await req.json().catch(() => ({ items: [] as InObs[] }));
-  if (!Array.isArray(items) || items.length === 0) {
-    return NextResponse.json({ error: "items[] required" }, { status: 400 });
+  const payload = await req.json().catch(() => ({}));
+  const list: InObs[] = Array.isArray(payload?.observations)
+    ? payload.observations
+    : Array.isArray(payload?.items)
+    ? payload.items
+    : [];
+
+  if (!Array.isArray(list) || list.length === 0) {
+    return NextResponse.json({ error: "observations[] required" }, { status: 400 });
   }
 
   const now = new Date().toISOString();
-  const rows = items.map((x) => ({
-    user_id: userId,
-    kind: x.kind.toLowerCase(),
-    value_num: x.value_num ?? null,
-    value_text: x.value_text ?? null,
-    unit: x.unit ?? null,
-    observed_at: x.observed_at ?? now,
-    thread_id: x.thread_id ?? null,
-    meta: x.meta ?? null,
-  }));
+  const rows = list.map(x => {
+    const name = String(x?.value_text ?? x?.kind ?? "Observation");
+    const hasNumericValue = x?.unit && x?.value_num != null;
+    const simple = hasNumericValue ? `${name} — ${x.value_num} ${x.unit}` : name;
+    const meta = { ...(x?.meta ?? {}) };
+    if (!meta.summary) meta.summary = simple;
+    if (!meta.text) meta.text = simple;
+    meta.source = meta.source ?? "bulk";
 
-  const { error, count } = await supabaseAdmin().from("observations").insert(rows, { count: "exact" });
+    return {
+      user_id: userId,
+      kind: typeof x?.kind === "string" ? x.kind.toLowerCase() : "observation",
+      value_num: x?.value_num ?? null,
+      value_text: x?.value_text ?? null,
+      unit: x?.unit ?? null,
+      observed_at: x?.observed_at ?? now,
+      thread_id: x?.thread_id ?? null,
+      meta,
+    };
+  });
+
+  const { data, error } = await supabaseAdmin()
+    .from("observations")
+    .insert(rows)
+    .select();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  return NextResponse.json({ ok: true, inserted: count ?? rows.length });
+  return NextResponse.json({ ok: true, observations: data ?? [] });
 }

--- a/app/api/observations/latest/route.ts
+++ b/app/api/observations/latest/route.ts
@@ -1,0 +1,36 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+import { NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase/admin";
+import { getUserId } from "@/lib/getUserId";
+
+export async function GET(req: Request) {
+  const userId = await getUserId();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const url = new URL(req.url);
+  const manualKind = url.searchParams.get("manualKind")?.trim();
+  if (!manualKind) {
+    return NextResponse.json({ error: "manualKind required" }, { status: 400 });
+  }
+
+  const sb = supabaseAdmin();
+  const { data, error } = await sb
+    .from("observations")
+    .select(
+      "id, kind, value_text, value_num, unit, observed_at, meta, file_path, file_bucket, upload_id",
+    )
+    .eq("user_id", userId)
+    .eq("kind", "note")
+    .filter("meta->>manualKind", "eq", manualKind)
+    .order("observed_at", { ascending: false, nullsFirst: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data ?? null);
+}

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -90,6 +90,27 @@ export default function Timeline(){
   const summaryShort = active?.meta?.summary;
   const text = active?.meta?.text;
   const hasFile = Boolean(active?.file?.path || active?.file?.upload_id);
+  const hasAiSummary = Boolean(summaryLong || summaryShort || text);
+  const isMed = (active?.kind ?? "").toLowerCase() === "medication";
+  const medName = active?.meta?.normalizedName || active?.value_text;
+  const titleFallback =
+    active?.meta?.title ||
+    active?.name ||
+    active?.meta?.file_name ||
+    active?.value_text ||
+    active?.kind ||
+    "Observation";
+  const niceTitle = isMed ? medName || "Medication" : titleFallback;
+  const dose =
+    active?.meta?.doseLabel ||
+    (active?.value_num != null
+      ? `${active.value_num}${active.unit ? ` ${active.unit}` : ""}`
+      : null);
+  const observed = active?.observed_at
+    ? new Date(active.observed_at).toLocaleString()
+    : null;
+  const source = active?.meta?.source;
+  const hasFallbackFacts = Boolean(dose || observed || source || (active?.unit && !dose));
 
   async function handleDelete(ob: { id: string }) {
     if (typeof window !== "undefined") {
@@ -152,16 +173,22 @@ export default function Timeline(){
         <input placeholder="Search…" value={q} onChange={e=>setQ(e.target.value)} className="ml-auto text-xs border rounded-md px-2 py-1 min-w-[160px]"/>
       </div>
       <ul className="space-y-2 text-sm">
-        {filtered.map((it:any)=>(
-          <li key={`${it.kind}:${it.id}`} className="rounded-xl p-3 cursor-pointer medx-surface text-medx"
-              onClick={()=>{ if (it.kind==="observation") { setActive(it); setOpen(true); }}}>
+        {filtered.map((it:any)=>{
+          const itemKind = (it?.kind ?? "").toLowerCase();
+          const isObservationItem = itemKind === "observation";
+          const isMedicationItem = itemKind === "medication";
+          const cardTitle = isMedicationItem && it.meta?.normalizedName ? it.meta.normalizedName : it.name;
+          const cardDose = it.meta?.doseLabel || (it.value != null ? `${String(it.value)}${it.unit ? ` ${it.unit}` : ""}` : null);
+          return (
+            <li key={`${it.kind}:${it.id}`} className="rounded-xl p-3 cursor-pointer medx-surface text-medx"
+              onClick={()=>{ if (isObservationItem || isMedicationItem) { setActive(it); setOpen(true); }}}>
             <div className="flex items-center justify-between text-xs text-muted-foreground gap-2">
               <div>
                 <span className="font-medium">Test date:</span> {new Date(it.observed_at).toLocaleString()}
                 {it.uploaded_at && <> · <span className="font-medium">Uploaded:</span> {new Date(it.uploaded_at).toLocaleString()}</>}
               </div>
               <div className="flex items-center gap-1">
-                {it.kind === "observation" && (
+                {(isObservationItem || isMedicationItem) && (
                   <button
                     className="shrink-0 p-2 rounded-md hover:bg-slate-100 dark:hover:bg-gray-800"
                     aria-label="Delete observation"
@@ -172,21 +199,31 @@ export default function Timeline(){
                     <Trash2 size={16} />
                   </button>
                 )}
-                <span className="text-[10px] px-2 py-0.5 rounded-full bg-muted">{it.kind==="prediction"?"AI":"Obs"}</span>
+                <span className="text-[10px] px-2 py-0.5 rounded-full bg-muted">
+                  {itemKind === "prediction" ? "AI" : itemKind === "medication" ? "Med" : "Obs"}
+                </span>
               </div>
             </div>
             <div className="mt-1 font-medium">
-              {it.name}
-              {it.kind==="prediction" && typeof it.probability==="number" && <> — {(it.probability*100).toFixed(0)}%</>}
-              {it.kind==="observation" && it.value!=null && <> — {String(it.value)}{it.unit?` ${it.unit}`:""}</>}
+              {cardTitle}
+              {itemKind==="prediction" && typeof it.probability==="number" && <> — {(it.probability*100).toFixed(0)}%</>}
+              {isObservationItem && it.value!=null && <> — {String(it.value)}{it.unit?` ${it.unit}`:""}</>}
             </div>
+            {isMedicationItem && (cardDose || it.observed_at) && (
+              <div className="mt-0.5 text-xs text-muted-foreground">
+                {cardDose && <span>{cardDose}</span>}
+                {cardDose && it.observed_at && <span> • </span>}
+                {it.observed_at && <span>{new Date(it.observed_at).toLocaleString()}</span>}
+              </div>
+            )}
             {it.meta?.summary && (
               <div className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
                 {it.meta.summary}
               </div>
             )}
-          </li>
-        ))}
+            </li>
+          );
+        })}
       </ul>
 
       {open && active && (
@@ -194,7 +231,12 @@ export default function Timeline(){
           <div className="fixed inset-0 bg-black/40 z-40" onClick={() => setOpen(false)} />
           <aside className="fixed right-0 top-0 bottom-0 z-50 w-full sm:w-[640px] bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 shadow-2xl ring-1 ring-black/5 overflow-y-auto">
             <header className="sticky top-0 bg-white/90 dark:bg-zinc-900/90 backdrop-blur border-b border-zinc-200/70 dark:border-zinc-800/70 px-4 py-3 flex items-center gap-2">
-              <h3 className="font-semibold truncate">{active.name || active.meta?.file_name || "Observation"}</h3>
+              <h3 className="font-semibold truncate flex items-center gap-2">
+                <span>{niceTitle}</span>
+                <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs">
+                  {isMed ? "Med" : (active?.kind || "Obs")}
+                </span>
+              </h3>
               <div className="ml-auto flex gap-2">
                 {(active.file?.path || active.file?.upload_id) && signedUrl && (
                   <button onClick={() => window.open(signedUrl, '_blank')} className="text-xs px-2 py-1 rounded-md border">Open</button>
@@ -202,7 +244,7 @@ export default function Timeline(){
                 {(active.file?.path || active.file?.upload_id) && signedUrl && (
                   <a href={signedUrl} download className="text-xs px-2 py-1 rounded-md border">Download</a>
                 )}
-                {!(active.file?.path || active.file?.upload_id) && (
+                {!hasFile && hasAiSummary && (
                   <a href={`/api/observations/${active.id}/export`} className="text-xs px-2 py-1 rounded-md border">Download Summary</a>
                 )}
                 {active.kind === "observation" && (
@@ -255,19 +297,44 @@ export default function Timeline(){
                     </Tabs>
                   ) : null}
                   {!hasFile && !summaryLong && !summaryShort && !text && (
-                    <div className="text-sm leading-6 space-y-1">
-                      <div><b>Name:</b> {active?.name ?? active?.kind ?? "Observation"}</div>
-                      {"value_num" in (active ?? {}) && active?.value_num != null && (
-                        <div><b>Value:</b> {String(active.value_num)}{active.unit ? ` ${active.unit}` : ""}</div>
+                    <div className="space-y-3 text-sm">
+                      {isMed && medName && (
+                        <div className="text-base font-medium">{medName}</div>
                       )}
-                      {!!active?.value_text && (<div><b>Text:</b> {active.value_text}</div>)}
-                      {!!active?.observed_at && (
-                        <div><b>Observed:</b> {new Date(active.observed_at).toLocaleString()}</div>
+
+                      {hasFallbackFacts && (
+                        <div className="grid grid-cols-2 gap-2">
+                          {dose && (
+                            <div className="rounded-md border px-2 py-1">
+                              <div className="text-[11px] uppercase opacity-70">Dose</div>
+                              <div>{dose}</div>
+                            </div>
+                          )}
+                          {observed && (
+                            <div className="rounded-md border px-2 py-1">
+                              <div className="text-[11px] uppercase opacity-70">Observed</div>
+                              <div>{observed}</div>
+                            </div>
+                          )}
+                          {source && (
+                            <div className="rounded-md border px-2 py-1">
+                              <div className="text-[11px] uppercase opacity-70">Source</div>
+                              <div className="capitalize">{String(source)}</div>
+                            </div>
+                          )}
+                          {active?.unit && !dose && (
+                            <div className="rounded-md border px-2 py-1">
+                              <div className="text-[11px] uppercase opacity-70">Unit</div>
+                              <div>{active.unit}</div>
+                            </div>
+                          )}
+                        </div>
                       )}
-                      {!!active?.meta && Object.keys(active.meta).length > 0 && (
-                        <pre className="mt-2 whitespace-pre-wrap break-words text-xs text-muted-foreground">
-                          {JSON.stringify(active.meta, null, 2)}
-                        </pre>
+
+                      {active?.value_text && (
+                        <div className="rounded-md border px-3 py-2">
+                          {active.value_text}
+                        </div>
                       )}
                     </div>
                   )}

--- a/lib/profile/extractManualObservation.ts
+++ b/lib/profile/extractManualObservation.ts
@@ -1,0 +1,23 @@
+export type ManualOb = { text: string; observedAt: string | null; raw?: any };
+
+export async function extractManualObservation(manualKind: string): Promise<ManualOb> {
+  const res = await fetch(
+    `/api/observations/latest?manualKind=${encodeURIComponent(manualKind)}`,
+    { cache: "no-store" },
+  );
+
+  if (!res.ok) {
+    return { text: "", observedAt: null };
+  }
+
+  const ob = await res.json().catch(() => null);
+  if (!ob) {
+    return { text: "", observedAt: null };
+  }
+
+  const meta = (ob as any)?.meta ?? {};
+  const text = meta?.summary || meta?.text || ob?.value_text || "";
+  const observedAt = typeof ob?.observed_at === "string" ? ob.observed_at : null;
+
+  return { text, observedAt, raw: ob };
+}


### PR DESCRIPTION
## Summary
- save vital, medication, and manual note observations through the bulk API with summary/text metadata so timeline drawers have readable fallbacks
- add optimistic delete controls for timeline observation cards and drawers backed by a new DELETE /api/observations/[id] endpoint
- harden the bulk observations route to auto-populate summary/text metadata for future clients

## Testing
- npm run lint *(blocked by Next.js interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ced1e3d4832fb210c8dbc93bf4b3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Delete observations directly from Timeline with confirmation and toasts.
  - Bulk add observations (e.g., medications, notes) with richer summaries.
  - Auto-load latest manual notes/next steps for profiles.
  - Timeline detail panel adds tabbed Summary/Full Text view and per-item Delete.
  - Open/Download files from observation details; download summaries when no file.

- Improvements
  - Clearer titles, chip labels, and summaries across observation types.
  - More informative medication doses and derived labels.
  - More consistent observation values and metadata.

- Bug Fixes
  - Safer handling of missing/invalid data and network errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->