### PR TITLE
Improve mobile trials card contrast

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -929,3 +929,90 @@ body {
     width: 100%;
   }
 }
+
+/* Defaults (light) */
+@media (max-width: 480px) {
+  .result-card {
+    --card-bg: #ffffff;
+    --card-fg: #0f172a;               /* slate-900 */
+    --card-border: rgba(2, 6, 23, 0.08);
+  }
+
+  .result-card .meta {
+    color: rgba(15, 23, 42, 0.72);
+  }
+
+  .result-card .chip {
+    background: rgba(15, 23, 42, 0.06);
+    color: var(--card-fg);
+    border-color: rgba(15, 23, 42, 0.14);
+  }
+
+  .result-card .btn {
+    background: rgba(15, 23, 42, 0.04);
+    color: var(--card-fg);
+    border-color: rgba(15, 23, 42, 0.12);
+  }
+
+  .result-card .btn:hover {
+    background: rgba(15, 23, 42, 0.08);
+  }
+
+  /* High contrast when Clinical+Research ON in Light mode */
+  .results-list[data-mobile-contrast="on"] .result-card {
+    --card-bg: #1e40af;               /* blue-800 */
+    --card-fg: #ffffff;
+    --card-border: rgba(255, 255, 255, 0.28);
+  }
+
+  .results-list[data-mobile-contrast="on"] .result-card h3 {
+    color: #fff;
+    font-weight: 700;
+    opacity: 0.98;
+  }
+
+  .results-list[data-mobile-contrast="on"] .result-card .meta {
+    color: rgba(255, 255, 255, 0.88);
+  }
+
+  .results-list[data-mobile-contrast="on"] .result-card .chip {
+    background: rgba(255, 255, 255, 0.16);
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.28);
+  }
+
+  .results-list[data-mobile-contrast="on"] .result-card .btn {
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.28);
+  }
+
+  .results-list[data-mobile-contrast="on"] .result-card .btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+  }
+}
+
+/* Dark mode unchanged */
+@media (prefers-color-scheme: dark) and (max-width: 480px) {
+  .result-card {
+    --card-bg: #0b1220;
+    --card-fg: #e5e7eb;
+    --card-border: rgba(255, 255, 255, 0.06);
+  }
+
+  .result-card .chip {
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--card-fg);
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .result-card .btn {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--card-fg);
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .result-card .btn:hover {
+    background: rgba(255, 255, 255, 0.16);
+  }
+}

--- a/components/TrialsRow.tsx
+++ b/components/TrialsRow.tsx
@@ -67,6 +67,47 @@ export function TrialsRow({
   );
 }
 
+export type TrialsMobileCardProps = {
+  title: string;
+  statusLine: string;
+  registryLine: string;
+  recruitingLabel: string;
+  onCopy: () => void;
+  onSummarize: () => void;
+};
+
+export function TrialsMobileCard({
+  title,
+  statusLine,
+  registryLine,
+  recruitingLabel,
+  onCopy,
+  onSummarize,
+}: TrialsMobileCardProps) {
+  return (
+    <div
+      className="
+        result-card
+        rounded-xl border transition p-4
+        bg-[var(--card-bg)] text-[var(--card-fg)] border-[var(--card-border)]
+      "
+    >
+      <h3 className="text-[15px] font-semibold leading-5 break-words hyphens-auto">{title}</h3>
+      <p className="meta mt-1 text-[12.5px] opacity-80">{statusLine}</p>
+      <p className="meta text-[11px] opacity-70">{registryLine}</p>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        <span className="chip chip-sm">Recruiting: {recruitingLabel}</span>
+        <button type="button" className="btn chip-sm" onClick={onCopy}>
+          Copy
+        </button>
+        <button type="button" className="btn chip-sm" onClick={onSummarize}>
+          Summarize
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function formatTrialBriefMarkdown(nctId: string, brief: any) {
   const bullets = (brief.bullets ?? []).slice(0, 3).map((b: string) => `- ${b}`).join("\n");
   const cite = (brief.citations ?? [])


### PR DESCRIPTION
## Summary
- add a responsive mobile wrapper in `TrialsResults` that toggles high-contrast styling when clinical research mode is active in light theme
- introduce a reusable `TrialsMobileCard` that applies CSS variables for card colors and shared button/chip styles
- define mobile-only CSS tokens and high-contrast overrides so cards remain legible without affecting desktop or dark mode

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7f2806fa4832f9dfb14a4400f1802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Mobile-friendly trial results with compact cards on small screens, showing status, registry, and recruiting info.
  * Quick actions on mobile cards: Copy and Summarize.
  * Automatic high-contrast variant on mobile when applicable for improved readability, aligned with theme/mode.

* Style
  * Responsive styles for result cards at small widths, including light/dark themes and hover states.
  * High-contrast styling option with adjusted colors and typography for better legibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->