### PR TITLE
Remove AI Doc options from sidebar

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,7 +10,6 @@ import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 export default function Sidebar() {
   const router = useRouter();
   const [threads, setThreads] = useState<Thread[]>([]);
-  const [aidocThreads, setAidocThreads] = useState<{ id: string; title: string | null }[]>([]);
   const [q, setQ] = useState("");
   const closeSidebar = useMobileUiStore((state) => state.closeSidebar);
 
@@ -24,11 +23,6 @@ export default function Sidebar() {
       window.removeEventListener("chat-threads-updated", load);
     };
   }, []);
-
-  useEffect(() => {
-    fetch("/api/aidoc/threads").then((r) => r.json()).then(setAidocThreads).catch(() => {});
-  }, []);
-
   const handleNewChat = () => {
     const id = createNewThreadId();
     closeSidebar();
@@ -94,29 +88,6 @@ export default function Sidebar() {
             </div>
           </div>
         ))}
-
-        {aidocThreads.length > 0 && (
-          <div className="mt-4">
-            <div className="mb-1 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">AI Doc</div>
-            {aidocThreads.map((t) => (
-              <div
-                key={t.id}
-                className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white/60 p-2 shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
-              >
-                <button
-                  onClick={() => {
-                    closeSidebar();
-                    router.push(`/?panel=ai-doc&threadId=${t.id}`);
-                  }}
-                  className="truncate text-left text-sm font-medium"
-                  title={t.title ?? ""}
-                >
-                  {t.title ?? "AI Doc — Case"}
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
       </div>
 
       <div className="mt-auto">

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -12,7 +12,6 @@ type Tab = {
 
 const tabs: Tab[] = [
   { key: "directory", label: "Directory", panel: "directory" },
-  { key: "ai-doc", label: "AI Doc", panel: "ai-doc" },
   { key: "profile", label: "Medical Profile", panel: "profile" },
   { key: "timeline", label: "Timeline", panel: "timeline" },
   { key: "alerts", label: "Alerts", panel: "alerts" },


### PR DESCRIPTION
## Summary
- remove the AI Doc tab from the sidebar navigation list
- stop loading and rendering AI Doc threads in the sidebar panel

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8035c3890832fb5fc876d4ab96a41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed the AI Doc tab and its content from the Sidebar.
  - Sidebar tabs updated to: Directory, Profile, Timeline, Alerts, Settings.
  - Eliminated AI Doc list rendering and related data loading to streamline the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->