### PR TITLE
Refine medical profile mobile styling

### DIFF
--- a/components/meds/MedicationInput.tsx
+++ b/components/meds/MedicationInput.tsx
@@ -18,9 +18,14 @@ type SuggestionResult = {
 export type MedicationInputProps = {
   onSave: (med: { name: string; dose?: string | null; rxnormId?: string | null }) => Promise<void> | void;
   placeholder?: string;
+  autoFocus?: boolean;
 };
 
-export default function MedicationInput({ onSave, placeholder = "Add a medication" }: MedicationInputProps) {
+export default function MedicationInput({
+  onSave,
+  placeholder = "Add a medication",
+  autoFocus = false,
+}: MedicationInputProps) {
   const { country } = useCountry();
   const [query, setQuery] = useState("");
   const [lockedName, setLockedName] = useState<string | null>(null);
@@ -151,10 +156,10 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
     <div className="space-y-3">
       <div className="flex flex-col gap-3">
         <div className="flex-1">
-          <label className="flex flex-col gap-1 text-sm">
+          <label className="flex flex-col gap-1.5 text-[13px]">
             <span className="text-xs font-medium text-muted-foreground">Medication name</span>
             <input
-              className="rounded-md border px-3 py-2"
+              className="h-10 w-full rounded-[10px] border border-border/70 bg-background px-3 text-[13px] leading-tight shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
               placeholder={placeholder}
               value={lockedName ?? query}
               onChange={e => {
@@ -164,6 +169,7 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
                 setQuery(e.target.value);
                 setError(null);
               }}
+              autoFocus={autoFocus}
               onKeyDown={event => {
                 if (!listOpen || displaySuggestions.length === 0) {
                   if (event.key === "Enter" && showSave) {
@@ -203,16 +209,18 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
               Searching suggestions…
             </p>
           ) : null}
-          {error ? <p className="mt-1 text-xs text-destructive">{error}</p> : null}
+          {error ? <p className="mt-1 text-[11px] text-destructive">{error}</p> : null}
           {!loading && listOpen && displaySuggestions.length > 0 ? (
-            <div className="mt-2 space-y-1 text-xs">
+            <div className="mt-2 space-y-1 text-[12px]">
               <p className="font-medium text-muted-foreground">Did you mean…</p>
-              <ul className="flex flex-wrap gap-1">
+              <ul className="flex flex-wrap gap-1.5">
                 {displaySuggestions.map((s, index) => (
                   <li key={`${s.rxnormId || s.name}`}>
                     <button
                       type="button"
-                      className={`rounded-full border px-3 py-1 hover:bg-muted ${highlightIndex === index ? "bg-muted" : ""}`}
+                      className={`inline-flex h-6 items-center rounded-full border border-border/70 px-3 text-[11px] font-medium transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 ${
+                        highlightIndex === index ? "bg-muted/70" : ""
+                      }`}
                       onMouseEnter={() => setHighlightIndex(index)}
                       onClick={() => selectSuggestion(s)}
                     >
@@ -228,10 +236,10 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
           ) : null}
         </div>
         {shouldShowDoseInput ? (
-          <label className="flex flex-col gap-1 text-sm">
+          <label className="flex flex-col gap-1.5 text-[13px]">
             <span className="text-xs font-medium text-muted-foreground">Dose (enter 0 if not applicable)</span>
             <input
-              className="rounded-md border px-3 py-2"
+              className="h-10 rounded-[10px] border border-border/70 bg-background px-3 text-[13px] leading-tight shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
               placeholder="e.g. 500 mg or 0"
               value={dose}
               onChange={e => setDose(e.target.value)}
@@ -241,7 +249,7 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
         {showSave ? (
           <button
             type="button"
-            className="inline-flex items-center justify-center self-start rounded-md border bg-primary px-3 py-2 text-sm text-primary-foreground shadow disabled:opacity-60"
+            className="inline-flex h-9 items-center justify-center self-start rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
             onClick={handleSave}
             disabled={loading || !showSave}
           >
@@ -250,7 +258,7 @@ export default function MedicationInput({ onSave, placeholder = "Add a medicatio
         ) : null}
       </div>
       {needsDose && !trimmedDose ? (
-        <p className="text-xs text-muted-foreground">Add a dose (enter 0 if not applicable) before saving.</p>
+        <p className="text-[11px] text-muted-foreground">Add a dose (enter 0 if not applicable) before saving.</p>
       ) : null}
     </div>
   );

--- a/components/meds/MedicationInput.tsx
+++ b/components/meds/MedicationInput.tsx
@@ -153,8 +153,8 @@ export default function MedicationInput({
   };
 
   return (
-    <div className="space-y-3">
-      <div className="flex flex-col gap-3">
+    <div className="space-y-2.5 md:space-y-3">
+      <div className="flex flex-col gap-2.5 md:gap-3">
         <div className="flex-1">
           <label className="flex flex-col gap-1.5 text-[13px]">
             <span className="text-xs font-medium text-muted-foreground">Medication name</span>
@@ -218,7 +218,7 @@ export default function MedicationInput({
                   <li key={`${s.rxnormId || s.name}`}>
                     <button
                       type="button"
-                      className={`inline-flex h-6 items-center rounded-full border border-border/70 px-3 text-[11px] font-medium transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 ${
+                      className={`inline-flex h-6 items-center rounded-full border border-border/70 px-2.5 text-[11px] font-medium transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 ${
                         highlightIndex === index ? "bg-muted/70" : ""
                       }`}
                       onMouseEnter={() => setHighlightIndex(index)}
@@ -249,7 +249,7 @@ export default function MedicationInput({
         {showSave ? (
           <button
             type="button"
-            className="inline-flex h-9 items-center justify-center self-start rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex h-9 items-center justify-center self-start rounded-[10px] border border-primary/70 bg-primary px-2.5 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60 md:px-3"
             onClick={handleSave}
             disabled={loading || !showSave}
           >

--- a/components/meds/MedicationTag.tsx
+++ b/components/meds/MedicationTag.tsx
@@ -11,7 +11,7 @@ export type MedicationTagProps = {
 
 export default function MedicationTag({ label, onRemove, disabled = false }: MedicationTagProps) {
   return (
-    <span className="inline-flex h-6 items-center gap-1.5 rounded-full border border-border/70 bg-muted/60 px-3 text-[11px] font-medium text-foreground/90 dark:border-border/40 dark:bg-muted/30">
+    <span className="inline-flex h-6 items-center gap-1.5 rounded-full border border-border/70 bg-muted/60 px-2.5 text-[11px] font-medium text-foreground/90 dark:border-border/40 dark:bg-muted/30">
       <span className="max-w-[10rem] truncate" title={typeof label === "string" ? label : undefined}>
         {label}
       </span>

--- a/components/meds/MedicationTag.tsx
+++ b/components/meds/MedicationTag.tsx
@@ -11,19 +11,19 @@ export type MedicationTagProps = {
 
 export default function MedicationTag({ label, onRemove, disabled = false }: MedicationTagProps) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-full border border-border bg-muted/50 px-3 py-1 text-sm text-foreground">
+    <span className="inline-flex h-6 items-center gap-1.5 rounded-full border border-border/70 bg-muted/60 px-3 text-[11px] font-medium text-foreground/90 dark:border-border/40 dark:bg-muted/30">
       <span className="max-w-[10rem] truncate" title={typeof label === "string" ? label : undefined}>
         {label}
       </span>
       {onRemove ? (
         <button
           type="button"
-          className="ml-1 flex h-8 w-8 items-center justify-center rounded-full transition hover:bg-muted"
+          className="ml-1 flex h-6 w-6 items-center justify-center rounded-full transition hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
           onClick={onRemove}
           disabled={disabled}
           aria-label="Remove medication"
         >
-          <X className="h-4 w-4" aria-hidden="true" />
+          <X className="h-3.5 w-3.5" aria-hidden="true" />
         </button>
       ) : null}
     </span>

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -749,23 +749,23 @@ export default function MedicalProfile() {
       <ProfileSection
         title="Personal details"
         actions={
-          <div className="flex w-full flex-wrap gap-2 sm:w-auto sm:justify-end">
+          <>
             <button
               type="button"
-              className="inline-flex h-9 w-full items-center justify-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground transition hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:w-auto dark:border-border/40"
+              className="inline-flex h-9 items-center justify-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
               onClick={() => router.push("/?panel=chat&threadId=med-profile&context=profile")}
             >
               Open in chat
             </button>
             <button
               type="button"
-              className="inline-flex h-9 w-full items-center justify-center rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+              className="inline-flex h-9 items-center justify-center rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground whitespace-nowrap shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
               onClick={handleProfileSave}
               disabled={savingProfile}
             >
               {savingProfile ? "Saving…" : "Save profile"}
             </button>
-          </div>
+          </>
         }
       >
         <div className="space-y-3 text-[13px]">
@@ -796,7 +796,7 @@ export default function MedicalProfile() {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 gap-3 min-[420px]:grid-cols-2">
+          <div className="grid grid-cols-1 gap-3 min-[380px]:grid-cols-2">
             <label className="flex flex-col gap-1.5">
               <span className="text-xs font-medium text-muted-foreground">Name</span>
               <input
@@ -986,7 +986,7 @@ export default function MedicalProfile() {
             />
           ) : (
             <div className="space-y-2">
-              <dl className="grid grid-cols-1 gap-3 text-[13px] min-[420px]:grid-cols-2 xl:grid-cols-4">
+              <dl className="grid grid-cols-1 gap-3 text-[13px] min-[380px]:grid-cols-2 xl:grid-cols-4">
                 {vitalsDisplay.map(item => (
                   <div key={item.label} className="rounded-[10px] border border-border/60 bg-muted/40 p-3 dark:border-border/30 dark:bg-muted/20">
                     <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{item.label}</dt>
@@ -1006,23 +1006,23 @@ export default function MedicalProfile() {
         <ProfileSection
           title="AI Summary"
           actions={
-            <div className="flex w-full flex-wrap gap-2 sm:w-auto sm:justify-end">
+            <>
               <button
                 type="button"
-                className="inline-flex h-9 w-full items-center justify-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground transition hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 sm:w-auto dark:border-border/40"
+                className="inline-flex h-9 items-center justify-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
                 onClick={() => router.push("/?panel=chat&threadId=med-profile&context=profile")}
               >
                 Discuss in chat
               </button>
               <button
                 type="button"
-                className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+                className="inline-flex h-9 items-center justify-center gap-2 rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground whitespace-nowrap shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
                 onClick={onRecomputeRisk}
                 disabled={recomputeBusy}
               >
                 {recomputeBusy ? "Computing…" : "Recompute risk"}
               </button>
-            </div>
+            </>
           }
         >
           <div className="space-y-3 text-[13px]">
@@ -1275,15 +1275,13 @@ export default function MedicalProfile() {
         <ProfileSection
           title="Active Meds"
           actions={
-            <div className="flex w-full flex-wrap gap-2 sm:w-auto sm:justify-end">
-              <button
-                type="button"
-                className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
-                onClick={() => setShowMedicationComposer(open => !open)}
-              >
-                {showMedicationComposer || medications.length === 0 ? "Close" : "Add"}
-              </button>
-            </div>
+            <button
+              type="button"
+              className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+              onClick={() => setShowMedicationComposer(open => !open)}
+            >
+              {showMedicationComposer || medications.length === 0 ? "Close" : "Add"}
+            </button>
           }
         >
           <div className="space-y-3 text-[13px]">
@@ -1312,7 +1310,7 @@ export default function MedicalProfile() {
                       </div>
                       <button
                         type="button"
-                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 dark:border-border/40"
+                        className="inline-flex h-9 shrink-0 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 dark:border-border/40"
                         onClick={() => handleRemoveMedication(med)}
                       >
                         Remove

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -734,18 +734,37 @@ export default function MedicalProfile() {
     return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
   }, [fullName]);
 
-  if (isLoading) return <PanelLoader label="Medical Profile" />;
+  const mobileShellClass =
+    "mx-auto w-full max-w-[360px] space-y-2.5 p-3 md:mx-0 md:max-w-none md:space-y-4 md:p-6";
+
+  if (isLoading) {
+    return (
+      <div className={mobileShellClass}>
+        <PanelLoader label="Medical Profile" />
+      </div>
+    );
+  }
   if (error) {
     return (
-      <div className="p-6 text-sm text-red-500">Couldn’t load profile. Retrying in background…</div>
+      <div className={mobileShellClass}>
+        <div className="rounded-[12px] border border-border/70 bg-background/95 p-3 text-sm text-red-500 shadow-sm dark:border-border/40 dark:bg-background/60">
+          Couldn’t load profile. Retrying in background…
+        </div>
+      </div>
     );
   }
   if (!data) {
-    return <div className="p-6 text-sm text-muted-foreground">No profile yet.</div>;
+    return (
+      <div className={mobileShellClass}>
+        <div className="rounded-[12px] border border-border/70 bg-background/95 p-3 text-sm text-muted-foreground shadow-sm dark:border-border/40 dark:bg-background/60">
+          No profile yet.
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div className="space-y-2.5 p-3 md:space-y-4 md:p-6">
+    <div className={mobileShellClass}>
       <ProfileSection
         title="Personal details"
         actions={

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -1025,13 +1025,14 @@ export default function MedicalProfile() {
         <ProfileSection
           title="AI Summary"
           actions={
-            <>
+            <div className="flex w-full flex-wrap justify-start gap-1.5 sm:w-auto sm:justify-end sm:gap-2">
               <button
                 type="button"
                 className="inline-flex h-9 items-center justify-center rounded-[10px] border border-border/70 px-2.5 text-[13px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
                 onClick={() => router.push("/?panel=chat&threadId=med-profile&context=profile")}
               >
-                Discuss in chat
+                <span className="md:hidden">Chat</span>
+                <span className="hidden md:inline">Discuss in chat</span>
               </button>
               <button
                 type="button"
@@ -1039,9 +1040,11 @@ export default function MedicalProfile() {
                 onClick={onRecomputeRisk}
                 disabled={recomputeBusy}
               >
-                {recomputeBusy ? "Computing…" : "Recompute risk"}
+                <span className="md:hidden">{recomputeBusy ? "Computing" : "Recompute"}</span>
+                <span className="hidden md:inline">{recomputeBusy ? "Computing…" : "Recompute risk"}</span>
+                <span className="md:hidden">{recomputeBusy ? "…" : " risk"}</span>
               </button>
-            </>
+            </div>
           }
         >
           <div className="space-y-2.5 text-[13px] md:space-y-3">
@@ -1066,14 +1069,14 @@ export default function MedicalProfile() {
                 </button>
               ) : null}
             </div>
-            <div className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-amber-500/40 bg-amber-500/10 px-2.5 py-1 text-[11px] text-amber-700 dark:border-amber-400/40 dark:bg-amber-500/5 dark:text-amber-200 md:gap-2 md:px-3">
+            <div className="flex max-w-full flex-wrap items-center gap-1.5 rounded-full border border-amber-500/40 bg-amber-500/10 px-2.5 py-1 text-[11px] text-amber-700 dark:border-amber-400/40 dark:bg-amber-500/5 dark:text-amber-200 md:inline-flex md:gap-2 md:px-3">
               <span aria-hidden>⚠️</span>
               <span className="truncate">
                 This is AI-generated support, not a medical diagnosis. Always consult a clinician.
               </span>
             </div>
-            <div className="grid grid-cols-1 gap-2.5 lg:grid-cols-3">
-              <div className="space-y-1.5 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10 md:space-y-2">
+            <div className="grid grid-cols-1 gap-2.5 min-[420px]:grid-cols-2 lg:grid-cols-3">
+              <div className="min-w-0 space-y-1.5 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10 md:space-y-2">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Active Meds</h4>
                 {medications.length ? (
                   <div className="flex flex-wrap gap-1.5">
@@ -1115,7 +1118,7 @@ export default function MedicalProfile() {
                   </button>
                 )}
               </div>
-              <div className="space-y-1.5 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10 md:space-y-2">
+              <div className="min-w-0 space-y-1.5 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10 md:space-y-2">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Symptoms &amp; Notes</h4>
                 {displayedNotes && !notesEditing ? (
                   <p className="text-[13px] leading-relaxed text-foreground/90 whitespace-pre-wrap">{displayedNotes}</p>
@@ -1195,7 +1198,7 @@ export default function MedicalProfile() {
                   </button>
                 )}
               </div>
-              <div className="space-y-1.5 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10 md:space-y-2">
+              <div className="min-w-0 space-y-1.5 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10 md:space-y-2">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Next Steps</h4>
                 {displayedNextSteps && !nextStepsEditing ? (
                   <p className="text-[13px] leading-relaxed text-foreground/90 whitespace-pre-wrap">{displayedNextSteps}</p>

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -745,21 +745,21 @@ export default function MedicalProfile() {
   }
 
   return (
-    <div className="space-y-3 p-3 md:p-6">
+    <div className="space-y-2.5 p-3 md:space-y-4 md:p-6">
       <ProfileSection
         title="Personal details"
         actions={
           <>
             <button
               type="button"
-              className="inline-flex h-9 items-center justify-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+              className="inline-flex h-9 items-center justify-center rounded-[10px] border border-border/70 px-2.5 text-[13px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
               onClick={() => router.push("/?panel=chat&threadId=med-profile&context=profile")}
             >
               Open in chat
             </button>
             <button
               type="button"
-              className="inline-flex h-9 items-center justify-center rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground whitespace-nowrap shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex h-9 items-center justify-center rounded-[10px] border border-primary/70 bg-primary px-2.5 text-[13px] font-semibold text-primary-foreground whitespace-nowrap shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60 md:px-3"
               onClick={handleProfileSave}
               disabled={savingProfile}
             >
@@ -768,13 +768,13 @@ export default function MedicalProfile() {
           </>
         }
       >
-        <div className="space-y-3 text-[13px]">
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="flex h-12 w-12 items-center justify-center rounded-[12px] bg-muted text-base font-semibold text-foreground">
+        <div className="space-y-2.5 text-[13px] md:space-y-3">
+          <div className="flex flex-wrap items-center gap-2.5">
+            <div className="flex h-12 w-12 items-center justify-center rounded-[12px] bg-muted text-sm font-semibold text-foreground md:text-base">
               {initials}
             </div>
             <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-2">
+              <div className="flex flex-wrap items-center gap-1.5 md:gap-2">
                 <span
                   className={
                     fullName
@@ -785,18 +785,18 @@ export default function MedicalProfile() {
                   {fullName || "Add full name"}
                 </span>
                 {isVerified ? (
-                  <span className="inline-flex h-5 items-center rounded-full border border-emerald-500/60 bg-emerald-500/10 px-2 text-[11px] font-semibold uppercase tracking-wide text-emerald-700 dark:border-emerald-400/40 dark:text-emerald-200">
+                  <span className="inline-flex h-5 items-center rounded-full border border-emerald-500/60 bg-emerald-500/10 px-2 text-[10.5px] font-semibold uppercase tracking-wide text-emerald-700 dark:border-emerald-400/40 dark:text-emerald-200">
                     Verified
                   </span>
                 ) : null}
               </div>
-              <p className="mt-1 truncate text-xs text-muted-foreground">
+              <p className="mt-0.5 truncate text-xs text-muted-foreground">
                 {identityDetails || "Add demographic details"}
               </p>
             </div>
           </div>
 
-          <div className="grid grid-cols-1 gap-3 min-[380px]:grid-cols-2">
+          <div className="grid grid-cols-1 gap-2.5 min-[380px]:grid-cols-2">
             <label className="flex flex-col gap-1.5">
               <span className="text-xs font-medium text-muted-foreground">Name</span>
               <input
@@ -871,7 +871,7 @@ export default function MedicalProfile() {
             </label>
           </div>
 
-          <div className="grid grid-cols-1 gap-3">
+          <div className="grid grid-cols-1 gap-2.5">
             <label className="flex flex-col gap-1.5">
               <span className="text-xs font-medium text-muted-foreground">Predispositions</span>
               <input
@@ -897,7 +897,7 @@ export default function MedicalProfile() {
                   <button
                     key={c}
                     type="button"
-                    className="inline-flex h-6 items-center gap-1.5 rounded-full border border-border/70 px-3 text-[11px] font-medium text-foreground/90 transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+                    className="inline-flex h-6 items-center gap-1.5 rounded-full border border-border/70 px-2.5 text-[11px] font-medium text-foreground/90 transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
                     onClick={() => setPredis(predis.filter(x => x !== c))}
                   >
                     <span className="truncate">{c}</span>
@@ -926,7 +926,7 @@ export default function MedicalProfile() {
                   <button
                     key={c}
                     type="button"
-                    className="inline-flex h-6 items-center gap-1.5 rounded-full border border-border/70 px-3 text-[11px] font-medium text-foreground/90 transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+                    className="inline-flex h-6 items-center gap-1.5 rounded-full border border-border/70 px-2.5 text-[11px] font-medium text-foreground/90 transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
                     onClick={() => setChronic(chronic.filter(x => x !== c))}
                   >
                     <span className="truncate">{c}</span>
@@ -945,7 +945,7 @@ export default function MedicalProfile() {
           actions={
             <button
               type="button"
-              className="inline-flex h-9 items-center justify-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+              className="inline-flex h-9 items-center justify-center rounded-[10px] border border-border/70 px-2.5 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
               onClick={() => setEditingVitals(open => !open)}
             >
               {editingVitals ? "Close" : "Edit"}
@@ -1009,14 +1009,14 @@ export default function MedicalProfile() {
             <>
               <button
                 type="button"
-                className="inline-flex h-9 items-center justify-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+                className="inline-flex h-9 items-center justify-center rounded-[10px] border border-border/70 px-2.5 text-[13px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
                 onClick={() => router.push("/?panel=chat&threadId=med-profile&context=profile")}
               >
                 Discuss in chat
               </button>
               <button
                 type="button"
-                className="inline-flex h-9 items-center justify-center gap-2 rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground whitespace-nowrap shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
+                className="inline-flex h-9 items-center justify-center gap-2 rounded-[10px] border border-primary/70 bg-primary px-2.5 text-[13px] font-semibold text-primary-foreground whitespace-nowrap shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60 md:px-3"
                 onClick={onRecomputeRisk}
                 disabled={recomputeBusy}
               >
@@ -1025,8 +1025,8 @@ export default function MedicalProfile() {
             </>
           }
         >
-          <div className="space-y-3 text-[13px]">
-            <div className="space-y-2">
+          <div className="space-y-2.5 text-[13px] md:space-y-3">
+            <div className="space-y-1.5">
               <p
                 className="whitespace-pre-wrap text-[14px] leading-[1.6] text-foreground"
                 style={
@@ -1047,14 +1047,14 @@ export default function MedicalProfile() {
                 </button>
               ) : null}
             </div>
-            <div className="inline-flex max-w-full items-center gap-2 rounded-full border border-amber-500/40 bg-amber-500/10 px-3 py-1 text-[11px] text-amber-700 dark:border-amber-400/40 dark:bg-amber-500/5 dark:text-amber-200">
+            <div className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-amber-500/40 bg-amber-500/10 px-2.5 py-1 text-[11px] text-amber-700 dark:border-amber-400/40 dark:bg-amber-500/5 dark:text-amber-200 md:gap-2 md:px-3">
               <span aria-hidden>⚠️</span>
               <span className="truncate">
                 This is AI-generated support, not a medical diagnosis. Always consult a clinician.
               </span>
             </div>
-            <div className="grid grid-cols-1 gap-3 lg:grid-cols-3">
-              <div className="space-y-2 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10">
+            <div className="grid grid-cols-1 gap-2.5 lg:grid-cols-3">
+              <div className="space-y-1.5 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10 md:space-y-2">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Active Meds</h4>
                 {medications.length ? (
                   <div className="flex flex-wrap gap-1.5">
@@ -1070,16 +1070,16 @@ export default function MedicalProfile() {
                   <p className="text-[12px] text-muted-foreground">No medications recorded yet.</p>
                 )}
                 {summaryMedsEditing ? (
-                  <div className="space-y-2">
+                  <div className="space-y-1.5 md:space-y-2">
                     <MedicationInput
                       onSave={handleAddMedication}
                       placeholder="Add a medication"
                       autoFocus
                     />
-                    <div className="flex flex-wrap gap-2">
+                    <div className="flex flex-wrap gap-1.5 md:gap-2">
                       <button
                         type="button"
-                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
                         onClick={() => setSummaryMedsEditing(false)}
                       >
                         Done
@@ -1089,14 +1089,14 @@ export default function MedicalProfile() {
                 ) : (
                   <button
                     type="button"
-                    className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+                    className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
                     onClick={() => setSummaryMedsEditing(true)}
                   >
                     Add medication
                   </button>
                 )}
               </div>
-              <div className="space-y-2 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10">
+              <div className="space-y-1.5 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10 md:space-y-2">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Symptoms &amp; Notes</h4>
                 {displayedNotes && !notesEditing ? (
                   <p className="text-[13px] leading-relaxed text-foreground/90 whitespace-pre-wrap">{displayedNotes}</p>
@@ -1104,17 +1104,17 @@ export default function MedicalProfile() {
                   <p className="text-[12px] text-muted-foreground">{NO_DATA_TEXT}</p>
                 ) : null}
                 {notesEditing ? (
-                  <div className="space-y-2">
+                  <div className="space-y-1.5 md:space-y-2">
                     <textarea
                       className="w-full rounded-[10px] border border-border/70 bg-background px-3 py-2 text-[13px] leading-relaxed shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
                       rows={3}
                       value={notesDraft}
                       onChange={e => setNotesDraft(e.target.value)}
                     />
-                    <div className="flex flex-wrap gap-2">
+                    <div className="flex flex-wrap gap-1.5 md:gap-2">
                       <button
                         type="button"
-                        className="inline-flex h-9 items-center rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
+                        className="inline-flex h-9 items-center rounded-[10px] border border-primary/70 bg-primary px-2.5 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60 md:px-3"
                         onClick={handleSaveNotes}
                         disabled={savingNotes}
                       >
@@ -1122,7 +1122,7 @@ export default function MedicalProfile() {
                       </button>
                       <button
                         type="button"
-                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40"
+                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40 md:px-3"
                         onClick={() => setNotesEditing(false)}
                         disabled={savingNotes}
                       >
@@ -1131,7 +1131,7 @@ export default function MedicalProfile() {
                       {manualNotes ? (
                         <button
                           type="button"
-                          className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40"
+                          className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40 md:px-3"
                           onClick={handleClearNotes}
                           disabled={savingNotes}
                         >
@@ -1141,10 +1141,10 @@ export default function MedicalProfile() {
                     </div>
                   </div>
                 ) : displayedNotes ? (
-                  <div className="flex flex-wrap gap-2">
+                  <div className="flex flex-wrap gap-1.5 md:gap-2">
                     <button
                       type="button"
-                      className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+                      className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
                       onClick={() => {
                         setNotesDraft(displayedNotes ?? "");
                         setNotesEditing(true);
@@ -1155,7 +1155,7 @@ export default function MedicalProfile() {
                     {manualNotes ? (
                       <button
                         type="button"
-                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 dark:border-border/40"
+                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 dark:border-border/40 md:px-3"
                         onClick={handleClearNotes}
                         disabled={savingNotes}
                       >
@@ -1166,7 +1166,7 @@ export default function MedicalProfile() {
                 ) : (
                   <button
                     type="button"
-                    className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+                    className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
                     onClick={() => {
                       setNotesDraft("");
                       setNotesEditing(true);
@@ -1176,7 +1176,7 @@ export default function MedicalProfile() {
                   </button>
                 )}
               </div>
-              <div className="space-y-2 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10">
+              <div className="space-y-1.5 rounded-[10px] border border-border/60 bg-muted/20 p-3 dark:border-border/30 dark:bg-muted/10 md:space-y-2">
                 <h4 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Next Steps</h4>
                 {displayedNextSteps && !nextStepsEditing ? (
                   <p className="text-[13px] leading-relaxed text-foreground/90 whitespace-pre-wrap">{displayedNextSteps}</p>
@@ -1191,10 +1191,10 @@ export default function MedicalProfile() {
                       value={nextStepsDraft}
                       onChange={e => setNextStepsDraft(e.target.value)}
                     />
-                    <div className="flex flex-wrap gap-2">
+                    <div className="flex flex-wrap gap-1.5 md:gap-2">
                       <button
                         type="button"
-                        className="inline-flex h-9 items-center rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
+                        className="inline-flex h-9 items-center rounded-[10px] border border-primary/70 bg-primary px-2.5 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60 md:px-3"
                         onClick={handleSaveNextSteps}
                         disabled={savingNextSteps}
                       >
@@ -1202,7 +1202,7 @@ export default function MedicalProfile() {
                       </button>
                       <button
                         type="button"
-                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40"
+                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40 md:px-3"
                         onClick={() => setNextStepsEditing(false)}
                         disabled={savingNextSteps}
                       >
@@ -1211,7 +1211,7 @@ export default function MedicalProfile() {
                       {manualNextSteps ? (
                         <button
                           type="button"
-                          className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40"
+                          className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40 md:px-3"
                           onClick={handleClearNextSteps}
                           disabled={savingNextSteps}
                         >
@@ -1221,10 +1221,10 @@ export default function MedicalProfile() {
                     </div>
                   </div>
                 ) : displayedNextSteps ? (
-                  <div className="flex flex-wrap gap-2">
+                  <div className="flex flex-wrap gap-1.5 md:gap-2">
                     <button
                       type="button"
-                      className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+                      className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
                       onClick={() => {
                         setNextStepsDraft(displayedNextSteps ?? "");
                         setNextStepsEditing(true);
@@ -1235,7 +1235,7 @@ export default function MedicalProfile() {
                     {manualNextSteps ? (
                       <button
                         type="button"
-                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 dark:border-border/40"
+                        className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 dark:border-border/40 md:px-3"
                         onClick={handleClearNextSteps}
                         disabled={savingNextSteps}
                       >
@@ -1246,7 +1246,7 @@ export default function MedicalProfile() {
                 ) : (
                   <button
                     type="button"
-                    className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+                    className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[12px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
                     onClick={() => {
                       setNextStepsDraft("");
                       setNextStepsEditing(true);
@@ -1277,14 +1277,14 @@ export default function MedicalProfile() {
           actions={
             <button
               type="button"
-              className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
+              className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[13px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40 md:px-3"
               onClick={() => setShowMedicationComposer(open => !open)}
             >
               {showMedicationComposer || medications.length === 0 ? "Close" : "Add"}
             </button>
           }
         >
-          <div className="space-y-3 text-[13px]">
+          <div className="space-y-2.5 text-[13px] md:space-y-3">
             {medications.length ? (
               <>
                 <div className="flex flex-wrap gap-1.5">
@@ -1300,7 +1300,7 @@ export default function MedicalProfile() {
                   {medications.map(med => (
                     <li
                       key={`row-${med.key}`}
-                      className="flex items-center justify-between gap-3 rounded-[10px] border border-border/60 bg-background px-3 py-2.5 dark:border-border/30 dark:bg-muted/10"
+                      className="flex items-center justify-between gap-2.5 rounded-[10px] border border-border/60 bg-background px-3 py-2 dark:border-border/30 dark:bg-muted/10 md:gap-3"
                     >
                       <div className="min-w-0">
                         <p className="truncate text-[13px] font-semibold text-foreground">{med.name}</p>
@@ -1310,7 +1310,7 @@ export default function MedicalProfile() {
                       </div>
                       <button
                         type="button"
-                        className="inline-flex h-9 shrink-0 items-center rounded-[10px] border border-border/70 px-3 text-[12px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 dark:border-border/40"
+                        className="inline-flex h-9 shrink-0 items-center rounded-[10px] border border-border/70 px-2.5 text-[12px] font-medium text-foreground whitespace-nowrap transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/40 dark:border-border/40 md:px-3"
                         onClick={() => handleRemoveMedication(med)}
                       >
                         Remove

--- a/components/profile/ProfileSection.tsx
+++ b/components/profile/ProfileSection.tsx
@@ -33,7 +33,7 @@ export default function ProfileSection({
     <section
       className={`rounded-[12px] border border-border/70 bg-background/95 p-3 shadow-sm backdrop-blur-sm transition-colors dark:border-border/40 dark:bg-background/60 ${className}`}
     >
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+      <header className="flex flex-col gap-1.5 sm:flex-row sm:items-start sm:justify-between">
         <button
           type="button"
           className="flex flex-1 items-center gap-2 text-left text-sm font-semibold text-foreground"
@@ -57,7 +57,7 @@ export default function ProfileSection({
           </div>
         ) : null}
       </header>
-      <div id={sectionId(title)} className={open ? "mt-3" : "mt-3 hidden"}>
+      <div id={sectionId(title)} className={open ? "mt-2.5" : "mt-2.5 hidden"}>
         {isLoading ? (
           <div className="space-y-2">
             <SkeletonLine />

--- a/components/profile/ProfileSection.tsx
+++ b/components/profile/ProfileSection.tsx
@@ -30,23 +30,29 @@ export default function ProfileSection({
 }: ProfileSectionProps) {
   const [open, setOpen] = useState(defaultOpen);
   return (
-    <section className={`rounded-xl border bg-background p-4 shadow-sm ${className}`}>
-      <header className="flex items-start justify-between gap-3">
+    <section
+      className={`rounded-[12px] border border-border/70 bg-background/95 p-3 shadow-sm backdrop-blur-sm transition-colors dark:border-border/40 dark:bg-background/60 ${className}`}
+    >
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <button
           type="button"
-          className="flex flex-1 items-center gap-2 text-left font-semibold"
+          className="flex flex-1 items-center gap-2 text-left text-sm font-semibold text-foreground"
           onClick={() => setOpen(v => !v)}
           aria-expanded={open}
           aria-controls={sectionId(title)}
         >
           {open ? (
-            <ChevronDown className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
           ) : (
-            <ChevronRight className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
           )}
-          <span>{title}</span>
+          <span className="truncate">{title}</span>
         </button>
-        {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+        {actions ? (
+          <div className="flex flex-wrap gap-2 sm:justify-end" aria-label={`${title} actions`}>
+            {actions}
+          </div>
+        ) : null}
       </header>
       <div id={sectionId(title)} className={open ? "mt-3" : "mt-3 hidden"}>
         {isLoading ? (

--- a/components/profile/ProfileSection.tsx
+++ b/components/profile/ProfileSection.tsx
@@ -49,7 +49,10 @@ export default function ProfileSection({
           <span className="truncate">{title}</span>
         </button>
         {actions ? (
-          <div className="flex flex-wrap gap-2 sm:justify-end" aria-label={`${title} actions`}>
+          <div
+            className="flex flex-wrap items-center gap-x-2 gap-y-1.5 sm:justify-end"
+            aria-label={`${title} actions`}
+          >
             {actions}
           </div>
         ) : null}

--- a/components/profile/VitalsEditor.tsx
+++ b/components/profile/VitalsEditor.tsx
@@ -149,77 +149,74 @@ export default function VitalsEditor({
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
-        <label className="flex flex-col gap-1">
+      <div className="grid grid-cols-1 gap-3 text-[13px] min-[420px]:grid-cols-2 md:grid-cols-4">
+        <label className="flex flex-col gap-1.5">
           <span className="text-xs font-medium text-muted-foreground">
             Systolic (mmHg)
           </span>
           <input
             type="number"
             inputMode="numeric"
-            className="rounded-md border px-3 py-2"
+            className="h-10 rounded-[10px] border border-border/70 bg-background px-3 text-[13px] leading-tight shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
             placeholder="120"
             value={systolic}
             onChange={event => setSystolic(event.target.value)}
             disabled={isSaving}
           />
         </label>
-        <label className="flex flex-col gap-1">
+        <label className="flex flex-col gap-1.5">
           <span className="text-xs font-medium text-muted-foreground">
             Diastolic (mmHg)
           </span>
           <input
             type="number"
             inputMode="numeric"
-            className="rounded-md border px-3 py-2"
+            className="h-10 rounded-[10px] border border-border/70 bg-background px-3 text-[13px] leading-tight shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
             placeholder="80"
             value={diastolic}
             onChange={event => setDiastolic(event.target.value)}
             disabled={isSaving}
           />
         </label>
-        <label className="flex flex-col gap-1">
+        <label className="flex flex-col gap-1.5">
           <span className="text-xs font-medium text-muted-foreground">
             Heart rate (BPM)
           </span>
           <input
             type="number"
             inputMode="numeric"
-            className="rounded-md border px-3 py-2"
+            className="h-10 rounded-[10px] border border-border/70 bg-background px-3 text-[13px] leading-tight shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
             placeholder="72"
             value={heartRate}
             onChange={event => setHeartRate(event.target.value)}
             disabled={isSaving}
           />
         </label>
-      </div>
-
-      <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-3">
-        <label className="flex flex-col gap-1">
+        <label className="flex flex-col gap-1.5">
           <span className="text-xs font-medium text-muted-foreground">BMI (kg/m²)</span>
           <input
             type="number"
             inputMode="decimal"
-            className="rounded-md border px-3 py-2"
+            className="h-10 rounded-[10px] border border-border/70 bg-background px-3 text-[13px] leading-tight shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-border/40"
             value={computedBmi != null ? String(computedBmi) : manualBmi}
             onChange={event => setManualBmi(event.target.value)}
             placeholder="e.g. 24.6"
             disabled={computedBmi != null || isSaving}
           />
           {computedBmi != null ? (
-            <span className="text-xs text-muted-foreground">
+            <span className="text-[11px] text-muted-foreground">
               Calculated automatically from recorded height and weight.
             </span>
           ) : null}
         </label>
       </div>
 
-      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      {error ? <p className="text-[11px] text-destructive">{error}</p> : null}
 
       <div className="flex flex-wrap gap-2">
         <button
           type="button"
-          className="inline-flex items-center rounded-md border bg-primary px-3 py-1.5 text-sm text-primary-foreground shadow disabled:opacity-60"
+          className="inline-flex h-9 items-center rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
           onClick={handleSave}
           disabled={isSaving}
         >
@@ -227,7 +224,7 @@ export default function VitalsEditor({
         </button>
         <button
           type="button"
-          className="inline-flex items-center rounded-md border px-3 py-1.5 text-sm"
+          className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40"
           onClick={onCancel}
           disabled={isSaving}
         >

--- a/components/profile/VitalsEditor.tsx
+++ b/components/profile/VitalsEditor.tsx
@@ -148,8 +148,8 @@ export default function VitalsEditor({
   };
 
   return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-1 gap-3 text-[13px] min-[420px]:grid-cols-2 md:grid-cols-4">
+    <div className="space-y-3 md:space-y-4">
+      <div className="grid grid-cols-1 gap-2.5 text-[13px] min-[420px]:grid-cols-2 md:grid-cols-4">
         <label className="flex flex-col gap-1.5">
           <span className="text-xs font-medium text-muted-foreground">
             Systolic (mmHg)
@@ -216,7 +216,7 @@ export default function VitalsEditor({
       <div className="flex flex-wrap gap-2">
         <button
           type="button"
-          className="inline-flex h-9 items-center rounded-[10px] border border-primary/70 bg-primary px-3 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60"
+          className="inline-flex h-9 items-center rounded-[10px] border border-primary/70 bg-primary px-2.5 text-[13px] font-semibold text-primary-foreground shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 disabled:cursor-not-allowed disabled:opacity-60 md:px-3"
           onClick={handleSave}
           disabled={isSaving}
         >
@@ -224,7 +224,7 @@ export default function VitalsEditor({
         </button>
         <button
           type="button"
-          className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-3 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40"
+          className="inline-flex h-9 items-center rounded-[10px] border border-border/70 px-2.5 text-[13px] font-medium text-foreground transition hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60 dark:border-border/40 md:px-3"
           onClick={onCancel}
           disabled={isSaving}
         >


### PR DESCRIPTION
## Summary
- restyle medical profile sections with updated spacing, typography, and interactive controls tuned for mobile
- add collapsed AI summary with disclaimer badge and refreshed editing flows for notes, medications, and next steps
- refresh vitals and medication editors plus shared section wrapper to honor new design tokens

## Testing
- pnpm lint *(fails: interactive Next.js ESLint init prompt prevents automated run)*

------
https://chatgpt.com/codex/tasks/task_e_68d800a3cd4c832fa6720ccbbd57a107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Medication input supports optional auto-focus.
  - Medical profile expanded with richer personal details, structured sections (Personal details, Vitals, AI Summary, Active Meds, etc.), collapsible AI summary, inline medication composer, and compact vitals statistic cards with freshness indicators.

- Style
  - Medication tags made more compact; smaller remove button/icon with improved hover/focus states.
  - Profile sections redesigned with responsive headers, improved action alignment, truncated titles, and tighter spacing.
  - Vitals editor restyled: updated inputs, buttons, labels, and helper/error text for better readability and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->