### PR TITLE
Auto-detect country from IP on initial load

### DIFF
--- a/app/api/geoip/route.ts
+++ b/app/api/geoip/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { byCode2 } from "@/data/countries";
+
+const DEFAULT_HEADERS = {
+  "User-Agent": "MedX/1.0 (geoip) support@medx.local",
+};
+
+async function lookupByIp(ip?: string | null) {
+  const endpoint = ip ? `https://ipapi.co/${ip}/json/` : "https://ipapi.co/json/";
+  const res = await fetch(endpoint, {
+    headers: DEFAULT_HEADERS,
+    next: { revalidate: 60 * 60 },
+  });
+  if (!res.ok) return null;
+  const data = (await res.json()) as { country_code?: string };
+  if (!data?.country_code) return null;
+  return data.country_code.toUpperCase();
+}
+
+export async function GET(req: Request) {
+  const headers = req.headers;
+  const headerCountry =
+    headers.get("x-vercel-ip-country") || headers.get("cf-ipcountry") || headers.get("x-appengine-country");
+
+  let countryCode2 = headerCountry?.toUpperCase() || null;
+
+  if (!countryCode2) {
+    const forwarded = headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+    try {
+      countryCode2 = await lookupByIp(forwarded);
+    } catch (err) {
+      console.error("geoip lookup failed", err);
+    }
+  }
+
+  const match = countryCode2 ? byCode2(countryCode2) : undefined;
+
+  return NextResponse.json({ country: match ?? null });
+}

--- a/lib/country.tsx
+++ b/lib/country.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { createContext, useContext, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { COUNTRIES, byCode2 } from "@/data/countries";
 
 const STORAGE_KEY = "medx.country.code3";
@@ -31,11 +31,40 @@ export function CountryProvider({ children }: { children: React.ReactNode }) {
     return localStorage.getItem(STORAGE_KEY) || inferFromLocale();
   });
 
-  const setCountry = (newCode3: string) => {
+  const setCountry = useCallback((newCode3: string) => {
     setCode3(newCode3);
     if (typeof window !== "undefined")
       localStorage.setItem(STORAGE_KEY, newCode3);
-  };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (localStorage.getItem(STORAGE_KEY)) return;
+
+    const controller = new AbortController();
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await fetch("/api/geoip", { signal: controller.signal });
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          country?: { code3?: string | null } | null;
+        };
+        const ipCode3 = data?.country?.code3;
+        if (!ipCode3) return;
+        if (cancelled) return;
+        setCountry(ipCode3);
+      } catch (err) {
+        if ((err as Error)?.name === "AbortError") return;
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [setCountry]);
 
   const cur =
     COUNTRIES.find(c => c.code3 === code3) ||


### PR DESCRIPTION
## Summary
- add a /api/geoip endpoint that resolves the request IP to a supported country
- update the CountryProvider to fetch the detected country when no preference is stored

## Testing
- not run (pending project-specific instructions)


------
https://chatgpt.com/codex/tasks/task_e_68d81ad6538c832faca67e990d18a6c4