### PR TITLE
Handle back gesture for timeline overlay on mobile

### DIFF
--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Trash2 } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useTimeline } from "@/lib/hooks/useAppData";
@@ -201,6 +201,36 @@ export default function Timeline(){
   const [open, setOpen] = useState(false);
   const [active, setActive] = useState<any|null>(null);
   const [signedUrl, setSignedUrl] = useState<string|null>(null);
+  const overlayHistoryRef = useRef(false);
+
+  const closeOverlay = useCallback((options?: { skipHistory?: boolean }) => {
+    const hadHistoryEntry = overlayHistoryRef.current;
+    overlayHistoryRef.current = false;
+    setOpen(false);
+    setActive(null);
+    setSignedUrl(null);
+    if (!options?.skipHistory && hadHistoryEntry && typeof window !== "undefined") {
+      window.history.back();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!open) return;
+
+    const handlePopState = () => {
+      if (!overlayHistoryRef.current) return;
+      closeOverlay({ skipHistory: true });
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    window.history.pushState({ timelineOverlay: true }, "");
+    overlayHistoryRef.current = true;
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+    };
+  }, [open, closeOverlay]);
   useEffect(()=>{
     if (!open || !active?.file) { setSignedUrl(null); return; }
     const f = active.file;
@@ -249,8 +279,7 @@ export default function Timeline(){
     const previous = observations;
     setObservations(prev => prev.filter(x => x.id !== ob.id));
     if (active?.id === ob.id) {
-      setActive(null);
-      setOpen(false);
+      closeOverlay();
     }
 
     try {
@@ -372,7 +401,7 @@ export default function Timeline(){
 
       {open && active && (
         <>
-          <div className="fixed inset-0 bg-black/40 z-40" onClick={() => setOpen(false)} />
+          <div className="fixed inset-0 bg-black/40 z-40" onClick={() => closeOverlay()} />
           <aside className="fixed right-0 top-0 bottom-0 z-50 w-full sm:w-[640px] bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 shadow-2xl ring-1 ring-black/5 overflow-y-auto">
             <header className="sticky top-0 bg-white/90 dark:bg-zinc-900/90 backdrop-blur border-b border-zinc-200/70 dark:border-zinc-800/70 px-4 py-3 flex items-center gap-2">
               <h3 className="font-semibold truncate flex items-center gap-2">
@@ -402,7 +431,7 @@ export default function Timeline(){
                 >
                   <Trash2 size={16} />
                 </button>
-                <button onClick={() => setOpen(false)} className="text-xs px-2 py-1 rounded-md border">Close</button>
+                <button onClick={() => closeOverlay()} className="text-xs px-2 py-1 rounded-md border">Close</button>
               </div>
             </header>
             <div className="px-5 py-4">


### PR DESCRIPTION
## Summary
- add history stack handling so the timeline overlay closes when the browser back gesture is used
- centralize overlay closing logic to keep active state and history in sync when files are closed or deleted

## Testing
- npm run lint *(fails: command prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e25aa8a8832f949336cf42f1d11f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - The browser Back button now closes the Timeline overlay and may redirect to chat when appropriate.
  - Opening the Timeline overlay creates a history entry for seamless navigation.

- Bug Fixes
  - Overlay dismissal is consistent across Close button, backdrop click, and delete actions, preventing stuck or mismatched UI states.

- Refactor
  - Streamlined overlay lifecycle and history handling for more reliable navigation and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->