### PR TITLE
Add mobile close control to timeline overlay

### DIFF
--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Trash2 } from "lucide-react";
+import { ArrowLeft, Trash2 } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useTimeline } from "@/lib/hooks/useAppData";
 import { useIsAiDocMode } from "@/hooks/useIsAiDocMode";
@@ -429,6 +429,14 @@ export default function Timeline(){
           <div className="fixed inset-0 bg-black/40 z-40" onClick={() => closeOverlay()} />
           <aside className="fixed right-0 top-0 bottom-0 z-50 w-full sm:w-[640px] bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100 shadow-2xl ring-1 ring-black/5 overflow-y-auto">
             <header className="sticky top-0 bg-white/90 dark:bg-zinc-900/90 backdrop-blur border-b border-zinc-200/70 dark:border-zinc-800/70 px-4 py-3 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => closeOverlay()}
+                className="sm:hidden -ml-1 rounded-md p-2 hover:bg-slate-100 dark:hover:bg-gray-800"
+                aria-label="Close details"
+              >
+                <ArrowLeft size={18} />
+              </button>
               <h3 className="font-semibold truncate flex items-center gap-2">
                 <span>{displayTitle}</span>
                 {chipLabel && (


### PR DESCRIPTION
## Summary
- add a mobile-only back button to the timeline observation overlay header so the detail view can be closed on small screens

## Testing
- npm run dev *(fails: ENETUNREACH while fetching Next.js telemetry data)*

------
https://chatgpt.com/codex/tasks/task_e_68d8ee0a7918832f9142cc7f2b365ec7