### PR TITLE
Refine preferences entry point and modal

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import PreferencesModal from "@/components/settings/PreferencesModal";
 import { useRouter } from "next/navigation";
 import ChatPane from "@/components/panels/ChatPane";
@@ -23,23 +23,6 @@ export default function Page({ searchParams }: { searchParams: Search }) {
   const mainPanel = showPrefs ? "chat" : panel;
   const router = useRouter();
   const chatInputRef = useRef<HTMLInputElement>(null);
-
-  const makeParams = useCallback(
-    (nextPanel: string) => {
-      const params = new URLSearchParams();
-      Object.entries(searchParams).forEach(([key, value]) => {
-        if (key === "panel" || key === "tab") return;
-        if (typeof value === "string") {
-          params.append(key, value);
-        } else if (Array.isArray(value)) {
-          value.forEach((entry) => params.append(key, entry));
-        }
-      });
-      params.set("panel", nextPanel);
-      return params;
-    },
-    [searchParams]
-  );
 
   useEffect(() => {
     const handler = () => chatInputRef.current?.focus();
@@ -80,7 +63,11 @@ export default function Page({ searchParams }: { searchParams: Search }) {
       <PreferencesModal
         open={showPrefs}
         defaultTab={defaultTab as any}
-        onClose={() => router.push(`/?${makeParams("chat").toString()}`)}
+        onClose={() => {
+          const params = new URLSearchParams(window.location.search);
+          params.set("panel", "chat");
+          router.push(`/?${params.toString()}`);
+        }}
       />
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 import { useEffect, useRef } from "react";
+import PreferencesModal from "@/components/settings/PreferencesModal";
+import { useRouter } from "next/navigation";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
 import Timeline from "@/components/panels/Timeline";
 import AlertsPane from "@/components/panels/AlertsPane";
-import SettingsPane from "@/components/panels/SettingsPane";
 import { ResearchFiltersProvider } from "@/store/researchFilters";
 import AiDocPane from "@/components/panels/AiDocPane";
 import DirectoryPane from "@/components/panels/DirectoryPane";
@@ -13,6 +14,10 @@ type Search = { panel?: string };
 
 export default function Page({ searchParams }: { searchParams: Search }) {
   const panel = searchParams.panel?.toLowerCase() || "chat";
+  const showPrefs = panel === "settings" || panel === "preferences";
+  const defaultTab = (searchParams as any).tab || "General";
+  const mainPanel = showPrefs ? "chat" : panel;
+  const router = useRouter();
   const chatInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -22,15 +27,13 @@ export default function Page({ searchParams }: { searchParams: Search }) {
   }, []);
 
   const renderPane = () => {
-    switch (panel) {
+    switch (mainPanel) {
       case "profile":
         return <MedicalProfile />;
       case "timeline":
         return <Timeline />;
       case "alerts":
         return <AlertsPane />;
-      case "settings":
-        return <SettingsPane />;
       case "ai-doc":
         return <AiDocPane />;
       case "directory":
@@ -42,7 +45,7 @@ export default function Page({ searchParams }: { searchParams: Search }) {
 
   return (
     <div className="flex flex-1 min-h-0 flex-col">
-      {panel === "chat" ? (
+      {mainPanel === "chat" ? (
         <ResearchFiltersProvider>
           <ChatPane inputRef={chatInputRef} />
         </ResearchFiltersProvider>
@@ -53,6 +56,11 @@ export default function Page({ searchParams }: { searchParams: Search }) {
           </div>
         </div>
       )}
+      <PreferencesModal
+        open={showPrefs}
+        defaultTab={defaultTab as any}
+        onClose={() => router.push("/?panel=chat")}
+      />
     </div>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -56,7 +56,7 @@ export default function Sidebar() {
         <Tabs />
       </div>
 
-      <div className="mt-2 flex-1 space-y-1 overflow-y-auto pr-1">
+      <div className="mt-2 flex-1 space-y-1 overflow-y-auto pr-1 pb-16">
         {filtered.map((t) => (
           <div
             key={t.id}
@@ -90,16 +90,18 @@ export default function Sidebar() {
         ))}
       </div>
 
-      <div className="mt-auto">
-        <div className="sticky bottom-0 left-0 -mx-4 border-t border-black/5 bg-white/60 px-4 py-3 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/50">
-          <button
-            type="button"
-            className="flex items-center gap-1.5 rounded-md border border-slate-200 bg-white/70 px-3 py-2 text-sm text-slate-900 transition hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 dark:hover:bg-slate-900"
-          >
-            <Settings size={14} /> Preferences
-          </button>
-        </div>
-      </div>
+      <div className="mt-auto" />
+      <button
+        type="button"
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          router.push("/?panel=settings");
+        }}
+        className="fixed bottom-3 left-3 z-20 flex items-center gap-1.5 rounded-md border border-black/10 bg-white/70 px-3 py-2 text-sm shadow-sm hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/70 dark:hover:bg-slate-900"
+      >
+        <Settings size={14} /> Preferences
+      </button>
     </div>
   );
 }

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 export default function Sidebar() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const threadId = searchParams.get("threadId") ?? "";
   const [threads, setThreads] = useState<Thread[]>([]);
   const [q, setQ] = useState("");
   const closeSidebar = useMobileUiStore((state) => state.closeSidebar);
@@ -97,9 +98,12 @@ export default function Sidebar() {
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          const params = new URLSearchParams(searchParams?.toString() ?? "");
+          closeSidebar?.();
+          const params = new URLSearchParams(window.location.search);
           params.set("panel", "settings");
-          params.delete("tab");
+          if (threadId) {
+            params.set("threadId", threadId);
+          }
           router.push(`/?${params.toString()}`);
         }}
         className="fixed bottom-3 left-3 z-20 flex items-center gap-1.5 rounded-md border border-black/10 bg-white/70 px-3 py-2 text-sm shadow-sm hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/70 dark:hover:bg-slate-900"

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Search, Settings } from "lucide-react";
 import Tabs from "./sidebar/Tabs";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { createNewThreadId, listThreads, Thread } from "@/lib/chatThreads";
 import ThreadKebab from "@/components/chat/ThreadKebab";
@@ -9,6 +9,7 @@ import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 
 export default function Sidebar() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [threads, setThreads] = useState<Thread[]>([]);
   const [q, setQ] = useState("");
   const closeSidebar = useMobileUiStore((state) => state.closeSidebar);
@@ -96,7 +97,10 @@ export default function Sidebar() {
         onClick={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          router.push("/?panel=settings");
+          const params = new URLSearchParams(searchParams?.toString() ?? "");
+          params.set("panel", "settings");
+          params.delete("tab");
+          router.push(`/?${params.toString()}`);
         }}
         className="fixed bottom-3 left-3 z-20 flex items-center gap-1.5 rounded-md border border-black/10 bg-white/70 px-3 py-2 text-sm shadow-sm hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/70 dark:hover:bg-slate-900"
       >

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -1029,8 +1029,9 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     if (!threadId && !isProfileThread) {
       const id = createNewThreadId();
       const params = new URLSearchParams(sp.toString());
-      params.set("panel", "chat");
-      params.set("threadId", id);
+      const currentPanel = sp.get('panel') ?? 'chat';
+      params.set('panel', currentPanel);
+      params.set('threadId', id);
       router.replace(`/?${params.toString()}`);
     }
   }, [threadId, isProfileThread, router, sp]);

--- a/components/panels/SettingsPane.tsx
+++ b/components/panels/SettingsPane.tsx
@@ -1,12 +1,5 @@
 'use client';
-import Preferences from "../settings/Preferences";
-import { MemorySettings } from "../settings/MemorySettings";
 
 export default function SettingsPane() {
-  return (
-    <div className="p-4 space-y-4">
-      <Preferences />
-      <MemorySettings />
-    </div>
-  );
+  return null;
 }

--- a/components/settings/PreferencesModal.tsx
+++ b/components/settings/PreferencesModal.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  X,
+  Bell,
+  SlidersHorizontal,
+  Link2,
+  CalendarClock,
+  Database,
+  Lock,
+  User,
+  Home,
+} from "lucide-react";
+import GeneralPanel from "./panels/General";
+import NotificationsPanel from "./panels/Notifications";
+import PersonalizationPanel from "./panels/Personalization";
+import ConnectorsPanel from "./panels/Connectors";
+import SchedulesPanel from "./panels/Schedules";
+import DataControlsPanel from "./panels/DataControls";
+import SecurityPanel from "./panels/Security";
+import AccountPanel from "./panels/Account";
+
+const cn = (...classes: (string | false | null | undefined)[]) =>
+  classes.filter(Boolean).join(" ");
+
+type TabKey =
+  | "General"
+  | "Notifications"
+  | "Personalization"
+  | "Connectors"
+  | "Schedules"
+  | "Data controls"
+  | "Security"
+  | "Account";
+
+const TABS: { key: TabKey; label: string; icon: any }[] = [
+  { key: "General", label: "General", icon: Home },
+  { key: "Notifications", label: "Notifications", icon: Bell },
+  { key: "Personalization", label: "Personalization", icon: SlidersHorizontal },
+  { key: "Connectors", label: "Connectors", icon: Link2 },
+  { key: "Schedules", label: "Schedules", icon: CalendarClock },
+  { key: "Data controls", label: "Data controls", icon: Database },
+  { key: "Security", label: "Security", icon: Lock },
+  { key: "Account", label: "Account", icon: User },
+];
+
+export default function PreferencesModal({
+  open,
+  defaultTab = "General",
+  onClose,
+}: {
+  open: boolean;
+  defaultTab?: TabKey;
+  onClose: () => void;
+}) {
+  const [tab, setTab] = useState<TabKey>(defaultTab);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [ignoreFirst, setIgnoreFirst] = useState(false);
+
+  useEffect(() => {
+    if (open) setTab(defaultTab);
+  }, [open, defaultTab]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.documentElement.style.overflow;
+    document.documentElement.style.overflow = "hidden";
+    return () => {
+      document.documentElement.style.overflow = prev;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setIgnoreFirst(true);
+    const id = requestAnimationFrame(() => setIgnoreFirst(false));
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const root = cardRef.current!;
+    const selector = [
+      "button",
+      "[href]",
+      "input",
+      "select",
+      "textarea",
+      "[tabindex]:not([tabindex='-1'])",
+    ].join(",");
+    const getFocusables = () =>
+      Array.from(root.querySelectorAll<HTMLElement>(selector)).filter(
+        (el) => !el.hasAttribute("disabled")
+      );
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const nodes = getFocusables();
+      if (!nodes.length) return;
+      const first = nodes[0];
+      const last = nodes[nodes.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    root.addEventListener("keydown", onKey as any);
+    const closeBtn = root.querySelector<HTMLButtonElement>("[data-close]");
+    closeBtn?.focus();
+    return () => root.removeEventListener("keydown", onKey as any);
+  }, [open]);
+
+  const Panel = useMemo(() => {
+    switch (tab) {
+      case "General":
+        return <GeneralPanel />;
+      case "Notifications":
+        return <NotificationsPanel />;
+      case "Personalization":
+        return <PersonalizationPanel />;
+      case "Connectors":
+        return <ConnectorsPanel />;
+      case "Schedules":
+        return <SchedulesPanel />;
+      case "Data controls":
+        return <DataControlsPanel />;
+      case "Security":
+        return <SecurityPanel />;
+      case "Account":
+        return <AccountPanel />;
+    }
+  }, [tab]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100]">
+      <div
+        className={cn(
+          "absolute inset-0 bg-black/40",
+          ignoreFirst && "pointer-events-none"
+        )}
+        onMouseDown={(e) => {
+          if (ignoreFirst) return;
+          if (e.target === e.currentTarget) onClose();
+        }}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Preferences"
+        ref={cardRef}
+        onMouseDown={(e) => e.stopPropagation()}
+        className="absolute left-1/2 top-1/2 h-[min(92vh,620px)] w-[min(96vw,980px)] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-2xl bg-white/90 ring-1 ring-black/5 backdrop-blur-md shadow-2xl dark:bg-slate-900/80 dark:ring-white/10"
+      >
+        <div className="flex h-full">
+          <aside className="w-[280px] border-r border-black/5 bg-white/70 p-2 pr-1 dark:border-white/10 dark:bg-slate-900/60">
+            <div className="flex items-center justify-between px-2 py-2">
+              <div className="text-sm font-semibold opacity-70">Preferences</div>
+              <button
+                data-close
+                onClick={onClose}
+                className="rounded-md p-1.5 hover:bg-black/5 dark:hover:bg-white/10"
+                aria-label="Close"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <nav className="mt-1 space-y-1 overflow-auto pr-1">
+              {TABS.map(({ key, label, icon: Icon }) => (
+                <button
+                  key={key}
+                  onClick={() => setTab(key)}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-[13px] hover:bg-black/5 dark:hover:bg-white/10",
+                    tab === key &&
+                      "bg-black/5 ring-1 ring-black/5 dark:bg-white/10 dark:ring-white/10"
+                  )}
+                >
+                  <Icon size={14} className="opacity-70" />
+                  <span>{label}</span>
+                </button>
+              ))}
+            </nav>
+          </aside>
+
+          <section className="flex min-w-0 flex-1 flex-col">
+            <header className="border-b border-black/5 px-5 py-3 text-[15px] font-semibold dark:border-white/10">
+              {tab}
+            </header>
+            <div className="flex-1 overflow-auto divide-y divide-black/5 dark:divide-white/10">
+              {Panel}
+            </div>
+            <footer className="flex items-center justify-end gap-2 border-t border-black/5 px-4 py-3 dark:border-white/10">
+              <button
+                onClick={onClose}
+                className="rounded-lg border border-black/10 bg-white/70 px-3.5 py-1.5 text-sm hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/60 dark:hover:bg-slate-900/80"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={onClose}
+                className="rounded-lg bg-blue-600 px-3.5 py-1.5 text-sm font-semibold text-white hover:bg-blue-500"
+              >
+                Save changes
+              </button>
+            </footer>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/settings/PreferencesModal.tsx
+++ b/components/settings/PreferencesModal.tsx
@@ -12,6 +12,7 @@ import {
   User,
   Home,
 } from "lucide-react";
+import cn from "clsx";
 import GeneralPanel from "./panels/General";
 import NotificationsPanel from "./panels/Notifications";
 import PersonalizationPanel from "./panels/Personalization";
@@ -20,9 +21,6 @@ import SchedulesPanel from "./panels/Schedules";
 import DataControlsPanel from "./panels/DataControls";
 import SecurityPanel from "./panels/Security";
 import AccountPanel from "./panels/Account";
-
-const cn = (...classes: (string | false | null | undefined)[]) =>
-  classes.filter(Boolean).join(" ");
 
 type TabKey =
   | "General"

--- a/components/settings/panels/Account.tsx
+++ b/components/settings/panels/Account.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function AccountPanel() {
+  return (
+    <div className="space-y-4 p-6 text-sm text-slate-600 dark:text-slate-300">
+      <p>Manage account details and subscription information.</p>
+    </div>
+  );
+}

--- a/components/settings/panels/Connectors.tsx
+++ b/components/settings/panels/Connectors.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function ConnectorsPanel() {
+  return (
+    <div className="space-y-4 p-6 text-sm text-slate-600 dark:text-slate-300">
+      <p>Manage integrations and third-party connectors from this panel.</p>
+    </div>
+  );
+}

--- a/components/settings/panels/DataControls.tsx
+++ b/components/settings/panels/DataControls.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { MemorySettings } from "../MemorySettings";
+import Preferences from "../Preferences";
 
 export default function DataControlsPanel() {
   return (
-    <div className="space-y-4 p-6">
-      <MemorySettings />
-    </div>
+    <>
+      <div className="px-5 py-3 text-[13px] text-slate-500 dark:text-slate-400">
+        Adjust how MedX behaves and personalizes your care.
+      </div>
+      <div className="px-5 py-4">
+        <Preferences />
+      </div>
+      {/* Export + Clear rows (stub) */}
+    </>
   );
 }

--- a/components/settings/panels/DataControls.tsx
+++ b/components/settings/panels/DataControls.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { MemorySettings } from "../MemorySettings";
+
+export default function DataControlsPanel() {
+  return (
+    <div className="space-y-4 p-6">
+      <MemorySettings />
+    </div>
+  );
+}

--- a/components/settings/panels/General.tsx
+++ b/components/settings/panels/General.tsx
@@ -1,11 +1,51 @@
 "use client";
 
-import Preferences from "../Preferences";
+import type { ReactNode } from "react";
+import { ChevronDown, Play } from "lucide-react";
+
+const Row = ({ title, sub, right }: { title: string; sub?: string; right: ReactNode }) => (
+  <div className="flex items-center justify-between gap-4 px-5 py-4">
+    <div>
+      <div className="text-[13px] font-semibold">{title}</div>
+      {sub ? <div className="text-xs text-slate-500 dark:text-slate-400">{sub}</div> : null}
+    </div>
+    <div className="flex items-center gap-2">{right}</div>
+  </div>
+);
+
+const Select = ({ label }: { label: string }) => (
+  <button className="inline-flex items-center justify-between gap-2 rounded-lg border border-black/10 bg-white/70 px-3 py-1.5 text-sm dark:border-white/10 dark:bg-slate-900/60">
+    {label} <ChevronDown size={14} className="opacity-70" />
+  </button>
+);
+
+const Pill = ({ dot = "#7C3AED", label = "Purple" }: { dot?: string; label?: string }) => (
+  <button className="inline-flex items-center gap-2 rounded-lg border border-black/10 bg-white/70 px-3 py-1.5 text-sm dark:border-white/10 dark:bg-slate-900/60">
+    <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ background: dot }} /> {label}
+  </button>
+);
 
 export default function GeneralPanel() {
   return (
-    <div className="space-y-4 p-6">
-      <Preferences />
-    </div>
+    <>
+      <div className="px-5 py-3 text-[13px] text-slate-500 dark:text-slate-400">
+        Adjust how MedX behaves and personalizes your care.
+      </div>
+      <Row title="Theme" sub="Select how the interface adapts to your system." right={<Select label="System" />} />
+      <Row title="Accent color" sub="Update highlight elements across the app." right={<Pill />} />
+      <Row title="Language" sub="Choose your preferred conversational language." right={<Select label="Hindi" />} />
+      <Row
+        title="Voice"
+        sub="Preview and select the voice used for spoken responses."
+        right={
+          <>
+            <button className="inline-flex items-center gap-1.5 rounded-lg border border-black/10 bg-white/70 px-3 py-1.5 text-sm dark:border-white/10 dark:bg-slate-900/60">
+              <Play size={14} /> Play
+            </button>
+            <Select label="Cove" />
+          </>
+        }
+      />
+    </>
   );
 }

--- a/components/settings/panels/General.tsx
+++ b/components/settings/panels/General.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import Preferences from "../Preferences";
+
+export default function GeneralPanel() {
+  return (
+    <div className="space-y-4 p-6">
+      <Preferences />
+    </div>
+  );
+}

--- a/components/settings/panels/Notifications.tsx
+++ b/components/settings/panels/Notifications.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function NotificationsPanel() {
+  return (
+    <div className="space-y-4 p-6 text-sm text-slate-600 dark:text-slate-300">
+      <p>Email and in-app notification preferences will appear here.</p>
+    </div>
+  );
+}

--- a/components/settings/panels/Personalization.tsx
+++ b/components/settings/panels/Personalization.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function PersonalizationPanel() {
+  return (
+    <div className="space-y-4 p-6 text-sm text-slate-600 dark:text-slate-300">
+      <p>Customize the MedX experience with personalization controls.</p>
+    </div>
+  );
+}

--- a/components/settings/panels/Schedules.tsx
+++ b/components/settings/panels/Schedules.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function SchedulesPanel() {
+  return (
+    <div className="space-y-4 p-6 text-sm text-slate-600 dark:text-slate-300">
+      <p>Configure automation and scheduling options here.</p>
+    </div>
+  );
+}

--- a/components/settings/panels/Security.tsx
+++ b/components/settings/panels/Security.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function SecurityPanel() {
+  return (
+    <div className="space-y-4 p-6 text-sm text-slate-600 dark:text-slate-300">
+      <p>Update login, authentication, and session security settings.</p>
+    </div>
+  );
+}

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -15,7 +15,6 @@ const tabs: Tab[] = [
   { key: "profile", label: "Medical Profile", panel: "profile" },
   { key: "timeline", label: "Timeline", panel: "timeline" },
   { key: "alerts", label: "Alerts", panel: "alerts" },
-  { key: "settings", label: "Settings", panel: "settings" },
 ];
 
 function NavLink({

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.57.0",
         "@tanstack/react-query": "^5.89.0",
+        "clsx": "^2.1.1",
         "framer-motion": "^12.23.12",
         "html-to-image": "^1.11.11",
         "isomorphic-dompurify": "2.13.0",
@@ -1964,6 +1965,15 @@
     "node_modules/client-only": {
       "version": "0.0.1",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.57.0",
     "@tanstack/react-query": "^5.89.0",
+    "clsx": "^2.1.1",
     "framer-motion": "^12.23.12",
     "html-to-image": "^1.11.11",
     "isomorphic-dompurify": "2.13.0",


### PR DESCRIPTION
## Summary
- remove the Settings sidebar tab and anchor the Preferences trigger to the bottom-left
- keep chat as the primary view while exposing Preferences via a modal overlay that is addressable by route
- implement the refreshed Preferences modal with accessibility fixes and stub panels for future sections

## Testing
- npm run lint *(fails: command prompts for ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d92789fe30832fb705db046c64ad26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preferences modal with tabs: General, Notifications, Personalization, Connectors, Schedules, Data controls, Security, Account; supports opening to a default tab via URL.

* **UI Changes**
  * Floating Preferences button (bottom-left); sidebar spacing adjusted; Settings tab/pane removed from main navigation.
  * Modal displays alongside the main chat/drawer; closing returns to chat.

* **Bug Fixes**
  * URL parameters preserved when navigating; panel selection retained when auto-creating threads.

* **Chores**
  * Added a small dependency for UI utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->