### PR TITLE
Fix thread options menu stacking

### DIFF
--- a/components/chat/ThreadKebab.tsx
+++ b/components/chat/ThreadKebab.tsx
@@ -36,7 +36,7 @@ export default function ThreadKebab({ id, title, onRenamed, onDeleted }: {
       </button>
 
       {open && (
-        <div className="absolute right-0 mt-1 w-44 rounded-md border bg-white dark:bg-slate-900 dark:border-slate-700 shadow-lg z-20">
+        <div className="absolute right-0 mt-1 w-44 rounded-md border bg-white dark:bg-slate-900 dark:border-slate-700 shadow-lg z-50">
           <button
             className="w-full text-left px-3 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
             onClick={() => { setAskRename(true); setOpen(false); }}


### PR DESCRIPTION
## Summary
- raise the z-index of the sidebar thread options menu so rename/delete controls appear above other UI buttons

## Testing
- not run (tests require further configuration)

------
https://chatgpt.com/codex/tasks/task_e_68d932736bac832f99e2d047619fbcd3