### PR TITLE
Add translation formatter helper for legal footer

### DIFF
--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -3,7 +3,7 @@
 import type { CSSProperties } from "react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Scale } from "lucide-react";
-import { useT } from "@/components/hooks/useI18n";
+import { tfmt, useT } from "@/components/hooks/useI18n";
 
 type CookiePrefs = {
   essential: true;
@@ -31,12 +31,6 @@ const DEFAULT_PREFS: CookiePrefs = {
 };
 
 const COOKIE_KEYS: ToggleableCookie[] = ["analytics", "functional", "marketing"];
-
-const formatTokens = (template: string, tokens: Record<string, string>) =>
-  Object.entries(tokens).reduce(
-    (acc, [token, value]) => acc.replaceAll(`{${token}}`, value),
-    template,
-  );
 
 const parseConsentValue = (value: string | null): "true" | "false" | null => {
   if (value === null) return null;
@@ -72,12 +66,12 @@ export default function LegalPrivacyFooter() {
   const marqueeTextRef = useRef<HTMLSpanElement | null>(null);
   const [marqueeVars, setMarqueeVars] = useState<{ duration: number; distance: number } | null>(null);
 
-  const legalNotice = formatTokens(t("Legal marquee notice"), { brand: BRAND });
+  const legalNotice = tfmt(t("Legal marquee notice"), { brand: BRAND });
   const sectionCopy = useMemo(
     () => [
       {
         title: t("Introduction"),
-        body: [formatTokens(t("Introduction body"), { brand: BRAND })],
+        body: [tfmt(t("Introduction body"), { brand: BRAND })],
       },
       {
         title: t("Medical Advice Disclaimer"),
@@ -94,7 +88,7 @@ export default function LegalPrivacyFooter() {
     ],
     [t],
   );
-  const liabilityCopy = formatTokens(t("Liability & Governing Law body"), {
+  const liabilityCopy = tfmt(t("Liability & Governing Law body"), {
     brand: BRAND,
     law: GOVERNING_LAW,
   });

--- a/components/hooks/useI18n.ts
+++ b/components/hooks/useI18n.ts
@@ -1,6 +1,21 @@
 "use client";
 import { usePrefs } from "@/components/providers/PreferencesProvider";
 
+export type TranslationTokens = Record<string, string | number>;
+
+export function tfmt(
+  template: string | null | undefined,
+  tokens?: TranslationTokens,
+) {
+  const base = typeof template === "string" ? template : "";
+  if (!tokens) return base;
+
+  return Object.entries(tokens).reduce(
+    (acc, [token, value]) => acc.replaceAll(`{${token}}`, String(value)),
+    base,
+  );
+}
+
 const DICTIONARY: Record<string, Record<string, string>> = {
   en: {
     Preferences: "Preferences",


### PR DESCRIPTION
## Summary
- add a shared tfmt helper to safely replace tokens in translated strings
- update the legal and privacy footer to rely on tfmt for marquee and body copy formatting

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68da5807d384832f8fa6f902cebb4492