### PR TITLE
Improve localization of Google place details

### DIFF
--- a/app/api/directory/search/route.ts
+++ b/app/api/directory/search/route.ts
@@ -137,7 +137,6 @@ async function googleNearby({
   if (kw) url.searchParams.set("keyword", kw);
   url.searchParams.set("key", key);
   url.searchParams.set("language", lang);
-  console.debug("GOOGLE params", { languageOrHeader: lang });
 
   const resp = await fetch(url.toString(), { cache: "no-store" });
   if (!resp.ok) throw new Error("google nearby failed");
@@ -186,9 +185,7 @@ async function googlePlaceDetailsV1(placeId: string, key: string, lang: string):
   const endpoint = new URL(
     `https://places.googleapis.com/v1/places/${encodeURIComponent(placeId)}`,
   );
-  endpoint.searchParams.set("fields", fields);
   endpoint.searchParams.set("languageCode", lang);
-  console.debug("GOOGLE params", { languageOrHeader: lang });
   const res = await fetch(endpoint, {
     headers: {
       "X-Goog-Api-Key": key,
@@ -394,7 +391,6 @@ async function osmFallback(
       out tags center 200;`;
   }
   const body = buildOverpassQL(kindFilters(uiType));
-  console.debug("OSM header", { acceptLanguage: lang });
   const r = await fetch("https://overpass-api.de/api/interpreter", {
     method: "POST",
     headers: {
@@ -484,8 +480,6 @@ export async function GET(req: Request) {
     searchParams.get("radius") ?? "",
     lang,
   ].join("|");
-  console.debug("DIR api", { appLang, mapped: lang });
-
   const globalAny = globalThis as typeof globalThis & {
     __dirCache?: Map<string, { data: Place[]; updatedAt: string; provider: "google" | "osm" }>;
   };


### PR DESCRIPTION
## Summary
- compose addresses from Google Places v1 components using CLDR country names
- request address components in details lookups and surface composed addresses to consumers
- apply qualifier localization consistently to provider names

## Testing
- npm run lint *(fails: command prompts for ESLint config interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68daa5874520832f80f0372941c86e4d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Addresses are now composed and displayed using the user-selected language for more natural, locale-aware results.
  * Place details include richer, human-readable addresses when available; address previews prefer the composed address with smart fallback.
  * Provider names are consistently localized across all results.

* **Chores**
  * Minor logging/trace cleanup and reliability of existing fallback to alternative data sources preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->