### PR TITLE
Localize timeline filters and restore Tailwind margins

### DIFF
--- a/components/hooks/useI18n.ts
+++ b/components/hooks/useI18n.ts
@@ -137,6 +137,7 @@ const DICTIONARY: Record<string, Record<string, string>> = {
     Loading: "Loading",
     "Searching…": "Searching…",
     "Search…": "Search…",
+    "Search...": "Search...",
     Registry: "Registry",
     Status: "Status",
     Phase: "Phase",


### PR DESCRIPTION
## Summary
- restore standard Tailwind margin utilities on the timeline action buttons
- localize the timeline tab labels, date range label, search placeholder, and row badges
- add the missing "Search..." dictionary entry for translation lookups

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dad8100170832f801ddfd3c9d3492c