### PR TITLE
Localize mode banners and research toggle

### DIFF
--- a/components/ResearchToggle.tsx
+++ b/components/ResearchToggle.tsx
@@ -1,21 +1,52 @@
 "use client";
+
 import { useEffect, useState } from "react";
 
-export function ResearchToggle({ defaultOn=false, onChange }:{defaultOn?:boolean; onChange?:(v:boolean)=>void}) {
+import { useT } from "@/components/hooks/useI18n";
+
+export function ResearchToggle({
+  defaultOn = false,
+  onChange,
+}: {
+  defaultOn?: boolean;
+  onChange?: (v: boolean) => void;
+}) {
+  const t = useT();
   const [mounted, setMounted] = useState(false);
   const [on, setOn] = useState(defaultOn);
-  useEffect(()=>setMounted(true),[]);
-  if(!mounted) return null;
 
-  const toggle = () => { const v = !on; setOn(v); onChange?.(v); };
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  const toggle = () => {
+    const next = !on;
+    setOn(next);
+    onChange?.(next);
+  };
+
+  const label = on
+    ? t("Research: On — web evidence")
+    : t("Research: Off — enable web evidence");
+
   return (
-    <button type="button" aria-pressed={on} onClick={toggle}
+    <button
+      type="button"
+      aria-pressed={on}
+      onClick={toggle}
       className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition
-        ${on
-        ? "bg-emerald-100 text-emerald-900 border-emerald-200/60 dark:bg-emerald-900/30 dark:text-emerald-200 dark:border-emerald-800"
-        : "bg-slate-100 text-slate-800 border-slate-200 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700"}`}>
-      <span className={`inline-block h-2.5 w-2.5 rounded-full ${on?"bg-emerald-500":"bg-slate-400"}`} />
-      {on ? "Research On" : "Research Off"}
+        ${
+          on
+            ? "bg-emerald-100 text-emerald-900 border-emerald-200/60 dark:bg-emerald-900/30 dark:text-emerald-200 dark:border-emerald-800"
+            : "bg-slate-100 text-slate-800 border-slate-200 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700"
+        }`}
+    >
+      <span
+        className={`inline-block h-2.5 w-2.5 rounded-full ${
+          on ? "bg-emerald-500" : "bg-slate-400"
+        }`}
+      />
+      {label}
     </button>
   );
 }

--- a/components/chat/WelcomeCard.tsx
+++ b/components/chat/WelcomeCard.tsx
@@ -13,8 +13,9 @@ export default function WelcomeCard({ header, body, status, onDismiss }: Welcome
   const t = useT();
   const fallbackHeader = t("Start a new conversation");
   const fallbackBody = t("Ask about wellness, therapy, research or clinical topics.");
-  const resolvedHeader = header ?? fallbackHeader;
-  const resolvedBody = body ?? fallbackBody;
+  const resolvedHeader = header ? t(header) : fallbackHeader;
+  const resolvedBody = body ? t(body) : fallbackBody;
+  const resolvedStatus = status ? t(status) : undefined;
 
   return (
     <div className="rounded-2xl border border-[color:var(--medx-outline)] bg-[color:var(--medx-panel)] p-6 text-center shadow-sm dark:border-white/10 dark:bg-[color:var(--medx-panel)]">
@@ -24,7 +25,9 @@ export default function WelcomeCard({ header, body, status, onDismiss }: Welcome
       {resolvedBody ? (
         <p className="mt-2 text-sm text-[color:var(--medx-subtle-text)]">{resolvedBody}</p>
       ) : null}
-      {status ? <p className="mt-2 text-xs text-[color:var(--medx-subtle-text)]">{status}</p> : null}
+      {status ? (
+        <p className="mt-2 text-xs text-[color:var(--medx-subtle-text)]">{resolvedStatus ?? status}</p>
+      ) : null}
       {onDismiss ? (
         <div className="mt-3">
           <button type="button" className="btn-subtle" onClick={onDismiss}>

--- a/components/hooks/useI18n.ts
+++ b/components/hooks/useI18n.ts
@@ -110,6 +110,19 @@ const DICTIONARY: Record<string, Record<string, string>> = {
     Research: "Research",
     Clinical: "Clinical",
     "AI Doc": "AI Doc",
+    "Wellness Mode: ON": "Wellness Mode: ON",
+    "Clinical Mode: ON": "Clinical Mode: ON",
+    "AI Doc: ON": "AI Doc: ON",
+    "Therapy Mode: ON": "Therapy Mode: ON",
+    "Your health, made simple. Reports, tips, medication, diets, and fitness—explained in clear language.":
+      "Your health, made simple. Reports, tips, medication, diets, and fitness—explained in clear language.",
+    "Evidence-ready, clinician-first.": "Evidence-ready, clinician-first.",
+    "Your records, organized. Upload, store, and retrieve securely.":
+      "Your records, organized. Upload, store, and retrieve securely.",
+    "Therapy guidance, made clear. Tools and support; not for emergencies.":
+      "Therapy guidance, made clear. Tools and support; not for emergencies.",
+    "Research: On — web evidence": "Research: On — web evidence",
+    "Research: Off — enable web evidence": "Research: Off — enable web evidence",
     "Type a message": "Type a message",
     "Send a message": "Send a message",
     Send: "Send",
@@ -293,6 +306,19 @@ const DICTIONARY: Record<string, Record<string, string>> = {
     Research: "रिसर्च",
     Clinical: "क्लिनिकल",
     "AI Doc": "एआई डॉक",
+    "Wellness Mode: ON": "वेलनेस मोड: चालू",
+    "Clinical Mode: ON": "क्लिनिकल मोड: चालू",
+    "AI Doc: ON": "एआई डॉक: चालू",
+    "Therapy Mode: ON": "थेरेपी मोड: चालू",
+    "Your health, made simple. Reports, tips, medication, diets, and fitness—explained in clear language.":
+      "आपका स्वास्थ्य, सरल बनाया गया। रिपोर्ट, सुझाव, दवा, आहार और फिटनेस—सब कुछ स्पष्ट भाषा में समझाया गया है।",
+    "Evidence-ready, clinician-first.": "साक्ष्य तैयार, पहले चिकित्सकों के लिए।",
+    "Your records, organized. Upload, store, and retrieve securely.":
+      "आपके रिकॉर्ड, व्यवस्थित। सुरक्षित रूप से अपलोड करें, सहेजें और प्राप्त करें।",
+    "Therapy guidance, made clear. Tools and support; not for emergencies.":
+      "थेरेपी मार्गदर्शन, साफ़-सुथरा। उपकरण और समर्थन; आपात स्थितियों के लिए नहीं।",
+    "Research: On — web evidence": "रिसर्च: चालू — वेब साक्ष्य",
+    "Research: Off — enable web evidence": "रिसर्च: बंद — वेब साक्ष्य सक्षम करें",
     "Type a message": "संदेश लिखें",
     "Send a message": "संदेश भेजें",
     Send: "भेजें",
@@ -476,6 +502,19 @@ const DICTIONARY: Record<string, Record<string, string>> = {
     Research: "البحث",
     Clinical: "سريري",
     "AI Doc": "مستند ذكي",
+    "Wellness Mode: ON": "وضع العافية: مُفعل",
+    "Clinical Mode: ON": "الوضع السريري: مُفعل",
+    "AI Doc: ON": "طبيب الذكاء الاصطناعي: مُفعل",
+    "Therapy Mode: ON": "وضع العلاج: مُفعل",
+    "Your health, made simple. Reports, tips, medication, diets, and fitness—explained in clear language.":
+      "صحتك ببساطة. تقارير ونصائح وأدوية وحميات ولياقة — موضحة بلغة واضحة.",
+    "Evidence-ready, clinician-first.": "جاهز بالأدلة، موجه أولًا للأطباء.",
+    "Your records, organized. Upload, store, and retrieve securely.":
+      "سجلاتك منظمة. ارفعها وخزنها واسترجعها بأمان.",
+    "Therapy guidance, made clear. Tools and support; not for emergencies.":
+      "إرشاد علاجي واضح. أدوات ودعم؛ غير مخصص للطوارئ.",
+    "Research: On — web evidence": "البحث: مُفعل — أدلة من الويب",
+    "Research: Off — enable web evidence": "البحث: متوقف — فعّل أدلة الويب",
     "Type a message": "اكتب رسالة",
     Send: "إرسال",
     "Start a new conversation": "ابدأ محادثة جديدة",
@@ -658,6 +697,19 @@ const DICTIONARY: Record<string, Record<string, string>> = {
     Research: "Ricerca",
     Clinical: "Clinico",
     "AI Doc": "AI Doc",
+    "Wellness Mode: ON": "Modalità Benessere: ATTIVA",
+    "Clinical Mode: ON": "Modalità Clinica: ATTIVA",
+    "AI Doc: ON": "AI Doc: ATTIVO",
+    "Therapy Mode: ON": "Modalità Terapia: ATTIVA",
+    "Your health, made simple. Reports, tips, medication, diets, and fitness—explained in clear language.":
+      "La tua salute, resa semplice. Referti, consigli, farmaci, diete e fitness — spiegati con parole chiare.",
+    "Evidence-ready, clinician-first.": "Pronto all’evidenza, pensato prima per i clinici.",
+    "Your records, organized. Upload, store, and retrieve securely.":
+      "I tuoi referti, organizzati. Carica, archivia e recupera in modo sicuro.",
+    "Therapy guidance, made clear. Tools and support; not for emergencies.":
+      "Supporto terapeutico reso chiaro. Strumenti e sostegno; non per le emergenze.",
+    "Research: On — web evidence": "Ricerca: Attiva — evidenze dal web",
+    "Research: Off — enable web evidence": "Ricerca: Disattiva — abilita le evidenze dal web",
     "Type a message": "Scrivi un messaggio",
     Send: "Invia",
     "Start a new conversation": "Inizia una nuova conversazione",
@@ -840,6 +892,19 @@ const DICTIONARY: Record<string, Record<string, string>> = {
     Research: "研究",
     Clinical: "临床",
     "AI Doc": "智能文档",
+    "Wellness Mode: ON": "健康模式：已开启",
+    "Clinical Mode: ON": "临床模式：已开启",
+    "AI Doc: ON": "AI Doc：已开启",
+    "Therapy Mode: ON": "治疗模式：已开启",
+    "Your health, made simple. Reports, tips, medication, diets, and fitness—explained in clear language.":
+      "让健康更简单。报告、建议、用药、饮食与健身——用清晰语言讲解。",
+    "Evidence-ready, clinician-first.": "证据就绪，优先服务临床。",
+    "Your records, organized. Upload, store, and retrieve securely.":
+      "您的病历井然有序。安全上传、存储与调取。",
+    "Therapy guidance, made clear. Tools and support; not for emergencies.":
+      "治疗指导，简单明了。提供工具与支持；非紧急用途。",
+    "Research: On — web evidence": "研究：已开启 — 网络证据",
+    "Research: Off — enable web evidence": "研究：已关闭 — 启用网络证据",
     "Type a message": "输入消息",
     Send: "发送",
     "Start a new conversation": "开始新会话",
@@ -1022,6 +1087,19 @@ const DICTIONARY: Record<string, Record<string, string>> = {
     Research: "Investigación",
     Clinical: "Clínico",
     "AI Doc": "Doc IA",
+    "Wellness Mode: ON": "Modo bienestar: ACTIVADO",
+    "Clinical Mode: ON": "Modo clínico: ACTIVADO",
+    "AI Doc: ON": "AI Doc: ACTIVADO",
+    "Therapy Mode: ON": "Modo terapia: ACTIVADO",
+    "Your health, made simple. Reports, tips, medication, diets, and fitness—explained in clear language.":
+      "Tu salud, simplificada. Informes, consejos, medicación, dietas y ejercicio, explicados con un lenguaje claro.",
+    "Evidence-ready, clinician-first.": "Listo con evidencia, diseñado primero para clínicos.",
+    "Your records, organized. Upload, store, and retrieve securely.":
+      "Tus registros, organizados. Sube, guarda y recupera de forma segura.",
+    "Therapy guidance, made clear. Tools and support; not for emergencies.":
+      "Guía terapéutica clara. Herramientas y apoyo; no apto para emergencias.",
+    "Research: On — web evidence": "Investigación: Activada — evidencia web",
+    "Research: Off — enable web evidence": "Investigación: Desactivada — habilita evidencia web",
     "Type a message": "Escribe un mensaje",
     "Send a message": "Enviar un mensaje",
     Send: "Enviar",

--- a/components/ui/WelcomeCard.tsx
+++ b/components/ui/WelcomeCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { X } from "lucide-react";
 import { useT } from "@/components/hooks/useI18n";
 

--- a/components/ui/WelcomeCard.tsx
+++ b/components/ui/WelcomeCard.tsx
@@ -1,4 +1,5 @@
 import { X } from "lucide-react";
+import { useT } from "@/components/hooks/useI18n";
 
 export type WelcomeCardProps = {
   header: string;
@@ -19,6 +20,11 @@ export default function WelcomeCard({
   onDismiss,
   className,
 }: WelcomeCardProps) {
+  const t = useT();
+  const translatedHeader = header ? t(header) : undefined;
+  const translatedBody = body ? t(body) : undefined;
+  const translatedStatus = status ? t(status) : undefined;
+
   return (
     <div
       role="region"
@@ -41,9 +47,13 @@ export default function WelcomeCard({
         <X className="h-4 w-4" aria-hidden="true" />
       </button>
       <div className="pr-6">
-        <div className="text-[0.95rem] font-semibold">{header}</div>
-        <div className="mt-1 leading-snug text-blue-50 dark:text-blue-100">{body}</div>
-        {status ? <div className="mt-1 text-xs opacity-90">{status}</div> : null}
+        <div className="text-[0.95rem] font-semibold">{translatedHeader ?? header}</div>
+        <div className="mt-1 leading-snug text-blue-50 dark:text-blue-100">
+          {translatedBody ?? body}
+        </div>
+        {status ? (
+          <div className="mt-1 text-xs opacity-90">{translatedStatus ?? status}</div>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- localize welcome banners by translating titles, subtitles, and status lines in both welcome card variants
- add multilingual strings for new mode copy and research toggle states across supported locales
- update the research toggle label to use the localized research status strings

## Testing
- npm run lint *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dac66e9a18832fa3190fcd63291d60