### PR TITLE
Add localized directory name translations with user preference

### DIFF
--- a/components/panels/DirectoryPane.tsx
+++ b/components/panels/DirectoryPane.tsx
@@ -12,7 +12,7 @@ type DirectoryType = ReturnType<typeof useDirectory>["state"]["type"];
 const PREFS_STORAGE_KEY = "medx-prefs-v1";
 
 export default function DirectoryPane() {
-  const { lang } = usePrefs();
+  const { lang, directoryShowOriginalName } = usePrefs();
   const storedLang = useMemo(() => {
     if (typeof window === "undefined") return null;
     try {
@@ -199,7 +199,17 @@ export default function DirectoryPane() {
           </div>
         )}
         {data.map((place) => {
-          const displayName = place.localizedName ?? place.name;
+          const enriched = place as typeof place & {
+            name_display?: string;
+            name_localized?: string;
+          };
+          const showOriginal = directoryShowOriginalName !== false;
+          const displayName = showOriginal
+            ? enriched.name_display ?? enriched.name_localized ?? place.localizedName ?? place.name
+            : enriched.name_localized ?? place.localizedName ?? enriched.name_display ?? place.name;
+          const titleName = showOriginal
+            ? enriched.name_display ?? place.localizedName ?? place.name
+            : enriched.name_localized ?? place.localizedName ?? place.name;
           const displayAddress = place.localizedAddress ?? place.address;
           const typeLabel =
             place.category_display ??
@@ -283,7 +293,7 @@ export default function DirectoryPane() {
                   <div className="flex items-start justify-between gap-2 md:gap-3">
                     <div
                       className="break-words text-start text-[12.5px] font-semibold leading-[1.35] text-slate-900 dark:text-slate-50 md:truncate md:text-[14px]"
-                      title={place.name}
+                      title={titleName}
                     >
                       {displayName}
                     </div>

--- a/components/providers/PreferencesProvider.tsx
+++ b/components/providers/PreferencesProvider.tsx
@@ -21,6 +21,8 @@ export type Prefs = {
   labUpdates: boolean;
   weeklyDigest: boolean;
 
+  directoryShowOriginalName: boolean;
+
   passcode: boolean;
   maskSensitive: boolean;
   sessionTimeout: "Never" | "5m" | "15m" | "1h";
@@ -57,6 +59,8 @@ const DEFAULT: Prefs = {
   medReminders: false,
   labUpdates: false,
   weeklyDigest: false,
+
+  directoryShowOriginalName: true,
 
   passcode: false,
   maskSensitive: false,

--- a/components/settings/PreferencesModal.tsx
+++ b/components/settings/PreferencesModal.tsx
@@ -23,6 +23,7 @@ import DataControlsPanel from "./panels/DataControls";
 import SecurityPanel from "./panels/Security";
 import AccountPanel from "./panels/Account";
 import { useT } from "@/components/hooks/useI18n";
+import { usePrefs } from "@/components/providers/PreferencesProvider";
 
 type TabKey =
   | "General"
@@ -33,6 +34,48 @@ type TabKey =
   | "Data controls"
   | "Security"
   | "Account";
+
+function DirectoryPreferencesSection() {
+  const prefs = usePrefs();
+  const t = useT();
+  const showOriginal = prefs.directoryShowOriginalName !== false;
+
+  return (
+    <div className="divide-y divide-black/5 dark:divide-white/10">
+      <div className="px-5 py-3 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        {t("Directory")}
+      </div>
+      <div className="flex items-center justify-between gap-4 px-5 py-4">
+        <div className="max-w-[460px]">
+          <div className="text-[13px] font-semibold text-slate-900 dark:text-slate-50">
+            {t("Show original name alongside translation")}
+          </div>
+          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+            {t("Display the provider’s original name in parentheses when translations are available.")}
+          </div>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={showOriginal}
+          aria-label={t("Show original name alongside translation")}
+          onClick={() => prefs.set("directoryShowOriginalName", !showOriginal)}
+          className={cn(
+            "relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50",
+            showOriginal ? "bg-blue-500" : "bg-slate-300 dark:bg-slate-700",
+          )}
+        >
+          <span
+            className={cn(
+              "inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform",
+              showOriginal ? "translate-x-[22px]" : "translate-x-[2px]",
+            )}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export default function PreferencesModal({
   open,
@@ -134,7 +177,12 @@ export default function PreferencesModal({
   const Panel = useMemo(() => {
     switch (tab) {
       case "General":
-        return <GeneralPanel />;
+        return (
+          <>
+            <GeneralPanel />
+            <DirectoryPreferencesSection />
+          </>
+        );
       case "Notifications":
         return <NotificationsPanel />;
       case "Personalization":


### PR DESCRIPTION
## Summary
- localize directory place names on the server with rule-based translations, caching, and metadata for clients
- display translated names on directory cards while respecting the new preference to hide original names
- expose a Directory preference toggle so users can decide whether to show provider names in both languages

## Testing
- npm run lint *(fails because the Next.js ESLint setup prompt requires interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_68daefd3a700832fb32fa2c3c6608a06