### PR TITLE
Localize directory search results with feature flag

### DIFF
--- a/app/api/directory/search/route.ts
+++ b/app/api/directory/search/route.ts
@@ -3,11 +3,27 @@ import { providerLang } from "@/lib/i18n/providerLang";
 
 // meters per degree latitude (simple distance estimate)
 const M_PER_DEG = 111_320;
-const DIRECTORY_I18N_V1 =
-  ((process.env.DIRECTORY_I18N_V1 ?? process.env.NEXT_PUBLIC_DIRECTORY_I18N_V1 ?? "true").toString().toLowerCase() ||
-    "true") !== "false";
+
+function flagEnabled(value: string | undefined, defaultValue: boolean) {
+  if (value == null) return defaultValue;
+  const normalized = value.toString().trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return defaultValue;
+}
+
+const DIRECTORY_NAME_I18N_ENABLED = flagEnabled(
+  process.env.DIRECTORY_NAME_I18N ?? process.env.NEXT_PUBLIC_DIRECTORY_NAME_I18N,
+  true,
+);
+const DIRECTORY_ADDRESS_I18N_ENABLED = flagEnabled(
+  process.env.DIRECTORY_ADDRESS_I18N ?? process.env.NEXT_PUBLIC_DIRECTORY_ADDRESS_I18N,
+  false,
+);
 const NAME_CACHE_TTL_SECONDS = 86_400;
-const DETAILS_CACHE_TTL_MS = NAME_CACHE_TTL_SECONDS * 1000;
+const NAME_CACHE_TTL_MS = NAME_CACHE_TTL_SECONDS * 1000;
+const DETAILS_CACHE_TTL_MS = 86_400 * 1000;
 
 type NameLocalization = {
   name_original: string;
@@ -27,8 +43,12 @@ const GENERIC_TRANSLATIONS: Record<string, Record<string, string>> = {
   hi: {
     "medical center": "मेडिकल सेंटर",
     "medical centre": "मेडिकल सेंटर",
+    "medical centers": "मेडिकल सेंटर्स",
+    "medical centres": "मेडिकल सेंटर्स",
     center: "केंद्र",
     centre: "केंद्र",
+    centers: "केंद्र",
+    centres: "केंद्र",
     multispeciality: "बहु-विशेषता",
     multispecialty: "बहु-विशेषता",
     maternity: "मातृत्व",
@@ -36,27 +56,40 @@ const GENERIC_TRANSLATIONS: Record<string, Record<string, string>> = {
     ent: "ईएनटी",
     dermatology: "त्वचा रोग",
     pediatric: "बाल चिकित्सा",
+    pediatrics: "बाल चिकित्सा",
     paediatric: "बाल चिकित्सा",
+    paediatrics: "बाल चिकित्सा",
     orthopedic: "अस्थि रोग",
     orthopaedic: "अस्थि रोग",
+    orthopedics: "अस्थि रोग",
+    orthopaedics: "अस्थि रोग",
     gynecology: "स्त्री रोग",
     gynaecology: "स्त्री रोग",
     cardiac: "हृदय",
     dental: "दंत",
     eye: "नेत्र",
+    diagnostic: "डायग्नोस्टिक",
     diagnostics: "डायग्नोस्टिक्स",
     labs: "लैब्स",
     lab: "लैब",
+    clinics: "क्लिनिक",
     clinic: "क्लिनिक",
+    hospitals: "अस्पताल",
     hospital: "अस्पताल",
+    pharmacies: "फार्मेसियाँ",
     pharmacy: "फार्मेसी",
+    doctors: "डॉक्टर",
     doctor: "डॉक्टर",
   },
   ar: {
     "medical center": "مركز طبي",
     "medical centre": "مركز طبي",
+    "medical centers": "مراكز طبية",
+    "medical centres": "مراكز طبية",
     center: "مركز",
     centre: "مركز",
+    centers: "مراكز",
+    centres: "مراكز",
     multispeciality: "متعدد التخصصات",
     multispecialty: "متعدد التخصصات",
     maternity: "أمومة",
@@ -64,27 +97,40 @@ const GENERIC_TRANSLATIONS: Record<string, Record<string, string>> = {
     ent: "أنف وأذن وحنجرة",
     dermatology: "جلدية",
     pediatric: "أطفال",
+    pediatrics: "أطفال",
     paediatric: "أطفال",
+    paediatrics: "أطفال",
     orthopedic: "عظام",
     orthopaedic: "عظام",
+    orthopedics: "عظام",
+    orthopaedics: "عظام",
     gynecology: "نسائية",
     gynaecology: "نسائية",
     cardiac: "قلبي",
     dental: "أسنان",
     eye: "عيون",
+    diagnostic: "تشخيصي",
     diagnostics: "تشخيص",
     labs: "مختبرات",
     lab: "مختبر",
+    clinics: "عيادات",
     clinic: "عيادة",
+    hospitals: "مستشفيات",
     hospital: "مستشفى",
+    pharmacies: "صيدليات",
     pharmacy: "صيدلية",
+    doctors: "أطباء",
     doctor: "طبيب",
   },
   it: {
     "medical center": "Centro Medico",
     "medical centre": "Centro Medico",
+    "medical centers": "Centri Medici",
+    "medical centres": "Centri Medici",
     center: "Centro",
     centre: "Centro",
+    centers: "Centri",
+    centres: "Centri",
     multispeciality: "Polispecialistica",
     multispecialty: "Polispecialistica",
     maternity: "Maternità",
@@ -92,27 +138,40 @@ const GENERIC_TRANSLATIONS: Record<string, Record<string, string>> = {
     ent: "Otorinolaringoiatria",
     dermatology: "Dermatologia",
     pediatric: "Pediatria",
+    pediatrics: "Pediatria",
     paediatric: "Pediatria",
+    paediatrics: "Pediatria",
     orthopedic: "Ortopedia",
     orthopaedic: "Ortopedia",
+    orthopedics: "Ortopedia",
+    orthopaedics: "Ortopedia",
     gynecology: "Gynecologia",
     gynaecology: "Gynecologia",
     cardiac: "Cardiologia",
     dental: "Odontoiatria",
     eye: "Oculistica",
+    diagnostic: "Diagnostico",
     diagnostics: "Diagnostica",
     labs: "Laboratori",
     lab: "Laboratorio",
+    clinics: "Cliniche",
     clinic: "Clinica",
+    hospitals: "Ospedali",
     hospital: "Ospedale",
+    pharmacies: "Farmacie",
     pharmacy: "Farmacia",
+    doctors: "Medici",
     doctor: "Medico",
   },
   es: {
     "medical center": "Centro Médico",
     "medical centre": "Centro Médico",
+    "medical centers": "Centros Médicos",
+    "medical centres": "Centros Médicos",
     center: "Centro",
     centre: "Centro",
+    centers: "Centros",
+    centres: "Centros",
     multispeciality: "Multiespecialidad",
     multispecialty: "Multiespecialidad",
     maternity: "Maternidad",
@@ -120,27 +179,81 @@ const GENERIC_TRANSLATIONS: Record<string, Record<string, string>> = {
     ent: "Otorrinolaringología",
     dermatology: "Dermatología",
     pediatric: "Pediatría",
+    pediatrics: "Pediatría",
     paediatric: "Pediatría",
+    paediatrics: "Pediatría",
     orthopedic: "Ortopedia",
     orthopaedic: "Ortopedia",
+    orthopedics: "Ortopedia",
+    orthopaedics: "Ortopedia",
     gynecology: "Ginecología",
     gynaecology: "Ginecología",
     cardiac: "Cardiología",
     dental: "Dental",
     eye: "Oftalmología",
-    diagnostics: "Diagnóstico",
+    diagnostic: "Diagnóstico",
+    diagnostics: "Diagnósticos",
     labs: "Laboratorios",
     lab: "Laboratorio",
+    clinics: "Clínicas",
     clinic: "Clínica",
+    hospitals: "Hospitales",
     hospital: "Hospital",
+    pharmacies: "Farmacias",
     pharmacy: "Farmacia",
+    doctors: "Doctores",
     doctor: "Doctor",
+  },
+  fr: {
+    "medical center": "Centre médical",
+    "medical centre": "Centre médical",
+    "medical centers": "Centres médicaux",
+    "medical centres": "Centres médicaux",
+    center: "Centre",
+    centre: "Centre",
+    centers: "Centres",
+    centres: "Centres",
+    multispeciality: "Pluridisciplinaire",
+    multispecialty: "Pluridisciplinaire",
+    maternity: "Maternité",
+    physiotherapy: "Kinésithérapie",
+    ent: "ORL",
+    dermatology: "Dermatologie",
+    pediatric: "Pédiatrie",
+    pediatrics: "Pédiatrie",
+    paediatric: "Pédiatrie",
+    paediatrics: "Pédiatrie",
+    orthopedic: "Orthopédie",
+    orthopaedic: "Orthopédie",
+    orthopedics: "Orthopédie",
+    orthopaedics: "Orthopédie",
+    gynecology: "Gynécologie",
+    gynaecology: "Gynécologie",
+    cardiac: "Cardiologie",
+    dental: "Dentaire",
+    eye: "Ophtalmologie",
+    diagnostic: "Diagnostic",
+    diagnostics: "Diagnostics",
+    labs: "Laboratoires",
+    lab: "Laboratoire",
+    clinics: "Cliniques",
+    clinic: "Clinique",
+    hospitals: "Hôpitaux",
+    hospital: "Hôpital",
+    pharmacies: "Pharmacies",
+    pharmacy: "Pharmacie",
+    doctors: "Médecins",
+    doctor: "Médecin",
   },
   zh: {
     "medical center": "医疗中心",
     "medical centre": "医疗中心",
+    "medical centers": "医疗中心",
+    "medical centres": "医疗中心",
     center: "中心",
     centre: "中心",
+    centers: "中心",
+    centres: "中心",
     multispeciality: "多专科",
     multispecialty: "多专科",
     maternity: "产科",
@@ -148,20 +261,29 @@ const GENERIC_TRANSLATIONS: Record<string, Record<string, string>> = {
     ent: "耳鼻喉科",
     dermatology: "皮肤科",
     pediatric: "儿科",
+    pediatrics: "儿科",
     paediatric: "儿科",
+    paediatrics: "儿科",
     orthopedic: "骨科",
     orthopaedic: "骨科",
+    orthopedics: "骨科",
+    orthopaedics: "骨科",
     gynecology: "妇科",
     gynaecology: "妇科",
     cardiac: "心脏科",
     dental: "牙科",
     eye: "眼科",
+    diagnostic: "诊断",
     diagnostics: "诊断",
     labs: "实验室",
     lab: "实验室",
+    clinics: "诊所",
     clinic: "诊所",
+    hospitals: "医院",
     hospital: "医院",
+    pharmacies: "药店",
     pharmacy: "药店",
+    doctors: "医生",
     doctor: "医生",
   },
 };
@@ -171,6 +293,7 @@ const ABBREVIATION_TRANSLATIONS: Record<string, { pattern: RegExp; replacement: 
   ar: { pattern: /\bDr\.?/gi, replacement: "د." },
   it: { pattern: /\bDr\.?/gi, replacement: "Dott.ssa" },
   es: { pattern: /\bDr\.?/gi, replacement: "Dr." },
+  fr: { pattern: /\bDr\.?/gi, replacement: "Dr" },
   zh: { pattern: /\bDr\.?/gi, replacement: "医生" },
 };
 
@@ -280,8 +403,10 @@ function translateGenericTerms(name: string, lang: string) {
   const abbr = resolveLangMap(ABBREVIATION_TRANSLATIONS, lang);
   if (abbr) {
     const { pattern, replacement } = abbr;
-    if (pattern.test(text)) {
-      text = text.replace(pattern, replacement);
+    const regex = new RegExp(pattern.source, pattern.flags);
+    const updated = text.replace(regex, replacement);
+    if (updated !== text) {
+      text = updated;
       changed = true;
     }
   }
@@ -357,7 +482,7 @@ function localizeName(place: Place, lang: string, caches: DirectoryCaches): Name
     name_cache_ttl: NAME_CACHE_TTL_SECONDS,
   };
 
-  caches.__dirNameCache.set(cacheKey, { entry, expiresAt: now + DETAILS_CACHE_TTL_MS });
+  caches.__dirNameCache.set(cacheKey, { entry, expiresAt: now + NAME_CACHE_TTL_MS });
   return entry;
 }
 
@@ -391,6 +516,41 @@ type Place = {
   last_checked?: string;
   rank_score?: number;
 };
+
+function stripNameFields(place: Place & Partial<NameLocalization>): Place {
+  const { name_display, name_localized, name_original, name_method, name_cache_ttl, ...rest } = place;
+  return rest as Place;
+}
+
+function applyDirectoryFeatures(places: Place[], lang: string, caches: DirectoryCaches) {
+  return places.map(place => {
+    const base = place as Place & Partial<NameLocalization>;
+    let next: Place & Partial<NameLocalization> = { ...base };
+
+    if (DIRECTORY_ADDRESS_I18N_ENABLED) {
+      const localized = base.localizedAddress;
+      const fallback = base.address;
+      const resolved = localized ?? fallback ?? "";
+      next = { ...next, address: resolved };
+      if ("localizedAddress" in next) {
+        delete (next as Record<string, unknown>).localizedAddress;
+      }
+    }
+
+    if (DIRECTORY_NAME_I18N_ENABLED) {
+      const localizedName = localizeName(base, lang, caches);
+      next = { ...next, ...localizedName };
+    } else {
+      delete (next as Record<string, unknown>).name_display;
+      delete (next as Record<string, unknown>).name_localized;
+      delete (next as Record<string, unknown>).name_original;
+      delete (next as Record<string, unknown>).name_method;
+      delete (next as Record<string, unknown>).name_cache_ttl;
+    }
+
+    return next;
+  });
+}
 
 type GoogleAddressComponent = {
   longText?: string;
@@ -891,7 +1051,6 @@ export async function GET(req: Request) {
     searchParams.get("lng") ?? "",
     searchParams.get("radius") ?? "",
     lang,
-    DIRECTORY_I18N_V1 ? "i18n" : "base",
   ].join("|");
   const globalAny = globalThis as typeof globalThis & DirectoryCaches;
   globalAny.__dirCache ||= new Map();
@@ -899,7 +1058,8 @@ export async function GET(req: Request) {
 
   const cached = cache.get(cacheKey);
   if (cached) {
-    return NextResponse.json(cached);
+    const enriched = applyDirectoryFeatures(cached.data, lang, globalAny);
+    return NextResponse.json({ ...cached, data: enriched });
   }
 
   if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
@@ -936,16 +1096,7 @@ export async function GET(req: Request) {
         if (d?.phone) p.phones = [d.phone];
         if (d?.hours) p.hours = d.hours;
         const formattedAddress = d?.formattedAddress ?? d?.composedAddress;
-        if (DIRECTORY_I18N_V1) {
-          if (formattedAddress) {
-            p.address = formattedAddress;
-          } else if (!p.address) {
-            p.address = "";
-          }
-          if (p.localizedAddress) {
-            delete p.localizedAddress;
-          }
-        } else if (formattedAddress) {
+        if (formattedAddress) {
           if (!p.address) {
             p.address = formattedAddress;
           } else if (p.address !== formattedAddress) {
@@ -967,9 +1118,6 @@ export async function GET(req: Request) {
 
       normalized.sort((a, b) => (a.distance_m ?? 1e9) - (b.distance_m ?? 1e9));
       places = uniqueByNameAddr(normalized).slice(0, 120);
-      if (DIRECTORY_I18N_V1) {
-        places = places.map(p => ({ ...p, ...localizeName(p, lang, globalAny) }));
-      }
       usedGoogle = places.length > 0;
     } catch {
       // fall through to OSM
@@ -982,18 +1130,23 @@ export async function GET(req: Request) {
     if (Number.isFinite(maxKm)) filtered = filtered.filter(p => (p.distance_m ?? 1e9) <= maxKm * 1000);
     filtered.sort((a, b) => (a.distance_m ?? 1e9) - (b.distance_m ?? 1e9));
     places = filtered.slice(0, 120);
-    if (DIRECTORY_I18N_V1) {
-      places = places.map(p => ({ ...p, ...localizeName(p, lang, globalAny) }));
-    }
   }
 
+  const responsePlaces = applyDirectoryFeatures(places, lang, globalAny);
+  const updatedAtIso = new Date().toISOString();
+  const provider = usedGoogle ? "google" : "osm";
+
   const payload = {
-    data: places,
-    updatedAt: new Date().toISOString(),
-    provider: usedGoogle ? "google" : "osm",
+    data: responsePlaces,
+    updatedAt: updatedAtIso,
+    provider,
   } as const;
 
-  cache.set(cacheKey, payload);
+  cache.set(cacheKey, {
+    data: places.map(stripNameFields),
+    updatedAt: updatedAtIso,
+    provider,
+  });
 
   return NextResponse.json(payload);
 }

--- a/components/directory/AddressPicker.tsx
+++ b/components/directory/AddressPicker.tsx
@@ -15,12 +15,17 @@ export default function AddressPicker({
   const [opts, setOpts] = useState<{ label: string; lat: number; lng: number }[]>([]);
   const [open, setOpen] = useState(false);
   const timeoutRef = useRef<number | null>(null);
+  const langRef = useRef(lang);
   const t = useT();
   const placeholder = t("Enter area, city, or address");
 
   useEffect(() => {
     setQ(value);
   }, [value]);
+
+  useEffect(() => {
+    langRef.current = lang;
+  }, [lang]);
 
   useEffect(() => {
     if (timeoutRef.current) {
@@ -35,7 +40,7 @@ export default function AddressPicker({
 
     timeoutRef.current = window.setTimeout(async () => {
       try {
-        const params = new URLSearchParams({ q, lang });
+        const params = new URLSearchParams({ q, lang: langRef.current });
         const response = await fetch(`/api/geocode?${params.toString()}`, { cache: "no-store" });
         const json = await response.json();
         setOpts(json.data || []);
@@ -50,7 +55,7 @@ export default function AddressPicker({
         window.clearTimeout(timeoutRef.current);
       }
     };
-  }, [q, lang]);
+  }, [q]);
 
   return (
     <div className="relative w-full">

--- a/components/directory/AddressPicker.tsx
+++ b/components/directory/AddressPicker.tsx
@@ -2,6 +2,20 @@
 import { useEffect, useRef, useState } from "react";
 import { useT } from "@/components/hooks/useI18n";
 
+function parseFlag(value: string | undefined, defaultValue: boolean) {
+  if (value == null) return defaultValue;
+  const normalized = value.toString().trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return defaultValue;
+}
+
+const DIRECTORY_LOCATION_INPUT_STABILITY_ENABLED = parseFlag(
+  process.env.NEXT_PUBLIC_DIRECTORY_LOCATION_INPUT_STABILITY,
+  true,
+);
+
 export default function AddressPicker({
   value,
   onSelect,
@@ -40,7 +54,10 @@ export default function AddressPicker({
 
     timeoutRef.current = window.setTimeout(async () => {
       try {
-        const params = new URLSearchParams({ q, lang: langRef.current });
+        const params = new URLSearchParams({
+          q,
+          lang: DIRECTORY_LOCATION_INPUT_STABILITY_ENABLED ? langRef.current : lang,
+        });
         const response = await fetch(`/api/geocode?${params.toString()}`, { cache: "no-store" });
         const json = await response.json();
         setOpts(json.data || []);
@@ -55,7 +72,7 @@ export default function AddressPicker({
         window.clearTimeout(timeoutRef.current);
       }
     };
-  }, [q]);
+  }, [q, lang]);
 
   return (
     <div className="relative w-full">

--- a/components/panels/DirectoryPane.tsx
+++ b/components/panels/DirectoryPane.tsx
@@ -10,8 +10,17 @@ import { ISO_COUNTRIES } from "@/lib/i18n/isoCountries";
 type DirectoryType = ReturnType<typeof useDirectory>["state"]["type"];
 
 const PREFS_STORAGE_KEY = "medx-prefs-v1";
-const DIRECTORY_I18N_V1_ENABLED =
-  ((process.env.NEXT_PUBLIC_DIRECTORY_I18N_V1 ?? "true").toString().toLowerCase() || "true") !== "false";
+
+function parseFlag(value: string | undefined, defaultValue: boolean) {
+  if (value == null) return defaultValue;
+  const normalized = value.toString().trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return defaultValue;
+}
+
+const DIRECTORY_NAME_I18N_ENABLED = parseFlag(process.env.NEXT_PUBLIC_DIRECTORY_NAME_I18N, true);
 
 export default function DirectoryPane() {
   const prefs = usePrefs();
@@ -209,12 +218,12 @@ export default function DirectoryPane() {
           };
           const showOriginalName = prefs.directoryShowOriginalName !== false;
           const fallbackName = place.localizedName ?? place.name;
-          const displayName = DIRECTORY_I18N_V1_ENABLED
+          const displayName = DIRECTORY_NAME_I18N_ENABLED
             ? showOriginalName
               ? nameFields.name_display ?? nameFields.name_localized ?? fallbackName
               : nameFields.name_localized ?? fallbackName
             : fallbackName;
-          const titleAttr = DIRECTORY_I18N_V1_ENABLED
+          const titleAttr = DIRECTORY_NAME_I18N_ENABLED
             ? nameFields.name_original ?? displayName
             : place.name;
           const displayAddress = place.localizedAddress ?? place.address;

--- a/components/panels/DirectoryPane.tsx
+++ b/components/panels/DirectoryPane.tsx
@@ -116,8 +116,8 @@ export default function DirectoryPane() {
     <div className="mx-auto flex min-h-0 w-full max-w-[388px] flex-col md:mx-0 md:max-w-none">
       <div className="sticky top-0 z-10 space-y-1 border-b border-black/5 bg-white/85 px-2 pb-1 pt-1 backdrop-blur dark:border-white/10 dark:bg-slate-950/60 md:space-y-3 md:px-3 md:pb-3 md:pt-2">
         <div className="flex min-w-0 items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400 md:gap-2 md:text-[11px]">
-          <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500"></span>
-          <span className="min-w-0 truncate">{t("Using:")} {locationLabel}</span>
+          <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-green-500"></span>
+          <span className="min-w-0 flex-1 truncate">{t("Using:")} {locationLabel}</span>
           <button
             onClick={actions.useMyLocation}
             className="ml-auto inline-flex h-[30px] shrink-0 items-center gap-1 truncate rounded-full border border-slate-200 px-2.5 text-[11px] font-medium text-slate-600 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-1 dark:border-white/10 dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-blue-500/50 dark:focus-visible:ring-offset-slate-950 md:h-9 md:px-3 md:text-[11px]"

--- a/components/panels/DirectoryPane.tsx
+++ b/components/panels/DirectoryPane.tsx
@@ -115,19 +115,19 @@ export default function DirectoryPane() {
   return (
     <div className="mx-auto flex min-h-0 w-full max-w-[388px] flex-col md:mx-0 md:max-w-none">
       <div className="sticky top-0 z-10 space-y-1 border-b border-black/5 bg-white/85 px-2 pb-1 pt-1 backdrop-blur dark:border-white/10 dark:bg-slate-950/60 md:space-y-3 md:px-3 md:pb-3 md:pt-2">
-        <div className="flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400 md:gap-2 md:text-[11px]">
+        <div className="flex min-w-0 items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400 md:gap-2 md:text-[11px]">
           <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500"></span>
-          <span className="truncate">{t("Using:")} {locationLabel}</span>
+          <span className="min-w-0 truncate">{t("Using:")} {locationLabel}</span>
           <button
             onClick={actions.useMyLocation}
-            className="ml-auto inline-flex h-[30px] items-center gap-1 truncate rounded-full border border-slate-200 px-2.5 text-[11px] font-medium text-slate-600 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-1 dark:border-white/10 dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-blue-500/50 dark:focus-visible:ring-offset-slate-950 md:h-9 md:px-3 md:text-[11px]"
+            className="ml-auto inline-flex h-[30px] shrink-0 items-center gap-1 truncate rounded-full border border-slate-200 px-2.5 text-[11px] font-medium text-slate-600 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-1 dark:border-white/10 dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-blue-500/50 dark:focus-visible:ring-offset-slate-950 md:h-9 md:px-3 md:text-[11px]"
           >
             {t("Use my location")}
           </button>
         </div>
 
-        <div className="flex flex-col gap-1 md:flex-row md:items-center md:gap-2">
-          <div className="flex-1">
+        <div className="flex flex-col gap-1 md:min-w-0 md:flex-row md:items-center md:gap-2">
+          <div className="flex-1 md:min-w-0">
             <input
               className="h-[34px] w-full rounded-[10px] border border-slate-200 bg-white/90 px-3 text-[12px] text-slate-900 placeholder:text-slate-400 shadow-sm transition focus:border-slate-300 focus:outline-none focus:ring-0 dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 md:h-10 md:rounded-[10px] md:px-3 md:text-[13px]"
               placeholder={t("Search doctors, pharmacies, labs")}
@@ -135,7 +135,7 @@ export default function DirectoryPane() {
               onChange={(event) => actions.setQ(event.target.value)}
             />
           </div>
-          <div className="md:w-[320px]">
+          <div className="md:w-[320px] md:shrink-0">
             <AddressPicker value={locLabel} onSelect={actions.setAddress} lang={appLang} />
           </div>
         </div>

--- a/components/providers/PreferencesProvider.tsx
+++ b/components/providers/PreferencesProvider.tsx
@@ -13,6 +13,7 @@ export type Prefs = {
 
   lang: Lang;
   dir: "ltr" | "rtl";
+  directoryShowOriginalName: boolean;
 
   memoryEnabled: boolean;
   memoryAutosave: boolean;
@@ -50,6 +51,7 @@ const DEFAULT: Prefs = {
 
   lang: "en",
   dir: "ltr",
+  directoryShowOriginalName: true,
 
   memoryEnabled: true,
   memoryAutosave: true,

--- a/components/settings/panels/General.tsx
+++ b/components/settings/panels/General.tsx
@@ -86,6 +86,7 @@ function Menu({ value, onPick, items }: MenuProps) {
 export default function GeneralPanel() {
   const prefs = usePrefs();
   const t = useT();
+  const showOriginal = prefs.directoryShowOriginalName !== false;
 
   const Row = ({ title, sub, right }: { title: string; sub?: string; right: ReactNode }) => (
     <div className="flex items-center justify-between gap-4 px-5 py-4">
@@ -149,6 +150,32 @@ export default function GeneralPanel() {
           </>
         }
       />
+      <div className="px-5 pt-6 text-[13px] text-slate-500 dark:text-slate-400">{t("Directory")}</div>
+      <div className="flex items-center justify-between gap-4 px-5 py-4">
+        <div>
+          <div className="text-[13px] font-semibold">
+            {t("Show original name alongside translation")}
+          </div>
+          <div className="text-xs text-slate-500 dark:text-slate-400">
+            {t("Display localized provider names with originals in parentheses.")}
+          </div>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={showOriginal}
+          onClick={() => prefs.set("directoryShowOriginalName", !showOriginal)}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2 dark:focus-visible:ring-blue-500/50 ${
+            showOriginal ? "bg-blue-500" : "bg-slate-300 dark:bg-slate-700"
+          }`}
+        >
+          <span
+            className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
+              showOriginal ? "translate-x-5" : "translate-x-1"
+            }`}
+          />
+        </button>
+      </div>
     </>
   );
 }

--- a/components/settings/panels/General.tsx
+++ b/components/settings/panels/General.tsx
@@ -5,6 +5,17 @@ import { ChevronDown, Play } from "lucide-react";
 import { usePrefs } from "@/components/providers/PreferencesProvider";
 import { useT } from "@/components/hooks/useI18n";
 
+function parseFlag(value: string | undefined, defaultValue: boolean) {
+  if (value == null) return defaultValue;
+  const normalized = value.toString().trim().toLowerCase();
+  if (!normalized) return defaultValue;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return defaultValue;
+}
+
+const DIRECTORY_NAME_I18N_ENABLED = parseFlag(process.env.NEXT_PUBLIC_DIRECTORY_NAME_I18N, true);
+
 const LANG_LABELS = {
   en: "English",
   hi: "Hindi",
@@ -150,32 +161,36 @@ export default function GeneralPanel() {
           </>
         }
       />
-      <div className="px-5 pt-6 text-[13px] text-slate-500 dark:text-slate-400">{t("Directory")}</div>
-      <div className="flex items-center justify-between gap-4 px-5 py-4">
-        <div>
-          <div className="text-[13px] font-semibold">
-            {t("Show original name alongside translation")}
+      {DIRECTORY_NAME_I18N_ENABLED && (
+        <>
+          <div className="px-5 pt-6 text-[13px] text-slate-500 dark:text-slate-400">{t("Directory")}</div>
+          <div className="flex items-center justify-between gap-4 px-5 py-4">
+            <div>
+              <div className="text-[13px] font-semibold">
+                {t("Show original name alongside translation")}
+              </div>
+              <div className="text-xs text-slate-500 dark:text-slate-400">
+                {t("Display localized provider names with originals in parentheses.")}
+              </div>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={showOriginal}
+              onClick={() => prefs.set("directoryShowOriginalName", !showOriginal)}
+              className={`relative inline-flex h-6 w-11 items-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2 dark:focus-visible:ring-blue-500/50 ${
+                showOriginal ? "bg-blue-500" : "bg-slate-300 dark:bg-slate-700"
+              }`}
+            >
+              <span
+                className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
+                  showOriginal ? "translate-x-5" : "translate-x-1"
+                }`}
+              />
+            </button>
           </div>
-          <div className="text-xs text-slate-500 dark:text-slate-400">
-            {t("Display localized provider names with originals in parentheses.")}
-          </div>
-        </div>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={showOriginal}
-          onClick={() => prefs.set("directoryShowOriginalName", !showOriginal)}
-          className={`relative inline-flex h-6 w-11 items-center rounded-full transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-2 dark:focus-visible:ring-blue-500/50 ${
-            showOriginal ? "bg-blue-500" : "bg-slate-300 dark:bg-slate-700"
-          }`}
-        >
-          <span
-            className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
-              showOriginal ? "translate-x-5" : "translate-x-1"
-            }`}
-          />
-        </button>
-      </div>
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- introduce a directory_i18n_v1 feature gate that localizes provider names with translation/transliteration, caches results, and surfaces formatted addresses per language
- add a Directory preference to toggle showing original names, updating directory cards to honor new name fields
- keep location inputs stable when switching languages by avoiding key-based remounts and decoupling effects from the lang prop

## Testing
- npm run lint *(aborted: interactive configuration prompt from next lint)*

------
https://chatgpt.com/codex/tasks/task_e_68db05e99a7c832f86c1d993f59d3e91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Internationalized directory: names and addresses are translated/transliterated with per-item display choices and original-name toggle.
  * Enriched place details, per-item caching with TTLs for faster, more consistent results.
  * Preference persisted to control showing original place names (Settings > General).

* **Bug Fixes**
  * Language preference reliably applied to address lookups and debounced directory queries; stabilization of language used during input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->