### PR TITLE
Add translated display fields to timeline list

### DIFF
--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -298,7 +298,7 @@ export default function Timeline(){
     [t],
   );
   const [resetError, setResetError] = useState<string|null>(null);
-  const { data, error, isLoading, mutate } = useTimeline(isAiDoc);
+  const { data, error, isLoading, mutate } = useTimeline(isAiDoc, lang);
   const items = data?.items ?? [];
 
   const [observations, setObservations] = useState<any[]>(() =>
@@ -608,8 +608,9 @@ export default function Timeline(){
             ) : (
               filtered.map((it:any)=>{
                 const observedAt = formatDateTime(it?.observed_at);
-                const title = getDisplayTitle(it);
-                const short = getShortSummary(it);
+                const fallbackTitle = getDisplayTitle(it);
+                const title = it?.name_display ?? fallbackTitle;
+                const short = it?.summary_display ?? getShortSummary(it);
                 const chipLabel = getChipLabel(it, t);
                 return (
                   <li

--- a/lib/hooks/useAppData.ts
+++ b/lib/hooks/useAppData.ts
@@ -8,8 +8,10 @@ const fetcher = async (url: string) => {
 };
 
 // Cached across routes; no revalidate on focus (prevents reload on tab switch)
-export function useTimeline(enabled = true) {
-  const key = enabled ? "/api/timeline?mode=ai-doc" : null;
+export function useTimeline(enabled = true, lang?: string) {
+  const key = enabled
+    ? `/api/timeline?mode=ai-doc${lang ? `&lang=${encodeURIComponent(lang)}` : ""}`
+    : null;
   return useSWR<{ items: any[] }>(key, fetcher, {
     revalidateOnFocus: false,
     shouldRetryOnError: true,


### PR DESCRIPTION
## Summary
- batch translate timeline item names and summaries on the server and expose name_display and summary_display fields
- include the active language in the SWR key when fetching the timeline
- prefer translated display values when rendering the timeline list

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbcd5b5a20832fa514dbee54b84e06

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Timeline items are automatically translated based on the selected language (default: English).
  - Titles and summaries display translated text with graceful fallbacks; ensures every item has a readable title and summary.
- Refactor
  - Added language-aware data fetching and caching for timeline content to scope results per language.
  - Updated internal components to accept an optional language parameter; behavior remains backward compatible and requires no user changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->