### PR TITLE
Add multilingual timeline display fields

### DIFF
--- a/app/api/timeline/summary/route.ts
+++ b/app/api/timeline/summary/route.ts
@@ -8,16 +8,6 @@ import { buildShortSummaryFromText } from "@/lib/shortSummary";
 
 const NO_STORE = { "Cache-Control": "no-store, max-age=0" };
 
-const PROTECTED_UNIT = /^(?:mg\/dl|mmol\/l|bpm|cm|kg|%)$/i;
-
-type DrawerField = "summaryLong" | "summaryShort" | "text" | "valueText";
-
-type PreparedBlock = {
-  key: DrawerField;
-  sanitized: string;
-  replacements: string[];
-};
-
 function firstString(...values: any[]): string | null {
   for (const value of values) {
     if (Array.isArray(value)) {
@@ -32,46 +22,40 @@ function firstString(...values: any[]): string | null {
   return null;
 }
 
-function protectText(text: string) {
-  const tokens = text.split(/(\s+)/);
-  const replacements: string[] = [];
-  const sanitizedTokens = tokens.map(token => {
-    if (!token.trim()) return token;
-    if (/^\d/.test(token) || PROTECTED_UNIT.test(token)) {
-      const placeholder = `__MEDX_PROTECTED_${replacements.length}__`;
-      replacements.push(token);
-      return placeholder;
-    }
-    return token;
-  });
-  return { sanitized: sanitizedTokens.join(""), replacements };
-}
+type TimelineSummaryData = {
+  id: string;
+  summaryLong: string | null;
+  summaryShort: string | null;
+  text: string | null;
+  valueText: string | null;
+  summary: string;
+  fullText: string;
+  summary_display: string;
+  fullText_display: string;
+};
 
-function restoreText(text: string, replacements: string[]) {
-  return replacements.reduce(
-    (acc, value, index) => acc.replaceAll(`__MEDX_PROTECTED_${index}__`, value),
-    text,
-  );
-}
-
-export async function POST(req: Request) {
+async function handleTimelineSummary(
+  req: Request,
+  idParam: string | null,
+  langParam: string | null,
+) {
   const userId = await getUserId();
   if (!userId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: NO_STORE });
+    return NextResponse.json(
+      { ok: false, error: "Unauthorized" },
+      { status: 401, headers: NO_STORE },
+    );
   }
 
-  let body: any = null;
-  try {
-    body = await req.json();
-  } catch {}
-
-  const id = body?.id ? String(body.id) : null;
-  const langRaw = body?.lang ? String(body.lang) : "en";
-  const lang = langRaw || "en";
-
+  const id = idParam ? String(idParam) : null;
   if (!id) {
-    return NextResponse.json({ error: "id required" }, { status: 400, headers: NO_STORE });
+    return NextResponse.json(
+      { ok: false, error: "id required" },
+      { status: 400, headers: NO_STORE },
+    );
   }
+
+  const lang = (langParam || "en").trim() || "en";
 
   const sb = supabaseAdmin();
   const { data: obsRow } = await sb
@@ -93,72 +77,107 @@ export async function POST(req: Request) {
   }
 
   if (!row) {
-    return NextResponse.json({ error: "Not found" }, { status: 404, headers: NO_STORE });
+    return NextResponse.json(
+      { ok: false, error: "Not found" },
+      { status: 404, headers: NO_STORE },
+    );
   }
 
   const meta = (row?.meta ?? row?.details ?? {}) as Record<string, any>;
 
-  const summaryLong = firstString(meta.summary_long, meta.summaryLong, row?.summary_long, row?.summaryLong);
-  let summaryShort = firstString(meta.summary, meta.summaryShort, row?.summary, row?.summaryShort);
+  const summaryLong = firstString(
+    meta.summary_long,
+    meta.summaryLong,
+    row?.summary_long,
+    row?.summaryLong,
+  );
+  let summaryShort = firstString(
+    meta.summary,
+    meta.summaryShort,
+    row?.summary,
+    row?.summaryShort,
+  );
   const text = firstString(meta.text, row?.text);
   const valueText = firstString(row?.value_text, meta.value_text);
 
   if (!summaryShort && (text || summaryLong)) {
-    summaryShort = buildShortSummaryFromText(text ?? undefined, summaryLong ?? undefined) ?? null;
+    summaryShort =
+      buildShortSummaryFromText(text ?? undefined, summaryLong ?? undefined) ?? null;
   }
 
-  const base = {
-    summaryLong,
-    summaryShort,
-    text,
-    valueText,
-  } satisfies Record<DrawerField, string | null>;
+  const summarySource =
+    summaryLong ??
+    summaryShort ??
+    valueText ??
+    text ??
+    "";
+  const fullTextSource = text ?? valueText ?? "";
 
-  const translated: Partial<Record<DrawerField, string>> = {};
+  const data: TimelineSummaryData = {
+    id: String(row?.id ?? id),
+    summaryLong: summaryLong ?? null,
+    summaryShort: summaryShort ?? null,
+    text: text ?? null,
+    valueText: valueText ?? null,
+    summary: String(summarySource ?? ""),
+    fullText: String(fullTextSource ?? ""),
+    summary_display: String(summarySource ?? ""),
+    fullText_display: String(fullTextSource ?? ""),
+  };
 
-  if (lang.toLowerCase() !== "en") {
-    const prepared: PreparedBlock[] = [];
-    (Object.entries(base) as [DrawerField, string | null][]).forEach(([key, value]) => {
-      if (typeof value === "string" && value.trim()) {
-        const { sanitized, replacements } = protectText(value);
-        prepared.push({ key, sanitized, replacements });
-      }
+  const hasTranslatableContent = Boolean(
+    (data.summary && data.summary.trim()) ||
+      (data.fullText && data.fullText.trim()),
+  );
+
+  if (lang !== "en" && hasTranslatableContent) {
+    const url = new URL(req.url);
+    const blocks = [String(data.summary || ""), String(data.fullText || "")];
+
+    const p = fetch(`${url.origin}/api/translate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ textBlocks: blocks, target: lang }),
+      cache: "no-store",
     });
 
-    if (prepared.length) {
-      const url = new URL(req.url);
-      try {
-        const res = await fetch(`${url.origin}/api/translate`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ textBlocks: prepared.map(p => p.sanitized), target: lang }),
-          cache: "no-store",
-        });
-        if (res.ok) {
-          const data = await res.json();
-          const blocks = Array.isArray(data?.blocks) ? data.blocks : [];
-          prepared.forEach((item, index) => {
-            const candidate = typeof blocks[index] === "string" ? blocks[index] : "";
-            if (candidate && candidate.trim()) {
-              translated[item.key] = restoreText(candidate, item.replacements);
-            }
-          });
-        }
-      } catch (err) {
-        console.warn("[timeline/summary] translation failed", err);
-      }
+    try {
+      // 2.5s cap for modal
+      const res = (await Promise.race([
+        p.then(r => (r.ok ? r.json() : { blocks: [] })),
+        new Promise(resolve => setTimeout(() => resolve({ blocks: [] }), 2500)),
+      ])) as { blocks: string[] };
+
+      data.summary_display = res.blocks?.[0]?.trim() || data.summary || "";
+      data.fullText_display = res.blocks?.[1]?.trim() || data.fullText || "";
+    } catch (err) {
+      console.warn("[timeline/summary] translation failed", err);
     }
+  } else {
+    data.summary_display = data.summary || "";
+    data.fullText_display = data.fullText || "";
   }
 
   return NextResponse.json(
-    {
-      id,
-      summaryLong,
-      summaryShort,
-      text,
-      valueText,
-      translated,
-    },
+    { ok: true, data },
     { headers: NO_STORE },
   );
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const id = url.searchParams.get("id");
+  const lang = url.searchParams.get("lang");
+  return handleTimelineSummary(req, id, lang);
+}
+
+export async function POST(req: Request) {
+  let body: any = null;
+  try {
+    body = await req.json();
+  } catch {}
+
+  const id = body?.id ? String(body.id) : null;
+  const lang = body?.lang ? String(body.lang) : null;
+  return handleTimelineSummary(req, id, lang);
 }

--- a/lib/hooks/useAppData.ts
+++ b/lib/hooks/useAppData.ts
@@ -8,8 +8,10 @@ const fetcher = async (url: string) => {
 };
 
 // Cached across routes; no revalidate on focus (prevents reload on tab switch)
-export function useTimeline(enabled = true) {
-  const key = enabled ? "/api/timeline?mode=ai-doc" : null;
+export function useTimeline(enabled = true, lang?: string) {
+  const normalizedLang = (lang || "en").trim() || "en";
+  const params = new URLSearchParams({ mode: "ai-doc", lang: normalizedLang });
+  const key = enabled ? `/api/timeline?${params.toString()}` : null;
   return useSWR<{ items: any[] }>(key, fetcher, {
     revalidateOnFocus: false,
     shouldRetryOnError: true,


### PR DESCRIPTION
## Summary
- add batched translation with timeouts to the timeline list API and expose name_display/summary_display fields
- update the timeline summary API to return translated summary/full text display strings with shared timeout handling
- include the active language in the timeline data hook and UI so list rows and the modal prefer the translated display values

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd7ffcc10832f8e781dbabfe3b4c7