### PR TITLE
Harden timeline translation handling

### DIFF
--- a/app/api/timeline/summary/route.ts
+++ b/app/api/timeline/summary/route.ts
@@ -9,6 +9,62 @@ import { langBase } from "@/lib/i18n/langBase";
 
 const NO_STORE = { "Cache-Control": "no-store, max-age=0" };
 
+const measurementPatterns: RegExp[] = [
+  /\b\d+(?:[.,]\d+)?(?:\s?(?:[a-zA-Zµμ°%]+(?:\/[a-zA-Zµμ°%]+)?|per\s+[a-zA-Z]+))+\b/g,
+  /\b\d+(?:[.,]\d+)?\s*(?:-|to)\s*\d+(?:[.,]\d+)?\b/g,
+  /\b\d+(?:[.,]\d+)?\s*\/\s*\d+(?:[.,]\d+)?\b/g,
+  /\b\d+(?:[.,]\d+)?\s?(?:x|×)\s?10\^\d+\b/gi,
+];
+
+type MeasurementMatch = { start: number; end: number; value: string };
+
+function protectMeasurementBlocks(blocks: string[]) {
+  let counter = 0;
+  const replacements: { placeholder: string; value: string }[] = [];
+
+  const maskedBlocks = blocks.map(block => {
+    if (!block) return block;
+
+    const matchesMap = new Map<string, MeasurementMatch>();
+    for (const pattern of measurementPatterns) {
+      pattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(block)) !== null) {
+        const start = match.index;
+        const end = start + match[0].length;
+        const key = `${start}:${end}`;
+        if (!matchesMap.has(key)) {
+          matchesMap.set(key, { start, end, value: match[0] });
+        }
+      }
+    }
+
+    const matches = Array.from(matchesMap.values()).sort((a, b) => b.start - a.start);
+    let masked = block;
+    for (const match of matches) {
+      const placeholder = `[[MEDX_MEAS_${counter++}]]`;
+      replacements.push({ placeholder, value: match.value });
+      masked = masked.slice(0, match.start) + placeholder + masked.slice(match.end);
+    }
+
+    return masked;
+  });
+
+  const restore = (translated: string[]) =>
+    translated.map(block => {
+      if (!block) return block;
+      let restored = block;
+      for (const { placeholder, value } of replacements) {
+        if (restored.includes(placeholder)) {
+          restored = restored.split(placeholder).join(value);
+        }
+      }
+      return restored;
+    });
+
+  return { maskedBlocks, restore };
+}
+
 function firstString(...values: any[]): string | null {
   for (const value of values) {
     if (Array.isArray(value)) {
@@ -40,6 +96,15 @@ async function handleTimelineSummary(
   idParam: string | null,
   langParam: string | null,
 ) {
+  const requestUrl = new URL(req.url);
+  const mode = requestUrl.searchParams.get("mode")?.toLowerCase();
+  if (mode !== "ai-doc") {
+    return NextResponse.json(
+      { ok: false, error: "Timeline summary is available only in AI Doc mode" },
+      { status: 403, headers: NO_STORE },
+    );
+  }
+
   const userId = await getUserId();
   if (!userId) {
     return NextResponse.json(
@@ -132,27 +197,45 @@ async function handleTimelineSummary(
   );
 
   if (lang !== "en" && hasTranslatableContent) {
-    const url = new URL(req.url);
     const blocks = [String(data.summary || ""), String(data.fullText || "")];
+    const { maskedBlocks, restore } = protectMeasurementBlocks(blocks);
 
-    const p = fetch(`${url.origin}/api/translate`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ textBlocks: blocks, target: lang }),
-      cache: "no-store",
+    const controller = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const timeoutPromise = new Promise<{ blocks: string[] }>(resolve => {
+      timeoutId = setTimeout(() => {
+        controller.abort();
+        resolve({ blocks: [] });
+      }, 2500);
     });
 
-    try {
-      // 2.5s cap for modal
-      const res = (await Promise.race([
-        p.then(r => (r.ok ? r.json() : { blocks: [] })),
-        new Promise(resolve => setTimeout(() => resolve({ blocks: [] }), 2500)),
-      ])) as { blocks: string[] };
+    const translationPromise = fetch(new URL("/api/translate", requestUrl).toString(), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ textBlocks: maskedBlocks, target: lang }),
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(res => (res.ok ? res.json() : { blocks: [] }))
+      .catch(err => {
+        console.warn("[timeline/summary] translation failed", err);
+        return { blocks: [] };
+      });
 
-      data.summary_display = res.blocks?.[0]?.trim() || data.summary || "";
-      data.fullText_display = res.blocks?.[1]?.trim() || data.fullText || "";
-    } catch (err) {
-      console.warn("[timeline/summary] translation failed", err);
+    try {
+      const res = (await Promise.race([translationPromise, timeoutPromise])) as {
+        blocks: string[];
+      };
+      const translated = Array.isArray(res.blocks) ? res.blocks : [];
+      const restored = restore(translated);
+
+      data.summary_display = restored?.[0]?.trim() || data.summary || "";
+      data.fullText_display = restored?.[1]?.trim() || data.fullText || "";
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
     }
   } else {
     data.summary_display = data.summary || "";


### PR DESCRIPTION
## Summary
- gate the timeline summary endpoint behind AI Doc mode and preserve numeric measurements by masking them before translation
- wrap translation fetches with abortable timeouts and error handling to prevent failures from surfacing to clients
- clean up timeline logging to avoid emitting user identifiers while keeping diagnostics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe11c9664832fbd38a6a8224b2ae5