### PR TITLE
Guard timeline summary mode and harden translations

### DIFF
--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -482,7 +482,9 @@ export default function Timeline(){
       return;
     }
 
-    const url = `/api/timeline/summary?id=${encodeURIComponent(active.id)}&lang=${encodeURIComponent(lang)}`;
+    const url = `/api/timeline/summary?mode=ai-doc&id=${encodeURIComponent(
+      active.id,
+    )}&lang=${encodeURIComponent(lang)}`;
     let cancelled = false;
 
     fetch(url, { cache: "no-store" })


### PR DESCRIPTION
## Summary
- add the AI Doc mode gate to the timeline summary API and pass the mode flag from the client
- preserve numeric measurements during summary translations and abort translation requests after the timeout
- normalize language handling, guard against translation failures in the timeline list API, and drop user id logging

## Testing
- not run (npm run lint prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68dbe111b6e0832f9bc9e6c58f533c40