### PR TITLE
Add multi-provider translation fallback and localize timeline toasts

### DIFF
--- a/app/api/timeline/summary/route.ts
+++ b/app/api/timeline/summary/route.ts
@@ -191,7 +191,7 @@ async function handleTimelineSummary(
       timeoutId = setTimeout(() => {
         controller.abort();
         resolve({ blocks: [] });
-      }, 2500);
+      }, 6500);
     });
 
     try {

--- a/app/api/translate/route.ts
+++ b/app/api/translate/route.ts
@@ -3,80 +3,118 @@ import { NextResponse } from 'next/server';
 
 const cache = new Map<string, string>();
 
-export async function POST(req: NextRequest) {
-  const body = await req.json();
+const DEFAULT_TIMEOUT = Number(process.env.MT_TIMEOUT_MS || 6500);
+const ORDER = String(process.env.MT_PROVIDER_ORDER || 'google,openai')
+  .split(',')
+  .map(s => s.trim().toLowerCase())
+  .filter(Boolean) as Array<'google' | 'openai'>;
 
-  // === Batch translation for health education ===
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({} as any));
+
+  // Batch mode
   if (Array.isArray(body.textBlocks) && body.target) {
     const lang = String(body.target);
+    const providers = pickProviders(body.provider);
     const out: string[] = [];
     for (const t of body.textBlocks) {
-      const text = String(t || "");
-      const key = `${text}:${lang}`;
-      if (cache.has(key)) {
-        out.push(cache.get(key)!);
-        continue;
-      }
-      let translated = `[${lang}] ${text}`;
-      try {
-        const apiKey = process.env.OPENAI_API_KEY;
-        if (apiKey) {
-          const res = await fetch('https://api.openai.com/v1/chat/completions', {
-            method: 'POST',
-            headers: {
-              'Authorization': `Bearer ${apiKey}`,
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-              model: process.env.OPENAI_TEXT_MODEL || 'gpt-4o-mini',
-              messages: [
-                { role: 'system', content: 'Translate the user text.' },
-                { role: 'user', content: `Translate to ${lang}: ${text}` }
-              ]
-            })
-          });
-          if (res.ok) {
-            const data = await res.json();
-            translated = data.choices?.[0]?.message?.content?.trim() || translated;
-          }
-        }
-      } catch {}
-      cache.set(key, translated);
-      out.push(translated);
+      out.push(await translateOne(String(t || ''), lang, providers));
     }
-    return NextResponse.json({ blocks: out });
+    return NextResponse.json({ blocks: out }, noStore());
   }
 
-  // === Single-string translation ===
-  const { text, lang, id } = body;
-  const key = `${id ?? text}:${lang}`;
-  if (cache.has(key)) {
-    return NextResponse.json({ translated: cache.get(key) });
-  }
-  let translated = `[${lang}] ${text}`;
-  try {
-    const apiKey = process.env.OPENAI_API_KEY;
-    if (apiKey) {
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${apiKey}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          model: process.env.OPENAI_TEXT_MODEL || 'gpt-4o-mini',
-          messages: [
-            { role: 'system', content: 'Translate the user text.' },
-            { role: 'user', content: `Translate to ${lang}: ${text}` }
-          ]
-        })
-      });
-      if (res.ok) {
-        const data = await res.json();
-        translated = data.choices?.[0]?.message?.content?.trim() || translated;
+  // Single mode
+  const text = String(body.text || '');
+  const lang = String(body.target || body.lang || '');
+  const providers = pickProviders(body.provider);
+  const translated = await translateOne(text, lang, providers);
+  return NextResponse.json({ translated }, noStore());
+}
+
+function noStore() {
+  return { headers: { 'Cache-Control': 'no-store, max-age=0' } };
+}
+
+function pickProviders(override?: string | null): Array<'google'|'openai'> {
+  const ov = typeof override === 'string' ? override.toLowerCase().trim() : '';
+  if (ov === 'google') return ['google', 'openai'];
+  if (ov === 'openai') return ['openai', 'google'];
+  return ORDER.length ? ORDER : ['google', 'openai'];
+}
+
+async function translateOne(text: string, lang: string, order: Array<'google'|'openai'>): Promise<string> {
+  const key = `${text}::${lang}`;
+  if (cache.has(key)) return cache.get(key)!;
+
+  let lastError: any = null;
+  for (const provider of order) {
+    try {
+      const out = await withTimeout(
+        provider === 'google' ? translateGoogle(text, lang) : translateOpenAI(text, lang),
+        DEFAULT_TIMEOUT
+      );
+      if (out) {
+        const trimmed = String(out).trim();
+        cache.set(key, trimmed);
+        return trimmed;
       }
+    } catch (err) {
+      lastError = err;
+      // try next provider
     }
-  } catch {}
-  cache.set(key, translated);
-  return NextResponse.json({ translated });
+  }
+  throw lastError || new Error('MT providers unavailable');
+}
+
+async function translateGoogle(text: string, lang: string): Promise<string> {
+  const key = process.env.GOOGLE_TRANSLATE_API_KEY;
+  if (!key) throw new Error('GOOGLE_TRANSLATE_API_KEY missing');
+
+  const url = `https://translation.googleapis.com/language/translate/v2?key=${key}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ q: text, target: lang })
+  });
+  if (!res.ok) throw new Error(`Google MT HTTP ${res.status}`);
+  const data = await res.json().catch(() => ({}));
+  const translated = data?.data?.translations?.[0]?.translatedText;
+  if (!translated) throw new Error('Google MT empty');
+  return String(translated);
+}
+
+async function translateOpenAI(text: string, lang: string): Promise<string> {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) throw new Error('OPENAI_API_KEY missing');
+
+  // Hard lock to GPT-5
+  const model = 'gpt-5';
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${key}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model,
+      messages: [
+        { role: 'system', content: 'Translate the user text. Only output the translated text.' },
+        { role: 'user', content: `Translate to ${lang}: ${text}` }
+      ]
+    })
+  });
+  if (!res.ok) throw new Error(`OpenAI MT HTTP ${res.status}`);
+  const data = await res.json().catch(() => ({}));
+  const translated = data?.choices?.[0]?.message?.content?.trim();
+  if (!translated) throw new Error('OpenAI MT empty');
+  return translated;
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const id = setTimeout(() => reject(new Error(`MT timeout after ${ms}ms`)), ms);
+    p.then(v => { clearTimeout(id); resolve(v); })
+     .catch(e => { clearTimeout(id); reject(e); });
+  });
 }

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -592,7 +592,7 @@ export default function Timeline(){
 
   async function handleDelete(ob: { id: string }) {
     if (typeof window !== "undefined") {
-      const ok = window.confirm("Delete this from your timeline?\nThis action can’t be undone.");
+      const ok = window.confirm(t("Delete this from your timeline?\nThis action can’t be undone."));
       if (!ok) return;
     }
 
@@ -608,12 +608,12 @@ export default function Timeline(){
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
-      pushToast({ title: "Deleted" });
+      pushToast({ title: t("Deleted") });
     } catch (err) {
       setObservations(previous);
       await mutate();
       pushToast({
-        title: "Couldn't delete. Please try again.",
+        title: t("Couldn't delete. Please try again."),
         variant: "destructive",
       });
     } finally {
@@ -629,10 +629,10 @@ export default function Timeline(){
             <h2 className="text-lg font-semibold">{t("Timeline")}</h2>
             <button
               onClick={async () => {
-                if (!confirm('Reset all observations and predictions?')) return;
+                if (!confirm(t("Reset all observations and predictions?"))) return;
                 setResetError(null);
                 const res = await fetch('/api/observations/reset', { method: 'POST' });
-                if (res.status === 401) { setResetError('Please sign in'); return; }
+                if (res.status === 401) { setResetError(t("Please sign in")); return; }
                 await mutate();
               }}
               className="text-xs px-2 py-1 rounded-md border sm:ml-auto"


### PR DESCRIPTION
## Summary
- add a translation API that supports provider overrides, caching, and Google/OpenAI fallbacks
- extend the timeline summary translation timeout to 6.5 seconds to match MT defaults
- localize timeline deletion prompts and error toasts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbf239ce5c832f89ef6a9b3fcefad5