### PR TITLE
Improve translation outputs and caching

### DIFF
--- a/app/api/directory/_mt.ts
+++ b/app/api/directory/_mt.ts
@@ -8,6 +8,17 @@ type MTProvider = "google" | "openai";
 const PROVIDER = (process.env.MT_PROVIDER as MTProvider) || "google";
 const TARGETS = new Set(["en", "hi", "ar", "es", "it", "zh"]);
 
+function decodeHtmlEntities(s: string): string {
+  return String(s || "")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#34;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&#39;", "'")
+    .replaceAll("&amp;", "&")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">");
+}
+
 type Entry<T> = { v: T; exp: number };
 const cache = new Map<string, Entry<string>>();
 const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -125,7 +136,7 @@ async function googleTranslateV2(texts: string[], target: string): Promise<strin
     const arr = Array.isArray(json?.data?.translations) ? json.data.translations : [];
     return arr.map((item: any, idx: number) => {
       const translated = typeof item?.translatedText === "string" ? item.translatedText : undefined;
-      return translated ?? texts[idx] ?? "";
+      return decodeHtmlEntities(translated ?? texts[idx] ?? "");
     });
   } catch {
     return texts;

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -759,10 +759,10 @@ export default function Timeline(){
               </h3>
               <div className="ml-auto flex gap-2">
                 {(active.file?.path || active.file?.upload_id) && signedUrl && (
-                  <button onClick={() => window.open(signedUrl, '_blank')} className="text-xs px-2 py-1 rounded-md border">Open</button>
+                  <button onClick={() => window.open(signedUrl, '_blank')} className="text-xs px-2 py-1 rounded-md border">{t("Open")}</button>
                 )}
                 {(active.file?.path || active.file?.upload_id) && signedUrl && (
-                  <a href={signedUrl} download className="text-xs px-2 py-1 rounded-md border">Download</a>
+                  <a href={signedUrl} download className="text-xs px-2 py-1 rounded-md border">{t("Download")}</a>
                 )}
                 {!hasFile && hasAiSummary && (
                   <a
@@ -798,7 +798,7 @@ export default function Timeline(){
                 ) : /\.(png|jpe?g|gif|webp)(\?|$)/i.test(signedUrl) ? (
                   <img src={signedUrl} className="max-w-full max-h-[80vh] object-contain" />
                 ) : (
-                  <div className="text-sm text-muted-foreground text-center">Preview unavailable. Use <b>Open</b> or <b>Download</b>.</div>
+                  <div className="text-sm text-muted-foreground text-center">{t("Preview unavailable. Use <b>Open</b> or <b>Download</b>.")}</div>
                 )
               ) : (
                 <>
@@ -877,19 +877,19 @@ export default function Timeline(){
                         <div className="grid grid-cols-2 gap-2">
                           {dose && (
                             <div className="rounded-md border px-2 py-1">
-                              <div className="text-[11px] uppercase opacity-70">Dose</div>
+                              <div className="text-[11px] uppercase opacity-70">{t("Dose")}</div>
                               <div>{dose}</div>
                             </div>
                           )}
                           {observed && (
                             <div className="rounded-md border px-2 py-1">
-                              <div className="text-[11px] uppercase opacity-70">Observed</div>
+                              <div className="text-[11px] uppercase opacity-70">{t("Observed")}</div>
                               <div>{observed}</div>
                             </div>
                           )}
                           {source && (
                             <div className="rounded-md border px-2 py-1">
-                              <div className="text-[11px] uppercase opacity-70">Source</div>
+                              <div className="text-[11px] uppercase opacity-70">{t("Source")}</div>
                               <div className="capitalize">{String(source)}</div>
                             </div>
                           )}


### PR DESCRIPTION
## Summary
- decode Google Translate HTML entities so directory card titles and addresses render cleanly
- shorten the timeline translation timeout and cache translated summaries for faster reopen performance
- localize remaining timeline panel buttons and labels for non-English sessions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc0307d7ec832fab30ec1f04b2c9ec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added translation caching for timeline summaries to speed up non-English requests and reduce repeated translations.
  - Localized Timeline UI labels and messages (e.g., Open, Download, Dose, Observed, Source, preview notice) for translated interfaces.
- Bug Fixes
  - Cleaned machine-translated text by decoding common HTML entities, improving readability.
- Performance
  - Reduced latency and load by serving cached translations when available.
- Reliability
  - Improved fallback behavior to original content if translation or cache operations fail, with robust timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->