### PR TITLE
Localize chat composer placeholder and upload button

### DIFF
--- a/components/UnifiedUpload.tsx
+++ b/components/UnifiedUpload.tsx
@@ -200,20 +200,23 @@ export default function UnifiedUpload() {
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-3">
-        <label
+        <button
+          type="button"
           className="px-4 py-2 rounded bg-black text-white cursor-pointer"
           onClick={() => fileInputRef.current?.click()}
+          aria-label={t("Upload")}
+          title={t("Upload")}
         >
-          <span>{t("Upload")}</span>
-          <input
-            type="file"
-            accept="application/pdf,image/*"
-            multiple
-            onChange={onChange}
-            className="hidden"
-            ref={fileInputRef}
-          />
-        </label>
+          {t("Upload")}
+        </button>
+        <input
+          type="file"
+          accept="application/pdf,image/*"
+          multiple
+          onChange={onChange}
+          className="hidden"
+          ref={fileInputRef}
+        />
         <label className="flex items-center gap-2 text-sm">
           <input type="checkbox" checked={doctorMode} onChange={e=>setDoctorMode(e.target.checked)} />
           <span>Clinical Mode</span>

--- a/components/chat/ChatComposer.tsx
+++ b/components/chat/ChatComposer.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { forwardRef } from "react";
+import type { FormHTMLAttributes, InputHTMLAttributes, ReactNode, Ref } from "react";
+import { useT } from "@/components/hooks/useI18n";
+
+export interface ChatComposerProps extends FormHTMLAttributes<HTMLFormElement> {
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
+  inputRef?: Ref<HTMLInputElement>;
+  children?: ReactNode;
+}
+
+const ChatComposer = forwardRef<HTMLFormElement, ChatComposerProps>(function ChatComposer(
+  { inputProps, inputRef, children, ...formProps },
+  ref,
+) {
+  const t = useT();
+
+  return (
+    <form ref={ref} {...formProps}>
+      <input
+        {...inputProps}
+        ref={inputRef}
+        key={t.lang}
+        placeholder={t("Send a message")}
+        aria-label={t("Send a message")}
+      />
+      {children}
+    </form>
+  );
+});
+
+export default ChatComposer;


### PR DESCRIPTION
## Summary
- translate the chat composer placeholder/aria text using the active language and force the input to remount when the locale changes
- localize the unified upload trigger button label and aria text so it reflects the selected language immediately

## Testing
- npm run lint *(fails: prompts for ESLint configuration and exits)*

------
https://chatgpt.com/codex/tasks/task_e_68dc06ef2888832fb1f7c2d1fcffd857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Chat Composer with a localized “Send a message” placeholder and aria-label, supporting additional controls within the form.
- Refactor
  - Replaced the upload trigger with a standalone, localized “Upload” button that opens the file picker, improving clarity and accessibility without changing upload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->