### PR TITLE
Add language-aware hints to chat prompts

### DIFF
--- a/app/api/ai-doc/route.ts
+++ b/app/api/ai-doc/route.ts
@@ -37,7 +37,11 @@ export async function POST(req: NextRequest) {
   const userId = await getUserId(req);
   if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 
-  const { threadId, message, profileIntent, newProfile } = await req.json();
+  const payload = await req.json();
+  const { threadId, message, profileIntent, newProfile } = payload;
+  const requestedLang = typeof payload?.lang === "string" ? payload.lang : undefined;
+  const headerLang = req.headers.get("x-lang");
+  const lang = (requestedLang || headerLang || "en").toString().trim() || "en";
   if (!message) return NextResponse.json({ error: "no message" }, { status: 400 });
 
   // Ensure profile & load clinical state + memory
@@ -114,7 +118,7 @@ export async function POST(req: NextRequest) {
   }
 
   // System prompt with guardrails
-  let system = buildAiDocPrompt({ profile, labs, meds, conditions });
+  let system = buildAiDocPrompt({ profile, labs, meds, conditions, lang });
 
   const userText = String(message || "");
   const ctx = canonicalizeInputs(extractAll(userText));

--- a/app/api/ai-doc/route.ts
+++ b/app/api/ai-doc/route.ts
@@ -11,6 +11,7 @@ import { runRules } from "@/lib/aidoc/rules";
 import { buildPersonalPlan } from "@/lib/aidoc/planner";
 import { extractPrefsFromUser } from "@/lib/aidoc/extractors/prefs";
 import { buildAiDocPrompt } from "@/lib/ai/prompts/aidoc";
+import { normalizeLanguageTag } from "@/lib/ai/prompts/common";
 import { supabaseAdmin } from "@/lib/supabase/admin";
 import { extractAll, canonicalizeInputs } from "@/lib/medical/engine/extract";
 import { computeAll } from "@/lib/medical/engine/computeAll";
@@ -41,7 +42,7 @@ export async function POST(req: NextRequest) {
   const { threadId, message, profileIntent, newProfile } = payload;
   const requestedLang = typeof payload?.lang === "string" ? payload.lang : undefined;
   const headerLang = req.headers.get("x-lang");
-  const lang = (requestedLang || headerLang || "en").toString().trim() || "en";
+  const lang = normalizeLanguageTag(requestedLang || headerLang || "en");
   if (!message) return NextResponse.json({ error: "no message" }, { status: 400 });
 
   // Ensure profile & load clinical state + memory

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -36,7 +36,7 @@ import { singleTrialPatientPrompt, singleTrialClinicianPrompt } from "@/lib/prom
 import { searchTrials, dedupeTrials, rankValue } from "@/lib/trials/search";
 import { byName } from "@/data/countries";
 import { searchNearby } from "@/lib/openpass";
-import { languageInstruction } from "@/lib/ai/prompts/common";
+import { languageInstruction, normalizeLanguageTag } from "@/lib/ai/prompts/common";
 
 type WebHit = { title: string; snippet: string; url: string; source: string };
 
@@ -98,7 +98,7 @@ export async function POST(req: Request) {
   const headers = req.headers;
   const requestedLang = typeof body?.lang === "string" ? body.lang : undefined;
   const headerLang = headers.get("x-lang");
-  const lang = (requestedLang || headerLang || "en").toString().trim() || "en";
+  const lang = normalizeLanguageTag(requestedLang || headerLang || "en");
   const languageNote = languageInstruction(lang);
   console.log(`[chat] incoming: mode=${mode} research=${Boolean(researchOn)} lang=${lang}`);
   let conversationId = headers.get("x-conversation-id");

--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -3,7 +3,7 @@ import { profileChatSystem } from '@/lib/profileChatSystem';
 import { extractAll, canonicalizeInputs } from '@/lib/medical/engine/extract';
 import { BRAND_NAME } from "@/lib/brand";
 import { computeAll } from '@/lib/medical/engine/computeAll';
-import { languageInstruction } from '@/lib/ai/prompts/common';
+import { languageInstruction, normalizeLanguageTag } from '@/lib/ai/prompts/common';
 // === [MEDX_CALC_ROUTE_IMPORTS_START] ===
 import { composeCalcPrelude } from '@/lib/medical/engine/prelude';
 // === [MEDX_CALC_ROUTE_IMPORTS_END] ===
@@ -62,7 +62,7 @@ export async function POST(req: NextRequest) {
   const { context, clientRequestId } = body;
   const requestedLang = typeof body?.lang === 'string' ? body.lang : undefined;
   const headerLang = req.headers.get('x-lang');
-  const lang = (requestedLang || headerLang || 'en').toString().trim() || 'en';
+  const lang = normalizeLanguageTag(requestedLang || headerLang || 'en');
   const languageNote = languageInstruction(lang);
 
   const research =

--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -59,7 +59,7 @@ export async function POST(req: NextRequest) {
   const long = reqUrl.searchParams.get('long') === '1';
   let body: any = {};
   try { body = await req.json(); } catch {}
-  const { context, clientRequestId, mode } = body;
+  const { context, clientRequestId } = body;
   const requestedLang = typeof body?.lang === 'string' ? body.lang : undefined;
   const headerLang = req.headers.get('x-lang');
   const lang = (requestedLang || headerLang || 'en').toString().trim() || 'en';
@@ -67,6 +67,10 @@ export async function POST(req: NextRequest) {
 
   const research =
     qp === '1' || qp === 'true' || body?.research === true || body?.research === 'true';
+
+  const rawMode = body?.mode;
+  const mode = typeof rawMode === 'string' && rawMode.trim() ? rawMode : 'patient';
+  console.log(`[chat] incoming: mode=${mode} research=${research} lang=${lang}`);
 
   // 1) Gather existing conversation
   const history: Array<{role:'system'|'user'|'assistant'; content:string}> =
@@ -188,7 +192,6 @@ export async function POST(req: NextRequest) {
     ? (isShortQuery || briefTopic ? 220 : 360)
     : (isShortQuery || briefTopic ? 180 : 280);
   const brevitySystem = [
-    ...(languageNote ? [languageNote] : []),
     `You are ${BRAND_NAME} chat. Be concise and structured.`,
     `Aim to keep the entire answer under ${targetWordCap} words (SOFT cap).`,
     'If you are finishing a sentence, you may exceed the cap slightly to complete it (≤ +40 words).',

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -691,6 +691,7 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   const { country } = useCountry();
   const prefs = usePrefs();
   const t = useT();
+  const appLang = (t.lang || prefs.lang || 'en').trim();
   const { active, setFromAnalysis, setFromChat, clear: clearContext } = useActiveContext();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [userText, setUserText] = useState('');
@@ -2635,7 +2636,7 @@ ${systemCommon}` + baseSys;
           'Content-Type': 'application/json',
           'x-conversation-id': conversationId,
           'x-new-chat': messages.length === 0 ? 'true' : 'false',
-          'x-lang': prefs.lang
+          'x-lang': appLang
         },
         body: JSON.stringify({
           mode: mode === 'doctor' ? 'doctor' : 'patient',
@@ -2644,7 +2645,7 @@ ${systemCommon}` + baseSys;
           context,
           clientRequestId,
           research: researchMode,
-          lang: prefs.lang
+          lang: appLang
         }),
         signal: ctrl.signal
       });
@@ -3485,7 +3486,8 @@ ${systemCommon}` + baseSys;
           threadId,
           message: text,
           profileIntent,
-          newProfile
+          newProfile,
+          lang: appLang
         })
       });
       const data = await r.json();

--- a/lib/ai/prompts/aidoc.ts
+++ b/lib/ai/prompts/aidoc.ts
@@ -1,15 +1,21 @@
+import { languageInstruction } from "./common";
+
 type BuildInput = {
   profile: any;
   labs: any[];
   meds: any[];
   conditions: any[];
+  lang?: string;
 };
 
-export function buildAiDocPrompt({ profile, labs, meds, conditions }: BuildInput) {
+export function buildAiDocPrompt({ profile, labs, meds, conditions, lang }: BuildInput) {
   const now = Date.now();
   const recentLabs = (labs||[]).filter(l => (now - new Date(l.takenAt).getTime()) <= 90*24*60*60*1000);
 
+  const instruction = languageInstruction(lang);
+
   return [
+    ...(instruction ? [instruction] : []),
     "You are a clinically careful assistant for doctors. Do not cite risk scores or calculators unless all required inputs are present and relevant to the chief complaint. Avoid hospital-only triage scores (e.g., NEWS2, SOFA) unless actual vitals (RR, HR, SBP, temp, SpO₂) are provided. Never guess missing inputs; if data is incomplete, ask concise clarifying questions instead of quoting scores.",
     "Rules:",
     "- Do NOT quote lab values older than 90 days. If a relevant lab is stale, suggest repeating it instead of quoting numbers.",

--- a/lib/ai/prompts/common.ts
+++ b/lib/ai/prompts/common.ts
@@ -1,0 +1,19 @@
+export function languageInstruction(lang: string | null | undefined): string {
+  const raw = typeof lang === 'string' ? lang : '';
+  const normalized = raw.trim();
+  if (!normalized) return '';
+  if (normalized.toLowerCase().startsWith('en')) return '';
+
+  let humanReadable = normalized;
+  try {
+    const display = new Intl.DisplayNames([normalized], { type: 'language' });
+    const parts = normalized.split('-');
+    const base = parts[0];
+    const human = display.of(base || normalized);
+    if (human) humanReadable = human;
+  } catch {
+    // no-op: fallback to raw tag
+  }
+
+  return `IMPORTANT: Answer in ${humanReadable} (${normalized}). Do not switch languages unless explicitly asked.`;
+}

--- a/lib/ai/prompts/common.ts
+++ b/lib/ai/prompts/common.ts
@@ -1,5 +1,18 @@
+export function normalizeLanguageTag(input: unknown, fallback = 'en'): string {
+  const raw = String(input ?? '').trim();
+  if (!raw) return fallback;
+  const safe = raw.replace(/[^A-Za-z0-9-]/g, '');
+  if (!safe) return fallback;
+  try {
+    const [canonical] = Intl.getCanonicalLocales(safe);
+    return canonical || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
 export function languageInstruction(lang?: string | null): string {
-  const normalized = (typeof lang === 'string' ? lang : 'en').trim() || 'en';
+  const normalized = normalizeLanguageTag(lang, 'en');
 
   let human = normalized;
   try {

--- a/lib/ai/prompts/common.ts
+++ b/lib/ai/prompts/common.ts
@@ -1,19 +1,19 @@
-export function languageInstruction(lang: string | null | undefined): string {
-  const raw = typeof lang === 'string' ? lang : '';
-  const normalized = raw.trim();
-  if (!normalized) return '';
-  if (normalized.toLowerCase().startsWith('en')) return '';
+export function languageInstruction(lang?: string | null): string {
+  const normalized = (typeof lang === 'string' ? lang : 'en').trim() || 'en';
 
-  let humanReadable = normalized;
+  let human = normalized;
   try {
     const display = new Intl.DisplayNames([normalized], { type: 'language' });
-    const parts = normalized.split('-');
-    const base = parts[0];
-    const human = display.of(base || normalized);
-    if (human) humanReadable = human;
+    const base = normalized.split('-')[0];
+    const label = display.of(base || normalized);
+    if (label) human = label;
   } catch {
-    // no-op: fallback to raw tag
+    // fall back to the normalized tag if Intl.DisplayNames is unavailable
   }
 
-  return `IMPORTANT: Answer in ${humanReadable} (${normalized}). Do not switch languages unless explicitly asked.`;
+  return [
+    `IMPORTANT: Answer ONLY in ${human} (${normalized}).`,
+    'Do not switch languages even if the user writes in another language.',
+    'Do not translate user quotes or code; keep quoted/code content verbatim.',
+  ].join(' ');
 }


### PR DESCRIPTION
## Summary
- propagate the active UI language from the chat pane to streaming, non-streaming, and AI Doc requests
- inject a shared language instruction into chat prompt assembly, including research brief and AI Doc flows
- add a reusable helper for formatting language guidance in prompt builders

## Testing
- npm run lint *(fails: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dc09354394832f80039488a0319fe8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Assistant now reliably responds in your selected language (preference, UI locale, or header).
  - Improved language detection and normalization for more consistent localization.
  - Language instructions enforce answering only in the chosen language and preserve quoted/code text.
  - App consistently sends your language choice with chat and AI Doc requests, improving localized prompts.
  - Localization applied across all modes (doctor/patient, trial/research, streaming).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->