### PR TITLE
Propagate language directives across chat endpoints

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -161,7 +161,7 @@ export function ChatWindow() {
       if (locationToken) {
         const res = await fetch("/api/chat", {
           method: "POST",
-          headers: { "Content-Type": "application/json", "x-lang": lang },
+          headers: { "Content-Type": "application/json", "x-user-lang": lang },
           body: JSON.stringify({
             query: content,
             locationToken,
@@ -186,7 +186,7 @@ export function ChatWindow() {
       } else {
         const res = await fetch("/api/chat", {
           method: "POST",
-          headers: { "Content-Type": "application/json", "x-lang": lang },
+          headers: { "Content-Type": "application/json", "x-user-lang": lang },
           body: JSON.stringify({
             text: content,
             lang,

--- a/components/hooks/usePrefs.ts
+++ b/components/hooks/usePrefs.ts
@@ -8,7 +8,7 @@ import { usePrefs as useProviderPrefs } from "@/components/providers/Preferences
 export type LangMethod = "user" | "auto" | "fallback";
 
 const LANG_METHOD_KEY = "medx-lang-method";
-const DEFAULT_LANG = "en";
+export const DEFAULT_LANG = "en";
 const DEFAULT_LANG_METHOD: LangMethod = "user";
 
 function readStoredLangMethod(): LangMethod {
@@ -71,4 +71,9 @@ export function usePrefs(): Prefs {
     }),
     [base, langMethod, setLang],
   );
+}
+
+export function usePreferredLang(): string {
+  const prefs = useProviderPrefs();
+  return prefs.lang ?? DEFAULT_LANG;
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -2635,7 +2635,7 @@ ${systemCommon}` + baseSys;
           'Content-Type': 'application/json',
           'x-conversation-id': conversationId,
           'x-new-chat': messages.length === 0 ? 'true' : 'false',
-          'x-lang': prefs.lang
+          'x-user-lang': prefs.lang
         },
         body: JSON.stringify({
           mode: mode === 'doctor' ? 'doctor' : 'patient',

--- a/lib/prompt/system.ts
+++ b/lib/prompt/system.ts
@@ -1,15 +1,82 @@
 import { BRAND_NAME } from "@/lib/brand";
 
+export const SYSTEM_DEFAULT_LANG = "en";
+const DEFAULT_LOCALE = "en-IN";
+
+const LANGUAGE_NAMES: Record<string, string> = {
+  ar: "Arabic",
+  en: "English",
+  es: "Spanish",
+  fr: "French",
+  hi: "Hindi",
+  it: "Italian",
+};
+
+const LOCALE_MAP: Record<string, string> = {
+  ar: "ar-AE",
+  en: "en-IN",
+  es: "es-ES",
+  fr: "fr-FR",
+  hi: "hi-IN",
+  it: "it-IT",
+};
+
+const LANGUAGE_DIRECTIVES: Record<string, string> = {
+  ar: "أجب بالعربية. إذا كتب المستخدم بلغة أخرى، فاستمر في الرد بالعربية ما لم يطلب غير ذلك صراحةً.",
+  es: "Responde en español. Si el usuario escribe en otro idioma, responde en español a menos que lo pida explícitamente.",
+  fr: "Répondez en français. Si l’utilisateur écrit dans une autre langue, répondez tout de même en français sauf s’il le demande explicitement.",
+  hi: "उत्तर हिंदी में दें. यदि उपयोगकर्ता किसी अन्य भाषा में लिखता है, तब भी हिंदी में उत्तर दें जब तक कि वह स्पष्ट रूप से कुछ और न कहे.",
+  it: "Rispondi in italiano. Se l’utente scrive in un’altra lingua, rispondi comunque in italiano a meno che non lo richieda esplicitamente.",
+};
+
+function normalizeLang(input?: string): string {
+  if (!input) return SYSTEM_DEFAULT_LANG;
+  const trimmed = input.trim().toLowerCase();
+  if (!trimmed) return SYSTEM_DEFAULT_LANG;
+  return trimmed.split("-")[0];
+}
+
+export function languageNameFor(lang?: string): string {
+  const code = normalizeLang(lang);
+  return LANGUAGE_NAMES[code] ?? code.toUpperCase();
+}
+
+export function resolveLocaleForLang(lang?: string): string {
+  const code = normalizeLang(lang);
+  return LOCALE_MAP[code] ?? DEFAULT_LOCALE;
+}
+
+export function languageDirectiveFor(lang?: string): string {
+  const code = normalizeLang(lang);
+  if (LANGUAGE_DIRECTIVES[code]) {
+    return LANGUAGE_DIRECTIVES[code];
+  }
+  const languageName = languageNameFor(code);
+  return `Answer in ${languageName}. If the user writes in another language, still respond in ${languageName} unless they explicitly request otherwise.`;
+}
+
+type BuildSystemPromptOptions = {
+  persona?: string;
+  locale?: string;
+  lang?: string;
+  includeDirective?: boolean;
+};
+
 export function buildSystemPrompt({
   persona = `You are ${BRAND_NAME}, a medical assistant and health copilot.`,
-  locale = "en-IN",
-}: { persona?: string; locale?: string } = {}) {
-  return [
+  locale,
+  lang,
+  includeDirective = true,
+}: BuildSystemPromptOptions = {}) {
+  const langCode = normalizeLang(lang);
+  const resolvedLocale = locale ?? resolveLocaleForLang(langCode);
+  const languageName = languageNameFor(langCode);
+  const sections = [
     persona,
     `Writing style:
 - Professional yet warm and human.
 - Clear, concise sentences. No slang. No filler. No half words.
-- Use Indian English variants where natural (locale: ${locale}).
+- Use ${languageName} variants where natural (locale: ${resolvedLocale}).
 - Prefer short paragraphs and compact lists for readability.
 - No invented citations. Only cite if a verified source is available.
 - If unsure, ask a brief clarifying question (one line).`,
@@ -32,6 +99,11 @@ export function buildSystemPrompt({
     "- No ellipsis characters are used.",
     "- Numbers and units: use SI (kg, cm) unless the user requests otherwise.",
     "- Answer with at most six short paragraphs or twelve bullets unless the user asks for more depth.",
+  ];
 
-  ].join("\n\n");
+  if (includeDirective) {
+    sections.push(languageDirectiveFor(langCode));
+  }
+
+  return sections.join("\n\n");
 }


### PR DESCRIPTION
## Summary
- extend the system prompt builder with locale-aware language directives and helpers
- pass the user language header through chat context building and append the directive at the end of every system prompt, including streaming and final routes
- update client chat requests to send the new `x-user-lang` header and expose language defaults for reuse

## Testing
- `npm run lint` *(fails: command prompts for ESLint configuration and was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68dc28c0534c832fb879a261a20a4fde