### PR TITLE
Localize trials search filters

### DIFF
--- a/components/clinicalTrials.const.ts
+++ b/components/clinicalTrials.const.ts
@@ -1,0 +1,23 @@
+export const PHASES = [
+  { value: '1', labelKey: 'Phase 1' },
+  { value: '2', labelKey: 'Phase 2' },
+  { value: '3', labelKey: 'Phase 3' },
+  { value: '4', labelKey: 'Phase 4' },
+] as const;
+
+export const STATUSES = [
+  { value: 'recruiting', labelKey: 'Recruiting', apiValue: 'Recruiting' },
+  { value: 'active', labelKey: 'Active (not recruiting)', apiValue: 'Active, not recruiting' },
+  { value: 'completed', labelKey: 'Completed', apiValue: 'Completed' },
+  { value: 'any', labelKey: 'Any', apiValue: undefined },
+] as const;
+
+export const REGIONS = [
+  { value: 'United States', labelKey: 'United States' },
+  { value: 'India', labelKey: 'India' },
+  { value: 'European Union', labelKey: 'European Union' },
+  { value: 'United Kingdom', labelKey: 'United Kingdom' },
+  { value: 'Japan', labelKey: 'Japan' },
+  { value: 'China', labelKey: 'China' },
+  { value: 'Worldwide', labelKey: 'Worldwide' },
+] as const;


### PR DESCRIPTION
## Summary
- add shared constants for trial phases, statuses, and regions to decouple API values from display strings
- localize search input, filter chips, and action buttons in the trials filter UI using the existing translation hook and aria labels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc30903ad4832fae4310428b0aa297