### PR TITLE
Remove alerts panel from sidebar

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import ChatPane from "@/components/panels/ChatPane";
 import MedicalProfile from "@/components/panels/MedicalProfile";
 import Timeline from "@/components/panels/Timeline";
-import AlertsPane from "@/components/panels/AlertsPane";
 import { ResearchFiltersProvider } from "@/store/researchFilters";
 import AiDocPane from "@/components/panels/AiDocPane";
 import DirectoryPane from "@/components/panels/DirectoryPane";
@@ -84,8 +83,6 @@ export default function Page({ searchParams }: { searchParams: Search }) {
         return <MedicalProfile />;
       case "timeline":
         return <Timeline />;
-      case "alerts":
-        return <AlertsPane />;
       case "ai-doc":
         return <AiDocPane />;
       case "directory":

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -15,7 +15,6 @@ const TAB_DEFS: Tab[] = [
   { key: "directory", labelKey: "ui.nav.directory", panel: "directory" },
   { key: "profile", labelKey: "ui.nav.medical_profile", panel: "profile" },
   { key: "timeline", labelKey: "ui.nav.timeline", panel: "timeline" },
-  { key: "alerts", labelKey: "ui.nav.alerts", panel: "alerts" },
 ];
 
 function NavLink({


### PR DESCRIPTION
## Summary
- remove the Alerts navigation option from the sidebar tab list
- stop rendering the Alerts pane when a non-chat panel is requested

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc42636170832f8f5528776c21ca8e