### PR TITLE
Add icons for sidebar navigation

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Search, Settings } from "lucide-react";
+import { IconNewChat } from "@/components/icons/SidebarIcons";
 import Tabs from "./sidebar/Tabs";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -67,9 +68,18 @@ export default function Sidebar() {
         type="button"
         aria-label={t("threads.systemTitles.new_chat")}
         onClick={handleNewChat}
-        className="w-full rounded-full bg-blue-600 px-4 py-2.5 text-left text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
+        className="flex w-full items-center gap-2 rounded-full bg-blue-600 px-4 py-2.5 text-left text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
       >
-        + {t("threads.systemTitles.new_chat")}
+        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-white/15">
+          <IconNewChat
+            size={18}
+            strokeWidth={2}
+            aria-hidden="true"
+            title={t("threads.systemTitles.new_chat")}
+            className="text-white"
+          />
+        </span>
+        <span>{t("threads.systemTitles.new_chat")}</span>
       </button>
 
       <div>

--- a/components/icons/SidebarIcons.tsx
+++ b/components/icons/SidebarIcons.tsx
@@ -1,0 +1,124 @@
+import type { SVGProps } from "react";
+
+export type IconProps = SVGProps<SVGSVGElement> & {
+  size?: number;
+  strokeWidth?: number;
+  title?: string;
+};
+
+export function IconNewChat({
+  size = 24,
+  strokeWidth = 1.75,
+  title = "New Chat",
+  ...rest
+}: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      role="img"
+      aria-label={title}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...rest}
+    >
+      <title>{title}</title>
+      <rect x="3" y="4" width="18" height="14" rx="3" />
+      <polyline points="8 18 8 22 12 19.5" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="10" y1="11" x2="14" y2="11" />
+    </svg>
+  );
+}
+
+export function IconDirectory({
+  size = 24,
+  strokeWidth = 1.75,
+  title = "Directory",
+  ...rest
+}: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      role="img"
+      aria-label={title}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...rest}
+    >
+      <title>{title}</title>
+      <line x1="4" y1="7" x2="11" y2="7" />
+      <line x1="4" y1="11" x2="11" y2="11" />
+      <line x1="4" y1="15" x2="9" y2="15" />
+      <circle cx="16.5" cy="10" r="2.75" />
+      <path d="M16.5 13.5c0 2.2 3 3.2 3 5 0 .8-.7 1.5-1.5 1.5h-3c-.8 0-1.5-.7-1.5-1.5 0-1.8 3-2.8 3-5Z" />
+    </svg>
+  );
+}
+
+export function IconMedicalProfile({
+  size = 24,
+  strokeWidth = 1.75,
+  title = "Medical Profile",
+  ...rest
+}: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      role="img"
+      aria-label={title}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...rest}
+    >
+      <title>{title}</title>
+      <path d="M7 3h7l4 4v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z" />
+      <polyline points="14 3 14 7 18 7" />
+      <line x1="9" y1="12" x2="15" y2="12" />
+      <line x1="12" y1="9" x2="12" y2="15" />
+    </svg>
+  );
+}
+
+export function IconTimeline({
+  size = 24,
+  strokeWidth = 1.75,
+  title = "Timeline",
+  ...rest
+}: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      role="img"
+      aria-label={title}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...rest}
+    >
+      <title>{title}</title>
+      <line x1="3" y1="12" x2="21" y2="12" />
+      <circle cx="6" cy="12" r="2" />
+      <circle cx="12" cy="12" r="2" />
+      <circle cx="18" cy="12" r="2" />
+    </svg>
+  );
+}

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -3,29 +3,53 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 import { useT } from "@/components/hooks/useI18n";
+import {
+  IconDirectory,
+  IconMedicalProfile,
+  IconTimeline,
+} from "@/components/icons/SidebarIcons";
+import type { IconProps } from "@/components/icons/SidebarIcons";
 
 type Tab = {
   key: string;
   labelKey: string;
   panel: string;
   context?: string;
+  icon?: (props: IconProps) => JSX.Element;
 };
 
 const TAB_DEFS: Tab[] = [
-  { key: "directory", labelKey: "ui.nav.directory", panel: "directory" },
-  { key: "profile", labelKey: "ui.nav.medical_profile", panel: "profile" },
-  { key: "timeline", labelKey: "ui.nav.timeline", panel: "timeline" },
+  {
+    key: "directory",
+    labelKey: "ui.nav.directory",
+    panel: "directory",
+    icon: IconDirectory,
+  },
+  {
+    key: "profile",
+    labelKey: "ui.nav.medical_profile",
+    panel: "profile",
+    icon: IconMedicalProfile,
+  },
+  {
+    key: "timeline",
+    labelKey: "ui.nav.timeline",
+    panel: "timeline",
+    icon: IconTimeline,
+  },
   { key: "alerts", labelKey: "ui.nav.alerts", panel: "alerts" },
 ];
 
 function NavLink({
   panel,
-  children,
+  label,
   context,
+  icon: Icon,
 }: {
   panel: string;
-  children: React.ReactNode;
+  label: string;
   context?: string;
+  icon?: Tab["icon"];
 }) {
   const params = useSearchParams();
   const closeSidebar = useMobileUiStore((s) => s.closeSidebar);
@@ -42,11 +66,20 @@ function NavLink({
         closeSidebar();
         event.stopPropagation();
       }}
-      className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
+      className={`flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm transition hover:bg-muted ${active ? "bg-muted font-medium text-foreground" : "text-muted-foreground"}`}
       data-testid={`nav-${panel}`}
       aria-current={active ? "page" : undefined}
     >
-      {children}
+      {Icon ? (
+        <Icon
+          size={18}
+          strokeWidth={1.75}
+          aria-hidden="true"
+          title={label}
+          className={active ? "text-foreground" : "text-muted-foreground"}
+        />
+      ) : null}
+      <span className="truncate">{label}</span>
     </Link>
   );
 }
@@ -57,9 +90,12 @@ export default function Tabs() {
     <ul className="mt-2 space-y-1">
       {TAB_DEFS.map((tab) => (
         <li key={tab.key}>
-          <NavLink panel={tab.panel} context={tab.context}>
-            {t(tab.labelKey)}
-          </NavLink>
+          <NavLink
+            panel={tab.panel}
+            context={tab.context}
+            icon={tab.icon}
+            label={t(tab.labelKey)}
+          />
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- add accessible SVG icon components for new chat, directory, medical profile, and timeline views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc42ef0f88832f8adb562c5c5eff82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four sidebar icons: New Chat, Directory, Medical Profile, and Timeline.
  * Sidebar new-chat button now shows an icon beside its label; several tabs now display icons next to labels for easier navigation.

* **Style**
  * Unified icon visuals and spacing for consistent look and improved clarity across sizes.
  * Icons include descriptive titles for better accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->