### PR TITLE
Enable full French (fr) localization across UI & Directory (provider + MT); sync <html> lang/dir at runtime

### DIFF
--- a/app/api/directory/_mt.ts
+++ b/app/api/directory/_mt.ts
@@ -6,7 +6,7 @@ import "server-only";
 
 type MTProvider = "google" | "openai";
 const PROVIDER = (process.env.MT_PROVIDER as MTProvider) || "google";
-const TARGETS = new Set(["en", "hi", "ar", "es", "it", "zh"]);
+const TARGETS = new Set(["en", "hi", "ar", "es", "it", "zh", "fr"]);
 
 function decodeHtmlEntities(s: string): string {
   return String(s || "")

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export const metadata = { title: BRAND_NAME, description: "Global medical AI" };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" dir="ltr" suppressHydrationWarning>
+    <html suppressHydrationWarning>
       <head>
         <link rel="dns-prefetch" href="https://fonts.cdnfonts.com" />
         <link rel="preconnect" href="https://fonts.cdnfonts.com" crossOrigin="anonymous" />

--- a/components/providers/PreferencesProvider.tsx
+++ b/components/providers/PreferencesProvider.tsx
@@ -2,7 +2,7 @@
 import React, { createContext, useContext, useEffect, useMemo, useRef, useState, useCallback } from "react";
 
 type Plan = "free" | "pro";
-type Lang = "en" | "hi" | "ar" | "it" | "zh" | "es";
+type Lang = "en" | "hi" | "ar" | "it" | "zh" | "es" | "fr";
 
 export type Prefs = {
   theme: "system" | "light" | "dark";
@@ -139,6 +139,18 @@ export default function PreferencesProvider({ children }: { children: React.Reac
     if (!mounted.current) return;
     persist(state);
   }, [persist, state]);
+
+  // Sync document direction + language after hydration to reflect user preferences.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    try {
+      root.setAttribute("lang", state.lang);
+      root.setAttribute("dir", state.dir);
+    } catch {
+      // no-op
+    }
+  }, [state.lang, state.dir]);
 
   const api = useMemo<Prefs>(() => {
     const setLang = (l: Lang) => {

--- a/lib/i18n/providerLang.ts
+++ b/lib/i18n/providerLang.ts
@@ -7,6 +7,7 @@ export function providerLang(appLang?: string): string {
     case "es":
     case "it":
     case "ar":
+    case "fr":
       return base;
 
     case "zh": {


### PR DESCRIPTION
## Summary
- allow `fr` to be persisted in language preferences and mirror the current lang/dir onto the `<html>` element after hydration
- remove the hard-coded lang/dir attributes from the root layout so client prefs own the document direction
- enable French for both Places provider language mapping and MT targets so directory content can localize

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dce2bb9524832f9594560074cec38c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added French as a supported language across the app, including preferences and translations.
  - Batch translations now support French, with caching for French results.

- Bug Fixes
  - Page language and text direction now correctly sync with your selected preferences, rather than defaulting to English/left-to-right.

- Refactor
  - Removed hardcoded language/direction from the root HTML element to rely on dynamic preference-based attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->