### PR TITLE
Fix mobile overflow in Directory header

### DIFF
--- a/components/directory/AddressPicker.tsx
+++ b/components/directory/AddressPicker.tsx
@@ -53,7 +53,7 @@ export default function AddressPicker({
   }, [q, lang]);
 
   return (
-    <div className="relative w-full">
+    <div className="relative w-full min-w-0">
       <input
         className="h-[34px] w-full rounded-[10px] border border-slate-200 bg-white/90 px-3 text-[12px] text-slate-900 placeholder:text-slate-400 shadow-sm transition focus:border-slate-300 focus:outline-none dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 md:h-10 md:rounded-[10px] md:px-3 md:text-[13px]"
         placeholder={placeholder}

--- a/components/panels/DirectoryPane.tsx
+++ b/components/panels/DirectoryPane.tsx
@@ -118,19 +118,19 @@ export default function DirectoryPane() {
   return (
     <div className="mx-auto flex min-h-0 w-full max-w-[388px] flex-col md:mx-0 md:max-w-none">
       <div className="sticky top-0 z-10 space-y-1 border-b border-black/5 bg-white/85 px-2 pb-1 pt-1 backdrop-blur dark:border-white/10 dark:bg-slate-950/60 md:space-y-3 md:px-3 md:pb-3 md:pt-2">
-        <div className="flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400 md:gap-2 md:text-[11px]">
-          <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500"></span>
-          <span className="truncate">{t("Using:")} {locationLabel}</span>
+        <div className="flex min-w-0 flex-wrap items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400 sm:flex-nowrap md:gap-2 md:text-[11px]">
+          <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-green-500"></span>
+          <span className="min-w-0 flex-1 text-left sm:truncate">{t("Using:")} {locationLabel}</span>
           <button
             onClick={actions.useMyLocation}
-            className="ml-auto inline-flex h-[30px] items-center gap-1 truncate rounded-full border border-slate-200 px-2.5 text-[11px] font-medium text-slate-600 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-1 dark:border-white/10 dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-blue-500/50 dark:focus-visible:ring-offset-slate-950 md:h-9 md:px-3 md:text-[11px]"
+            className="mt-1 inline-flex h-[30px] w-full items-center justify-center gap-1 rounded-full border border-slate-200 px-2.5 text-[11px] font-medium text-slate-600 transition hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-1 dark:border-white/10 dark:text-slate-200 dark:hover:bg-slate-800 dark:focus-visible:ring-blue-500/50 dark:focus-visible:ring-offset-slate-950 sm:ml-auto sm:mt-0 sm:w-auto md:h-9 md:px-3 md:text-[11px]"
           >
             {t("Use my location")}
           </button>
         </div>
 
         <div className="flex flex-col gap-1 md:flex-row md:items-center md:gap-2">
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             <input
               className="h-[34px] w-full rounded-[10px] border border-slate-200 bg-white/90 px-3 text-[12px] text-slate-900 placeholder:text-slate-400 shadow-sm transition focus:border-slate-300 focus:outline-none focus:ring-0 dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 md:h-10 md:rounded-[10px] md:px-3 md:text-[13px]"
               placeholder={t("Search doctors, pharmacies, labs")}
@@ -138,7 +138,7 @@ export default function DirectoryPane() {
               onChange={(event) => actions.setQ(event.target.value)}
             />
           </div>
-          <div className="md:w-[320px]">
+          <div className="min-w-0 md:w-[320px]">
             <AddressPicker value={locLabel} onSelect={actions.setAddress} lang={appLang} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- allow the Directory header status row to wrap on mobile while keeping desktop styling and truncating the location text responsibly
- let the search input and location picker containers shrink without forcing horizontal scroll
- add a min-width guard to the AddressPicker wrapper so the input respects the available space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dce4004d70832fb04aea2ea087e57f