### PR TITLE
Refresh sidebar navigation icons

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { Search, Settings } from "lucide-react";
 import Tabs from "./sidebar/Tabs";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
+import { IconNewChat } from "@/components/icons/IconNewChat";
 import { createNewThreadId, listThreads, Thread } from "@/lib/chatThreads";
 import ThreadKebab from "@/components/chat/ThreadKebab";
 import { useMobileUiStore } from "@/lib/state/mobileUiStore";
@@ -39,6 +40,7 @@ export default function Sidebar() {
   const t = useT();
   const openPrefs = useUIStore((state) => state.openPrefs);
   const locale = useLocale();
+  const newChatLabel = t("threads.systemTitles.new_chat");
 
   useEffect(() => {
     const load = () => setThreads(listThreads());
@@ -65,11 +67,17 @@ export default function Sidebar() {
     <div className="sidebar-click-guard flex h-full w-full flex-col gap-4 px-4 pt-6 pb-0 text-medx">
       <button
         type="button"
-        aria-label={t("threads.systemTitles.new_chat")}
+        aria-label={newChatLabel}
         onClick={handleNewChat}
-        className="w-full rounded-full bg-blue-600 px-4 py-2.5 text-left text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
+        className="flex w-full items-center justify-center gap-2 rounded-full bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
       >
-        + {t("threads.systemTitles.new_chat")}
+        <IconNewChat
+          width={20}
+          height={20}
+          title={newChatLabel}
+          className="h-5 w-5"
+        />
+        <span>{newChatLabel}</span>
       </button>
 
       <div>

--- a/components/icons/Glyph.tsx
+++ b/components/icons/Glyph.tsx
@@ -1,0 +1,28 @@
+import type { SVGProps } from "react";
+
+export type IconProps = SVGProps<SVGSVGElement> & {
+  title?: string;
+  active?: boolean;
+};
+
+export function Glyph({ title = "Icon", active = false, children, style, ...rest }: IconProps) {
+  const strokeWidth = active ? 2.0 : 1.75;
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label={title}
+      style={{ transition: "opacity 0.15s ease, stroke-width 0.15s ease", ...style }}
+      {...rest}
+    >
+      <title>{title}</title>
+      {children}
+    </svg>
+  );
+}

--- a/components/icons/IconDirectory.tsx
+++ b/components/icons/IconDirectory.tsx
@@ -1,0 +1,15 @@
+import { Glyph, IconProps } from "./Glyph";
+
+export function IconDirectory({ title = "Directory", ...rest }: IconProps) {
+  return (
+    <Glyph title={title} {...rest}>
+      <circle cx={12} cy={12} r={7.25} />
+      <circle cx={9} cy={9.5} r={0.75} />
+      <circle cx={9} cy={12} r={0.75} />
+      <circle cx={9} cy={14.5} r={0.75} />
+      <line x1={11.25} y1={9.5} x2={15.5} y2={9.5} />
+      <line x1={11.25} y1={12} x2={15.5} y2={12} />
+      <line x1={11.25} y1={14.5} x2={15.5} y2={14.5} />
+    </Glyph>
+  );
+}

--- a/components/icons/IconMedicalProfile.tsx
+++ b/components/icons/IconMedicalProfile.tsx
@@ -1,0 +1,12 @@
+import { Glyph, IconProps } from "./Glyph";
+
+export function IconMedicalProfile({ title = "Medical Profile", ...rest }: IconProps) {
+  return (
+    <Glyph title={title} {...rest}>
+      <circle cx={12} cy={12} r={7.25} />
+      <rect x={9} y={9} width={6} height={6} rx={1.25} />
+      <line x1={12} y1={10.5} x2={12} y2={13.5} />
+      <line x1={10.5} y1={12} x2={13.5} y2={12} />
+    </Glyph>
+  );
+}

--- a/components/icons/IconNewChat.tsx
+++ b/components/icons/IconNewChat.tsx
@@ -1,0 +1,11 @@
+import { Glyph, IconProps } from "./Glyph";
+
+export function IconNewChat({ title = "New Chat", ...rest }: IconProps) {
+  return (
+    <Glyph title={title} {...rest}>
+      <circle cx={12} cy={12} r={7.25} />
+      <line x1={12} y1={9} x2={12} y2={15} />
+      <line x1={9} y1={12} x2={15} y2={12} />
+    </Glyph>
+  );
+}

--- a/components/icons/IconTimeline.tsx
+++ b/components/icons/IconTimeline.tsx
@@ -1,0 +1,13 @@
+import { Glyph, IconProps } from "./Glyph";
+
+export function IconTimeline({ title = "Timeline", ...rest }: IconProps) {
+  return (
+    <Glyph title={title} {...rest}>
+      <circle cx={12} cy={12} r={7.25} />
+      <line x1={12} y1={8} x2={12} y2={16} />
+      <circle cx={12} cy={9.5} r={0.9} />
+      <circle cx={12} cy={12} r={0.9} />
+      <circle cx={12} cy={14.5} r={0.9} />
+    </Glyph>
+  );
+}

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,6 +1,14 @@
 "use client";
+
+import type { ComponentType } from "react";
+
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+
+import { IconDirectory } from "@/components/icons/IconDirectory";
+import { IconMedicalProfile } from "@/components/icons/IconMedicalProfile";
+import { IconTimeline } from "@/components/icons/IconTimeline";
+import { IconProps } from "@/components/icons/Glyph";
 import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 import { useT } from "@/components/hooks/useI18n";
 
@@ -9,23 +17,23 @@ type Tab = {
   labelKey: string;
   panel: string;
   context?: string;
+  icon: ComponentType<IconProps>;
 };
 
 const TAB_DEFS: Tab[] = [
-  { key: "directory", labelKey: "ui.nav.directory", panel: "directory" },
-  { key: "profile", labelKey: "ui.nav.medical_profile", panel: "profile" },
-  { key: "timeline", labelKey: "ui.nav.timeline", panel: "timeline" },
+  { key: "directory", labelKey: "ui.nav.directory", panel: "directory", icon: IconDirectory },
+  { key: "profile", labelKey: "ui.nav.medical_profile", panel: "profile", icon: IconMedicalProfile },
+  { key: "timeline", labelKey: "ui.nav.timeline", panel: "timeline", icon: IconTimeline },
 ];
 
-function NavLink({
-  panel,
-  children,
-  context,
-}: {
+type NavLinkProps = {
   panel: string;
-  children: React.ReactNode;
   context?: string;
-}) {
+  label: string;
+  Icon: ComponentType<IconProps>;
+};
+
+function NavLink({ panel, context, label, Icon }: NavLinkProps) {
   const params = useSearchParams();
   const closeSidebar = useMobileUiStore((s) => s.closeSidebar);
 
@@ -41,11 +49,20 @@ function NavLink({
         closeSidebar();
         event.stopPropagation();
       }}
-      className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
+      className={`group flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition hover:bg-muted ${
+        active ? "bg-muted font-medium text-foreground" : "text-foreground/80 hover:text-foreground"
+      }`}
       data-testid={`nav-${panel}`}
       aria-current={active ? "page" : undefined}
     >
-      {children}
+      <Icon
+        width={20}
+        height={20}
+        title={label}
+        active={active}
+        className="h-5 w-5 opacity-70 group-aria-[current=page]:opacity-100"
+      />
+      <span className="truncate">{label}</span>
     </Link>
   );
 }
@@ -54,13 +71,14 @@ export default function Tabs() {
   const t = useT();
   return (
     <ul className="mt-2 space-y-1">
-      {TAB_DEFS.map((tab) => (
-        <li key={tab.key}>
-          <NavLink panel={tab.panel} context={tab.context}>
-            {t(tab.labelKey)}
-          </NavLink>
-        </li>
-      ))}
+      {TAB_DEFS.map((tab) => {
+        const label = t(tab.labelKey);
+        return (
+          <li key={tab.key}>
+            <NavLink panel={tab.panel} context={tab.context} label={label} Icon={tab.icon} />
+          </li>
+        );
+      })}
     </ul>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable Glyph wrapper and new chat/directory/profile/timeline line icons styled like ChatGPT
- render the new glyphs in the sidebar navigation and new chat button while keeping accessibility metadata
- adjust sidebar item styling to provide consistent opacity and stroke changes between active and inactive states

## Testing
- npm run lint *(fails: prompts to configure ESLint interactively in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dce9bc7d08832f859a62535e388179