### PR TITLE
Add glyph-based sidebar icons

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 import { useT } from "@/components/hooks/useI18n";
 import { useLocale } from "@/components/hooks/useLocale";
 import { useUIStore } from "@/components/hooks/useUIStore";
+import { IconNewChat } from "@/components/icons";
 
 const LEGACY_NEW_CHAT_TITLES = new Set([
   "New chat",
@@ -67,9 +68,10 @@ export default function Sidebar() {
         type="button"
         aria-label={t("threads.systemTitles.new_chat")}
         onClick={handleNewChat}
-        className="w-full rounded-full bg-blue-600 px-4 py-2.5 text-left text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
+        className="flex w-full items-center justify-center gap-2 rounded-full bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
       >
-        + {t("threads.systemTitles.new_chat")}
+        <IconNewChat title={t("threads.systemTitles.new_chat")} active size={18} className="text-white" />
+        <span>{t("threads.systemTitles.new_chat")}</span>
       </button>
 
       <div>

--- a/components/icons/Glyph.tsx
+++ b/components/icons/Glyph.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+
+export type IconProps = React.SVGProps<SVGSVGElement> & {
+  title?: string;
+  /** Stroke weight when not active (default 1.5) */
+  weight?: number;
+  /** Stroke weight when active (default 1.9) */
+  activeWeight?: number;
+  /** Toggle thicker stroke + full opacity */
+  active?: boolean;
+  /** Size in px (CSS should usually control, default 20) */
+  size?: number;
+};
+
+export const Glyph = React.forwardRef<SVGSVGElement, IconProps>(
+  (
+    {
+      title = "Icon",
+      active = false,
+      weight = 1.5,
+      activeWeight = 1.9,
+      size = 20,
+      children,
+      ...rest
+    },
+    ref
+  ) => {
+    return (
+      <svg
+        ref={ref}
+        viewBox="0 0 24 24"
+        role="img"
+        aria-label={title}
+        width={size}
+        height={size}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={active ? activeWeight : weight}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{
+          opacity: active ? 1 : 0.72,
+          transition: "opacity .15s ease, stroke-width .15s ease",
+        }}
+        {...rest}
+      >
+        {children}
+      </svg>
+    );
+  }
+);
+Glyph.displayName = "Glyph";

--- a/components/icons/IconDirectory.tsx
+++ b/components/icons/IconDirectory.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { Glyph, IconProps } from "./Glyph";
+
+/** Directory — list + subtle pin */
+export function IconDirectory(props: IconProps) {
+  const { title = "Directory", ...rest } = props;
+  return (
+    <Glyph title={title} {...rest}>
+      <path d="M4.5 7.25h8.5" />
+      <path d="M4.5 11h7.25" />
+      <path d="M4.5 14.75h6" />
+      <circle cx="17.5" cy="10" r="2.5" />
+      <path d="M17.5 12.6c1.8 0 3.2 1.3 3.2 2.6 0 .7-.6 1.2-1.3 1.2h-3.8c-.7 0-1.3-.5-1.3-1.2 0-1.3 1.4-2.6 3.2-2.6z" />
+    </Glyph>
+  );
+}

--- a/components/icons/IconMedicalProfile.tsx
+++ b/components/icons/IconMedicalProfile.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { Glyph, IconProps } from "./Glyph";
+
+/** Medical Profile — document + cross */
+export function IconMedicalProfile(props: IconProps) {
+  const { title = "Medical profile", ...rest } = props;
+  return (
+    <Glyph title={title} {...rest}>
+      <path d="M8 4.5h6l3.5 3.5v11a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V6.5a2 2 0 0 1 2-2z" />
+      <path d="M14 4.5V8h3.5" />
+      <path d="M11.75 10v4" />
+      <path d="M9.75 12h4" />
+    </Glyph>
+  );
+}

--- a/components/icons/IconNewChat.tsx
+++ b/components/icons/IconNewChat.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+import { Glyph, IconProps } from "./Glyph";
+
+/** New Chat — minimal plus (container-free) */
+export function IconNewChat(props: IconProps) {
+  const { title = "New chat", ...rest } = props;
+  return (
+    <Glyph title={title} {...rest}>
+      <path d="M12 7.25v9.5" />
+      <path d="M7.25 12h9.5" />
+    </Glyph>
+  );
+}

--- a/components/icons/IconTimeline.tsx
+++ b/components/icons/IconTimeline.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { Glyph, IconProps } from "./Glyph";
+
+/** Timeline — rail + three nodes */
+export function IconTimeline(props: IconProps) {
+  const { title = "Timeline", ...rest } = props;
+  return (
+    <Glyph title={title} {...rest}>
+      <path d="M4 12h16" />
+      <circle cx="8" cy="12" r="1.1" />
+      <circle cx="12" cy="12" r="1.1" />
+      <circle cx="16" cy="12" r="1.1" />
+    </Glyph>
+  );
+}

--- a/components/icons/index.ts
+++ b/components/icons/index.ts
@@ -1,0 +1,6 @@
+export * from "./Glyph";
+export * from "./IconNewChat";
+export * from "./IconDirectory";
+export * from "./IconMedicalProfile";
+export * from "./IconTimeline";
+export { default as WwwGlobeIcon } from "./WwwGlobe";

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,29 +1,35 @@
 "use client";
+import type { ComponentType } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 import { useT } from "@/components/hooks/useI18n";
+import type { IconProps } from "@/components/icons";
+import { IconDirectory, IconMedicalProfile, IconTimeline } from "@/components/icons";
 
 type Tab = {
   key: string;
   labelKey: string;
   panel: string;
   context?: string;
+  Icon: ComponentType<IconProps>;
 };
 
 const TAB_DEFS: Tab[] = [
-  { key: "directory", labelKey: "ui.nav.directory", panel: "directory" },
-  { key: "profile", labelKey: "ui.nav.medical_profile", panel: "profile" },
-  { key: "timeline", labelKey: "ui.nav.timeline", panel: "timeline" },
+  { key: "directory", labelKey: "ui.nav.directory", panel: "directory", Icon: IconDirectory },
+  { key: "profile", labelKey: "ui.nav.medical_profile", panel: "profile", Icon: IconMedicalProfile },
+  { key: "timeline", labelKey: "ui.nav.timeline", panel: "timeline", Icon: IconTimeline },
 ];
 
 function NavLink({
   panel,
-  children,
+  label,
+  Icon,
   context,
 }: {
   panel: string;
-  children: React.ReactNode;
+  label: string;
+  Icon: ComponentType<IconProps>;
   context?: string;
 }) {
   const params = useSearchParams();
@@ -41,11 +47,16 @@ function NavLink({
         closeSidebar();
         event.stopPropagation();
       }}
-      className={`block w-full text-left rounded-md px-3 py-2 hover:bg-muted text-sm ${active ? "bg-muted font-medium" : ""}`}
+      className={`flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm transition ${
+        active
+          ? "bg-blue-600/10 font-semibold text-blue-600 dark:bg-sky-500/20 dark:text-sky-300"
+          : "text-slate-600 hover:bg-slate-100/70 dark:text-slate-300 dark:hover:bg-white/5"
+      }`}
       data-testid={`nav-${panel}`}
       aria-current={active ? "page" : undefined}
     >
-      {children}
+      <Icon title={label} active={active} className="shrink-0" />
+      <span className="truncate">{label}</span>
     </Link>
   );
 }
@@ -56,9 +67,7 @@ export default function Tabs() {
     <ul className="mt-2 space-y-1">
       {TAB_DEFS.map((tab) => (
         <li key={tab.key}>
-          <NavLink panel={tab.panel} context={tab.context}>
-            {t(tab.labelKey)}
-          </NavLink>
+          <NavLink panel={tab.panel} context={tab.context} Icon={tab.Icon} label={t(tab.labelKey)} />
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- add reusable Glyph wrapper with MedX-styled stroke behavior for sidebar icons
- implement dedicated icons for new chat, directory, medical profile, and timeline entries
- update sidebar navigation and new chat button to display the new glyphs with active state styling

## Testing
- ⚠️ `npm run lint` *(blocked by interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf70f2a30832f808c858dbf89701f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar tabs now display dedicated icons alongside labels.
  * “New chat” button includes a new icon for clearer affordance.
  * Expanded icon set available across the app (directory, medical profile, timeline, globe, and more).

* **Style**
  * Improved layout and alignment of the “New chat” button (centered content with balanced spacing).
  * Updated sidebar tab layout to align icons and labels consistently for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->