### PR TITLE
Allow desktop directory search row to shrink within viewport

### DIFF
--- a/components/panels/DirectoryPane.tsx
+++ b/components/panels/DirectoryPane.tsx
@@ -129,16 +129,16 @@ export default function DirectoryPane() {
           </button>
         </div>
 
-        <div className="flex flex-col gap-1 md:flex-row md:items-center md:gap-2">
-          <div className="flex-1 min-w-0">
+        <div className="flex w-full flex-col gap-1 md:flex-row md:items-center md:gap-2 lg:max-w-[100vw]">
+          <div className="flex-1 min-w-0 lg:min-w-0 lg:flex-shrink">
             <input
-              className="h-[34px] w-full rounded-[10px] border border-slate-200 bg-white/90 px-3 text-[12px] text-slate-900 placeholder:text-slate-400 shadow-sm transition focus:border-slate-300 focus:outline-none focus:ring-0 dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 md:h-10 md:rounded-[10px] md:px-3 md:text-[13px]"
+              className="h-[34px] w-full rounded-[10px] border border-slate-200 bg-white/90 px-3 text-[12px] text-slate-900 placeholder:text-slate-400 shadow-sm transition focus:border-slate-300 focus:outline-none focus:ring-0 dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-100 md:h-10 md:rounded-[10px] md:px-3 md:text-[13px] lg:w-full lg:max-w-full lg:overflow-x-auto lg:whitespace-nowrap"
               placeholder={t("Search doctors, pharmacies, labs")}
               value={q}
               onChange={(event) => actions.setQ(event.target.value)}
             />
           </div>
-          <div className="min-w-0 md:w-[320px]">
+          <div className="min-w-0 md:w-[320px] lg:min-w-0 lg:flex-shrink">
             <AddressPicker value={locLabel} onSelect={actions.setAddress} lang={appLang} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- limit the desktop directory search row to the viewport width while preserving layout
- allow search and location wrappers to shrink on large screens and let the location input scroll its value

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dcfb17446c832fa370fac5b7a41ec9