### PR TITLE
Remove French from preferences language toggle

### DIFF
--- a/components/settings/panels/General.tsx
+++ b/components/settings/panels/General.tsx
@@ -11,7 +11,6 @@ const LANG_LABELS = {
   hi: "Hindi",
   ar: "Arabic",
   es: "Spanish",
-  fr: "French",
   it: "Italian",
 } as const;
 


### PR DESCRIPTION
## Summary
- remove the French entry from the preferences language labels so it no longer appears in the selector

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2f9189b0832fa5e365dd4e580823