### PR TITLE
Keep brand logo size consistent in dark mode

### DIFF
--- a/components/brand/Logo.tsx
+++ b/components/brand/Logo.tsx
@@ -60,10 +60,13 @@ export default function Logo({
     <Link
       href="/"
       aria-label={`${BRAND_NAME} — Home`}
-      className={`inline-flex items-center gap-2 shrink-0 ${className}`}
+      className={`inline-flex items-center justify-center gap-2 shrink-0 ${className}`}
+      style={{ width, height }}
     >
       {showText || !src ? (
-        <span className="font-semibold tracking-tight">{BRAND_NAME}</span>
+        <span className="font-semibold tracking-tight text-center">
+          {BRAND_NAME}
+        </span>
       ) : (
         <Image
           key={src} // force re-render on src change

--- a/components/nav/Brand.tsx
+++ b/components/nav/Brand.tsx
@@ -2,5 +2,7 @@
 import Logo from "@/components/brand/Logo";
 
 export default function Brand() {
-  return <Logo />;
+  return (
+    <Logo className="dark:text-white dark:[&_img]:brightness-0 dark:[&_img]:invert" />
+  );
 }


### PR DESCRIPTION
## Summary
- apply dark-mode image filters in the Brand component so the primary logo renders white without swapping assets
- lock the Logo component's dimensions to keep the brand mark footprint consistent even if we fall back to text

## Testing
- npm run lint *(fails: command prompts for interactive ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd092eaef8832fb9d01e638c4d0d6f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Centered the logo within its clickable area for a more balanced header appearance.
  * Applied consistent logo dimensions to reduce layout shifts across pages.
  * Improved fallback text styling for the logo: centered alignment with consistent typography.
  * Enhanced dark mode presentation of the brand/logo for better contrast and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->