### PR TITLE
Add browser speech synthesis listening experience

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,15 +12,20 @@ import { Suspense } from "react";
 import MemorySnackbar from "@/components/memory/Snackbar";
 import UndoToast from "@/components/memory/UndoToast";
 import AppToastHost from "@/components/ui/AppToastHost";
-import dynamic from "next/dynamic";
 import Script from "next/script";
 import PreferencesProvider from "@/components/providers/PreferencesProvider";
 import LangDirEffect from "@/components/providers/LangDirEffect";
+import { ReaderProvider } from "@/components/voice/ReaderProvider";
+import dynamic from "next/dynamic";
 
 // Mobile-only UI (loaded client-side)
 const MobileHeader = dynamic(() => import("@/components/mobile/MobileHeader"), { ssr: false });
 const MobileSidebarOverlay = dynamic(() => import("@/components/mobile/MobileSidebarOverlay"), { ssr: false });
 const MobileActionsSheet = dynamic(() => import("@/components/mobile/MobileActionsSheet"), { ssr: false });
+const ReaderMiniPlayer = dynamic(
+  () => import("@/components/voice/ReaderMiniPlayer").then(mod => mod.ReaderMiniPlayer),
+  { ssr: false },
+);
 
 export const metadata = { title: BRAND_NAME, description: "Global medical AI" };
 
@@ -78,16 +83,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         </Script>
         <PreferencesProvider>
           <LangDirEffect />
-          <ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-            <CountryProvider>
-              <ContextProvider>
-                <TopicProvider>
-                  <div className="flex h-full min-h-screen flex-col medx-gradient">
+          <ReaderProvider>
+            <ThemeProvider
+              attribute="class"
+              defaultTheme="system"
+              enableSystem
+              disableTransitionOnChange
+            >
+              <CountryProvider>
+                <ContextProvider>
+                  <TopicProvider>
+                    <div className="flex h-full min-h-screen flex-col medx-gradient">
                     {/* Desktop Header */}
                     <Suspense fallback={<div className="h-[62px]" />}>
                       <div className="hidden md:block">
@@ -127,11 +133,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     {/* Mobile overlays/sheets (client side) */}
                     <MobileSidebarOverlay />
                     <MobileActionsSheet />
-                  </div>
-                </TopicProvider>
-              </ContextProvider>
-            </CountryProvider>
-          </ThemeProvider>
+                    <ReaderMiniPlayer />
+                    </div>
+                  </TopicProvider>
+                </ContextProvider>
+              </CountryProvider>
+            </ThemeProvider>
+          </ReaderProvider>
         </PreferencesProvider>
       </body>
     </html>

--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 import Markdown from "react-markdown";
 import FeedbackControls from "./FeedbackControls";
+import { ListenButton } from "@/components/voice/ListenButton";
+import { useT } from "@/components/hooks/useI18n";
 
 type ChatMessage = {
   id: string;
@@ -16,6 +20,10 @@ interface MessageProps {
 }
 
 export default function Message({ message }: MessageProps) {
+  const t = useT();
+  const lang = t.lang;
+  const textContent = message.content ?? "";
+
   if (message.kind === "image" && message.imageUrl) {
     return (
       <div className={`my-2 flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
@@ -35,7 +43,12 @@ export default function Message({ message }: MessageProps) {
 
   return (
     <div>
-      <Markdown>{message.content ?? ""}</Markdown>
+      {message.role === "assistant" && textContent.trim() && (
+        <div className="mb-2 flex justify-end">
+          <ListenButton getText={() => textContent} lang={lang} className="text-[11px]" />
+        </div>
+      )}
+      <Markdown>{textContent}</Markdown>
       <div className="mt-2">
         <FeedbackControls messageId={message.id} />
       </div>

--- a/components/hooks/useReader.ts
+++ b/components/hooks/useReader.ts
@@ -1,0 +1,6 @@
+"use client";
+
+import { useContext } from "react";
+import { ReaderContext } from "@/components/voice/ReaderProvider";
+
+export const useReader = () => useContext(ReaderContext);

--- a/components/panels/DirectoryPane.tsx
+++ b/components/panels/DirectoryPane.tsx
@@ -4,6 +4,7 @@ import { Phone, MessageSquare, Navigation, Star } from "lucide-react";
 import AddressPicker from "@/components/directory/AddressPicker";
 import { tfmt, useT } from "@/components/hooks/useI18n";
 import { usePrefs } from "@/components/providers/PreferencesProvider";
+import { ListenButton } from "@/components/voice/ListenButton";
 import { useDirectory } from "@/hooks/useDirectory";
 import { ISO_COUNTRIES } from "@/lib/i18n/isoCountries";
 
@@ -293,6 +294,21 @@ export default function DirectoryPane() {
             render: JSX.Element;
           }[];
 
+          const getListenText = () => {
+            const parts: string[] = [];
+            if (displayName) parts.push(displayName);
+            if (typeLabel) parts.push(typeLabel);
+            if (typeof place.rating === "number") {
+              parts.push(`${t("Rating")}: ${numberFormatter.format(place.rating)}`);
+            }
+            if (typeof place.distance_m === "number") {
+              parts.push(`${numberFormatter.format(place.distance_m / 1000)} ${t("km")}`);
+            }
+            parts.push(place.open_now ? t("Open now") : t("Hours not available"));
+            if (displayAddress) parts.push(displayAddress);
+            return parts.filter(Boolean).join(". ");
+          };
+
           return (
             <div
               key={place.id}
@@ -307,8 +323,11 @@ export default function DirectoryPane() {
                     >
                       {displayName}
                     </div>
-                    <div className="inline-flex h-[16px] items-center whitespace-nowrap rounded-full border border-blue-200 bg-blue-50 px-1.5 text-[9px] capitalize text-blue-900 dark:border-white/10 dark:bg-slate-800/70 dark:text-slate-100 md:h-[22px] md:px-2 md:text-[11px]">
-                      {typeLabel}
+                    <div className="flex items-center gap-1.5">
+                      <div className="inline-flex h-[16px] items-center whitespace-nowrap rounded-full border border-blue-200 bg-blue-50 px-1.5 text-[9px] capitalize text-blue-900 dark:border-white/10 dark:bg-slate-800/70 dark:text-slate-100 md:h-[22px] md:px-2 md:text-[11px]">
+                        {typeLabel}
+                      </div>
+                      <ListenButton getText={getListenText} lang={appLang} className="text-[11px]" />
                     </div>
                   </div>
 

--- a/components/panels/MedicalProfile.tsx
+++ b/components/panels/MedicalProfile.tsx
@@ -14,6 +14,7 @@ import { useProfile } from "@/lib/hooks/useAppData";
 import { pushToast } from "@/lib/ui/toast";
 import { fromSearchParams } from "@/lib/modes/url";
 import { extractManualObservation } from "@/lib/profile/extractManualObservation";
+import { ListenButton } from "@/components/voice/ListenButton";
 import { useSWRConfig } from "swr";
 
 const SEXES = ["male", "female", "other"] as const;
@@ -1633,6 +1634,51 @@ export function MedicalProfileMobile(props: MedicalProfileMobileProps) {
   const notesCount = Array.isArray(notes) ? notes.length : 0;
   const nextStepsCount = Array.isArray(nextSteps) ? nextSteps.length : 0;
 
+  const summarySpeech = useMemo(() => {
+    const entries: string[] = [];
+    entries.push(`${t("Patient")}: ${safeName}`);
+    const sexLabel = safeSex === noDataDisplay ? noDataDisplay : safeSexDisplay;
+    const bloodGroupLabel = safeBloodGroup === noDataDisplay ? noDataDisplay : safeBloodGroup;
+    entries.push(
+      `${t("Sex")}: ${sexLabel}, ${t("Age")}: ${safeAge}, ${t("Blood group")}: ${bloodGroupLabel}`,
+    );
+    entries.push(`${t("Chronic conditions")}: ${safeChronic}`);
+    entries.push(`${t("Predispositions")}: ${safePredispositions}`);
+    entries.push(
+      `${t("Active meds")}: ${
+        medsCount > 0 ? `${n(medsCount)} ${t("items")}` : noDataDisplay
+      }`,
+    );
+    entries.push(`${t("Recent labs")}: ${labsLine}`);
+    entries.push(`${t("AI prediction")}: ${noDataDisplay}`);
+    entries.push(
+      `${t("Symptoms/Notes")}: ${
+        notesCount > 0 ? `${n(notesCount)} ${t("items")}` : noDataDisplay
+      }`,
+    );
+    entries.push(
+      `${t("Next Steps")}: ${
+        nextStepsCount > 0 ? `${n(nextStepsCount)} ${t("items")}` : noDataDisplay
+      }`,
+    );
+    return entries.join(". ");
+  }, [
+    t,
+    safeName,
+    safeSex,
+    safeSexDisplay,
+    safeAge,
+    safeBloodGroup,
+    safeChronic,
+    safePredispositions,
+    medsCount,
+    n,
+    noDataDisplay,
+    labsLine,
+    notesCount,
+    nextStepsCount,
+  ]);
+
   return (
     <div className="space-y-4">
       <Section
@@ -1675,24 +1721,27 @@ export function MedicalProfileMobile(props: MedicalProfileMobileProps) {
       </Section>
 
       <Section title={t("AI Summary")}>
-        <p className="text-[13px] leading-5 text-slate-600 dark:text-slate-300">
-          {t("Patient")}: {safeName} (
-          {t("Sex")}: {safeSex === noDataDisplay ? "—" : safeSexDisplay}, {t("Age")}: {safeAge}, {t("Blood group")}: {safeBloodGroup === noDataDisplay ? "—" : safeBloodGroup})
-          <br />
-          {t("Chronic conditions")}: {safeChronic}
-          <br />
-          {t("Predispositions")}: {safePredispositions}
-          <br />
-          {t("Active meds")}: {medsCount > 0 ? `${n(medsCount)} ${t("items")}` : noDataDisplay}
-          <br />
-          {t("Recent labs")}: {labsLine}
-          <br />
-          {t("AI prediction")}: {noDataDisplay}
-          <br />
-          {t("Symptoms/Notes")}: {notesCount > 0 ? `${n(notesCount)} ${t("items")}` : noDataDisplay}
-          <br />
-          {t("Next Steps")}: {nextStepsCount > 0 ? `${n(nextStepsCount)} ${t("items")}` : noDataDisplay}
-        </p>
+        <div className="flex items-start justify-between gap-3">
+          <p className="flex-1 text-[13px] leading-5 text-slate-600 dark:text-slate-300">
+            {t("Patient")}: {safeName} (
+            {t("Sex")}: {safeSex === noDataDisplay ? "—" : safeSexDisplay}, {t("Age")}: {safeAge}, {t("Blood group")}: {safeBloodGroup === noDataDisplay ? "—" : safeBloodGroup})
+            <br />
+            {t("Chronic conditions")}: {safeChronic}
+            <br />
+            {t("Predispositions")}: {safePredispositions}
+            <br />
+            {t("Active meds")}: {medsCount > 0 ? `${n(medsCount)} ${t("items")}` : noDataDisplay}
+            <br />
+            {t("Recent labs")}: {labsLine}
+            <br />
+            {t("AI prediction")}: {noDataDisplay}
+            <br />
+            {t("Symptoms/Notes")}: {notesCount > 0 ? `${n(notesCount)} ${t("items")}` : noDataDisplay}
+            <br />
+            {t("Next Steps")}: {nextStepsCount > 0 ? `${n(nextStepsCount)} ${t("items")}` : noDataDisplay}
+          </p>
+          <ListenButton getText={() => summarySpeech} lang={lang} className="text-[12px] shrink-0" />
+        </div>
 
         <div className="mt-3 flex gap-2">
           {onDiscussAI ? (

--- a/components/panels/Timeline.tsx
+++ b/components/panels/Timeline.tsx
@@ -8,6 +8,7 @@ import PanelLoader from "@/components/mobile/PanelLoader";
 import { pushToast } from "@/lib/ui/toast";
 import { useRouter } from "next/navigation";
 import { useT } from "@/components/hooks/useI18n";
+import { ListenButton } from "@/components/voice/ListenButton";
 import { langBase } from "@/lib/i18n/langBase";
 
 function normalizeKind(k?: string) {
@@ -683,6 +684,14 @@ export default function Timeline(){
                 const title = it?.name_display ?? it?.name ?? t("Observation");
                 const short = it?.summary_display ?? getShortSummary(it);
                 const chipLabel = getChipLabel(it, t);
+                const getListenText = () => {
+                  const parts: string[] = [];
+                  if (title) parts.push(title);
+                  if (observedAt) parts.push(observedAt);
+                  if (short) parts.push(short);
+                  if (chipLabel) parts.push(chipLabel);
+                  return parts.join(". ");
+                };
                 return (
                   <li
                     key={`${it.kind}:${it.id}`}
@@ -714,6 +723,12 @@ export default function Timeline(){
                             {chipLabel}
                           </span>
                         )}
+                        <ListenButton
+                          getText={getListenText}
+                          lang={langFull}
+                          className="text-[11px] shrink-0"
+                          stopPropagation
+                        />
                         <button
                           className="shrink-0 p-2 rounded-md hover:bg-slate-100 dark:hover:bg-gray-800"
                           aria-label={t("Delete")}

--- a/components/voice/ListenButton.tsx
+++ b/components/voice/ListenButton.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import React from "react";
+import { useReader } from "@/components/hooks/useReader";
+
+type ListenButtonProps = {
+  getText: () => string;
+  lang?: string;
+  className?: string;
+  stopPropagation?: boolean;
+  label?: string;
+  stopLabel?: string;
+};
+
+export function ListenButton({
+  getText,
+  lang,
+  className = "",
+  stopPropagation = false,
+  label = "Listen",
+  stopLabel = "Stop",
+}: ListenButtonProps) {
+  const { canUse, status, read, stop } = useReader();
+
+  if (!canUse) return null;
+
+  const isActive = status === "speaking" || status === "paused" || status === "loading";
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (stopPropagation) {
+      event.stopPropagation();
+    }
+    event.preventDefault();
+    if (isActive) {
+      stop();
+      return;
+    }
+    const text = getText();
+    if (!text || !text.trim()) return;
+    read({ text, lang });
+  };
+
+  const displayLabel = isActive ? stopLabel : label;
+
+  return (
+    <button
+      type="button"
+      aria-label={displayLabel}
+      aria-pressed={isActive}
+      onClick={handleClick}
+      className={`inline-flex items-center gap-1.5 rounded-full border border-transparent px-2 py-1 text-xs text-slate-600 transition hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 focus-visible:ring-offset-1 dark:text-slate-300 dark:hover:text-white ${className}`.trim()}
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" className="opacity-80">
+        <path d="M3 10v4h4l5 5V5L7 10H3z" fill="currentColor" />
+        <path d="M16 7.5a6.5 6.5 0 0 1 0 9M18.5 5a9 9 0 0 1 0 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+      <span className="font-medium">{displayLabel}</span>
+    </button>
+  );
+}

--- a/components/voice/ReaderMiniPlayer.tsx
+++ b/components/voice/ReaderMiniPlayer.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React from "react";
+import { useReader } from "@/components/hooks/useReader";
+
+const formatReason = (reason?: string) => {
+  if (!reason) return "";
+  if (reason === "match-prefix") return "matched locale";
+  if (reason === "match-base") return "matched language";
+  if (reason === "no-voices") return "no voices";
+  return reason;
+};
+
+export function ReaderMiniPlayer() {
+  const { status, pause, resume, stop, speed, setSpeed, reason } = useReader();
+  const visible = status !== "idle";
+
+  if (!visible) return null;
+
+  const readableReason = formatReason(reason);
+
+  return (
+    <div
+      role="region"
+      aria-label="Reader controls"
+      className="fixed bottom-3 left-1/2 z-[60] flex -translate-x-1/2 items-center gap-3 rounded-full border border-slate-200 bg-white/90 px-4 py-2 text-xs shadow-lg backdrop-blur dark:border-slate-700 dark:bg-slate-900/90"
+    >
+      <span className="font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Reader</span>
+      {status === "speaking" ? (
+        <button type="button" onClick={pause} className="underline">
+          Pause
+        </button>
+      ) : status === "paused" ? (
+        <button type="button" onClick={resume} className="underline">
+          Resume
+        </button>
+      ) : (
+        <span className="text-slate-400">Loading…</span>
+      )}
+      <label className="flex items-center gap-2">
+        <span className="uppercase tracking-wide text-[10px] text-slate-500 dark:text-slate-300">Speed</span>
+        <input
+          type="range"
+          min={0.6}
+          max={1.8}
+          step={0.1}
+          value={speed}
+          onChange={event => {
+            const next = parseFloat(event.target.value);
+            if (!Number.isNaN(next)) {
+              setSpeed(next);
+            }
+          }}
+          className="h-2 w-24 accent-blue-600"
+        />
+      </label>
+      <button type="button" onClick={stop} className="underline">
+        Stop
+      </button>
+      {readableReason ? (
+        <span className="text-[10px] text-slate-400 dark:text-slate-500">({readableReason})</span>
+      ) : null}
+    </div>
+  );
+}

--- a/components/voice/ReaderProvider.tsx
+++ b/components/voice/ReaderProvider.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { chunkText, hasSpeech, loadVoices, preferVoiceForLang } from "@/lib/tts";
+
+type ReaderStatus = "idle" | "loading" | "speaking" | "paused";
+
+type ReaderCtx = {
+  status: ReaderStatus;
+  lang: string;
+  speed: number;
+  reason?: string;
+  canUse: boolean;
+  setSpeed: (value: number) => void;
+  read: (opts: { text: string; lang?: string }) => Promise<void>;
+  pause: () => void;
+  resume: () => void;
+  stop: () => void;
+};
+
+const noop = () => {};
+
+export const ReaderContext = createContext<ReaderCtx>({
+  status: "idle",
+  lang: "en",
+  speed: 1,
+  canUse: false,
+  setSpeed: noop,
+  read: async () => {},
+  pause: noop,
+  resume: noop,
+  stop: noop,
+});
+
+type ProviderProps = {
+  children: React.ReactNode;
+  appLang?: string;
+};
+
+const SPEED_KEY = "medx:tts:speed";
+const MIN_SPEED = 0.6;
+const MAX_SPEED = 1.8;
+
+export function ReaderProvider({ children, appLang }: ProviderProps) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<ReaderStatus>("idle");
+  const [speed, setSpeedState] = useState<number>(() => {
+    if (typeof window === "undefined") return 1;
+    try {
+      const stored = window.localStorage.getItem(SPEED_KEY);
+      if (!stored) return 1;
+      const parsed = parseFloat(stored);
+      if (Number.isNaN(parsed)) return 1;
+      return Math.min(MAX_SPEED, Math.max(MIN_SPEED, parsed));
+    } catch {
+      return 1;
+    }
+  });
+  const [reason, setReason] = useState<string | undefined>(undefined);
+
+  const synthRef = useRef<SpeechSynthesis | null>(null);
+  const voiceRef = useRef<SpeechSynthesisVoice | null>(null);
+  const queueRef = useRef<SpeechSynthesisUtterance[]>([]);
+
+  const enabledFlag = process.env.NEXT_PUBLIC_TTS_ENABLED;
+  const canUse =
+    typeof window !== "undefined" &&
+    hasSpeech() &&
+    (enabledFlag === undefined || enabledFlag?.toLowerCase() !== "false");
+
+  const lang = appLang || (typeof window !== "undefined" ? ((window as any).__APP_LANG__ as string | undefined) : undefined) || "en";
+
+  const stop = useCallback(() => {
+    if (!canUse) return;
+    try {
+      synthRef.current?.cancel();
+    } catch {
+      // ignore cancellation errors
+    }
+    queueRef.current = [];
+    setStatus("idle");
+  }, [canUse]);
+
+  const pause = useCallback(() => {
+    if (!canUse) return;
+    try {
+      synthRef.current?.pause();
+      setStatus("paused");
+    } catch {
+      // ignore pause errors
+    }
+  }, [canUse]);
+
+  const resume = useCallback(() => {
+    if (!canUse) return;
+    try {
+      synthRef.current?.resume();
+      setStatus("speaking");
+    } catch {
+      // ignore resume errors
+    }
+  }, [canUse]);
+
+  const setSpeed = useCallback((value: number) => {
+    const clamped = Math.min(MAX_SPEED, Math.max(MIN_SPEED, value));
+    setSpeedState(clamped);
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.setItem(SPEED_KEY, String(clamped));
+      } catch {
+        // ignore storage errors
+      }
+    }
+  }, []);
+
+  const read = useCallback(
+    async ({ text, lang: overrideLang }: { text: string; lang?: string }) => {
+      if (!canUse) return;
+      const trimmed = text?.trim();
+      if (!trimmed) return;
+
+      stop();
+      setStatus("loading");
+
+      const voices = await loadVoices();
+      const pick = preferVoiceForLang(voices, overrideLang || lang);
+      voiceRef.current = pick.voice;
+      setReason(pick.reason);
+
+      const chunks = chunkText(trimmed, 1800);
+      if (!chunks.length) {
+        setStatus("idle");
+        return;
+      }
+
+      queueRef.current = chunks.map(chunk => {
+        const utterance = new SpeechSynthesisUtterance(chunk);
+        utterance.rate = speed;
+        if (voiceRef.current) utterance.voice = voiceRef.current;
+        utterance.onstart = () => {
+          setStatus("speaking");
+        };
+        utterance.onend = () => {
+          queueRef.current.shift();
+          if (queueRef.current.length === 0) {
+            setStatus("idle");
+          }
+        };
+        utterance.onerror = () => {
+          queueRef.current = [];
+          setStatus("idle");
+        };
+        return utterance;
+      });
+
+      setStatus("speaking");
+      const synth = synthRef.current;
+      if (!synth) {
+        setStatus("idle");
+        return;
+      }
+
+      setTimeout(() => {
+        queueRef.current.forEach(utterance => {
+          try {
+            synth.speak(utterance);
+          } catch {
+            setStatus("idle");
+          }
+        });
+      }, 0);
+    },
+    [canUse, stop, speed, lang],
+  );
+
+  useEffect(() => {
+    if (!canUse) return;
+    synthRef.current = window.speechSynthesis;
+    let mounted = true;
+
+    (async () => {
+      setStatus(prev => (prev === "idle" ? "loading" : prev));
+      const voices = await loadVoices();
+      if (!mounted) return;
+      const pick = preferVoiceForLang(voices, lang);
+      voiceRef.current = pick.voice;
+      setReason(pick.reason);
+      setStatus("idle");
+    })();
+
+    return () => {
+      mounted = false;
+      try {
+        synthRef.current?.cancel();
+      } catch {
+        // ignore cancellation errors
+      }
+      queueRef.current = [];
+    };
+  }, [lang, canUse]);
+
+  useEffect(() => {
+    queueRef.current.forEach(utterance => {
+      utterance.rate = speed;
+    });
+  }, [speed]);
+
+  useEffect(() => {
+    if (!pathname) return;
+    stop();
+  }, [pathname, searchParams, stop]);
+
+  const value = useMemo<ReaderCtx>(
+    () => ({ status, lang, speed, reason, canUse, setSpeed, read, pause, resume, stop }),
+    [status, lang, speed, reason, canUse, setSpeed, read, pause, resume, stop],
+  );
+
+  return <ReaderContext.Provider value={value}>{children}</ReaderContext.Provider>;
+}

--- a/lib/tts.ts
+++ b/lib/tts.ts
@@ -1,0 +1,67 @@
+export type TtsVoicePick = { voice: SpeechSynthesisVoice | null; reason: string };
+
+export const hasSpeech = () =>
+  typeof window !== "undefined" &&
+  "speechSynthesis" in window &&
+  "SpeechSynthesisUtterance" in window;
+
+export function preferVoiceForLang(voices: SpeechSynthesisVoice[], appLang: string): TtsVoicePick {
+  if (!voices?.length) return { voice: null, reason: "no-voices" };
+  const lang = (appLang || "en").toLowerCase();
+
+  let v = voices.find(voice => voice.lang?.toLowerCase().startsWith(lang));
+  if (v) return { voice: v, reason: "match-prefix" };
+
+  const base = lang.split("-")[0];
+  v = voices.find(voice => voice.lang?.toLowerCase().startsWith(base));
+  if (v) return { voice: v, reason: "match-base" };
+
+  v = voices.find(voice => voice.default) || voices[0] || null;
+  return { voice: v, reason: "fallback" };
+}
+
+export function chunkText(input: string, maxLen = 1800): string[] {
+  const text = (input || "").replace(/\s+/g, " ").trim();
+  if (!text) return [];
+
+  const sentences = text.split(/([.!?।]+)\s+/);
+  const chunks: string[] = [];
+  let buf = "";
+
+  for (let i = 0; i < sentences.length; i += 1) {
+    const part = sentences[i];
+    if (!part) continue;
+    const next = buf ? `${buf} ${part}` : part;
+    if (next.length > maxLen) {
+      if (buf) chunks.push(buf);
+      if (part.length > maxLen) {
+        for (let j = 0; j < part.length; j += maxLen) {
+          chunks.push(part.slice(j, j + maxLen));
+        }
+        buf = "";
+      } else {
+        buf = part;
+      }
+    } else {
+      buf = next;
+    }
+  }
+  if (buf) chunks.push(buf);
+  return chunks;
+}
+
+export function loadVoices(): Promise<SpeechSynthesisVoice[]> {
+  return new Promise(resolve => {
+    if (!hasSpeech()) return resolve([]);
+    const synth = window.speechSynthesis;
+    const existing = synth.getVoices();
+    if (existing && existing.length) return resolve(existing);
+    const handler = () => {
+      synth.removeEventListener("voiceschanged", handler);
+      resolve(synth.getVoices());
+    };
+    synth.addEventListener("voiceschanged", handler);
+    synth.getVoices();
+    setTimeout(() => resolve(synth.getVoices()), 500);
+  });
+}


### PR DESCRIPTION
## Summary
- add speech synthesis utilities and a ReaderProvider to coordinate Web Speech playback with persisted speed settings
- expose a reusable ListenButton and floating ReaderMiniPlayer that select voices based on the current locale
- surface the Listen affordance on directory cards, the medical AI summary, timeline entries, and assistant chat replies

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0ba8ede8832fb34c40341a3b7a98