### PR TITLE
Add personalization payload and respect history toggles

### DIFF
--- a/app/api/ai-doc/route.ts
+++ b/app/api/ai-doc/route.ts
@@ -14,6 +14,7 @@ import { buildAiDocPrompt } from "@/lib/ai/prompts/aidoc";
 import { supabaseAdmin } from "@/lib/supabase/admin";
 import { extractAll, canonicalizeInputs } from "@/lib/medical/engine/extract";
 import { computeAll } from "@/lib/medical/engine/computeAll";
+import { languageDirectiveFor, personaFromPrefs, SYSTEM_DEFAULT_LANG } from "@/lib/prompt/system";
 // === [MEDX_CALC_ROUTE_IMPORTS_START] ===
 // === [MEDX_CALC_ROUTE_IMPORTS_END] ===
 
@@ -37,7 +38,15 @@ export async function POST(req: NextRequest) {
   const userId = await getUserId(req);
   if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
 
-  const { threadId, message, profileIntent, newProfile } = await req.json();
+  const body = await req.json();
+  const { threadId, message, profileIntent, newProfile, personalization, lang: langTag } = body;
+  const allowHistory = body?.allowHistory !== false;
+  const headerLang = req.headers.get("x-user-lang") || req.headers.get("x-lang") || undefined;
+  const langTagStr = (typeof langTag === "string" ? langTag.trim() : "") || (headerLang?.trim() ?? "") || SYSTEM_DEFAULT_LANG;
+  const lang = langTagStr.toLowerCase();
+  const sysPrelude = [languageDirectiveFor(lang), personaFromPrefs(personalization)]
+    .filter(Boolean)
+    .join("\n\n");
   if (!message) return NextResponse.json({ error: "no message" }, { status: 400 });
 
   // Ensure profile & load clinical state + memory
@@ -101,20 +110,25 @@ export async function POST(req: NextRequest) {
   ]);
 
   // Opportunistically capture preferences from user's message
-  for (const p of extractPrefsFromUser(message)) {
-    await upsertMem(threadId, "aidoc.pref", p.key, p.value);
-    await prisma.timelineEvent.create({
-      data: {
-        profileId: profile.id,
-        at: new Date(),
-        type: "preference",
-        summary: `Saved preference: ${p.key} = ${p.value}`,
-      },
-    });
+  if (allowHistory) {
+    for (const p of extractPrefsFromUser(message)) {
+      await upsertMem(threadId, "aidoc.pref", p.key, p.value);
+      await prisma.timelineEvent.create({
+        data: {
+          profileId: profile.id,
+          at: new Date(),
+          type: "preference",
+          summary: `Saved preference: ${p.key} = ${p.value}`,
+        },
+      });
+    }
   }
 
   // System prompt with guardrails
   let system = buildAiDocPrompt({ profile, labs, meds, conditions });
+  if (sysPrelude) {
+    system = [sysPrelude, system].filter(Boolean).join("\n\n");
+  }
 
   const userText = String(message || "");
   const ctx = canonicalizeInputs(extractAll(userText));
@@ -236,162 +250,167 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  // Persist structured saves + timeline
-  for (const p of out?.save?.prefs ?? []) {
-    await upsertMem(threadId, "aidoc.pref", p.key, String(p.value));
+  let memAfter = mem;
+  if (allowHistory) {
+    for (const p of out?.save?.prefs ?? []) {
+      await upsertMem(threadId, "aidoc.pref", p.key, String(p.value));
+      await prisma.timelineEvent.create({
+        data: {
+          profileId: profile.id,
+          at: new Date(),
+          type: "preference",
+          summary: `Saved preference: ${p.key} = ${p.value}`,
+        },
+      });
+    }
+
+    const save = out?.save || {};
+    await prisma.$transaction(async (tx) => {
+      // CONDITIONS
+      for (const c of save.conditions ?? []) {
+        const existing = await tx.condition.findFirst({
+          where: { profileId: profile.id, label: c.label, status: (c.status as any) ?? "active" },
+        });
+        if (existing) {
+          await tx.condition.update({
+            where: { id: existing.id },
+            data: { code: c.code ?? existing.code, since: c.since ?? existing.since },
+          });
+        } else {
+          const row = await tx.condition.create({
+            data: {
+              profileId: profile.id,
+              label: c.label,
+              status: (c.status as any) ?? "active",
+              code: c.code ?? null,
+              since: c.since ?? null,
+            },
+          });
+          await tx.timelineEvent.create({
+            data: { profileId: profile.id, at: new Date(), type: "diagnosis", refId: row.id, summary: c.label },
+          });
+        }
+      }
+
+      // MEDICATIONS
+      for (const m of save.medications ?? []) {
+        const existing = await tx.medication.findFirst({
+          where: { profileId: profile.id, name: m.name, dose: m.dose ?? null, stoppedAt: null },
+        });
+        if (existing) {
+          await tx.medication.update({
+            where: { id: existing.id },
+            data: { since: m.since ?? existing.since },
+          });
+        } else {
+          const row = await tx.medication.create({
+            data: {
+              profileId: profile.id,
+              name: m.name,
+              dose: m.dose ?? null,
+              since: m.since ?? null,
+              stoppedAt: m.stoppedAt ?? null,
+            },
+          });
+          await tx.timelineEvent.create({
+            data: {
+              profileId: profile.id,
+              at: new Date(),
+              type: "med_start",
+              refId: row.id,
+              summary: (`Started ${m.name} ${m.dose || ""}`).trim(),
+            },
+          });
+        }
+      }
+
+      // LABS
+      for (const l of save.labs ?? []) {
+        const takenAt = l.takenAt ? new Date(l.takenAt) : null;
+        const existing = await tx.labResult.findFirst({
+          where: { profileId: profile.id, name: l.name, takenAt },
+        });
+        if (existing) {
+          await tx.labResult.update({
+            where: { id: existing.id },
+            data: {
+              value: (l as any).value ?? existing.value,
+              unit: l.unit ?? existing.unit,
+              refLow: (l as any).normalLow ?? existing.refLow,
+              refHigh: (l as any).normalHigh ?? existing.refHigh,
+              abnormal: (l as any).abnormal ?? existing.abnormal,
+            },
+          });
+        } else {
+          const row = await tx.labResult.create({
+            data: {
+              profileId: profile.id,
+              panel: l.panel ?? null,
+              name: l.name,
+              value: (l as any).value ?? null,
+              unit: l.unit ?? null,
+              refLow: (l as any).normalLow ?? null,
+              refHigh: (l as any).normalHigh ?? null,
+              takenAt,
+              abnormal: (l as any).abnormal ?? null,
+            },
+          });
+          await tx.timelineEvent.create({
+            data: {
+              profileId: profile.id,
+              at: new Date(),
+              type: "lab",
+              refId: row.id,
+              summary: (`${l.name}: ${l.value ?? ""}${l.unit ?? ""}`).trim(),
+            },
+          });
+        }
+      }
+
+      // NOTES
+      for (const note of save.notes ?? []) {
+        const row = await tx.note.create({ data: { profileId: profile.id, body: note } });
+        await tx.timelineEvent.create({
+          data: { profileId: profile.id, at: new Date(), type: "note", refId: row.id, summary: note },
+        });
+      }
+
+      // PREFS
+      for (const p of save.prefs ?? []) {
+        const existing = await tx.preference.findFirst({ where: { profileId: profile.id, key: p.key } });
+        if (existing) {
+          await tx.preference.update({ where: { id: existing.id }, data: { value: p.value } });
+        } else {
+          await tx.preference.create({ data: { profileId: profile.id, key: p.key, value: p.value } });
+        }
+      }
+    });
+
+    memAfter = await getMemByThread(threadId || "");
+  }
+
+  // Personalization via rule engine
+  const ruled = runRules({ labs, meds, conditions, mem: memAfter });
+  const plan = buildPersonalPlan(ruled, memAfter, { symptomsText: message });
+
+  if (allowHistory) {
+    // Keep core alerts fresh (stale/abnormal)
+    await fetch(new URL("/api/alerts/recompute", req.url), {
+      method: "POST",
+      headers: { cookie: req.headers.get("cookie") || "" },
+    }).catch(() => {});
+
+    // Log which rules fired
     await prisma.timelineEvent.create({
       data: {
         profileId: profile.id,
         at: new Date(),
-        type: "preference",
-        summary: `Saved preference: ${p.key} = ${p.value}`,
+        type: "ai_reason",
+        summary: `Rules: ${plan.rulesFired.join(", ")}`,
+        details: JSON.stringify({ rules: plan.rulesFired }),
       },
     });
   }
-
-  const save = out?.save || {};
-  await prisma.$transaction(async (tx) => {
-    // CONDITIONS
-    for (const c of save.conditions ?? []) {
-      const existing = await tx.condition.findFirst({
-        where: { profileId: profile.id, label: c.label, status: (c.status as any) ?? "active" },
-      });
-      if (existing) {
-        await tx.condition.update({
-          where: { id: existing.id },
-          data: { code: c.code ?? existing.code, since: c.since ?? existing.since },
-        });
-      } else {
-        const row = await tx.condition.create({
-          data: {
-            profileId: profile.id,
-            label: c.label,
-            status: (c.status as any) ?? "active",
-            code: c.code ?? null,
-            since: c.since ?? null,
-          },
-        });
-        await tx.timelineEvent.create({
-          data: { profileId: profile.id, at: new Date(), type: "diagnosis", refId: row.id, summary: c.label },
-        });
-      }
-    }
-
-    // MEDICATIONS
-    for (const m of save.medications ?? []) {
-      const existing = await tx.medication.findFirst({
-        where: { profileId: profile.id, name: m.name, dose: m.dose ?? null, stoppedAt: null },
-      });
-      if (existing) {
-        await tx.medication.update({
-          where: { id: existing.id },
-          data: { since: m.since ?? existing.since },
-        });
-      } else {
-        const row = await tx.medication.create({
-          data: {
-            profileId: profile.id,
-            name: m.name,
-            dose: m.dose ?? null,
-            since: m.since ?? null,
-            stoppedAt: m.stoppedAt ?? null,
-          },
-        });
-        await tx.timelineEvent.create({
-          data: {
-            profileId: profile.id,
-            at: new Date(),
-            type: "med_start",
-            refId: row.id,
-            summary: (`Started ${m.name} ${m.dose || ""}`).trim(),
-          },
-        });
-      }
-    }
-
-    // LABS
-    for (const l of save.labs ?? []) {
-      const takenAt = l.takenAt ? new Date(l.takenAt) : null;
-      const existing = await tx.labResult.findFirst({
-        where: { profileId: profile.id, name: l.name, takenAt },
-      });
-      if (existing) {
-        await tx.labResult.update({
-          where: { id: existing.id },
-          data: {
-            value: (l as any).value ?? existing.value,
-            unit: l.unit ?? existing.unit,
-            refLow: (l as any).normalLow ?? existing.refLow,
-            refHigh: (l as any).normalHigh ?? existing.refHigh,
-            abnormal: (l as any).abnormal ?? existing.abnormal,
-          },
-        });
-      } else {
-        const row = await tx.labResult.create({
-          data: {
-            profileId: profile.id,
-            panel: l.panel ?? null,
-            name: l.name,
-            value: (l as any).value ?? null,
-            unit: l.unit ?? null,
-            refLow: (l as any).normalLow ?? null,
-            refHigh: (l as any).normalHigh ?? null,
-            takenAt,
-            abnormal: (l as any).abnormal ?? null,
-          },
-        });
-        await tx.timelineEvent.create({
-          data: {
-            profileId: profile.id,
-            at: new Date(),
-            type: "lab",
-            refId: row.id,
-            summary: (`${l.name}: ${l.value ?? ""}${l.unit ?? ""}`).trim(),
-          },
-        });
-      }
-    }
-
-    // NOTES
-    for (const note of save.notes ?? []) {
-      const row = await tx.note.create({ data: { profileId: profile.id, body: note } });
-      await tx.timelineEvent.create({
-        data: { profileId: profile.id, at: new Date(), type: "note", refId: row.id, summary: note },
-      });
-    }
-
-    // PREFS
-    for (const p of save.prefs ?? []) {
-      const existing = await tx.preference.findFirst({ where: { profileId: profile.id, key: p.key } });
-      if (existing) {
-        await tx.preference.update({ where: { id: existing.id }, data: { value: p.value } });
-      } else {
-        await tx.preference.create({ data: { profileId: profile.id, key: p.key, value: p.value } });
-      }
-    }
-  });
-
-  // Personalization via rule engine
-  const memAfter = await getMemByThread(threadId || "");
-  const ruled = runRules({ labs, meds, conditions, mem: memAfter });
-  const plan = buildPersonalPlan(ruled, memAfter, { symptomsText: message });
-
-  // Keep core alerts fresh (stale/abnormal)
-  await fetch(new URL("/api/alerts/recompute", req.url), {
-    method: "POST",
-    headers: { cookie: req.headers.get("cookie") || "" },
-  }).catch(() => {});
-
-  // Log which rules fired
-  await prisma.timelineEvent.create({
-    data: {
-      profileId: profile.id,
-      at: new Date(),
-      type: "ai_reason",
-      summary: `Rules: ${plan.rulesFired.join(", ")}`,
-      details: JSON.stringify({ rules: plan.rulesFired }),
-    },
-  });
 
   return NextResponse.json({
     reply: out.reply,

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -108,14 +108,7 @@ export async function POST(req: Request) {
   const langTag = (requestedLang && requestedLang.trim()) || (headerLang && headerLang.trim()) || SYSTEM_DEFAULT_LANG;
   const lang = langTag.toLowerCase();
   const languageName = languageNameFor(lang);
-  const persona = personaFromPrefs({
-    enabled: personalization?.enabled,
-    personality: personalization?.personality,
-    customInstructions: personalization?.customInstructions,
-    nickname: personalization?.nickname,
-    occupation: personalization?.occupation,
-    about: personalization?.about,
-  });
+  const persona = personaFromPrefs(personalization);
   let conversationId = headers.get("x-conversation-id");
   let isNewChat = headers.get("x-new-chat") === "true";
   if (!conversationId) {

--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -60,6 +60,7 @@ export async function POST(req: NextRequest) {
   let body: any = {};
   try { body = await req.json(); } catch {}
   const { context, clientRequestId, mode } = body;
+  const allowHistory = body?.allowHistory !== false;
   const requestedLang = typeof body?.lang === 'string' ? body.lang : undefined;
   const headerLang = req.headers.get('x-user-lang') || req.headers.get('x-lang') || undefined;
   const langTag = (requestedLang && requestedLang.trim()) || (headerLang && headerLang.trim()) || SYSTEM_DEFAULT_LANG;
@@ -73,7 +74,7 @@ export async function POST(req: NextRequest) {
 
   // 1) Gather existing conversation
   const history: Array<{role:'system'|'user'|'assistant'; content:string}> =
-    Array.isArray(body?.messages) ? body.messages : [];
+    allowHistory && Array.isArray(body?.messages) ? body.messages : [];
 
   // 2) Determine latest user turn for research sourcing + chat flow
   const recent = takeRecentTurns(history, 8);                 // keep continuity

--- a/components/providers/PreferencesProvider.tsx
+++ b/components/providers/PreferencesProvider.tsx
@@ -11,6 +11,24 @@ type Personality =
   | "encouraging"
   | "genz";
 
+export type PersonalizationPayload = {
+  enabled: boolean;
+  personality: Personality | null;
+  customInstructions: string;
+  nickname: string;
+  occupation: string;
+  about: string;
+};
+
+export const buildPersonalizationPayload = (prefs: Partial<Prefs> | null | undefined): PersonalizationPayload => ({
+  enabled: !!prefs?.personalizationEnabled,
+  personality: (prefs?.personality as Personality | null | undefined) ?? null,
+  customInstructions: prefs?.customInstructions ?? "",
+  nickname: prefs?.nickname ?? "",
+  occupation: prefs?.occupation ?? "",
+  about: prefs?.about ?? "",
+});
+
 export type Prefs = {
   theme: "system" | "light" | "dark";
   accent: "purple";
@@ -23,6 +41,7 @@ export type Prefs = {
 
   memoryEnabled: boolean;
   memoryAutosave: boolean;
+  allowHistory: boolean;
 
   personalizationEnabled: boolean;
   personality: Personality;
@@ -71,6 +90,7 @@ const DEFAULT: Prefs = {
 
   memoryEnabled: true,
   memoryAutosave: true,
+  allowHistory: true,
 
   personalizationEnabled: true,
   personality: "nerd",


### PR DESCRIPTION
## Summary
- add a reusable personalization payload builder and remember the new allowHistory preference
- include personalization, language, and allowHistory metadata in chat client requests while guarding local memory/indexing
- prepend language/persona directives on chat/therapy/ai-doc APIs and skip persistent writes when history is disabled

## Testing
- npm run lint *(fails: prompts for Next.js ESLint setup so command aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4f8d5fd4832f897c1498780a3a3f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Personalization: responses reflect your persona/preferences across chat, streaming, therapy.
  * Privacy toggle: “Allow history” controls whether conversations, memories, and notes are saved.
  * Stateless mode: requests can run without using or persisting prior history.

* Enhancements
  * Language and persona now consistently shape system prompts and reply language.
  * Therapy notes capture richer metadata and can trigger profile rebuilds.
  * Preferences produce a unified personalization payload shared across APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->