### PR TITLE
Wire personalization sanitization into therapy route and add E2E coverage

### DIFF
--- a/e2e/preferences.history.gate.spec.ts
+++ b/e2e/preferences.history.gate.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+
+test("History OFF excludes prior turns; ON includes", async ({ page }) => {
+  await page.goto("/");
+  // seed some history
+  await page.getByRole("textbox", { name: /send a message/i }).fill("Seed history 1");
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("assistant-turn").first()).toBeVisible();
+
+  // Turn OFF history
+  await page.getByRole("button", { name: /preferences/i }).click();
+  await page.getByRole("tab", { name: /personalization/i }).click();
+  await page.getByRole("switch", { name: /allow history/i }).uncheck();
+  await page.getByRole("button", { name: /save/i }).click();
+
+  // Intercept to assert empty/absent history
+  await page.route("**/api/chat", async (route) => {
+    const b = route.request().postDataJSON();
+    expect(!b.history || b.history.length === 0).toBeTruthy();
+    await route.continue();
+  });
+
+  await page.getByRole("textbox").fill("Follow-up (should ignore earlier context)");
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("assistant-turn").first()).toBeVisible();
+
+  // Turn ON history
+  await page.getByRole("button", { name: /preferences/i }).click();
+  await page.getByRole("tab", { name: /personalization/i }).click();
+  await page.getByRole("switch", { name: /allow history/i }).check();
+  await page.getByRole("button", { name: /save/i }).click();
+
+  // Intercept to assert history present
+  await page.route("**/api/chat", async (route) => {
+    const b = route.request().postDataJSON();
+    expect(Array.isArray(b.history) && b.history.length >= 1).toBeTruthy();
+    await route.continue();
+  });
+
+  await page.getByRole("textbox").fill("Another follow-up (should include previous turns)");
+  await page.keyboard.press("Enter");
+  await expect(page.getByTestId("assistant-turn").first()).toBeVisible();
+});

--- a/e2e/preferences.personalization.routes.spec.ts
+++ b/e2e/preferences.personalization.routes.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+
+async function intercept(page, path: string, assertBody: (b: any) => void) {
+  await page.route(path, async (route) => {
+    const req = route.request();
+    if (req.method() === "POST") {
+      const b = req.postDataJSON();
+      assertBody(b);
+    }
+    await route.continue();
+  });
+}
+
+test.describe("Personalization payload across routes", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.getByRole("button", { name: /preferences/i }).click();
+    await page.getByRole("tab", { name: /personalization/i }).click();
+    await page.getByRole("switch", { name: /enable customization/i }).check();
+    await page.getByRole("button", { name: /witty/i }).click();
+    await page.getByLabel(/custom instructions/i).fill("Be innovative and think outside the box.");
+    await page.getByRole("button", { name: /save/i }).click();
+  });
+
+  test("Chat / Therapy / AI-Doc carry personalization + lang", async ({ page }) => {
+    await intercept(page, "**/api/chat",  (b) => { expect(b.personalization?.enabled).toBe(true); expect(typeof b.lang).toBe("string"); });
+    await intercept(page, "**/api/therapy", (b) => { expect(b.personalization?.enabled).toBe(true); expect(typeof b.lang).toBe("string"); });
+    await intercept(page, "**/api/ai-doc", (b) => { expect(b.personalization?.enabled).toBe(true); expect(typeof b.lang).toBe("string"); });
+
+    // Chat send
+    await page.getByRole("textbox", { name: /send a message/i }).fill("Hydration benefits?");
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("assistant-turn").first()).toBeVisible();
+
+    // Therapy send
+    await page.getByRole("tab", { name: /therapy/i }).click();
+    await page.getByRole("textbox").fill("I feel overwhelmed.");
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("assistant-turn").first()).toBeVisible();
+
+    // AI-Doc send
+    await page.getByRole("tab", { name: /ai[- ]?doc/i }).click();
+    await page.getByRole("textbox").fill("Explain CBC basics.");
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("assistant-turn").first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add shared personalization sanitization helpers and persona builder updates
- ensure the therapy API route prepends the sanitized system prelude and honors the history gate
- cover personalization propagation and history gating with new Playwright E2E specs

## Testing
- pnpm test:e2e *(fails: script not found in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5a42bec8832f98aa212f1b170910