### PR TITLE
Align new chat nav entry with sidebar tabs

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Search, Settings } from "lucide-react";
-import Tabs from "./sidebar/Tabs";
+import { SIDEBAR_TABS, SidebarNavLink } from "./sidebar/Tabs";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { createNewThreadId, listThreads, Thread } from "@/lib/chatThreads";
@@ -63,30 +63,45 @@ export default function Sidebar() {
   };
   const filtered = threads.filter((t) => t.title.toLowerCase().includes(q.toLowerCase()));
   return (
-    <div className="sidebar-click-guard flex h-full w-full flex-col gap-4 px-4 pt-6 pb-0 text-medx">
-      <button
-        type="button"
-        aria-label={t("threads.systemTitles.new_chat")}
-        onClick={handleNewChat}
-        className="flex w-full items-center justify-center gap-2 rounded-full bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-500"
-      >
-        <IconNewChat title={t("threads.systemTitles.new_chat")} active size={18} className="text-white" />
-        <span>{t("threads.systemTitles.new_chat")}</span>
-      </button>
+    <div className="sidebar-click-guard flex h-full w-full flex-col gap-5 px-4 pt-6 pb-0 text-medx">
+      <ul className="space-y-1">
+        <li>
+          <button
+            type="button"
+            aria-label={t("threads.systemTitles.new_chat")}
+            onClick={handleNewChat}
+            className="group flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm text-slate-600 transition hover:bg-slate-100/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 dark:text-slate-300 dark:hover:bg-white/5 dark:focus-visible:outline-slate-500"
+          >
+            <IconNewChat
+              title={t("threads.systemTitles.new_chat")}
+              size={20}
+              className="shrink-0 text-slate-500 transition group-hover:text-slate-700 dark:text-slate-300 dark:group-hover:text-slate-100"
+            />
+            <span className="truncate">{t("threads.systemTitles.new_chat")}</span>
+          </button>
+        </li>
+        {SIDEBAR_TABS.map((tab) => (
+          <li key={tab.key}>
+            <SidebarNavLink
+              panel={tab.panel}
+              context={tab.context}
+              Icon={tab.Icon}
+              label={t(tab.labelKey)}
+            />
+          </li>
+        ))}
+      </ul>
 
-      <div>
-        <div className="relative">
-          <input
-            className="w-full h-10 rounded-full border border-slate-200 bg-white/80 px-3 pr-8 text-sm text-slate-900 placeholder:text-slate-400 shadow-sm transition focus:border-slate-300 focus:outline-none focus:ring-0 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-400"
-            placeholder={t("Search")}
-            onChange={(e) => handleSearch(e.target.value)}
-          />
-          <Search size={16} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 dark:text-slate-400" />
-        </div>
-        <Tabs />
+      <div className="relative">
+        <input
+          className="h-10 w-full rounded-full border border-slate-200 bg-white/80 px-3 pr-8 text-sm text-slate-900 placeholder:text-slate-400 shadow-sm transition focus:border-slate-300 focus:outline-none focus:ring-0 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-400"
+          placeholder={t("Search")}
+          onChange={(e) => handleSearch(e.target.value)}
+        />
+        <Search size={16} className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 dark:text-slate-400" />
       </div>
 
-      <div className="mt-2 flex-1 space-y-1 overflow-y-auto pr-1 pb-16">
+      <div className="flex-1 space-y-1 overflow-y-auto pr-1 pb-16">
         {filtered.map((thread) => {
           const rawTitle = (thread.title ?? "").trim();
           const systemKey = thread.therapy && LEGACY_THERAPY_TITLES.has(rawTitle)

--- a/components/icons/IconNewChat.tsx
+++ b/components/icons/IconNewChat.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
 import { Glyph, IconProps } from "./Glyph";
 
-/** New Chat — minimal plus (container-free) */
+/** New Chat — chat bubble with plus */
 export function IconNewChat(props: IconProps) {
   const { title = "New chat", ...rest } = props;
   return (
     <Glyph title={title} {...rest}>
-      <path d="M12 7.25v9.5" />
-      <path d="M7.25 12h9.5" />
+      <path d="M7 5.25h10a3.25 3.25 0 0 1 3.25 3.25v4.5A3.25 3.25 0 0 1 17 16.25h-3.25L9.5 19.5v-3.25H7A3.25 3.25 0 0 1 3.75 13V8.5A3.25 3.25 0 0 1 7 5.25Z" />
+      <path d="M12 9.25v4" />
+      <path d="M10 11.25h4" />
     </Glyph>
   );
 }

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -7,7 +7,7 @@ import { useT } from "@/components/hooks/useI18n";
 import type { IconProps } from "@/components/icons";
 import { IconDirectory, IconMedicalProfile, IconTimeline } from "@/components/icons";
 
-type Tab = {
+export type SidebarTab = {
   key: string;
   labelKey: string;
   panel: string;
@@ -15,13 +15,13 @@ type Tab = {
   Icon: ComponentType<IconProps>;
 };
 
-const TAB_DEFS: Tab[] = [
+export const SIDEBAR_TABS: SidebarTab[] = [
   { key: "directory", labelKey: "ui.nav.directory", panel: "directory", Icon: IconDirectory },
   { key: "profile", labelKey: "ui.nav.medical_profile", panel: "profile", Icon: IconMedicalProfile },
   { key: "timeline", labelKey: "ui.nav.timeline", panel: "timeline", Icon: IconTimeline },
 ];
 
-function NavLink({
+export function SidebarNavLink({
   panel,
   label,
   Icon,
@@ -65,9 +65,9 @@ export default function Tabs() {
   const t = useT();
   return (
     <ul className="mt-2 space-y-1">
-      {TAB_DEFS.map((tab) => (
+      {SIDEBAR_TABS.map((tab) => (
         <li key={tab.key}>
-          <NavLink panel={tab.panel} context={tab.context} Icon={tab.Icon} label={t(tab.labelKey)} />
+          <SidebarNavLink panel={tab.panel} context={tab.context} Icon={tab.Icon} label={t(tab.labelKey)} />
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## Summary
- integrate the New Chat entry directly into the sidebar navigation list so it matches the Directory and other tabs
- expose the sidebar tab configuration so the navigation renderer can be shared between the New Chat action and the existing tabs

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7e3d930c832f9b97d0a484daa7ba