### PR TITLE
feat(chat): defer thread creation until first send

### DIFF
--- a/app/api/threads/route.ts
+++ b/app/api/threads/route.ts
@@ -1,0 +1,9 @@
+import { randomUUID } from "crypto";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}));
+  const title = typeof body?.titleHint === "string" ? body.titleHint : typeof body?.title === "string" ? body.title : "New chat";
+  const id = randomUUID();
+  return NextResponse.json({ id, title });
+}

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -385,7 +385,16 @@ export function ChatWindow() {
 
     const lang = langOverride ?? prefs.lang;
 
-    await persistIfTemp();
+    const snapshotState = useChatStore.getState();
+    const draftTitleFromStore = snapshotState.currentId
+      ? snapshotState.threads[snapshotState.currentId]?.title
+      : undefined;
+    const computedTitle =
+      draftTitleFromStore && draftTitleFromStore.trim().length > 0
+        ? draftTitleFromStore
+        : content.split(/\s+/).slice(0, 6).join(" ") || "New chat";
+
+    await persistIfTemp({ title: computedTitle });
     const persistedThreadId = useChatStore.getState().currentId;
     const effectiveThreadId = persistedThreadId ?? currentId;
     const research = getResearchFlagFromUrl();

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -386,6 +386,8 @@ export function ChatWindow() {
     const lang = langOverride ?? prefs.lang;
 
     await persistIfTemp();
+    const persistedThreadId = useChatStore.getState().currentId;
+    const effectiveThreadId = persistedThreadId ?? currentId;
     const research = getResearchFlagFromUrl();
     const pendingId =
       typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
@@ -420,8 +422,8 @@ export function ChatWindow() {
           locationToken,
           research,
           lang,
-          activeThreadId: currentId,
-          threadId: currentId,
+          activeThreadId: effectiveThreadId,
+          threadId: effectiveThreadId,
           mode: modeChoice,
           personalization,
           include: includeFlags,
@@ -429,8 +431,8 @@ export function ChatWindow() {
       : {
           text: content,
           lang,
-          activeThreadId: currentId,
-          threadId: currentId,
+          activeThreadId: effectiveThreadId,
+          threadId: effectiveThreadId,
           mode: modeChoice,
           researchOn: research,
           personalization,
@@ -458,7 +460,7 @@ export function ChatWindow() {
       const { replyText, results: nextResults } = await runAssistantRequest(
         pendingId,
         snapshot,
-        currentId,
+        effectiveThreadId,
       );
       setResults(nextResults);
       markPendingAssistantStreaming(pendingId);

--- a/components/ThreadView.tsx
+++ b/components/ThreadView.tsx
@@ -9,7 +9,7 @@ export default function ThreadView({ id }: { id: string }) {
 
   useEffect(() => {
     upsertThread({ id });
-    setCurrent({ currentId: id });
+    setCurrent({ currentId: id, draft: null });
   }, [id, upsertThread, setCurrent]);
 
   return <ChatWindow />;

--- a/lib/chat/persist.ts
+++ b/lib/chat/persist.ts
@@ -1,18 +1,23 @@
 import { useChatStore } from "@/lib/state/chatStore";
+import { createThreadIfNeeded } from "@/lib/chat/threadClient";
 
 export async function persistIfTemp() {
-  const { currentId, threads, upsertThread } = useChatStore.getState();
+  const { currentId, threads } = useChatStore.getState();
   if (!currentId) return;
   const t = threads[currentId];
   if (!t?.isTemp) return;
-  // call your existing create-thread endpoint
-  const res = await fetch("/api/chat", { method: "POST", body: JSON.stringify({ title: t.title }) });
-  try {
-    await res.json();
-  } catch {
-    throw new Error("Network error");
+  const newId = await createThreadIfNeeded({
+    mode: "wellness",
+    research: undefined,
+    titleHint: t.title,
+  });
+  if (newId && newId !== currentId) {
+    const nextThreads = { ...threads };
+    delete nextThreads[currentId];
+    nextThreads[newId] = { ...t, id: newId, isTemp: false };
+    useChatStore.setState({ currentId: newId, threads: nextThreads });
+    return;
   }
-  // If you want to swap ids, you can re-key; else just clear isTemp:
-  upsertThread({ id: currentId, isTemp: false });
+  useChatStore.getState().upsertThread({ id: currentId, isTemp: false });
 }
 

--- a/lib/chat/persist.ts
+++ b/lib/chat/persist.ts
@@ -1,23 +1,69 @@
-import { useChatStore } from "@/lib/state/chatStore";
 import { createThreadIfNeeded } from "@/lib/chat/threadClient";
+import { useChatStore } from "@/lib/state/chatStore";
 
-export async function persistIfTemp() {
-  const { currentId, threads } = useChatStore.getState();
-  if (!currentId) return;
-  const t = threads[currentId];
-  if (!t?.isTemp) return;
-  const newId = await createThreadIfNeeded({
-    mode: "wellness",
-    research: undefined,
-    titleHint: t.title,
-  });
-  if (newId && newId !== currentId) {
-    const nextThreads = { ...threads };
-    delete nextThreads[currentId];
-    nextThreads[newId] = { ...t, id: newId, isTemp: false };
-    useChatStore.setState({ currentId: newId, threads: nextThreads });
+const persistLocks = new Map<string, Promise<void>>();
+
+export async function persistIfTemp({ title }: { title: string }): Promise<void> {
+  const { currentId } = useChatStore.getState();
+  const key = currentId ?? "draft";
+  const existing = persistLocks.get(key);
+  if (existing) {
+    await existing;
     return;
   }
-  useChatStore.getState().upsertThread({ id: currentId, isTemp: false });
+
+  const run = (async () => {
+    const state = useChatStore.getState();
+    const { draft, threads } = state;
+    const threadId = state.currentId;
+    const thread = threadId ? threads[threadId] : undefined;
+
+    if (!thread) {
+      return;
+    }
+
+    const resolvedId = await createThreadIfNeeded({
+      threadId: thread.isTemp ? null : threadId,
+      mode: draft.mode,
+      research: draft.research,
+      titleHint: title,
+    });
+
+    if (!threadId) {
+      return;
+    }
+
+    if (resolvedId !== threadId) {
+      const latest = useChatStore.getState();
+      const latestThread = latest.threads[threadId];
+      if (!latestThread) {
+        return;
+      }
+      const nextThread = { ...latestThread, id: resolvedId, isTemp: false };
+      useChatStore.setState(s => {
+        const nextThreads = { ...s.threads };
+        delete nextThreads[threadId];
+        nextThreads[resolvedId] = nextThread;
+        return { ...s, currentId: resolvedId, threads: nextThreads };
+      });
+    } else if (thread.isTemp) {
+      useChatStore.setState(s => ({
+        ...s,
+        threads: {
+          ...s.threads,
+          [threadId]: { ...s.threads[threadId], isTemp: false },
+        },
+      }));
+    }
+
+    useChatStore.getState().upsertThread({ id: resolvedId, isTemp: false });
+  })();
+
+  persistLocks.set(key, run);
+  try {
+    await run;
+  } finally {
+    persistLocks.delete(key);
+  }
 }
 

--- a/lib/chat/threadClient.ts
+++ b/lib/chat/threadClient.ts
@@ -1,0 +1,26 @@
+export async function createThreadIfNeeded({
+  threadId,
+  mode,
+  research,
+  titleHint,
+}: {
+  threadId?: string | null;
+  mode: "clinical" | "wellness" | "ai-doc";
+  research?: boolean;
+  titleHint?: string;
+}): Promise<string> {
+  if (threadId) return threadId;
+  const res = await fetch("/api/threads", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mode, research, titleHint: titleHint ?? "New chat" }),
+  });
+  try {
+    const json = await res.json();
+    const id = typeof json?.id === "string" ? json.id : null;
+    if (id) return id;
+  } catch {
+    // ignore JSON errors and fall back to client id
+  }
+  return crypto.randomUUID();
+}

--- a/lib/chat/threadClient.ts
+++ b/lib/chat/threadClient.ts
@@ -1,26 +1,42 @@
+import { mapDraftToThreadMode, type DraftMode } from "./types";
+
 export async function createThreadIfNeeded({
   threadId,
   mode,
   research,
   titleHint,
 }: {
-  threadId?: string | null;
-  mode: "clinical" | "wellness" | "ai-doc";
+  threadId: string | null;
+  mode: DraftMode;
   research?: boolean;
   titleHint?: string;
 }): Promise<string> {
   if (threadId) return threadId;
-  const res = await fetch("/api/threads", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ mode, research, titleHint: titleHint ?? "New chat" }),
-  });
   try {
-    const json = await res.json();
-    const id = typeof json?.id === "string" ? json.id : null;
-    if (id) return id;
-  } catch {
-    // ignore JSON errors and fall back to client id
+    const res = await fetch("/api/threads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        mode: mapDraftToThreadMode(mode),
+        research: !!research,
+        titleHint: titleHint ?? "New chat",
+      }),
+    });
+
+    if (!res.ok) {
+      console.error(`Failed to create thread: ${res.status} ${res.statusText}`);
+      return crypto.randomUUID();
+    }
+
+    try {
+      const json = await res.json();
+      const id = typeof json?.id === "string" ? json.id : null;
+      if (id) return id;
+    } catch {
+      console.error("Failed to parse thread creation response");
+    }
+  } catch (error) {
+    console.error("Network error creating thread:", error);
   }
   return crypto.randomUUID();
 }

--- a/lib/chat/types.ts
+++ b/lib/chat/types.ts
@@ -1,0 +1,9 @@
+export type DraftMode = "clinical" | "wellness" | "ai-doc";
+export type ThreadMode = "patient" | "doctor";
+
+export function mapDraftToThreadMode(mode: DraftMode): ThreadMode {
+  if (mode === "clinical") {
+    return "doctor";
+  }
+  return "patient";
+}

--- a/lib/state/chatStore.ts
+++ b/lib/state/chatStore.ts
@@ -54,10 +54,12 @@ type ChatState = {
 };
 
 export function createDefaultDraft(): PendingDraft {
-  mode: "wellness",
-  research: false,
-  text: "",
-  attachments: [],
+  return {
+    mode: "wellness",
+    research: false,
+    text: "",
+    attachments: [],
+  };
 }
 
 const initialDraft = createDefaultDraft();

--- a/lib/state/chatStore.ts
+++ b/lib/state/chatStore.ts
@@ -2,6 +2,13 @@ import { create } from "zustand";
 import { nanoid } from "nanoid";
 import type { AppMode } from "@/lib/welcomeMessages";
 
+export type PendingDraft = {
+  mode: "clinical" | "wellness" | "ai-doc";
+  research?: boolean;
+  text: string;
+  attachments: File[];
+};
+
 export type ChatMessageMeta = {
   error?: boolean;
   route?: string;
@@ -33,22 +40,35 @@ type Thread = {
 type ChatState = {
   currentId: string | null;
   threads: Record<string, Thread>;
+  draft: PendingDraft | null;
   startNewThread: () => string;
   upsertThread: (t: Partial<Thread> & { id: string }) => void;
   addMessage: (m: Omit<ChatMessage, "id" | "ts"> & { id?: string }) => void;
   removeMessage: (id: string) => void;
   resetToEmpty: () => void;
+  setDraft: (draft: PendingDraft | null) => void;
+  setDraftText: (text: string) => void;
+  addDraftAttachments: (files: File[]) => void;
+  clearDraft: () => void;
 };
+
+const createDefaultDraft = (): PendingDraft => ({
+  mode: "wellness",
+  research: false,
+  text: "",
+  attachments: [],
+});
 
 export const useChatStore = create<ChatState>((set, get) => ({
   currentId: null,
   threads: {},
+  draft: createDefaultDraft(),
 
   startNewThread: () => {
     const id = `temp_${nanoid(8)}`;
     const now = Date.now();
     const t: Thread = { id, title: "New chat", createdAt: now, updatedAt: now, messages: [], isTemp: true };
-    set(s => ({ currentId: id, threads: { ...s.threads, [id]: t } }));
+    set(s => ({ currentId: id, threads: { ...s.threads, [id]: t }, draft: null }));
     return id;
   },
 
@@ -77,7 +97,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   removeMessage: (id) => {
     set(s => {
       const { currentId } = s;
-      if (!currentId) return s;
+      if (currentId == null) return s;
       const thread = s.threads[currentId];
       if (!thread) return s;
       const messages = thread.messages.filter(message => message.id !== id);
@@ -86,6 +106,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
     });
   },
 
-  resetToEmpty: () => set({ currentId: null, threads: {} }),
+  resetToEmpty: () => set({ currentId: null, threads: {}, draft: createDefaultDraft() }),
+
+  setDraft: (draft) => set({ draft: draft ?? createDefaultDraft() }),
+
+  setDraftText: (text) => {
+    set(s => {
+      const draft = s.draft ?? createDefaultDraft();
+      return { draft: { ...draft, text } };
+    });
+  },
+
+  addDraftAttachments: (files) => {
+    if (files.length === 0) return;
+    set(s => {
+      const draft = s.draft ?? createDefaultDraft();
+      return { draft: { ...draft, attachments: [...draft.attachments, ...files] } };
+    });
+  },
+
+  clearDraft: () => set({ draft: createDefaultDraft() }),
 }));
 


### PR DESCRIPTION
## Summary
- introduce a pending draft in the chat store so new sessions stage text and files without allocating a thread id
- update the chat composer to sync with the pending draft and only create a thread when the first message is sent
- ensure persisted thread ids flow through the send pipeline by adding a thread helper, updating persistence, and providing a threads API stub

## Testing
- npm run lint *(fails: command prompted for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8280ac2c832f88118fc83ba3f1b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Compose and autosave drafts (text + attachments) before a thread exists; attachments can be added to drafts.
  * New server-backed thread creation with sensible default title ("New chat") when needed.

* Improvements
  * Prevents duplicate sends and disables inputs while sending.
  * More reliable, consistent thread selection and targeting across requests.
  * Draft titles persist when a chat is sent; selecting a thread clears transient drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->