### PR TITLE
Align desktop chat layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Shared desktop container */
+.so-container {
+  max-width: 1100px;
+  margin-inline: auto;
+  padding-inline: 24px;
+  width: 100%;
+}
+
+:root {
+  --so-gap-1: 8px;
+  --so-gap-2: 12px;
+  --so-gap-3: 16px;
+  --so-gap-4: 24px;
+  --so-row-h: 48px;
+}
+
 /* smooth theme transitions */
 * { transition: background-color .15s ease, color .15s ease, border-color .15s ease; }
 
@@ -194,6 +210,21 @@ body.font-loading *::after {
 
 /* tiny hover polish without shifting layout */
 .medx-surface:hover { filter: brightness(1.03); }
+
+
+.composer {
+  margin-bottom: var(--so-gap-2);
+}
+
+.footer-disclaimer {
+  margin-top: var(--so-gap-2);
+}
+
+.banner .close {
+  height: 32px;
+  width: 32px;
+  line-height: 32px;
+}
 
 
 @keyframes caret {

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -80,12 +80,12 @@ export function ChatInput({
   return (
     <form
       onSubmit={handleSubmit}
-      className="chat-input-container flex w-full items-end gap-2 rounded-2xl border border-[color:var(--medx-outline)] bg-[color:var(--medx-surface)] px-3 py-2 shadow-sm transition dark:border-white/10 dark:bg-[color:var(--medx-panel)] md:border-0 md:bg-transparent md:px-0 md:py-0 md:shadow-none"
+      className="chat-input-container flex w-full items-center gap-3 rounded-2xl border border-[color:var(--medx-outline)] bg-[color:var(--medx-surface)] px-3 py-2 shadow-sm transition dark:border-white/10 dark:bg-[color:var(--medx-panel)] md:border-0 md:bg-transparent md:px-0 md:py-0 md:shadow-none"
     >
       <button
         type="button"
         aria-label={uploadText}
-        className="flex h-11 w-11 items-center justify-center rounded-full text-[color:var(--medx-text)] transition-colors hover:bg-black/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-[color:var(--medx-text)] dark:hover:bg-white/10"
+        className="inline-flex h-12 w-12 items-center justify-center rounded-full text-[color:var(--medx-text)] transition-colors hover:bg-black/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:text-[color:var(--medx-text)] dark:hover:bg-white/10"
         onClick={() => {
           ensureThread();
           fileInputRef.current?.click();
@@ -120,14 +120,14 @@ export function ChatInput({
             void handleSend();
           }
         }}
-        className="min-h-[40px] max-h-[120px] flex-1 resize-none bg-transparent text-base leading-snug text-[color:var(--medx-text)] placeholder:text-slate-400 focus:outline-none dark:text-[color:var(--medx-text)] dark:placeholder:text-slate-500"
+        className="min-h-[48px] max-h-[120px] flex-1 resize-none bg-transparent text-base leading-snug text-[color:var(--medx-text)] placeholder:text-slate-400 focus:outline-none dark:text-[color:var(--medx-text)] dark:placeholder:text-slate-500"
       />
       <button
         type="submit"
         aria-label={sendText}
         title={sendText}
         disabled={!text.trim()}
-        className="flex h-11 w-11 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-sky-500 dark:hover:bg-sky-400"
+        className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-sky-500 dark:hover:bg-sky-400"
       >
         <SendHorizontal className="h-5 w-5" />
       </button>

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -573,13 +573,13 @@ export function ChatWindow() {
     <div className="flex h-full flex-col" dir={prefs.dir}>
       <div
         ref={chatRef}
-        className={`flex-1 pt-4 md:px-0 md:pt-0 ${
+        className={`flex-1 pt-4 md:pt-0 ${
           hasScrollableContent
             ? "overflow-y-auto mobile-chat-scroll"
             : "overflow-hidden mobile-chat-scroll-empty"
         } md:pb-0 md:overflow-y-auto`}
       >
-        <div className="px-4">
+        <div className="so-container pb-4">
           {showWelcomeCard ? (
             <div className="py-10">
               <WelcomeCard />
@@ -644,7 +644,9 @@ export function ChatWindow() {
         </div>
       </div>
       <div ref={composerRef} className="mobile-composer md:static md:bg-transparent md:p-0 md:shadow-none">
-        <ChatInput onSend={handleSend} canSend={prefs.canSend} />
+        <div className="so-container composer">
+          <ChatInput onSend={handleSend} canSend={prefs.canSend} />
+        </div>
       </div>
       <ScrollToBottom targetRef={chatRef} rebindKey={currentId} />
     </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,7 +7,7 @@ import ThemeToggle from '@/components/ThemeToggle';
 export default function Header() {
   return (
     <header className="sticky top-0 z-40 border-b border-black/10 bg-white/80 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/40">
-      <div className="mx-auto flex h-[62px] w-full max-w-screen-2xl items-center gap-4 px-6">
+      <div className="so-container flex h-[62px] w-full items-center gap-4">
         <div className="flex shrink-0 items-center gap-3 text-base font-semibold md:text-lg">
           <Brand />
         </div>
@@ -16,7 +16,7 @@ export default function Header() {
           <ModeBar />
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex flex-1 justify-end gap-3">
           <ThemeToggle />
           <CountryGlobe />
         </div>

--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -308,7 +308,7 @@ export default function LegalPrivacyFooter() {
     <>
       <footer
         ref={footerRef}
-        className="mobile-footer flex-shrink-0 border-t border-black/10 bg-white/80 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/60"
+        className="mobile-footer footer-disclaimer flex-shrink-0 border-t border-black/10 bg-white/80 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/60"
       >
         <div className="mobile-footer-inner mx-auto flex w-full max-w-screen-2xl items-center justify-center gap-1.5 px-6 text-center text-[11px] text-slate-600 dark:text-slate-300 md:gap-3 md:py-1.5 md:text-xs">
           <div

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -63,45 +63,49 @@ export default function Sidebar() {
   };
   const filtered = threads.filter((t) => t.title.toLowerCase().includes(q.toLowerCase()));
   return (
-    <div className="sidebar-click-guard flex h-full w-full flex-col gap-5 px-4 pt-6 pb-0 text-medx">
-      <ul className="space-y-1">
-        <li>
-          <button
-            type="button"
-            aria-label={t("threads.systemTitles.new_chat")}
-            onClick={handleNewChat}
-            className="group flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm text-slate-600 transition hover:bg-slate-100/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 dark:text-slate-300 dark:hover:bg-white/5 dark:focus-visible:outline-slate-500"
-          >
-            <IconNewChat
-              title={t("threads.systemTitles.new_chat")}
-              size={20}
-              className="shrink-0 text-slate-500 transition group-hover:text-slate-700 dark:text-slate-300 dark:group-hover:text-slate-100"
-            />
-            <span className="truncate">{t("threads.systemTitles.new_chat")}</span>
-          </button>
-        </li>
-        {SIDEBAR_TABS.map((tab) => (
-          <li key={tab.key}>
-            <SidebarNavLink
-              panel={tab.panel}
-              context={tab.context}
-              Icon={tab.Icon}
-              label={t(tab.labelKey)}
-            />
+    <div className="sidebar-click-guard flex h-full w-full flex-col text-medx">
+      <div className="flex flex-col gap-4 px-3 pt-8 pb-4">
+        <ul className="space-y-1">
+          <li>
+            <button
+              type="button"
+              aria-label={t("threads.systemTitles.new_chat")}
+              onClick={handleNewChat}
+              className="group flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm text-slate-600 transition hover:bg-slate-100/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 dark:text-slate-300 dark:hover:bg-white/5 dark:focus-visible:outline-slate-500"
+            >
+              <IconNewChat
+                title={t("threads.systemTitles.new_chat")}
+                size={20}
+                className="shrink-0 text-slate-500 transition group-hover:text-slate-700 dark:text-slate-300 dark:group-hover:text-slate-100"
+              />
+              <span className="truncate">{t("threads.systemTitles.new_chat")}</span>
+            </button>
           </li>
-        ))}
-      </ul>
+          {SIDEBAR_TABS.map((tab) => (
+            <li key={tab.key}>
+              <SidebarNavLink
+                panel={tab.panel}
+                context={tab.context}
+                Icon={tab.Icon}
+                label={t(tab.labelKey)}
+              />
+            </li>
+          ))}
+        </ul>
 
-      <div className="relative">
-        <input
-          className="h-10 w-full rounded-full border border-slate-200 bg-white/80 px-3 pr-8 text-sm text-slate-900 placeholder:text-slate-400 shadow-sm transition focus:border-slate-300 focus:outline-none focus:ring-0 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-400"
-          placeholder={t("Search")}
-          onChange={(e) => handleSearch(e.target.value)}
-        />
-        <Search size={16} className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 dark:text-slate-400" />
+        <div className="flex h-[var(--so-row-h)] items-center gap-2 rounded-full border border-slate-200 bg-white/80 px-3 text-sm text-slate-900 shadow-sm transition focus-within:border-slate-300 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100">
+          <span className="inline-flex h-5 w-5 items-center justify-center text-slate-500 dark:text-slate-400">
+            <Search size={16} />
+          </span>
+          <input
+            className="flex-1 h-8 bg-transparent text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none dark:text-slate-100 dark:placeholder:text-slate-400"
+            placeholder={t("Search")}
+            onChange={(e) => handleSearch(e.target.value)}
+          />
+        </div>
       </div>
 
-      <div className="flex-1 space-y-1 overflow-y-auto pr-1 pb-16">
+      <div className="flex-1 space-y-2 overflow-y-auto px-3 pb-12">
         {filtered.map((thread) => {
           const rawTitle = (thread.title ?? "").trim();
           const systemKey = thread.therapy && LEGACY_THERAPY_TITLES.has(rawTitle)
@@ -113,7 +117,7 @@ export default function Sidebar() {
           return (
             <div
               key={thread.id}
-              className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white/60 p-2 shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
+              className="flex h-[var(--so-row-h)] items-center gap-2 rounded-xl border border-slate-200 bg-white/60 px-3 shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/60"
             >
               <button
                 onClick={() => {
@@ -125,43 +129,46 @@ export default function Sidebar() {
               >
                 {displayTitle || t("threads.systemTitles.new_chat")}
               </button>
-            <div className="ml-auto">
-              <ThreadKebab
-                id={thread.id}
-                title={thread.title}
-                onRenamed={(nt) => {
-                  setThreads((prev) =>
-                    prev.map((x) => (x.id === thread.id ? { ...x, title: nt, updatedAt: Date.now() } : x))
-                  );
-                }}
-                onDeleted={() => {
-                  setThreads((prev) => prev.filter((x) => x.id !== thread.id));
-                }}
-              />
-            </div>
+              <div className="ml-auto inline-flex items-center">
+                <ThreadKebab
+                  id={thread.id}
+                  title={thread.title}
+                  onRenamed={(nt) => {
+                    setThreads((prev) =>
+                      prev.map((x) => (x.id === thread.id ? { ...x, title: nt, updatedAt: Date.now() } : x))
+                    );
+                  }}
+                  onDeleted={() => {
+                    setThreads((prev) => prev.filter((x) => x.id !== thread.id));
+                  }}
+                />
+              </div>
             </div>
           );
         })}
       </div>
 
-      <div className="mt-auto" />
-      <button
-        type="button"
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          closeSidebar?.();
-          openPrefs();
-        }}
-        className="fixed bottom-3 left-3 z-20 flex items-center gap-1.5 rounded-md border border-black/10 bg-white/70 px-3 py-2 text-sm shadow-sm hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/70 dark:hover:bg-slate-900"
-        aria-label={`${t("Preferences")} · ${locale.label}`}
-      >
-        <Settings size={14} />
-        <span>{t("Preferences")}</span>
-        <span className="ml-1 whitespace-nowrap text-xs text-slate-500 dark:text-slate-400">
-          {locale.label}
-        </span>
-      </button>
+      <div className="prefs sticky bottom-0 px-3 py-3 bg-inherit">
+        <div className="h-10 flex items-center">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              closeSidebar?.();
+              openPrefs();
+            }}
+            className="flex w-full items-center gap-1.5 rounded-md border border-black/10 bg-white/70 px-3 py-2 text-sm shadow-sm hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/70 dark:hover:bg-slate-900"
+            aria-label={`${t("Preferences")} · ${locale.label}`}
+          >
+            <Settings size={14} />
+            <span>{t("Preferences")}</span>
+            <span className="ml-1 whitespace-nowrap text-xs text-slate-500 dark:text-slate-400">
+              {locale.label}
+            </span>
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -28,7 +28,7 @@ export default function ModeBar() {
   const doctorActive = state.base === "doctor";
 
   return (
-    <div className="inline-flex flex-wrap items-center gap-2 rounded-full border border-black/10 bg-white/60 px-2 py-1 backdrop-blur dark:border-white/10 dark:bg-slate-900/40">
+    <div className="flex flex-wrap items-center justify-center gap-3 rounded-full border border-black/10 bg-white/60 px-2 py-1 backdrop-blur dark:border-white/10 dark:bg-slate-900/40">
       <button
         className={btn(wellnessActive)}
         onClick={() => togglePatient()}


### PR DESCRIPTION
## Summary
- introduce a shared desktop container and spacing tokens for consistent gutters
- center the header mode bar and chat composer within the main column
- tidy the sidebar search, thread rows, and dock the preferences chip to avoid overlap

## Testing
- ⚠️ `npm run lint` *(fails because Next.js prompts for ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8e2c2d7c832fb1b35daa13add5bf