### PR TITLE
Align desktop header mode buttons with welcome card

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -21,7 +21,7 @@ export default function Header() {
           <CountryGlobe />
         </div>
 
-        <div className="pointer-events-none absolute left-1/2 top-1/2 hidden w-full max-w-3xl -translate-x-1/2 -translate-y-1/2 justify-center md:left-[calc(50%+3.5rem)] md:flex">
+        <div className="pointer-events-none absolute left-1/2 top-1/2 hidden w-full max-w-3xl -translate-x-1/2 -translate-y-1/2 justify-center md:flex">
           <div className="pointer-events-auto">
             <ModeBar />
           </div>


### PR DESCRIPTION
## Summary
- center the desktop mode toggle bar in the header by positioning it independently of the side utilities
- keep the original in-flow mode toggle layout on smaller breakpoints so mobile UI remains unchanged

## Testing
- npm run dev (fails to fetch optional remote assets due to sandboxed network)


------
https://chatgpt.com/codex/tasks/task_e_68dd96e25394832fbd2d4b258c42c7a7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an overlay-centered ModeBar on larger screens for clearer focus and easier access.

- **Style**
  - Improved header responsiveness: ModeBar visible on small screens, overlaid and centered on medium and larger screens.
  - Right-side actions aligned to the far right for consistent layout.
  - Overlay ModeBar enables pointer interaction and adjusts positioning across breakpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->