### PR TITLE
Center desktop chat chrome with composer column

### DIFF
--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -18,6 +18,7 @@ import { newIdempotencyKey } from "@/lib/net/idempotency";
 import { retryFetch } from "@/lib/net/retry";
 import { normalizeNetworkError } from "@/lib/net/errors";
 import { pollJob } from "@/lib/net/pollJob";
+import CenterCol from "@/components/layout/CenterCol";
 
 const CHAT_UX_V2_ENABLED = process.env.NEXT_PUBLIC_CHAT_UX_V2 !== "0";
 const JOB_STORAGE_KEY = "lastJob";
@@ -580,6 +581,8 @@ export function ChatWindow() {
     ],
   );
 
+  const welcomeCard = <WelcomeCard />;
+
   return (
     <div className="flex h-full flex-col" dir={prefs.dir}>
       <div
@@ -592,9 +595,10 @@ export function ChatWindow() {
       >
         <div className="px-4">
           {showWelcomeCard ? (
-            <div className="py-10">
-              <WelcomeCard />
-            </div>
+            <>
+              <div className="py-10 lg:hidden">{welcomeCard}</div>
+              <CenterCol className="py-10">{welcomeCard}</CenterCol>
+            </>
           ) : null}
           {messages.map(m => {
             if (m.role === "assistant" && m.error) {

--- a/components/layout/CenterCol.tsx
+++ b/components/layout/CenterCol.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+type Props = React.PropsWithChildren<{
+  className?: string;
+}>;
+
+/**
+ * Desktop-only center column that matches the Chat Composer width exactly.
+ * IMPORTANT: Replace the placeholder WIDTH_SIGNATURE below with the EXACT
+ * className you copied from the Composer’s outer wrapper. Do not change values.
+ */
+export const CenterCol: React.FC<Props> = ({ className = "", children }) => {
+  return (
+    <div
+      className={
+        [
+          // ---- WIDTH_SIGNATURE (copy from Composer) ----
+          // Example: "mx-auto max-w-[720px] px-6"
+          "mx-auto max-w-3xl space-y-3 px-4 py-4",
+          // ----------------------------------------------
+          // Desktop only: on mobile/tablet we do nothing
+          "hidden lg:block",
+          className,
+        ].join(" ")
+      }
+    >
+      {children}
+    </div>
+  );
+};
+
+export default CenterCol;

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useModeController } from "@/hooks/useModeController";
 import { useT } from "@/components/hooks/useI18n";
+import CenterCol from "@/components/layout/CenterCol";
 
 export default function ModeBar() {
   const {
@@ -27,7 +28,7 @@ export default function ModeBar() {
   const wellnessActive = state.base === "patient" && !state.therapy;
   const doctorActive = state.base === "doctor";
 
-  return (
+  const Pills = () => (
     <div className="inline-flex flex-wrap items-center gap-2 rounded-full border border-black/10 bg-white/60 px-2 py-1 backdrop-blur dark:border-white/10 dark:bg-slate-900/40">
       <button
         className={btn(wellnessActive)}
@@ -68,5 +69,16 @@ export default function ModeBar() {
         {t("ui.modes.ai_doc")}
       </button>
     </div>
+  );
+
+  return (
+    <>
+      <div className="lg:hidden">
+        <Pills />
+      </div>
+      <CenterCol className="py-0">
+        <Pills />
+      </CenterCol>
+    </>
   );
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -12,6 +12,7 @@ import { useResearchFilters } from '@/store/researchFilters';
 import { Send, Paperclip, Clipboard, Stethoscope, Users, ChevronDown, ChevronUp } from 'lucide-react';
 import { useCountry } from '@/lib/country';
 import WelcomeCard from '@/components/ui/WelcomeCard';
+import CenterCol from '@/components/layout/CenterCol';
 import { getWelcomeOptions, pickWelcome, type AppMode, type WelcomeMessage } from '@/lib/welcomeMessages';
 import { useActiveContext } from '@/lib/context';
 import { isFollowUp } from '@/lib/followup';
@@ -3524,26 +3525,48 @@ ${systemCommon}` + baseSys;
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {showWelcomeCard && welcomeContent ? (
-        <div className="px-6 pt-6">
-          <div className="mx-auto w-full max-w-3xl">
-            <WelcomeCard
-              header={
-                welcomeContent.header
-                  ? t(welcomeContent.header)
-                  : undefined
-              }
-              body={
-                welcomeContent.body ? t(welcomeContent.body) : undefined
-              }
-              status={
-                welcomeContent.status
-                  ? t(welcomeContent.status)
-                  : undefined
-              }
-              onDismiss={dismissWelcome}
-            />
+        <>
+          <div className="px-6 pt-6 lg:hidden">
+            <div className="mx-auto w-full max-w-3xl">
+              <WelcomeCard
+                header={
+                  welcomeContent.header
+                    ? t(welcomeContent.header)
+                    : undefined
+                }
+                body={
+                  welcomeContent.body ? t(welcomeContent.body) : undefined
+                }
+                status={
+                  welcomeContent.status
+                    ? t(welcomeContent.status)
+                    : undefined
+                }
+                onDismiss={dismissWelcome}
+              />
+            </div>
           </div>
-        </div>
+          <CenterCol className="pt-6 pb-0">
+            <div className="w-full">
+              <WelcomeCard
+                header={
+                  welcomeContent.header
+                    ? t(welcomeContent.header)
+                    : undefined
+                }
+                body={
+                  welcomeContent.body ? t(welcomeContent.body) : undefined
+                }
+                status={
+                  welcomeContent.status
+                    ? t(welcomeContent.status)
+                    : undefined
+                }
+                onDismiss={dismissWelcome}
+              />
+            </div>
+          </CenterCol>
+        </>
       ) : null}
       <div
         ref={chatRef}


### PR DESCRIPTION
## Summary
- add a desktop-only CenterCol wrapper that reuses the chat composer's width signature
- wrap the mode bar in the new CenterCol while keeping the original mobile rendering
- center the welcome card in both chat window variants using the shared layout helper

## Testing
- npm run lint *(fails/aborted: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ddad1804c4832f8659ed74ddeea616