### PR TITLE
Replace chat upload icon with plus sign

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -9,7 +9,7 @@ import { LinkBadge } from '@/components/SafeLink';
 import TrialsResults from "@/components/TrialsResults";
 import type { TrialRow } from "@/types/trials";
 import { useResearchFilters } from '@/store/researchFilters';
-import { Send, Paperclip, Clipboard, Stethoscope, Users, ChevronDown, ChevronUp } from 'lucide-react';
+import { Send, Plus, Clipboard, Stethoscope, Users, ChevronDown, ChevronUp } from 'lucide-react';
 import { useCountry } from '@/lib/country';
 import WelcomeCard from '@/components/ui/WelcomeCard';
 import { getWelcomeOptions, pickWelcome, type AppMode, type WelcomeMessage } from '@/lib/welcomeMessages';
@@ -3861,11 +3861,11 @@ ${systemCommon}` + baseSys;
                 className="flex w-full items-end gap-3 rounded-2xl border border-slate-200/60 bg-white/90 px-3 py-2 dark:border-slate-700/60 dark:bg-slate-900/80"
               >
                 <label
-                  className="inline-flex cursor-pointer items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-200/60 dark:text-slate-200 dark:hover:bg-slate-800/60"
+                  className="inline-flex cursor-pointer items-center justify-center rounded-full px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-200/60 dark:text-slate-200 dark:hover:bg-slate-800/60"
                   title="Upload PDF or image"
                 >
-                  <Paperclip size={16} aria-hidden="true" />
-                  <span className="hidden sm:inline">Upload</span>
+                  <Plus aria-hidden="true" className="h-4 w-4" strokeWidth={3} />
+                  <span className="sr-only">Upload</span>
                   <input
                     type="file"
                     accept="application/pdf,image/*"


### PR DESCRIPTION
## Summary
- replace the chat composer upload trigger with a plus icon to match ChatGPT styling
- retain the hidden upload label for accessibility while keeping the existing upload input intact

## Testing
- npm run dev (fails to fetch remote resources in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddb23ec120832f99a705e223a71702