### PR TITLE
Center header mode bar with chat composer

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -7,12 +7,12 @@ import ThemeToggle from '@/components/ThemeToggle';
 export default function Header() {
   return (
     <header className="sticky top-0 z-40 border-b border-black/10 bg-white/80 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/40">
-      <div className="mx-auto flex h-[62px] w-full max-w-screen-2xl items-center gap-4 px-6">
+      <div className="relative mx-auto flex h-[62px] w-full max-w-screen-2xl items-center gap-4 px-6 md:justify-between">
         <div className="flex shrink-0 items-center gap-3 text-base font-semibold md:text-lg">
           <Brand />
         </div>
 
-        <div className="flex flex-1 justify-center">
+        <div className="flex flex-1 justify-center md:absolute md:left-1/2 md:top-1/2 md:w-full md:max-w-3xl md:-translate-x-1/2 md:-translate-y-1/2 md:px-4">
           <ModeBar />
         </div>
 


### PR DESCRIPTION
## Summary
- absolutely center the header mode bar on desktop so it aligns with the chat composer
- match the desktop mode bar container width and padding to the chat composer for consistent centering

## Testing
- npm run dev *(fails to fetch external Next.js metadata because of network restrictions, but the local dev server still served the app)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc1528178832f8b5b2002353ad58b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Improved header responsiveness and visual balance on medium screens: the ModeBar is now centered, while the brand remains left-aligned and controls (theme toggle, country selector) stay on the right.
  * Enhances readability and focus by creating a clear central focal point without disrupting existing navigation elements.
  * No functional changes; purely layout and alignment refinements for a smoother experience across breakpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->