### PR TITLE
Align mobile new chat icon with sidebar

### DIFF
--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -190,7 +190,13 @@ export default function MobileHeader() {
           className="mobile-icon-btn"
           onClick={handleNewChat}
         >
-          <IconNewChat className="h-5 w-5" size={20} />
+          <IconNewChat
+            className="h-5 w-5"
+            size={20}
+            weight={2}
+            activeWeight={2}
+            style={{ opacity: 1, transition: "opacity .15s ease, stroke-width .15s ease" }}
+          />
         </button>
         <button
           type="button"

--- a/components/mobile/MobileHeader.tsx
+++ b/components/mobile/MobileHeader.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, ChevronDown, Menu, MoreHorizontal, PlusCircle } from "lucide-react";
+import { Check, ChevronDown, Menu, MoreHorizontal } from "lucide-react";
 import { useMobileUiStore } from "@/lib/state/mobileUiStore";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createNewThreadId } from "@/lib/chatThreads";
 import { useModeController } from "@/hooks/useModeController";
 import WwwGlobeIcon from "@/components/icons/WwwGlobe";
+import { IconNewChat } from "@/components/icons";
 
 export default function MobileHeader() {
   const openSidebar = useMobileUiStore(state => state.openSidebar);
@@ -189,7 +190,7 @@ export default function MobileHeader() {
           className="mobile-icon-btn"
           onClick={handleNewChat}
         >
-          <PlusCircle className="h-5 w-5" />
+          <IconNewChat className="h-5 w-5" size={20} />
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- replace the mobile header new chat icon with the sidebar chat bubble icon
- update imports to use the shared IconNewChat component in the mobile header

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddd4ebe67c832f975fdbaa3a5c1ba6