### PR TITLE
Adjust legal footer spacing on desktop

### DIFF
--- a/components/LegalPrivacyFooter.tsx
+++ b/components/LegalPrivacyFooter.tsx
@@ -310,7 +310,7 @@ export default function LegalPrivacyFooter() {
         ref={footerRef}
         className="mobile-footer flex-shrink-0 border-t border-black/10 bg-white/80 backdrop-blur-sm dark:border-white/10 dark:bg-slate-900/60"
       >
-        <div className="mobile-footer-inner mx-auto flex w-full max-w-screen-2xl items-center justify-center gap-1.5 px-6 text-center text-[11px] text-slate-600 dark:text-slate-300 md:gap-3 md:py-1.5 md:text-xs">
+        <div className="mobile-footer-inner mx-auto flex w-full max-w-screen-2xl items-center justify-center gap-1.5 px-6 text-center text-[11px] text-slate-600 dark:text-slate-300 md:gap-3 md:py-1.5 md:pl-10 md:text-xs">
           <div
             ref={marqueeContainerRef}
             className={`mobile-footer-message${marqueeVars ? " mobile-footer-marquee-active" : ""}`}


### PR DESCRIPTION
## Summary
- shift the legal marquee message and icon slightly right on desktop by adding extra left padding

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dddcab8f00832fa45851f81e592dec