### PR TITLE
chore: unify light-mode palette and composer interactions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -22,7 +22,57 @@ body.font-loading *::after {
   body {
     font-family: var(--font-proxima-nova, "Proxima Nova", "Proxima Nova Rg", "ProximaNova", "proxima-nova");
   }
+
+  :root {
+    /* Brand ramp — LIGHT */
+    --brand:            #1E6FFF;   /* primary */
+    --brand-strong:     #1556C7;   /* hover/pressed */
+    --brand-weak:       #E6F0FF;   /* selected fill */
+    --brand-weakest:    #F3F8FF;   /* hover fill */
+
+    /* Neutrals — LIGHT */
+    --bg:               #FFFFFF;
+    --panel:            #FFFFFF;
+    --surface:          #FAFBFF;   /* cards/composer */
+    --surface-2:        #F3F6FB;
+    --border:           #E6EAF2;
+    --text:             #0F172A;
+    --text-muted:       #475569;
+
+    /* Affordances */
+    --link:             var(--brand);
+    --focus:            var(--brand);
+    --hover:            var(--brand-weakest); /* unified hover */
+    --selected:         var(--brand-weak);    /* unified selected */
+  }
+
+  .dark {
+    /* Keep your dark vibe; just map tokens */
+    --bg:               #0B1220;
+    --panel:            #0F1628;
+    --surface:          #0F1628;
+    --surface-2:        #0B1324;
+    --border:           #1E293B;
+    --text:             #E6EDF7;
+    --text-muted:       #94A3B8;
+
+    --brand:            #5CA3FF;
+    --brand-strong:     #3C8DFB;
+    --brand-weak:       rgba(92,163,255,0.18);
+    --brand-weakest:    rgba(92,163,255,0.10);
+
+    --link:             var(--brand);
+    --focus:            var(--brand);
+    --hover:            var(--brand-weakest);
+    --selected:         var(--brand-weak);
+  }
 }
+
+/* iOS Safari safeguards */
+html { -webkit-text-size-adjust: 100%; }
+textarea { overflow-y: auto; }
+a { color: var(--link); }
+*:focus-visible { outline-color: var(--focus); }
 
 .btn-secondary{
   @apply inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-sm transition

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -3,7 +3,7 @@
 import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import { useChatStore } from "@/lib/state/chatStore";
 import { useOpenPass } from "@/hooks/useOpenPass";
-import { Plus, SendHorizontal } from "lucide-react";
+import { Plus, SendHorizontal, Square } from "lucide-react";
 import { useT } from "@/components/hooks/useI18n";
 import { usePrefs } from "@/components/providers/PreferencesProvider";
 import { useUIStore } from "@/components/hooks/useUIStore";
@@ -22,12 +22,15 @@ export function ChatInput({
   const draft = useChatStore(s => s.draft);
   const setDraftText = useChatStore(s => s.setDraftText);
   const clearDraft = useChatStore(s => s.clearDraft);
+  const isStreaming = useChatStore(s => s.isStreaming);
+  const stopStream = useChatStore(s => s.stopStream);
   const openPass = useOpenPass();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const t = useT();
   const uploadText = t("ui.composer.upload");
   const sendText = t("ui.composer.send");
+  const stopText = t("actions.stop");
   const composerPlaceholder = t("ui.composer.placeholder");
   const { lang } = usePrefs();
   const openPrefs = useUIStore((state) => state.openPrefs);
@@ -94,7 +97,7 @@ export function ChatInput({
 
   const onDropFiles = (files: FileList | null) => {
     if (!files?.length) return;
-    // TODO: feed your existing upload pipeline here.
+    // TODO: feed to your upload pipeline; do NOT create thread here
   };
 
   return (
@@ -108,18 +111,18 @@ export function ChatInput({
         e.preventDefault();
         onDropFiles(e.dataTransfer.files);
       }}
-      className="chat-input-container flex w-full items-end gap-2 rounded-2xl border border-[color:var(--medx-outline)] bg-[color:var(--medx-surface)] px-3 py-2 shadow-sm transition dark:border-white/10 dark:bg-[color:var(--medx-panel)] md:border-0 md:bg-transparent md:px-0 md:py-0 md:shadow-none"
+      className="chat-input-container flex w-full items-end gap-2 rounded-2xl border border-[var(--border)] bg-[var(--surface)] px-3 py-2 shadow-sm transition md:border-0 md:bg-transparent md:px-0 md:py-0 md:shadow-none"
     >
       <button
         type="button"
-        disabled={!!currentId}
-        aria-label={currentId ? "Attach files is available before you start a new chat" : uploadText}
-        className="flex h-11 w-11 items-center justify-center rounded-full text-[color:var(--medx-text)] transition-colors hover:bg-black/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:text-[color:var(--medx-text)] dark:hover:bg-white/10"
+        aria-label={uploadText}
+        title={uploadText}
+        className="flex h-11 w-11 items-center justify-center rounded-md border border-[var(--border)] bg-[var(--surface)] hover:bg-[var(--hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus)]"
         onClick={() => {
           fileInputRef.current?.click();
         }}
       >
-        <Plus className="h-5 w-5" />
+        <Plus className="h-5 w-5 text-[var(--text-muted)]" />
       </button>
       <input
         ref={fileInputRef}
@@ -130,7 +133,7 @@ export function ChatInput({
         onChange={event => {
           const files = Array.from(event.target.files ?? []);
           if (files.length === 0) return;
-          // TODO: pass `files` into your upload pipeline (do not create thread yet)
+          // TODO: queue files in your upload pipeline; do NOT create thread yet
           event.target.value = "";
         }}
       />
@@ -155,16 +158,27 @@ export function ChatInput({
             void handleSend();
           }
         }}
-        className="min-h-[40px] max-h-[160px] flex-1 resize-none bg-transparent text-base leading-snug text-[color:var(--medx-text)] placeholder:text-slate-400 focus:outline-none dark:text-[color:var(--medx-text)] dark:placeholder:text-slate-500"
+        className="min-h-[40px] max-h-[160px] flex-1 resize-none overflow-y-auto rounded-md bg-transparent px-3 py-2 text-[15px] leading-[1.2] text-[var(--text)] outline-none placeholder:text-[var(--text-muted)] md:text-[14px]"
       />
+      {isStreaming && (
+        <button
+          type="button"
+          aria-label={stopText}
+          title={stopText}
+          onClick={stopStream}
+          className="flex h-11 w-11 items-center justify-center rounded-md border border-[var(--brand)] text-[var(--brand)] hover:bg-[var(--hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus)]"
+        >
+          <Square className="h-4 w-4" />
+        </button>
+      )}
       <button
         type="submit"
         aria-label={sendText}
         title={sendText}
         disabled={!text.trim() || isSending}
-        className="flex h-11 w-11 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-sky-500 dark:hover:bg-sky-400"
+        className="flex h-11 w-11 items-center justify-center rounded-md border border-[var(--border)] bg-[var(--brand)] hover:bg-[var(--brand-strong)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus)] disabled:cursor-not-allowed disabled:opacity-50"
       >
-        <SendHorizontal className="h-5 w-5" />
+        <SendHorizontal className="h-5 w-5 text-white" />
       </button>
     </form>
   );

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 "use client";
+import clsx from "clsx";
 import { Search, Settings } from "lucide-react";
 import { SIDEBAR_TABS, SidebarNavLink } from "./sidebar/Tabs";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -63,27 +64,22 @@ export default function Sidebar() {
   };
   const filtered = threads.filter((t) => t.title.toLowerCase().includes(q.toLowerCase()));
   return (
-    <div className="sidebar-click-guard flex h-full w-full flex-col gap-5 px-4 pt-6 pb-0 text-medx">
+    <aside className="sidebar-click-guard flex h-full w-full flex-col gap-5 px-4 pt-6 pb-0 text-medx bg-[var(--panel)] border-r border-[var(--border)]">
       <ul className="space-y-1">
         <li>
           <button
             type="button"
             aria-label={t("threads.systemTitles.new_chat")}
             onClick={handleNewChat}
-            className={[
-              "flex w-full items-center gap-2 rounded-md h-9 px-3",
-              "text-slate-600 hover:bg-slate-100/70 dark:text-slate-300 dark:hover:bg-white/5",
-              "text-sm leading-5 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 dark:focus-visible:outline-slate-500",
-            ].join(" ")}
+            className={clsx(
+              "flex h-9 w-full items-center gap-2 rounded-md px-3 text-sm leading-5 transition-colors",
+              "text-[var(--text)] hover:bg-[var(--hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus)]",
+            )}
           >
-            <span className="flex h-4 w-4 items-center justify-center" aria-hidden>
-              <IconNewChat
-                title={t("threads.systemTitles.new_chat")}
-                size={16}
-                className="text-slate-500 dark:text-slate-300"
-              />
+            <span className="flex h-4 w-4 items-center justify-center text-[var(--text-muted)]" aria-hidden>
+              <IconNewChat title={t("threads.systemTitles.new_chat")} size={16} className="text-current" />
             </span>
-            <span className="truncate">{t("threads.systemTitles.new_chat")}</span>
+            <span className="truncate text-[var(--text)]">{t("threads.systemTitles.new_chat")}</span>
           </button>
         </li>
         {SIDEBAR_TABS.map((tab) => (
@@ -100,16 +96,16 @@ export default function Sidebar() {
 
       <div className="relative">
         <input
-          className="h-10 w-full rounded-full border border-slate-200 bg-white/80 px-3 pr-8 text-sm text-slate-900 placeholder:text-slate-400 shadow-sm transition focus:border-slate-300 focus:outline-none focus:ring-0 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:placeholder:text-slate-400"
+          className="h-10 w-full rounded-full border border-[var(--border)] bg-[var(--surface)] px-3 pr-8 text-sm text-[var(--text)] placeholder:text-[var(--text-muted)] shadow-sm transition focus:border-[var(--brand)] focus:outline-none focus:ring-0"
           placeholder={t("Search")}
           onChange={(e) => handleSearch(e.target.value)}
         />
-        <Search size={16} className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 dark:text-slate-400" />
+        <Search size={16} className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)]" />
       </div>
 
       {/* Section heading above chat threads */}
       <div className="px-3 pb-0 pt-1">
-        <h3 className="text-sm font-medium text-slate-500 dark:text-slate-400">
+        <h3 className="text-sm font-medium text-[var(--text-muted)]">
           {t?.("Chats") ?? "Chats"}
         </h3>
       </div>
@@ -129,17 +125,16 @@ export default function Sidebar() {
             return (
               <div
                 key={thread.id}
-                className={[
-                  "group flex items-center gap-2 rounded-md h-9 px-3",
-                  "transition-colors focus-within:ring-2 focus-within:ring-offset-0",
+                className={clsx(
+                  "group flex h-9 items-center gap-2 rounded-md px-3 transition-colors focus-within:ring-2 focus-within:ring-offset-0",
                   active
-                    ? "bg-blue-600/10 font-semibold text-blue-600 dark:bg-sky-500/20 dark:text-sky-300"
-                    : "text-slate-600 hover:bg-slate-100/70 dark:text-slate-300 dark:hover:bg-white/5",
-                ].join(" ")}
+                    ? "bg-[var(--selected)] border border-[var(--brand)] text-[var(--text)]"
+                    : "text-[var(--text)] hover:bg-[var(--hover)]",
+                )}
                 aria-current={active ? "page" : undefined}
                 title={displayTitle || rawTitle}
               >
-                <span className="shrink-0 h-4 w-4" aria-hidden>
+                <span className="h-4 w-4 shrink-0 text-[var(--text-muted)]" aria-hidden>
                   <svg viewBox="0 0 24 24" className="h-4 w-4">
                     <path d="M4 5h16v10H8l-3 3V5z" fill="currentColor" />
                   </svg>
@@ -150,12 +145,12 @@ export default function Sidebar() {
                     closeSidebar();
                     router.push(`/?panel=chat&threadId=${thread.id}`);
                   }}
-                  className="min-w-0 flex-1 truncate text-left text-sm leading-5 py-0 my-0"
+                  className="my-0 min-w-0 flex-1 truncate py-0 text-left text-sm leading-5 text-[var(--text)]"
                 >
                   {displayTitle || t("threads.systemTitles.new_chat")}
                 </button>
 
-                <div className="ml-auto opacity-80 group-hover:opacity-100 leading-none">
+                <div className="ml-auto leading-none text-[var(--text-muted)] opacity-80 group-hover:opacity-100">
                   <ThreadKebab
                     id={thread.id}
                     title={thread.title}
@@ -184,15 +179,15 @@ export default function Sidebar() {
           closeSidebar?.();
           openPrefs();
         }}
-        className="fixed bottom-3 left-3 z-20 flex items-center gap-1.5 rounded-md border border-black/10 bg-white/70 px-3 py-2 text-sm shadow-sm hover:bg-white/90 dark:border-white/10 dark:bg-slate-900/70 dark:hover:bg-slate-900"
+        className="fixed bottom-3 left-3 z-20 flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text)] shadow-sm hover:bg-[var(--hover)]"
         aria-label={`${t("Preferences")} · ${locale.label}`}
       >
         <Settings size={14} />
         <span>{t("Preferences")}</span>
-        <span className="ml-1 whitespace-nowrap text-xs text-slate-500 dark:text-slate-400">
+        <span className="ml-1 whitespace-nowrap text-xs text-[var(--text-muted)]">
           {locale.label}
         </span>
       </button>
-    </div>
+    </aside>
   );
 }

--- a/components/hooks/useI18n.ts
+++ b/components/hooks/useI18n.ts
@@ -30,6 +30,7 @@ const DEFAULT_DIGITS_POLICY: DigitsPolicy = "latn";
 
 const BASE_DICTIONARY: Record<string, Record<string, string>> = {
   en: {
+    "actions.stop": "Stop",
     "ui.composer.placeholder": "Send a message",
     "ui.composer.send": "Send",
     "ui.composer.upload": "Upload",
@@ -329,6 +330,7 @@ const BASE_DICTIONARY: Record<string, Record<string, string>> = {
     "Custom…": "Custom…",
   },
   hi: {
+    "actions.stop": "रोकें",
     "ui.composer.placeholder": "संदेश भेजें",
     "ui.composer.send": "भेजें",
     "ui.composer.upload": "अपलोड",
@@ -628,6 +630,7 @@ const BASE_DICTIONARY: Record<string, Record<string, string>> = {
     "Custom…": "कस्टम…",
   },
   ar: {
+    "actions.stop": "إيقاف",
     "ui.composer.placeholder": "أرسل رسالة",
     "ui.composer.send": "إرسال",
     "ui.composer.upload": "رفع",
@@ -926,6 +929,7 @@ const BASE_DICTIONARY: Record<string, Record<string, string>> = {
     "Custom…": "مخصص…",
   },
   it: {
+    "actions.stop": "Ferma",
     "ui.composer.placeholder": "Invia un messaggio",
     "ui.composer.send": "Invia",
     "ui.composer.upload": "Carica",
@@ -1224,6 +1228,7 @@ const BASE_DICTIONARY: Record<string, Record<string, string>> = {
     "Custom…": "Personalizzato…",
   },
   zh: {
+    "actions.stop": "停止",
     "ui.composer.placeholder": "发送消息",
     "ui.composer.send": "发送",
     "ui.composer.upload": "上传",
@@ -1516,6 +1521,7 @@ const BASE_DICTIONARY: Record<string, Record<string, string>> = {
     "Custom…": "自定义…",
   },
   es: {
+    "actions.stop": "Detener",
     "ui.composer.placeholder": "Enviar un mensaje",
     "ui.composer.send": "Enviar",
     "ui.composer.upload": "Subir",
@@ -1815,6 +1821,7 @@ const BASE_DICTIONARY: Record<string, Record<string, string>> = {
     "Custom…": "Personalizado…",
   },
   fr: {
+    "actions.stop": "Arrêter",
     "Network error": "Erreur réseau",
     Retry: "Réessayer",
     "Retrying…": "Nouvelle tentative…",

--- a/components/modes/ModeBar.tsx
+++ b/components/modes/ModeBar.tsx
@@ -1,4 +1,5 @@
 "use client";
+import clsx from "clsx";
 import { useModeController } from "@/hooks/useModeController";
 import { useT } from "@/components/hooks/useI18n";
 
@@ -15,20 +16,19 @@ export default function ModeBar() {
   const t = useT();
 
   const btn = (active: boolean, disabled?: boolean) =>
-    [
+    clsx(
       "h-9 rounded-full border px-4 text-sm font-medium transition",
-      active
-        ? "bg-blue-600 border-blue-600 text-white shadow-sm"
-        : "bg-white/70 text-slate-900 border-slate-200 hover:bg-slate-100 dark:bg-slate-800/70 dark:text-white dark:border-slate-700 dark:hover:bg-slate-800",
-      disabled ? "opacity-60 cursor-not-allowed" : "",
-    ].filter(Boolean).join(" ");
+      "border-[var(--border)] bg-[var(--surface)] text-[var(--text)] hover:bg-[var(--hover)]",
+      active && "bg-[var(--selected)] border-[var(--brand)]",
+      disabled && "cursor-not-allowed opacity-60",
+    );
 
   const aidocOn = state.base === "aidoc";
   const wellnessActive = state.base === "patient" && !state.therapy;
   const doctorActive = state.base === "doctor";
 
   return (
-    <div className="inline-flex flex-wrap items-center gap-2 rounded-full border border-black/10 bg-white/60 px-2 py-1 backdrop-blur dark:border-white/10 dark:bg-slate-900/40">
+    <div className="inline-flex flex-wrap items-center gap-2 rounded-full border border-[var(--border)] bg-[var(--surface)] px-2 py-1 text-[var(--text)] backdrop-blur">
       <button
         className={btn(wellnessActive)}
         onClick={() => togglePatient()}

--- a/components/sidebar/Tabs.tsx
+++ b/components/sidebar/Tabs.tsx
@@ -1,4 +1,5 @@
 "use client";
+import clsx from "clsx";
 import type { ComponentType } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -47,16 +48,17 @@ export function SidebarNavLink({
         closeSidebar();
         event.stopPropagation();
       }}
-      className={`flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm transition ${
+      className={clsx(
+        "flex w-full items-center gap-3 rounded-xl px-3 py-2 text-sm transition",
         active
-          ? "bg-blue-600/10 font-semibold text-blue-600 dark:bg-sky-500/20 dark:text-sky-300"
-          : "text-slate-600 hover:bg-slate-100/70 dark:text-slate-300 dark:hover:bg-white/5"
-      }`}
+          ? "bg-[var(--selected)] border border-[var(--brand)] text-[var(--text)]"
+          : "text-[var(--text)] hover:bg-[var(--hover)]",
+      )}
       data-testid={`nav-${panel}`}
       aria-current={active ? "page" : undefined}
     >
       <Icon title={label} active={active} className="shrink-0" />
-      <span className="truncate">{label}</span>
+      <span className="truncate text-[var(--text)]">{label}</span>
     </Link>
   );
 }

--- a/components/ui/StopButton.tsx
+++ b/components/ui/StopButton.tsx
@@ -13,22 +13,19 @@ export function StopButton({ onClick, className, title = "Stop generating (Esc)"
     <motion.button
       type="button"
       onClick={onClick}
-      aria-label="Stop generating"
+      aria-label={title}
       title={title}
       initial={{ scale: 0.9, opacity: 0 }}
       animate={{ scale: 1, opacity: 1 }}
       whileTap={{ scale: 0.92 }}
-      className={[
-        "h-9 w-9 rounded-full",
-        "bg-white/80 dark:bg-zinc-900/70 backdrop-blur",
-        "ring-1 ring-zinc-300 hover:ring-red-400 dark:ring-zinc-700 shadow-sm",
-        "flex items-center justify-center",
-        "transition-colors hover:bg-white dark:hover:bg-zinc-900",
-        "focus:outline-none focus:ring-2 focus:ring-blue-500",
-        className || ""
-      ].join(" ")}
+        className={[
+          "flex h-9 w-9 items-center justify-center rounded-md border",
+          "border-[var(--brand)] bg-transparent text-[var(--brand)]",
+          "transition-colors hover:bg-[var(--hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus)]",
+          className || ""
+        ].join(" ")}
     >
-      <Square className="h-4 w-4 text-zinc-700 dark:text-zinc-200" strokeWidth={2.25} />
+      <Square className="h-4 w-4 text-current" strokeWidth={2.25} />
       <span className="sr-only">Stop</span>
     </motion.button>
   );

--- a/lib/state/chatStore.ts
+++ b/lib/state/chatStore.ts
@@ -51,6 +51,11 @@ type ChatState = {
   setDraftText: (text: string) => void;
   addDraftAttachments: (files: File[]) => void;
   clearDraft: () => void;
+  isStreaming: boolean;
+  setStreaming: (streaming: boolean) => void;
+  setStopHandler: (handler: (() => void) | null) => void;
+  stopStream: () => void;
+  stopHandler: (() => void) | null;
 };
 
 export function createDefaultDraft(): PendingDraft {
@@ -68,6 +73,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   currentId: null,
   threads: {},
   draft: initialDraft,
+  isStreaming: false,
+  stopHandler: null,
 
   startNewThread: () => {
     const id = `temp_${nanoid(8)}`;
@@ -125,5 +132,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
   },
 
   clearDraft: () => set({ draft: createDefaultDraft() }),
+
+  setStreaming: (streaming) => set({ isStreaming: streaming }),
+
+  setStopHandler: (handler) => set({ stopHandler: handler }),
+
+  stopStream: () => {
+    const handler = get().stopHandler;
+    if (handler) {
+      try {
+        handler();
+      } catch {}
+    }
+    set({ isStreaming: false, stopHandler: null });
+  },
 }));
 


### PR DESCRIPTION
## Summary
- add a light-mode token palette and apply unified hover/selected styling to the sidebar and mode bar
- restyle chat composers with the shared surface/border tokens, 4-line textarea cap, and branded controls
- expose a streaming stop handler with localized copy and convert the stop button to the brand outline style

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dddaab610c832fb19ebc561f37a907