### PR TITLE
Shift ModeBar slightly right on desktop header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,7 +12,7 @@ export default function Header() {
           <Brand />
         </div>
 
-        <div className="flex flex-1 justify-center md:pl-24 lg:pl-40">
+        <div className="flex flex-1 justify-center md:pl-28 lg:pl-44">
           <ModeBar />
         </div>
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,7 +12,7 @@ export default function Header() {
           <Brand />
         </div>
 
-        <div className="flex flex-1 justify-center">
+        <div className="flex flex-1 justify-center md:pl-12 lg:pl-16">
           <ModeBar />
         </div>
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,7 +12,7 @@ export default function Header() {
           <Brand />
         </div>
 
-        <div className="flex flex-1 justify-center md:pl-12 lg:pl-16">
+        <div className="flex flex-1 justify-center md:pl-16 lg:pl-24">
           <ModeBar />
         </div>
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,7 +12,7 @@ export default function Header() {
           <Brand />
         </div>
 
-        <div className="flex flex-1 justify-center md:pl-20 lg:pl-32">
+        <div className="flex flex-1 justify-center md:pl-24 lg:pl-40">
           <ModeBar />
         </div>
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,7 +12,7 @@ export default function Header() {
           <Brand />
         </div>
 
-        <div className="flex flex-1 justify-center md:pl-16 lg:pl-24">
+        <div className="flex flex-1 justify-center md:pl-20 lg:pl-32">
           <ModeBar />
         </div>
 


### PR DESCRIPTION
## Summary
- keep the ModeBar centered on small screens while nudging it right on desktop with additional padding

## Testing
- npm run dev *(fails: Next.js attempts to reach remote resources and hits ENETUNREACH in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dde0972ea0832fbbb2b27030190e7b