### PR TITLE
Sanitize timeline content and improve lab headings

### DIFF
--- a/lib/health/sanitize.ts
+++ b/lib/health/sanitize.ts
@@ -1,0 +1,36 @@
+export function compactWhitespace(s: string): string {
+  return s.replace(/[\t\r\f\v]+/g, " ").replace(/\s{2,}/g, " ").trim();
+}
+
+/** collapse accidental token repeats like `242.2242.2242` or word.word */
+export function dedupeRuns(s: string): string {
+  return s
+    .replace(/(\b[\w\.-]{2,})(?:\s*\1\b)+/g, "$1")
+    .replace(/(\d{1,3}(?:[\.,]\d{1,3}){1,})(?:\1)+/g, "$1");
+}
+
+export function normalizeUnits(s: string): string {
+  return s
+    .replace(/\bmg\/dl\b/gi, "mg/dL")
+    .replace(/\bmmol\/l\b/gi, "mmol/L")
+    .replace(/\bu\/l\b/gi, "U/L")
+    .replace(/\bg\/dl\b/gi, "g/dL");
+}
+
+export function sanitizeFreeText(input?: string | null): string {
+  if (!input) return "";
+  return normalizeUnits(compactWhitespace(dedupeRuns(String(input))));
+}
+
+/** Build `TestName Value Unit (Flag)` headline for lab items */
+export function formatLabHeadline(meta: any, ob: any): string {
+  const name = meta?.testName || ob?.name || ob?.value_text || "Lab";
+  const value = ob?.value_num != null ? String(ob.value_num) : "";
+  const unit = ob?.unit ? normalizeUnits(ob.unit) : "";
+  const flag = (meta?.flags || meta?.abnormalHint || meta?.severity || meta?.priority || "")
+    .toString()
+    .trim();
+  const flagLabel = flag ? ` (${flag.charAt(0).toUpperCase()}${flag.slice(1)})` : "";
+  const head = [name, [value, unit].filter(Boolean).join(" ")].filter(Boolean).join(" ");
+  return sanitizeFreeText((head + flagLabel).trim());
+}


### PR DESCRIPTION
## Summary
- add reusable health text sanitizers for whitespace, deduplication, and unit normalization
- apply sanitization to timeline summaries, value text, and remote payload fallbacks before rendering
- replace generic lab titles with formatted headlines that include test name, value, unit, and abnormal flag

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68de7886306c832fa577e48c52fee520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Lab results now show clearer headlines combining test name, value, unit, and flags.
- Bug Fixes
  - Text across timeline items (labs, medications, notes, symptoms, imaging) is cleaned for extra spaces, duplicates, and inconsistent units for more readable summaries.
  - Safer rendering of summaries and full text by sanitizing user-visible content throughout.
  - More consistent short summaries and value displays, including better fallbacks when data is missing.
  - Improved unit normalization (e.g., mg/dL, mmol/L) for consistent lab presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->