### PR TITLE
feat: add AI Doc lab snapshot formatter

### DIFF
--- a/app/api/aidoc/chat/route.ts
+++ b/app/api/aidoc/chat/route.ts
@@ -108,10 +108,9 @@ export async function POST(req: NextRequest) {
     }
 
     if (labsError && !labsPacket) {
-      const fallbackMessage =
-        labIntent.kind === "snapshot"
-          ? "**Patient Snapshot**\n\nI couldn’t load your lab reports right now. Please try again in a bit.\n\n**What to do next**\n- Discuss abnormal or outdated results with your clinician before making changes.\n- Upload new lab reports when you receive them so this view stays current.\n- Keep up balanced meals, movement, and sleep unless your clinician advises otherwise."
-          : `**${labIntent.metric.label} — Comparison**\n\nI couldn’t load your lab reports right now. Please try again in a bit.\n\n**What to do next**\n- Discuss abnormal or outdated results with your clinician before making changes.\n- Upload new lab reports when you receive them so this view stays current.\n- Keep up balanced meals, movement, and sleep unless your clinician advises otherwise.`;
+      const fallbackMessage = formatLabIntentResponse([], labIntent, {
+        emptyMessage: "I couldn’t load your lab reports right now. Please try again in a bit.",
+      });
       return streamTextResponse(fallbackMessage);
     }
 

--- a/app/api/labs/summary/route.ts
+++ b/app/api/labs/summary/route.ts
@@ -31,7 +31,7 @@ export async function GET(req: Request) {
     const sb = supabaseAdmin();
     const { data, error } = await sb
       .from("observations")
-      .select("kind,value_num,unit,observed_at,thread_id,report_id")
+      .select("kind,value_num,unit,observed_at,thread_id,report_id,meta")
       .eq("user_id", userId)
       .not("value_num", "is", null)
       .order("observed_at", { ascending: false })

--- a/docs/codex-brief.md
+++ b/docs/codex-brief.md
@@ -1,0 +1,101 @@
+## Mandatory Fixes (no code shown here)
+
+Locate & Mute the Legacy Summarizer
+
+Search repo for any producer of these strings and disable it for AI-Doc intents:
+
+“on the provided packet and snapshot”
+
+“Patient Reports” / “Patient Overview”
+
+“Follow-up Question:” / “What is your primary concern”
+
+When the incoming message matches our AI-Doc intents (below), do not emit this legacy output. Either early-return a benign placeholder or let routing continue to the new Snapshot/Compare path.
+
+Top-of-Route Intercepts (must execute before anything else)
+
+In both routes:
+
+AI-Doc route (e.g., /api/aidoc/chat)
+
+Generic stream route (e.g., /api/chat/stream)
+Add a deterministic intercept at the very top of POST() that:
+
+Detect these intents (case/spacing tolerant):
+“pull my reports”, “pull all my reports”, “show/list my reports”,
+“compare my reports”,
+“compare my (ldl|hba1c|a1c|alt|ast|hdl|triglycerides|total cholesterol|fasting glucose)”,
+“how is my health overall”.
+
+Confirm the thread is AI-Doc:
+
+Prefer threadType from request body.
+
+If missing, look up by threadId in DB to get the thread type.
+
+On match, return the new Snapshot/Compare markdown from this intercept (single message). Do not call legacy code.
+
+Data Rules (to remove noise & wrong labels)
+
+Group labs by YYYY-MM-DD.
+
+De-dup inside each date:
+
+First by (document_id, test) if available.
+
+Then keep the latest value per canonical test name (LDL/LDL-C, HbA1c/A1c, ALT/SGPT, AST/SGOT, TG/Triglycerides, TC/Total Cholesterol, Fasting Glucose).
+
+Status only when safe: compute high/low/normal only if reference ranges exist; otherwise set status: "unknown" and still show value + unit.
+
+Snapshot format (markdown):
+
+Header: ## Patient Snapshot
+
+For each date (newest first): one-line mini summary (e.g., “Cholesterol high; liver enzymes high; glucose normal.”), then up to 6 inline chips like `LDL: 172.3 mg/dL (high)` and “+N more” if needed.
+
+Compare format (markdown):
+
+Header: ## Compare <Metric>
+
+Chronological list of dates + values. If <2 values, include “Need ≥2 results to assess trend.”
+
+Feature Flag & Safety Lever
+
+Gate with AIDOC_FORCE_INTERCEPT=1 (on in Preview/Prod).
+
+Add AIDOC_FORCE_INTERCEPT_HARD=1 (off by default). When set, intercept even if thread type cannot be resolved — use only for short-term verification.
+
+No Fallthrough for These Intents
+
+If unauthenticated → return a single friendly markdown line (“Please sign in to view your reports.”).
+
+If no labs → return Snapshot header + friendly note.
+
+Never fall back to the legacy paragraph block for these intents.
+
+24-Hour Observability
+
+Log once per intercepted request: flag state, resolved thread type, detected intent.
+
+Remove logs after validation.
+
+Acceptance Tests (must pass)
+
+AI-Doc / Pull: “pull my reports” → One markdown message starting with ## Patient Snapshot.
+No duplicate tests per date; mini summary + chips; content reflects real values.
+
+AI-Doc / Compare: “compare my LDL” → ## Compare LDL list; if only one value, shows the “Need ≥2 results…” line.
+
+AI-Doc / Overall: “how is my health overall” → Snapshot again (same clean format).
+
+Negative Routing: In a non-AI-Doc thread, the same phrases do not trigger the Snapshot; behavior unchanged.
+
+Content sanity on current data:
+
+LDL 172.3 vs 161.9 → correct dates; no “vs itself” comparison.
+
+ALT 219 vs 220 → treated as flat, not “↓”.
+
+Vitamin D 48.7 ng/mL → not labeled low unless range says so (use “unknown” if no range).
+
+Legacy block ban: For these intents, the legacy “packet & snapshot” paragraph and “What is your primary concern…” must never appear.

--- a/lib/aidoc/labsSnapshot.ts
+++ b/lib/aidoc/labsSnapshot.ts
@@ -1,0 +1,535 @@
+import type { LabSeriesPoint, LabTrend } from "../labs/summary";
+import { getTestDefinitions } from "../labs/summary";
+
+type DerivedStatus = "critical" | "high" | "low" | "normal" | "unknown";
+type SummaryStatus = DerivedStatus | "mixed";
+
+type SnapshotTest = {
+  code: string;
+  name: string;
+  shortName: string;
+  value: number;
+  unit: string;
+  status: DerivedStatus;
+  severity: number;
+  timestamp: number;
+};
+
+type SnapshotBucket = {
+  key: string;
+  timestamp: number;
+  displayDate: string;
+  tests: Map<string, SnapshotTest>;
+};
+
+type MetricInfo = {
+  code: string;
+  label: string;
+};
+
+type MetricPattern = {
+  regex: RegExp;
+  metric: MetricInfo;
+};
+
+export type LabSnapshotIntent =
+  | { kind: "snapshot" }
+  | { kind: "compare"; metric: MetricInfo };
+
+const FEATURE_FLAG = (process.env.FEATURE_AIDOC_LAB_SNAPSHOT ?? "1") !== "0";
+
+const SNAPSHOT_PATTERNS: RegExp[] = [
+  /\bpull (?:all )?my reports?\b/i,
+  /\bshow (?:all )?my reports?\b/i,
+  /\bfetch (?:all )?my reports?\b/i,
+  /\bwhat do my reports say\b/i,
+  /\bcompare my reports?\b/i,
+  /\blab (?:history|trend)\b/i,
+  /\breport (?:history|trend)\b/i,
+  /\bdate\s*wise\b/i,
+  /\bdatewise\b/i,
+  /\bhow(?:'s|\s+is) my health overall\b/i,
+  /\bhow(?:'s|\s+is) my overall health\b/i,
+];
+
+const EXTRA_ALIAS: Record<string, string[]> = {
+  "LDL-C": ["ldl-c", "ldl cholesterol", "bad cholesterol"],
+  "HDL-C": ["hdl-c", "hdl cholesterol", "good cholesterol"],
+  TG: ["triglyceride", "triglycerides"],
+  TC: ["total cholesterol", "cholesterol total", "cholesterol"],
+  HBA1C: ["a1c", "glycated hemoglobin", "glycosylated hemoglobin"],
+  FBG: ["fasting blood glucose", "fasting glucose", "fbg", "glucose fasting"],
+  "ALT (SGPT)": ["alt", "sgpt", "alanine aminotransferase"],
+  "AST (SGOT)": ["ast", "sgot", "aspartate aminotransferase"],
+  GGT: ["gamma gt", "gamma glutamyl transferase", "ggt"],
+  ALP: ["alkaline phosphatase"],
+  CREAT: ["serum creatinine", "creatinine"],
+  EGFR: ["estimated gfr", "gfr", "egfr"],
+  UREA: ["blood urea nitrogen", "bun", "urea"],
+  CRP: ["c reactive protein", "c-reactive protein"],
+  ESR: ["erythrocyte sedimentation rate", "sed rate", "esr"],
+  FERRITIN: ["serum ferritin", "ferritin"],
+  VITD: ["vitamin d", "vit d", "25 oh vitamin d", "25-oh vitamin d", "vitd"],
+  UIBC: ["unsaturated iron binding capacity", "uibc"],
+  TIBC: ["total iron binding capacity", "tibc"],
+};
+
+const SUFFIX_PATTERN = "(?:\\s+(?:levels?|level|results?|result|values?|value|numbers?|number|trend|trends|history|changes?|change|over\\s+time|over-time|reading|readings?))*";
+
+const METRIC_PATTERNS: MetricPattern[] = buildMetricPatterns();
+
+const SHORT_NAME_MAP: Record<string, string> = {
+  "LDL-C": "LDL",
+  "HDL-C": "HDL",
+  TG: "Triglycerides",
+  TC: "Total Cholesterol",
+  HBA1C: "HbA1c",
+  FBG: "Fasting Glucose",
+  "ALT (SGPT)": "ALT",
+  "AST (SGOT)": "AST",
+  GGT: "GGT",
+  ALP: "ALP",
+  CREAT: "Creatinine",
+  EGFR: "eGFR",
+  UREA: "Urea",
+  CRP: "CRP",
+  ESR: "ESR",
+  FERRITIN: "Ferritin",
+  VITD: "Vitamin D",
+  UIBC: "UIBC",
+  TIBC: "TIBC",
+};
+
+const GROUP_LABEL_BY_CODE: Record<string, string> = {
+  "LDL-C": "Cholesterol",
+  "HDL-C": "Cholesterol",
+  TG: "Cholesterol",
+  TC: "Cholesterol",
+  HBA1C: "Glucose",
+  FBG: "Glucose",
+  "ALT (SGPT)": "Liver enzymes",
+  "AST (SGOT)": "Liver enzymes",
+  GGT: "Liver enzymes",
+  ALP: "Liver enzymes",
+  CREAT: "Kidney function",
+  EGFR: "Kidney function",
+  UREA: "Kidney function",
+  CRP: "Inflammation",
+  ESR: "Inflammation",
+  FERRITIN: "Iron stores",
+  UIBC: "Iron stores",
+  TIBC: "Iron stores",
+  VITD: "Vitamins",
+};
+
+const NEXT_STEPS = [
+  "Discuss abnormal or outdated results with your clinician before making changes.",
+  "Upload new lab reports when you receive them so this view stays current.",
+  "Keep up balanced meals, movement, and sleep unless your clinician advises otherwise.",
+];
+
+const MAX_DATES = 5;
+const MAX_CHIPS = 6;
+const MAX_SUMMARY_SEGMENTS = 3;
+
+export function isLabSnapshotEnabled(): boolean {
+  return FEATURE_FLAG;
+}
+
+export function detectLabSnapshotIntent(message: string): LabSnapshotIntent | null {
+  if (!FEATURE_FLAG) return null;
+  if (!message) return null;
+  const text = message.trim();
+  if (!text) return null;
+  const lower = text.toLowerCase();
+
+  for (const re of SNAPSHOT_PATTERNS) {
+    if (re.test(lower)) {
+      return { kind: "snapshot" };
+    }
+  }
+
+  for (const entry of METRIC_PATTERNS) {
+    if (entry.regex.test(lower)) {
+      return { kind: "compare", metric: entry.metric };
+    }
+  }
+
+  return null;
+}
+
+export function formatLabIntentResponse(
+  trendInput: LabTrend[] | undefined,
+  intent: LabSnapshotIntent,
+  opts: { emptyMessage?: string } = {},
+): string {
+  const trend = Array.isArray(trendInput) ? trendInput : [];
+  return intent.kind === "snapshot"
+    ? buildSnapshotResponse(trend, opts)
+    : buildComparisonResponse(trend, intent.metric, opts);
+}
+
+function buildSnapshotResponse(trend: LabTrend[], opts: { emptyMessage?: string }): string {
+  const buckets = buildBuckets(trend).slice(0, MAX_DATES);
+  const lines: string[] = ["**Patient Snapshot**", ""];
+
+  if (buckets.length === 0) {
+    if (opts.emptyMessage) {
+      lines.push(opts.emptyMessage);
+    } else {
+      lines.push("No structured lab results found yet. Add recent reports or ask your clinician to share them.");
+    }
+  } else {
+    for (const bucket of buckets) {
+      const tests = Array.from(bucket.tests.values());
+      if (tests.length === 0) continue;
+      const summary = buildMiniSummary(tests);
+      lines.push(`${bucket.displayDate} — ${summary}`);
+      const chips = buildChipsLine(tests);
+      if (chips) lines.push(chips);
+      lines.push("");
+    }
+  }
+
+  trimTrailingBlanks(lines);
+  appendNextSteps(lines);
+  return lines.join("\n");
+}
+
+function buildComparisonResponse(trend: LabTrend[], metric: MetricInfo, opts: { emptyMessage?: string }): string {
+  const lines: string[] = [`**${metric.label} — Comparison**`, ""];
+  const entry = trend.find((t) => t.test_code === metric.code || canonicalize(t.test_name) === canonicalize(metric.label));
+
+  const points = entry?.series
+    ?.filter((p) => Number.isFinite(p.value) && typeof p.sample_date === "string" && p.sample_date)
+    .map((p) => ({
+      value: p.value,
+      unit: formatUnit(p.unit || entry?.unit || ""),
+      status: deriveStatus(p),
+      sample_date: p.sample_date,
+    })) ?? [];
+
+  points.sort((a, b) => {
+    const aTime = Date.parse(a.sample_date);
+    const bTime = Date.parse(b.sample_date);
+    if (!Number.isFinite(aTime) || !Number.isFinite(bTime)) return a.sample_date.localeCompare(b.sample_date);
+    return aTime - bTime;
+  });
+
+  if (points.length === 0) {
+    if (opts.emptyMessage) {
+      lines.push(opts.emptyMessage);
+    } else {
+      lines.push(`No ${metric.label} results found yet. Add recent reports or ask your clinician to share them.`);
+      lines.push("", "Need ≥2 results to comment on a trend.");
+    }
+  } else {
+    for (const point of points) {
+      const dateLabel = formatDateLabel(point.sample_date);
+      const valueLabel = formatNumber(point.value);
+      const unitPart = point.unit ? ` ${point.unit}` : "";
+      lines.push(`${dateLabel}: ${valueLabel}${unitPart} (${statusWord(point.status)})`);
+    }
+    if (points.length < 2) {
+      lines.push("", "Need ≥2 results to comment on a trend.");
+    }
+  }
+
+  trimTrailingBlanks(lines);
+  appendNextSteps(lines);
+  return lines.join("\n");
+}
+
+function buildBuckets(trend: LabTrend[]): SnapshotBucket[] {
+  const buckets = new Map<string, SnapshotBucket>();
+
+  for (const series of trend) {
+    const code = series.test_code;
+    const name = series.test_name;
+    const shortName = SHORT_NAME_MAP[code] ?? series.test_name;
+
+    for (const point of series.series || []) {
+      if (!Number.isFinite(point.value)) continue;
+      if (!point.sample_date) continue;
+      const date = new Date(point.sample_date);
+      if (Number.isNaN(date.getTime())) continue;
+      const dateKey = point.sample_date.slice(0, 10);
+      const baseTs = Date.parse(`${dateKey}T00:00:00Z`);
+      const timestamp = Number.isFinite(baseTs) ? baseTs : date.getTime();
+      const displayDate = formatDateLabel(point.sample_date);
+      const bucket = buckets.get(dateKey) ?? {
+        key: dateKey,
+        timestamp,
+        displayDate,
+        tests: new Map<string, SnapshotTest>(),
+      };
+      if (!bucket.tests.size || bucket.timestamp < timestamp) {
+        bucket.timestamp = Math.max(bucket.timestamp, timestamp);
+        bucket.displayDate = displayDate;
+      }
+      const status = deriveStatus(point);
+      const severity = statusPriority(status);
+      const unit = formatUnit(point.unit || "");
+      const test: SnapshotTest = {
+        code,
+        name,
+        shortName,
+        value: point.value,
+        unit,
+        status,
+        severity,
+        timestamp: date.getTime(),
+      };
+      const existing = bucket.tests.get(code);
+      if (!existing || existing.timestamp < test.timestamp) {
+        bucket.tests.set(code, test);
+      }
+      buckets.set(dateKey, bucket);
+    }
+  }
+
+  return Array.from(buckets.values()).sort((a, b) => b.timestamp - a.timestamp);
+}
+
+function buildMiniSummary(tests: SnapshotTest[]): string {
+  const segments: string[] = [];
+  const groupStatuses = new Map<string, DerivedStatus[]>();
+
+  for (const test of tests) {
+    const group = GROUP_LABEL_BY_CODE[test.code];
+    if (group) {
+      const arr = groupStatuses.get(group) ?? [];
+      arr.push(test.status);
+      groupStatuses.set(group, arr);
+    }
+  }
+
+  const groupSummaries: { label: string; status: SummaryStatus }[] = [];
+  for (const [label, statuses] of groupStatuses.entries()) {
+    const summaryStatus = summarizeStatuses(statuses);
+    if (summaryStatus !== "unknown") {
+      groupSummaries.push({ label, status: summaryStatus });
+    }
+  }
+
+  groupSummaries.sort((a, b) => {
+    const diff = statusPriority(b.status) - statusPriority(a.status);
+    return diff !== 0 ? diff : a.label.localeCompare(b.label);
+  });
+
+  for (const summary of groupSummaries) {
+    segments.push(`${summary.label} ${statusWord(summary.status)}`);
+  }
+
+  const individual = tests
+    .filter((t) => !GROUP_LABEL_BY_CODE[t.code] && t.status !== "unknown")
+    .sort((a, b) => {
+      const diff = b.severity - a.severity;
+      return diff !== 0 ? diff : a.shortName.localeCompare(b.shortName);
+    });
+
+  for (const test of individual) {
+    segments.push(`${test.shortName} ${statusWord(test.status)}`);
+  }
+
+  if (segments.length === 0) {
+    return "Values listed below (status unknown).";
+  }
+
+  return segments.slice(0, MAX_SUMMARY_SEGMENTS).join("; ") + ".";
+}
+
+function buildChipsLine(tests: SnapshotTest[]): string {
+  const sorted = tests
+    .slice()
+    .sort((a, b) => {
+      const diff = b.severity - a.severity;
+      return diff !== 0 ? diff : a.shortName.localeCompare(b.shortName);
+    });
+
+  const chips = sorted.map((test) => {
+    const value = formatNumber(test.value);
+    const unit = test.unit ? ` ${test.unit}` : "";
+    return `${test.shortName}: ${value}${unit} (${statusWord(test.status)})`;
+  });
+
+  if (chips.length === 0) return "";
+  const visible = chips.slice(0, MAX_CHIPS);
+  const remaining = chips.length - visible.length;
+  if (remaining > 0) visible.push(`+${remaining} more`);
+  return visible.join(" • ");
+}
+
+function deriveStatus(point: LabSeriesPoint): DerivedStatus {
+  const fromStatus = normalizeStatusString(point.status);
+  if (fromStatus) return fromStatus;
+
+  const fromFlag = normalizeStatusString(point.flag);
+  if (fromFlag) return fromFlag;
+
+  const value = Number(point.value);
+  if (!Number.isFinite(value)) return "unknown";
+  const low = Number.isFinite(point.ref_low ?? NaN) ? Number(point.ref_low) : null;
+  const high = Number.isFinite(point.ref_high ?? NaN) ? Number(point.ref_high) : null;
+
+  if (low != null && value < low) return "low";
+  if (high != null && value > high) return "high";
+  if (low != null || high != null) {
+    const aboveLow = low == null || value >= low;
+    const belowHigh = high == null || value <= high;
+    if (aboveLow && belowHigh) return "normal";
+  }
+  return "unknown";
+}
+
+function normalizeStatusString(raw: unknown): DerivedStatus | null {
+  if (typeof raw !== "string") return null;
+  const value = raw.trim().toLowerCase();
+  if (!value) return null;
+  if (/crit|panic/.test(value)) return "critical";
+  if (/(very\s+high|high|elev|above|raised)/.test(value)) return "high";
+  if (/(very\s+low|low|below|reduced|defici)/.test(value)) return "low";
+  if (/(normal|within|ok|fine|stable|adequate)/.test(value)) return "normal";
+  if (value === "h") return "high";
+  if (value === "l") return "low";
+  if (value === "n") return "normal";
+  if (value === "c") return "critical";
+  return null;
+}
+
+function summarizeStatuses(statuses: DerivedStatus[]): SummaryStatus {
+  const meaningful = statuses.filter((s) => s !== "unknown");
+  if (meaningful.length === 0) return "unknown";
+  if (meaningful.includes("critical")) return "critical";
+  const hasHigh = meaningful.includes("high");
+  const hasLow = meaningful.includes("low");
+  if (hasHigh && hasLow) return "mixed";
+  if (hasHigh) return "high";
+  if (hasLow) return "low";
+  if (meaningful.includes("normal")) return "normal";
+  return "unknown";
+}
+
+function statusPriority(status: SummaryStatus): number {
+  switch (status) {
+    case "critical":
+      return 5;
+    case "high":
+      return 4;
+    case "low":
+      return 3;
+    case "mixed":
+      return 2;
+    case "normal":
+      return 2;
+    default:
+      return 0;
+  }
+}
+
+function statusWord(status: SummaryStatus): string {
+  return status;
+}
+
+function formatDateLabel(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) return String(value);
+  const abs = Math.abs(value);
+  const format = (digits: number) => value.toFixed(digits).replace(/\.0+$/, "").replace(/\.([0-9]*?)0+$/, ".$1").replace(/\.$/, "");
+  if (abs >= 1000) return format(0);
+  if (abs >= 100) return format(1);
+  if (abs >= 10) return format(1);
+  return format(2);
+}
+
+function formatUnit(unit: string): string {
+  const trimmed = unit.trim();
+  if (!trimmed) return "";
+  const lower = trimmed.toLowerCase();
+  if (lower === "mg/dl") return "mg/dL";
+  if (lower === "mmol/l") return "mmol/L";
+  if (lower === "%") return "%";
+  if (lower === "u/l") return "U/L";
+  if (lower === "ng/ml") return "ng/mL";
+  if (lower === "pg/ml") return "pg/mL";
+  if (lower === "µiu/ml" || lower === "uiu/ml") return "µIU/mL";
+  return trimmed;
+}
+
+function appendNextSteps(lines: string[]) {
+  lines.push("", "**What to do next**");
+  for (const step of NEXT_STEPS) {
+    lines.push(`- ${step}`);
+  }
+}
+
+function trimTrailingBlanks(lines: string[]) {
+  while (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+}
+
+function canonicalize(input: string | null | undefined): string {
+  return (input || "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function buildMetricPatterns(): MetricPattern[] {
+  const defs = getTestDefinitions();
+  const patterns: MetricPattern[] = [];
+  const seen = new Set<string>();
+
+  for (const def of defs) {
+    const aliases = new Set<string>();
+    aliases.add(def.test_code);
+    aliases.add(def.test_name);
+    for (const kind of def.kinds) {
+      aliases.add(kind.replace(/_/g, " "));
+    }
+    for (const extra of EXTRA_ALIAS[def.test_code] ?? []) {
+      aliases.add(extra);
+    }
+
+    for (const alias of aliases) {
+      for (const variant of expandAlias(alias)) {
+        const pattern = aliasToPattern(variant);
+        if (!pattern) continue;
+        const source = `compare:${def.test_code}:${pattern}`;
+        if (seen.has(source)) continue;
+        seen.add(source);
+        const regex = new RegExp(
+          `\\bcompare\\b(?:\\s+all)?(?:\\s+of)?(?:\\s+my)?\\s+${pattern}${SUFFIX_PATTERN}(?=\\s|[?.!,]|$)`,
+          "i",
+        );
+        patterns.push({ regex, metric: { code: def.test_code, label: def.test_name } });
+      }
+    }
+  }
+
+  return patterns;
+}
+
+function expandAlias(alias: string): string[] {
+  const base = alias.trim().toLowerCase();
+  if (!base) return [];
+  const variants = new Set<string>();
+  variants.add(base);
+  variants.add(base.replace(/_/g, " "));
+  variants.add(base.replace(/-/g, " "));
+  variants.add(base.replace(/\s+/g, " "));
+  return Array.from(variants).filter(Boolean);
+}
+
+function aliasToPattern(alias: string): string {
+  const words = alias.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "";
+  return words.map((word) => escapeRegExp(word)).join("\\s+");
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/lib/aidoc/labsSnapshot.ts
+++ b/lib/aidoc/labsSnapshot.ts
@@ -49,7 +49,7 @@ const SNAPSHOT_PATTERNS: RegExp[] = [
   /\bfetch (?:all )?my reports?\b/i,
   /\blist(?:\s+out)? (?:all )?my reports?\b/i,
   /\bwhat do my reports say\b/i,
-  /\bcompare my reports?\b/i,
+  /\bcompare (?:all )?my reports?\b/i,
   /\blab (?:history|trend)\b/i,
   /\breport (?:history|trend)\b/i,
   /\bdate\s*wise\b/i,

--- a/lib/aidoc/threadType.ts
+++ b/lib/aidoc/threadType.ts
@@ -1,10 +1,23 @@
 const AIDOC_MATCH = /ai[\s_-]*doc/;
 
+function normalizeAidocCandidate(lower: string): string | null {
+  if (!lower) return null;
+  const compact = lower.replace(/[^a-z0-9]/g, "");
+  if (!compact) return null;
+  if (compact.includes("aidoc")) return "aidoc";
+  if (compact.startsWith("docai")) return "aidoc";
+  if (compact.startsWith("docmode")) return "aidoc";
+  if (compact.startsWith("aidocmode")) return "aidoc";
+  return null;
+}
+
 export function normalizeAidocThreadType(input: unknown): string | null {
   if (!input || typeof input !== "string") return null;
   const trimmed = input.trim();
   if (!trimmed) return null;
   const lower = trimmed.toLowerCase();
+  const direct = normalizeAidocCandidate(lower);
+  if (direct) return direct;
   if (AIDOC_MATCH.test(lower)) {
     return "aidoc";
   }
@@ -16,10 +29,14 @@ let loggedLookupError = false;
 export async function resolveAidocThreadType(params: {
   explicitType?: unknown;
   context?: unknown;
+  mode?: unknown;
   threadId?: unknown;
 }): Promise<string | null> {
   const explicit = normalizeAidocThreadType(params.explicitType);
   if (explicit) return explicit;
+
+  const fromMode = normalizeAidocThreadType(params.mode);
+  if (fromMode) return fromMode;
 
   const fromContext = normalizeAidocThreadType(params.context);
   if (fromContext) return fromContext;

--- a/lib/aidoc/threadType.ts
+++ b/lib/aidoc/threadType.ts
@@ -1,0 +1,67 @@
+const AIDOC_MATCH = /ai[\s_-]*doc/;
+
+export function normalizeAidocThreadType(input: unknown): string | null {
+  if (!input || typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const lower = trimmed.toLowerCase();
+  if (AIDOC_MATCH.test(lower)) {
+    return "aidoc";
+  }
+  return lower;
+}
+
+let loggedLookupError = false;
+
+export async function resolveAidocThreadType(params: {
+  explicitType?: unknown;
+  context?: unknown;
+  threadId?: unknown;
+}): Promise<string | null> {
+  const explicit = normalizeAidocThreadType(params.explicitType);
+  if (explicit) return explicit;
+
+  const fromContext = normalizeAidocThreadType(params.context);
+  if (fromContext) return fromContext;
+
+  const threadId = typeof params.threadId === "string" && params.threadId.trim() ? params.threadId.trim() : null;
+  if (!threadId) return null;
+
+  try {
+    const { supabaseAdmin } = await import("@/lib/supabase/admin");
+    const client = supabaseAdmin();
+    const tables = ["chat_threads", "aidoc_threads"];
+
+    for (const table of tables) {
+      const query = client
+        .from(table)
+        .select("type")
+        .eq("id", threadId)
+        .maybeSingle();
+      const { data, error } = await query;
+      if (error) {
+        // Ignore missing table errors; log others once for observability.
+        const code = (error as { code?: string }).code;
+        const missingTable = code === "42P01";
+        if (!missingTable && !loggedLookupError) {
+          loggedLookupError = true;
+          console.error("[aidoc-labs] thread type lookup failed", error);
+        }
+        continue;
+      }
+      if (data && typeof data.type === "string") {
+        const normalized = normalizeAidocThreadType(data.type);
+        if (normalized) {
+          return normalized;
+        }
+      }
+    }
+  } catch (err) {
+    if (!loggedLookupError) {
+      loggedLookupError = true;
+      console.error("[aidoc-labs] thread type resolve error", err);
+    }
+  }
+
+  return null;
+}

--- a/test/aidoc.labSnapshot.test.ts
+++ b/test/aidoc.labSnapshot.test.ts
@@ -7,84 +7,235 @@ const SAMPLE_TREND: LabTrend[] = [
     test_code: 'LDL-C',
     test_name: 'LDL Cholesterol',
     unit: 'mg/dl',
-    latest: { value: 172.3, sample_date: '2024-05-10T00:00:00.000Z' },
+    latest: { value: 172.3, sample_date: '2024-05-10T12:00:00.000Z' },
     previous: { value: 165, sample_date: '2023-12-01T00:00:00.000Z' },
     direction: 'worsening',
     series: [
-      { value: 172.3, unit: 'mg/dl', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 130, status: null, flag: 'H' },
-      { value: 165, unit: 'mg/dl', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 0, ref_high: 130, status: null, flag: 'H' },
+      {
+        value: 172.3,
+        unit: 'mg/dl',
+        sample_date: '2024-05-10T12:00:00.000Z',
+        ref_low: 0,
+        ref_high: 130,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20240510',
+        document_id: 'doc-20240510',
+      },
+      {
+        value: 170,
+        unit: 'mg/dl',
+        sample_date: '2024-05-10T08:00:00.000Z',
+        ref_low: 0,
+        ref_high: 130,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20240510',
+        document_id: 'doc-20240510',
+      },
+      {
+        value: 165,
+        unit: 'mg/dl',
+        sample_date: '2023-12-01T00:00:00.000Z',
+        ref_low: 0,
+        ref_high: 130,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20231201',
+        document_id: 'doc-20231201',
+      },
     ],
   },
   {
     test_code: 'HDL-C',
     test_name: 'HDL Cholesterol',
     unit: 'mg/dl',
-    latest: { value: 48, sample_date: '2024-05-10T00:00:00.000Z' },
+    latest: { value: 48, sample_date: '2024-05-10T12:00:00.000Z' },
     previous: { value: 50, sample_date: '2023-12-01T00:00:00.000Z' },
     direction: 'worsening',
     series: [
-      { value: 48, unit: 'mg/dl', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 40, ref_high: 100, status: 'normal', flag: 'N' },
-      { value: 50, unit: 'mg/dl', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 40, ref_high: 100, status: 'normal', flag: 'N' },
+      {
+        value: 48,
+        unit: 'mg/dl',
+        sample_date: '2024-05-10T12:00:00.000Z',
+        ref_low: 40,
+        ref_high: 100,
+        status: 'normal',
+        flag: 'N',
+        report_id: 'rep-20240510',
+        document_id: 'doc-20240510',
+      },
+      {
+        value: 50,
+        unit: 'mg/dl',
+        sample_date: '2023-12-01T00:00:00.000Z',
+        ref_low: 40,
+        ref_high: 100,
+        status: 'normal',
+        flag: 'N',
+        report_id: 'rep-20231201',
+        document_id: 'doc-20231201',
+      },
     ],
   },
   {
     test_code: 'TG',
     test_name: 'Triglycerides',
     unit: 'mg/dl',
-    latest: { value: 210, sample_date: '2024-05-10T00:00:00.000Z' },
+    latest: { value: 210, sample_date: '2024-05-10T12:00:00.000Z' },
     previous: { value: 190, sample_date: '2023-12-01T00:00:00.000Z' },
     direction: 'worsening',
     series: [
-      { value: 210, unit: 'mg/dl', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 150, status: null, flag: 'H' },
-      { value: 190, unit: 'mg/dl', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 0, ref_high: 150, status: null, flag: 'H' },
+      {
+        value: 210,
+        unit: 'mg/dl',
+        sample_date: '2024-05-10T12:00:00.000Z',
+        ref_low: 0,
+        ref_high: 150,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20240510',
+        document_id: 'doc-20240510',
+      },
+      {
+        value: 190,
+        unit: 'mg/dl',
+        sample_date: '2023-12-01T00:00:00.000Z',
+        ref_low: 0,
+        ref_high: 150,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20231201',
+        document_id: 'doc-20231201',
+      },
     ],
   },
   {
     test_code: 'ALT (SGPT)',
     test_name: 'ALT (SGPT)',
     unit: 'U/L',
-    latest: { value: 220, sample_date: '2024-05-10T00:00:00.000Z' },
+    latest: { value: 220, sample_date: '2024-05-10T12:00:00.000Z' },
     previous: { value: 200, sample_date: '2023-12-01T00:00:00.000Z' },
     direction: 'worsening',
     series: [
-      { value: 220, unit: 'U/L', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 40, status: null, flag: 'H' },
-      { value: 200, unit: 'U/L', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 0, ref_high: 40, status: null, flag: 'H' },
+      {
+        value: 220,
+        unit: 'U/L',
+        sample_date: '2024-05-10T12:00:00.000Z',
+        ref_low: 0,
+        ref_high: 40,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20240510',
+        document_id: 'doc-20240510',
+      },
+      {
+        value: 200,
+        unit: 'U/L',
+        sample_date: '2023-12-01T00:00:00.000Z',
+        ref_low: 0,
+        ref_high: 40,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20231201',
+        document_id: 'doc-20231201',
+      },
     ],
   },
   {
     test_code: 'AST (SGOT)',
     test_name: 'AST (SGOT)',
     unit: 'U/L',
-    latest: { value: 110, sample_date: '2024-05-10T00:00:00.000Z' },
+    latest: { value: 110, sample_date: '2024-05-10T12:00:00.000Z' },
     previous: { value: 105, sample_date: '2023-12-01T00:00:00.000Z' },
     direction: 'worsening',
     series: [
-      { value: 110, unit: 'U/L', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 40, status: null, flag: 'H' },
-      { value: 105, unit: 'U/L', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 0, ref_high: 40, status: null, flag: 'H' },
+      {
+        value: 110,
+        unit: 'U/L',
+        sample_date: '2024-05-10T12:00:00.000Z',
+        ref_low: 0,
+        ref_high: 40,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20240510',
+        document_id: 'doc-20240510',
+      },
+      {
+        value: 105,
+        unit: 'U/L',
+        sample_date: '2023-12-01T00:00:00.000Z',
+        ref_low: 0,
+        ref_high: 40,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20231201',
+        document_id: 'doc-20231201',
+      },
     ],
   },
   {
     test_code: 'HBA1C',
     test_name: 'HbA1c',
     unit: '%',
-    latest: { value: 5.6, sample_date: '2024-05-10T00:00:00.000Z' },
+    latest: { value: 5.6, sample_date: '2024-05-10T12:00:00.000Z' },
     previous: { value: 5.5, sample_date: '2023-12-01T00:00:00.000Z' },
     direction: 'worsening',
     series: [
-      { value: 5.6, unit: '%', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 4, ref_high: 5.6, status: null, flag: 'N' },
-      { value: 5.5, unit: '%', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 4, ref_high: 5.6, status: null, flag: 'N' },
+      {
+        value: 5.6,
+        unit: '%',
+        sample_date: '2024-05-10T12:00:00.000Z',
+        ref_low: 4,
+        ref_high: 5.6,
+        status: null,
+        flag: 'N',
+        report_id: 'rep-20240510',
+        document_id: 'doc-20240510',
+      },
+      {
+        value: 5.5,
+        unit: '%',
+        sample_date: '2023-12-01T00:00:00.000Z',
+        ref_low: 4,
+        ref_high: 5.6,
+        status: null,
+        flag: 'N',
+        report_id: 'rep-20231201',
+        document_id: 'doc-20231201',
+      },
     ],
   },
   {
     test_code: 'CRP',
     test_name: 'CRP',
     unit: 'mg/L',
-    latest: { value: 12, sample_date: '2024-05-10T00:00:00.000Z' },
+    latest: { value: 12, sample_date: '2024-05-10T12:00:00.000Z' },
     previous: { value: 10, sample_date: '2023-12-01T00:00:00.000Z' },
     direction: 'worsening',
     series: [
-      { value: 12, unit: 'mg/L', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 5, status: null, flag: 'H' },
-      { value: 10, unit: 'mg/L', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 0, ref_high: 5, status: null, flag: 'H' },
+      {
+        value: 12,
+        unit: 'mg/L',
+        sample_date: '2024-05-10T12:00:00.000Z',
+        ref_low: 0,
+        ref_high: 5,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20240510',
+        document_id: 'doc-20240510',
+      },
+      {
+        value: 10,
+        unit: 'mg/L',
+        sample_date: '2023-12-01T00:00:00.000Z',
+        ref_low: 0,
+        ref_high: 5,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20231201',
+        document_id: 'doc-20231201',
+      },
     ],
   },
 ];
@@ -98,7 +249,17 @@ const SINGLE_POINT_TREND: LabTrend[] = [
     previous: null,
     direction: 'unknown',
     series: [
-      { value: 160, unit: 'mg/dl', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 130, status: null, flag: 'H' },
+      {
+        value: 160,
+        unit: 'mg/dl',
+        sample_date: '2024-05-10T00:00:00.000Z',
+        ref_low: 0,
+        ref_high: 130,
+        status: null,
+        flag: 'H',
+        report_id: 'rep-20240510',
+        document_id: 'doc-20240510',
+      },
     ],
   },
 ];
@@ -108,12 +269,14 @@ describe('labs snapshot formatter', () => {
     const response = formatLabIntentResponse(SAMPLE_TREND, { kind: 'snapshot' });
     const preview = response.split('\n').slice(0, 4).join('\n');
     console.log('> pull my reports\n' + preview);
-    expect(response).toContain('**Patient Snapshot**');
+    expect(response).toContain('## Patient Snapshot');
     expect(response).toMatch(/Cholesterol high/i);
     expect(response).toMatch(/Liver enzymes high/i);
     expect(response).toMatch(/Inflammation high/i);
     expect(response).toMatch(/\+1 more/);
-    expect(response).toMatch(/What to do next/);
+    expect(response).toMatch(/LDL: 172\.3 mg\/dL/i);
+    expect(response).not.toMatch(/170 mg\/dL/);
+    expect(response).toMatch(/### What to do next/);
   });
 
   it('formats a comparison view for LDL', () => {
@@ -123,10 +286,10 @@ describe('labs snapshot formatter', () => {
     });
     const preview = comparison.split('\n').slice(0, 4).join('\n');
     console.log('> compare my LDL\n' + preview);
-    expect(comparison).toContain('**LDL Cholesterol — Comparison**');
+    expect(comparison).toContain('## Compare LDL');
     expect(comparison).toMatch(/2024/);
     expect(comparison).toMatch(/mg\/dL \(high\)/i);
-    expect(comparison).toMatch(/What to do next/);
+    expect(comparison).toMatch(/### What to do next/);
   });
 
   it('notes when a comparison has only one data point', () => {
@@ -139,6 +302,7 @@ describe('labs snapshot formatter', () => {
 
   it('detects snapshot intents from common phrases', () => {
     expect(detectLabSnapshotIntent('pull my reports')).toEqual({ kind: 'snapshot' });
+    expect(detectLabSnapshotIntent('list my reports')?.kind).toBe('snapshot');
     expect(detectLabSnapshotIntent('how is my health overall')?.kind).toBe('snapshot');
     const compareIntent = detectLabSnapshotIntent('compare my LDL');
     expect(compareIntent).toEqual({ kind: 'compare', metric: { code: 'LDL-C', label: 'LDL Cholesterol' } });

--- a/test/aidoc.labSnapshot.test.ts
+++ b/test/aidoc.labSnapshot.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { detectLabSnapshotIntent, formatLabIntentResponse } from '../lib/aidoc/labsSnapshot';
+import type { LabTrend } from '../lib/labs/summary';
+
+const SAMPLE_TREND: LabTrend[] = [
+  {
+    test_code: 'LDL-C',
+    test_name: 'LDL Cholesterol',
+    unit: 'mg/dl',
+    latest: { value: 172.3, sample_date: '2024-05-10T00:00:00.000Z' },
+    previous: { value: 165, sample_date: '2023-12-01T00:00:00.000Z' },
+    direction: 'worsening',
+    series: [
+      { value: 172.3, unit: 'mg/dl', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 130, status: null, flag: 'H' },
+      { value: 165, unit: 'mg/dl', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 0, ref_high: 130, status: null, flag: 'H' },
+    ],
+  },
+  {
+    test_code: 'HDL-C',
+    test_name: 'HDL Cholesterol',
+    unit: 'mg/dl',
+    latest: { value: 48, sample_date: '2024-05-10T00:00:00.000Z' },
+    previous: { value: 50, sample_date: '2023-12-01T00:00:00.000Z' },
+    direction: 'worsening',
+    series: [
+      { value: 48, unit: 'mg/dl', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 40, ref_high: 100, status: 'normal', flag: 'N' },
+      { value: 50, unit: 'mg/dl', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 40, ref_high: 100, status: 'normal', flag: 'N' },
+    ],
+  },
+  {
+    test_code: 'TG',
+    test_name: 'Triglycerides',
+    unit: 'mg/dl',
+    latest: { value: 210, sample_date: '2024-05-10T00:00:00.000Z' },
+    previous: { value: 190, sample_date: '2023-12-01T00:00:00.000Z' },
+    direction: 'worsening',
+    series: [
+      { value: 210, unit: 'mg/dl', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 150, status: null, flag: 'H' },
+      { value: 190, unit: 'mg/dl', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 0, ref_high: 150, status: null, flag: 'H' },
+    ],
+  },
+  {
+    test_code: 'ALT (SGPT)',
+    test_name: 'ALT (SGPT)',
+    unit: 'U/L',
+    latest: { value: 220, sample_date: '2024-05-10T00:00:00.000Z' },
+    previous: { value: 200, sample_date: '2023-12-01T00:00:00.000Z' },
+    direction: 'worsening',
+    series: [
+      { value: 220, unit: 'U/L', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 40, status: null, flag: 'H' },
+      { value: 200, unit: 'U/L', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 0, ref_high: 40, status: null, flag: 'H' },
+    ],
+  },
+  {
+    test_code: 'AST (SGOT)',
+    test_name: 'AST (SGOT)',
+    unit: 'U/L',
+    latest: { value: 110, sample_date: '2024-05-10T00:00:00.000Z' },
+    previous: { value: 105, sample_date: '2023-12-01T00:00:00.000Z' },
+    direction: 'worsening',
+    series: [
+      { value: 110, unit: 'U/L', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 40, status: null, flag: 'H' },
+      { value: 105, unit: 'U/L', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 0, ref_high: 40, status: null, flag: 'H' },
+    ],
+  },
+  {
+    test_code: 'HBA1C',
+    test_name: 'HbA1c',
+    unit: '%',
+    latest: { value: 5.6, sample_date: '2024-05-10T00:00:00.000Z' },
+    previous: { value: 5.5, sample_date: '2023-12-01T00:00:00.000Z' },
+    direction: 'worsening',
+    series: [
+      { value: 5.6, unit: '%', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 4, ref_high: 5.6, status: null, flag: 'N' },
+      { value: 5.5, unit: '%', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 4, ref_high: 5.6, status: null, flag: 'N' },
+    ],
+  },
+  {
+    test_code: 'CRP',
+    test_name: 'CRP',
+    unit: 'mg/L',
+    latest: { value: 12, sample_date: '2024-05-10T00:00:00.000Z' },
+    previous: { value: 10, sample_date: '2023-12-01T00:00:00.000Z' },
+    direction: 'worsening',
+    series: [
+      { value: 12, unit: 'mg/L', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 5, status: null, flag: 'H' },
+      { value: 10, unit: 'mg/L', sample_date: '2023-12-01T00:00:00.000Z', ref_low: 0, ref_high: 5, status: null, flag: 'H' },
+    ],
+  },
+];
+
+const SINGLE_POINT_TREND: LabTrend[] = [
+  {
+    test_code: 'LDL-C',
+    test_name: 'LDL Cholesterol',
+    unit: 'mg/dl',
+    latest: { value: 160, sample_date: '2024-05-10T00:00:00.000Z' },
+    previous: null,
+    direction: 'unknown',
+    series: [
+      { value: 160, unit: 'mg/dl', sample_date: '2024-05-10T00:00:00.000Z', ref_low: 0, ref_high: 130, status: null, flag: 'H' },
+    ],
+  },
+];
+
+describe('labs snapshot formatter', () => {
+  it('formats a patient snapshot with grouped summaries and chips', () => {
+    const response = formatLabIntentResponse(SAMPLE_TREND, { kind: 'snapshot' });
+    const preview = response.split('\n').slice(0, 4).join('\n');
+    console.log('> pull my reports\n' + preview);
+    expect(response).toContain('**Patient Snapshot**');
+    expect(response).toMatch(/Cholesterol high/i);
+    expect(response).toMatch(/Liver enzymes high/i);
+    expect(response).toMatch(/Inflammation high/i);
+    expect(response).toMatch(/\+1 more/);
+    expect(response).toMatch(/What to do next/);
+  });
+
+  it('formats a comparison view for LDL', () => {
+    const comparison = formatLabIntentResponse(SAMPLE_TREND, {
+      kind: 'compare',
+      metric: { code: 'LDL-C', label: 'LDL Cholesterol' },
+    });
+    const preview = comparison.split('\n').slice(0, 4).join('\n');
+    console.log('> compare my LDL\n' + preview);
+    expect(comparison).toContain('**LDL Cholesterol — Comparison**');
+    expect(comparison).toMatch(/2024/);
+    expect(comparison).toMatch(/mg\/dL \(high\)/i);
+    expect(comparison).toMatch(/What to do next/);
+  });
+
+  it('notes when a comparison has only one data point', () => {
+    const comparison = formatLabIntentResponse(SINGLE_POINT_TREND, {
+      kind: 'compare',
+      metric: { code: 'LDL-C', label: 'LDL Cholesterol' },
+    });
+    expect(comparison).toMatch(/Need ≥2 results to comment on a trend/);
+  });
+
+  it('detects snapshot intents from common phrases', () => {
+    expect(detectLabSnapshotIntent('pull my reports')).toEqual({ kind: 'snapshot' });
+    expect(detectLabSnapshotIntent('how is my health overall')?.kind).toBe('snapshot');
+    const compareIntent = detectLabSnapshotIntent('compare my LDL');
+    expect(compareIntent).toEqual({ kind: 'compare', metric: { code: 'LDL-C', label: 'LDL Cholesterol' } });
+  });
+});

--- a/test/aidoc.labSnapshot.test.ts
+++ b/test/aidoc.labSnapshot.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from 'vitest';
 import { detectLabSnapshotIntent, formatLabIntentResponse } from '../lib/aidoc/labsSnapshot';
+import { normalizeAidocThreadType } from '../lib/aidoc/threadType';
+
+describe('AI Doc lab intent detection', () => {
+  it('detects snapshot intents with optional all qualifier', () => {
+    const intent = detectLabSnapshotIntent('Compare all my reports');
+    expect(intent).toEqual({ kind: 'snapshot' });
+  });
+
+  it('detects metric comparisons deterministically', () => {
+    const intent = detectLabSnapshotIntent('compare my LDL results');
+    expect(intent).toMatchObject({ kind: 'compare', metric: { code: 'LDL-C' } });
+  });
+
+  it('normalizes common AI Doc thread labels', () => {
+    expect(normalizeAidocThreadType('Doc AI')).toBe('aidoc');
+    expect(normalizeAidocThreadType('doc-mode')).toBe('aidoc');
+    expect(normalizeAidocThreadType('AIDocPreview')).toBe('aidoc');
+  });
+});
 import type { LabTrend } from '../lib/labs/summary';
 
 const SAMPLE_TREND: LabTrend[] = [


### PR DESCRIPTION
## Summary
- introduce an AI Doc lab snapshot/comparison formatter with deterministic intent detection and reusable rendering helpers
- wire AI Doc chat and stream routes to short-circuit target phrases using the new formatter while keeping other modes unchanged
- enrich lab summaries with reference metadata and add unit tests covering snapshot and comparison outputs

## Testing
- npx vitest run test/aidoc.labSnapshot.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68debc0a5ee4832f986973bf4bedc656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Lab Snapshots: detect snapshot/compare requests and stream structured summaries, metric comparisons, trends, and next steps; prompts to sign in when needed. Early delivery of lab content can short‑circuit normal responses.

- **Refactor**
  - Replaced legacy timeline for non–AI-doc users with a locked-message flow; thread/context resolution improves intent routing.

- **Bug Fixes**
  - Better lab fetch error handling and richer lab metadata (reference ranges, flags, report/document IDs).

- **Tests**
  - Added intent-detection and snapshot/compare formatting tests.

- **Documentation**
  - New docs for intercept routing, outputs, feature flags, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->