### PR TITLE
Show AI Doc button only in AI Doc mode

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -3839,7 +3839,7 @@ ${systemCommon}` + baseSys;
       <div className="mt-auto mobile-composer-region">
         <div className="px-6 pb-4 md:pb-6">
           <div className="mx-auto max-w-3xl space-y-3 px-4 py-4">
-              {mode === 'doctor' && AIDOC_UI && (
+              {AIDOC_UI && isAiDocMode && (
                 <button
                   className="rounded-full border border-slate-200 px-3 py-1 text-sm hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
                   onClick={async () => {


### PR DESCRIPTION
## Summary
- display the "Next steps (AI Doc)" button only when the AI Doc experience is active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df83757c54832f994e4c5753c0ea59