### PR TITLE
Remove chat show more pagination

### DIFF
--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -20,37 +20,8 @@ function normalize(raw: string){
   return s + "\n";
 }
 
-function AutoCollapse({ children, maxHeight = 600 }: { children: React.ReactNode; maxHeight?: number }) {
-  const [expanded, setExpanded] = React.useState(false);
-  const ref = React.useRef<HTMLDivElement>(null);
-  const [collapse, setCollapse] = React.useState(false);
-  React.useEffect(() => {
-    if (!ref.current) return;
-    const shouldCollapse = ref.current.scrollHeight > maxHeight && !expanded;
-    setCollapse(shouldCollapse);
-    if (expanded && ref.current) {
-      ref.current.style.maxHeight = "none";
-    }
-  }, [expanded, maxHeight, children]);
-  return (
-    <div>
-      <div
-        ref={ref}
-        className={collapse ? "max-h-[600px] overflow-hidden" : ""}
-      >
-        {children}
-      </div>
-      {collapse && (
-        <button
-          type="button"
-          className="mt-3 text-sm underline opacity-80 transition hover:opacity-100"
-          onClick={() => setExpanded(true)}
-        >
-          Show more
-        </button>
-      )}
-    </div>
-  );
+function AutoCollapse({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
 }
 
 type MarkdownCodeProps = React.ComponentPropsWithoutRef<"code"> & {


### PR DESCRIPTION
## Summary
- show chat markdown messages in full by removing the Show more collapsible wrapper
- surface complete nearby search results at once and drop the Show more command hints

## Testing
- npm run lint *(fails: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dffb0a4d68832fa08e5aee6a9a44c6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Nearby results now display the full list in a single view; chunked paging and the “Show more” option have been removed.
  - “Previous” navigation continues to work but operates over the full result set instead of chunks.
  - Automatic content collapsing has been removed; long content renders fully without a “Show more” button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->