### PR TITLE
Remove chat show more toggle and improve stop handling

### DIFF
--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -20,39 +20,6 @@ function normalize(raw: string){
   return s + "\n";
 }
 
-function AutoCollapse({ children, maxHeight = 600 }: { children: React.ReactNode; maxHeight?: number }) {
-  const [expanded, setExpanded] = React.useState(false);
-  const ref = React.useRef<HTMLDivElement>(null);
-  const [collapse, setCollapse] = React.useState(false);
-  React.useEffect(() => {
-    if (!ref.current) return;
-    const shouldCollapse = ref.current.scrollHeight > maxHeight && !expanded;
-    setCollapse(shouldCollapse);
-    if (expanded && ref.current) {
-      ref.current.style.maxHeight = "none";
-    }
-  }, [expanded, maxHeight, children]);
-  return (
-    <div>
-      <div
-        ref={ref}
-        className={collapse ? "max-h-[600px] overflow-hidden" : ""}
-      >
-        {children}
-      </div>
-      {collapse && (
-        <button
-          type="button"
-          className="mt-3 text-sm underline opacity-80 transition hover:opacity-100"
-          onClick={() => setExpanded(true)}
-        >
-          Show more
-        </button>
-      )}
-    </div>
-  );
-}
-
 type MarkdownCodeProps = React.ComponentPropsWithoutRef<"code"> & {
   inline?: boolean;
   node?: unknown;
@@ -103,72 +70,70 @@ export default function ChatMarkdown({ content }: { content: string }) {
         leading-7 text-[15px]
       "
     >
-      <AutoCollapse>
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkMath]}
-          rehypePlugins={[rehypeKatex]}
-          components={{
-            a: ({ href, children }) => (
-              <LinkBadge href={href as string}>
-                {children}
-              </LinkBadge>
-            ),
-            ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
-            ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
-            hr: () => <hr className="my-3 border-dashed opacity-40" />,
-            p: ({ children }) => (
-              <p className="text-left">{children}</p>
-            ),
-            li: ({ children }) => (
-              <li>{children}</li>
-            ),
-            h1: ({ children }) => (
-              <h1>{children}</h1>
-            ),
-            h2: ({ children }) => (
-              <h2>{children}</h2>
-            ),
-            h3: ({ children }) => (
-              <h3>{children}</h3>
-            ),
-            h4: ({ children }) => (
-              <h4>{children}</h4>
-            ),
-            table: ({ children, ...props }) => (
-              <div className="overflow-x-auto">
-                <table {...props}>{children}</table>
-              </div>
-            ),
-            code: (props: MarkdownCodeProps) => {
-              const { inline, children, className, ...rest } = props;
-              if (inline) {
-                const combined = [
-                  "rounded bg-black/5 px-1 py-0.5 dark:bg-white/10",
-                  className || "",
-                ]
-                  .filter(Boolean)
-                  .join(" ");
-                return (
-                  <code
-                    {...rest}
-                    className={combined}
-                  >
-                    {children}
-                  </code>
-                );
-              }
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+        components={{
+          a: ({ href, children }) => (
+            <LinkBadge href={href as string}>
+              {children}
+            </LinkBadge>
+          ),
+          ul: ({ children }) => <ul className="list-disc pl-5">{children}</ul>,
+          ol: ({ children }) => <ol className="list-decimal pl-5">{children}</ol>,
+          hr: () => <hr className="my-3 border-dashed opacity-40" />,
+          p: ({ children }) => (
+            <p className="text-left">{children}</p>
+          ),
+          li: ({ children }) => (
+            <li>{children}</li>
+          ),
+          h1: ({ children }) => (
+            <h1>{children}</h1>
+          ),
+          h2: ({ children }) => (
+            <h2>{children}</h2>
+          ),
+          h3: ({ children }) => (
+            <h3>{children}</h3>
+          ),
+          h4: ({ children }) => (
+            <h4>{children}</h4>
+          ),
+          table: ({ children, ...props }) => (
+            <div className="overflow-x-auto">
+              <table {...props}>{children}</table>
+            </div>
+          ),
+          code: (props: MarkdownCodeProps) => {
+            const { inline, children, className, ...rest } = props;
+            if (inline) {
+              const combined = [
+                "rounded bg-black/5 px-1 py-0.5 dark:bg-white/10",
+                className || "",
+              ]
+                .filter(Boolean)
+                .join(" ");
+              return (
+                <code
+                  {...rest}
+                  className={combined}
+                >
+                  {children}
+                </code>
+              );
+            }
 
-              const text = Array.isArray(children)
-                ? children.join("")
-                : String(children ?? "");
+            const text = Array.isArray(children)
+              ? children.join("")
+              : String(children ?? "");
 
-              return <CodeBlock className={typeof className === "string" ? className : undefined}>{text}</CodeBlock>;
-            },
-          }}
-        >
-          {prepared}
-        </ReactMarkdown>
-      </AutoCollapse>
+            return <CodeBlock className={typeof className === "string" ? className : undefined}>{text}</CodeBlock>;
+          },
+        }}
+      >
+        {prepared}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -2791,8 +2791,8 @@ ${systemCommon}` + baseSys;
         const hasNewText = (acc ?? '').length > 0;
         if (regenTargetId && !hasNewText && prevAssistantSnapshot) {
           cancelPendingAssistant(pendingId);
-          replaceMessage(regenTargetId, prevAssistantSnapshot);
-          setMessages(list => list.filter(m => m.id !== pendingId));
+          setMessages(list => list.filter(m => m.id !== regenTargetId));
+          replaceMessage(pendingId, prevAssistantSnapshot);
         } else {
           finishPendingAssistant(pendingId, acc ?? '');
         }

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -317,7 +317,11 @@ type SendOpts = {
   skipUserMemory?: boolean;
   replacesId?: string;
   onFinish?: () => void;
-  onError?: (info?: { reason?: string }) => void;
+  onError?: (info?: {
+    reason?: string;
+    pendingId?: string;
+    regenTargetId?: string | null;
+  }) => void;
   onSuccess?: (newMessageId: string) => void;
   onPending?: (pendingMessageId: string) => void;
 };


### PR DESCRIPTION
## Summary
- remove the markdown auto-collapse wrapper so replies always render without a Show more button
- track the active streaming AbortController so the Stop action can cancel generation cleanly
- keep partial assistant text when streaming is aborted and clear the controller state when generation finishes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00c60986c832fa5aca904af584f27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Chat messages no longer auto-collapse; content is always fully expanded and the “Show more” control is removed.
  - Stopping/aborting in-progress assistant responses is more reliable and consistent.
  - Keyboard shortcuts for stopping generation behave more predictably.
  - Cancellations now surface clearer cancellation signaling for interrupted responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->