### PR TITLE
Adjust max tokens for doctor mode

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -4,12 +4,11 @@ import { languageDirectiveFor, personaFromPrefs, SYSTEM_DEFAULT_LANG } from '@/l
 import { extractAll, canonicalizeInputs } from '@/lib/medical/engine/extract';
 import { BRAND_NAME } from "@/lib/brand";
 import { computeAll } from '@/lib/medical/engine/computeAll';
+import { clamp } from '@/lib/medical/engine/calculators/utils';
 // === [MEDX_CALC_ROUTE_IMPORTS_START] ===
 import { composeCalcPrelude } from '@/lib/medical/engine/prelude';
 // === [MEDX_CALC_ROUTE_IMPORTS_END] ===
 import { RESEARCH_BRIEF_STYLE } from '@/lib/styles';
-
-const clamp = (n: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, n));
 
 function readIntEnv(name: string, fallback: number) {
   const raw = process.env[name];


### PR DESCRIPTION
## Summary
- add mode-specific max token calculation so doctor mode can use a higher configurable cap
- keep existing cap for other modes while reusing the computed target range

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e11e52ba08832f91611c4bfa33115b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Response-length limits are now configurable and adaptive: caps adjust based on mode, query length, and topic brevity for more consistent outputs.
  * A dedicated "doc/AI" mode supports higher, context-appropriate lengths while general chats keep balanced minimums.

* **Chores**
  * Deployment settings now include validated integer controls with warnings for invalid values; behavior is configurable without changing APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->