### PR TITLE
Support study and thinking chips in chat flow

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -9,7 +9,7 @@ import { clamp } from '@/lib/medical/engine/calculators/utils';
 import { composeCalcPrelude } from '@/lib/medical/engine/prelude';
 // === [MEDX_CALC_ROUTE_IMPORTS_END] ===
 import { RESEARCH_BRIEF_STYLE } from '@/lib/styles';
-import { STUDY_MODE_SYSTEM, THINKING_MODE_HINT, STUDY_OUTPUT_GUIDE } from '@/lib/prompts/presets';
+import { STUDY_MODE_SYSTEM, THINKING_MODE_HINT, STUDY_OUTPUT_GUIDE, languageInstruction } from '@/lib/prompts/presets';
 
 function readIntEnv(name: string, fallback: number) {
   const raw = process.env[name];
@@ -65,24 +65,22 @@ function gateFlagsByMode(
   mode: string | null,
   flags: { study: boolean; thinking: boolean },
 ) {
-  const normalized = (mode || '').toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  const normalized = (mode || '').toLowerCase();
   const allowedStudy = new Set([
     'wellness',
     'wellness_research',
-    'wellnessresearch',
     'clinical',
     'clinical_research',
-    'clinicalresearch',
     'research',
-    'patient',
-    'patient_research',
-    'patientresearch',
-    'doctor',
-    'doctor_research',
-    'doctorresearch',
   ]);
-  const allowedThinking = new Set(allowedStudy);
-  allowedThinking.add('aidoc');
+  const allowedThinking = new Set([
+    'wellness',
+    'wellness_research',
+    'clinical',
+    'clinical_research',
+    'research',
+    'aidoc',
+  ]);
 
   return {
     study: flags.study && allowedStudy.has(normalized),
@@ -103,14 +101,19 @@ export async function POST(req: NextRequest) {
   const studyFlag = reqUrl.searchParams.get('study') === '1';
   const thinkingFlag = reqUrl.searchParams.get('thinking') === '1';
   const modeTag = reqUrl.searchParams.get('mode');
+  const langQuery = reqUrl.searchParams.get('lang');
   let body: any = {};
   try { body = await req.json(); } catch {}
   const { context, clientRequestId, mode } = body;
   const flags = gateFlagsByMode(modeTag, { study: studyFlag, thinking: thinkingFlag });
+  const normalizedModeTag = (modeTag || '').toLowerCase();
   const allowHistory = body?.allowHistory !== false;
   const requestedLang = typeof body?.lang === 'string' ? body.lang : undefined;
   const headerLang = req.headers.get('x-user-lang') || req.headers.get('x-lang') || undefined;
-  const langTag = (requestedLang && requestedLang.trim()) || (headerLang && headerLang.trim()) || SYSTEM_DEFAULT_LANG;
+  const langTag = (langQuery && langQuery.trim())
+    || (requestedLang && requestedLang.trim())
+    || (headerLang && headerLang.trim())
+    || SYSTEM_DEFAULT_LANG;
   const lang = langTag.toLowerCase();
   const langDirective = languageDirectiveFor(lang);
   const persona = personaFromPrefs(body?.personalization);
@@ -156,10 +159,21 @@ export async function POST(req: NextRequest) {
         .join('\n\n')
     : '';
 
+  const researchPresetChunks: string[] = [];
+  if (sysPrelude) researchPresetChunks.push(sysPrelude);
+  if (lang) researchPresetChunks.push(languageInstruction(lang));
+  if (flags.study) researchPresetChunks.push(STUDY_MODE_SYSTEM.trim(), STUDY_OUTPUT_GUIDE.trim());
+  if (flags.thinking) researchPresetChunks.push(THINKING_MODE_HINT.trim());
+
+  const researchSystem = [
+    RESEARCH_BRIEF_STYLE + (srcBlock ? `\n\nSOURCES:\n${srcBlock}` : ''),
+    ...researchPresetChunks,
+  ].filter(Boolean).join('\n\n');
+
   const briefMessages: Array<{role:'system'|'user'|'assistant'; content:string}> =
     research && !long
       ? [
-          { role: 'system', content: RESEARCH_BRIEF_STYLE + (srcBlock ? `\n\nSOURCES:\n${srcBlock}` : '') },
+          { role: 'system', content: researchSystem },
           ...recent,             // preserve chat context
           latestUser             // ask the new question
         ]
@@ -217,8 +231,9 @@ export async function POST(req: NextRequest) {
   const isShortQuery = wordCount <= 6;
   const briefTopic = /\b(what is|types?|symptoms?|causes?|treatment|home care|prevention|red flags?)\b/i
     .test(latestUserMessage || '');
-  const isAiDoc = mode === 'doctor';
-  const targetWordCap = isAiDoc
+  const isDoctorLike = mode === 'doctor';
+  const isAiDoc = normalizedModeTag === 'aidoc';
+  const targetWordCap = (isAiDoc || isDoctorLike)
     ? (isShortQuery || briefTopic ? 220 : 360)
     : (isShortQuery || briefTopic ? 180 : 280);
   const AIDOC_MAX_TOKENS = readIntEnv('AIDOC_MAX_TOKENS', 3000);
@@ -299,6 +314,9 @@ export async function POST(req: NextRequest) {
   const nonSystemMessages = finalMessages.filter((m: any) => m.role !== 'system');
   const combinedSystem = systemMessages.map((m: any) => m.content).filter(Boolean).join('\n\n');
   const presetChunks: string[] = [];
+  if (lang) {
+    presetChunks.push(languageInstruction(lang));
+  }
   if (flags.study) {
     presetChunks.push(STUDY_MODE_SYSTEM.trim(), STUDY_OUTPUT_GUIDE.trim());
   }
@@ -309,16 +327,17 @@ export async function POST(req: NextRequest) {
   finalMessages = finalSystem ? [{ role: 'system', content: finalSystem }, ...nonSystemMessages] : nonSystemMessages;
 
   const requestedMaxTokens = typeof body?.max_tokens === 'number' ? body.max_tokens : undefined;
-  const computedMaxTokens = isAiDoc
-    ? clamp(Math.max(200, targetMax), 200, AIDOC_MAX_TOKENS)
-    : clamp(Math.max(200, targetMax), 200, 768);
-  const adjustedMaxTokens = flags.thinking
-    ? Math.min(
-        Math.round(computedMaxTokens * 1.1),
-        isAiDoc ? AIDOC_MAX_TOKENS : 900,
-      )
-    : computedMaxTokens;
-  const max_tokens = Math.min(2048, requestedMaxTokens ?? adjustedMaxTokens);
+  const defaultMaxTokens = typeof body?.default_max_tokens === 'number' ? body.default_max_tokens : undefined;
+  const fallbackDefault = clamp(Math.max(200, targetMax), 200, isAiDoc ? AIDOC_MAX_TOKENS : 768);
+  let computedMaxTokens = defaultMaxTokens ?? fallbackDefault;
+  if (flags.thinking) {
+    const boosted = Math.round(computedMaxTokens * 1.1);
+    computedMaxTokens = Math.min(boosted, isAiDoc ? AIDOC_MAX_TOKENS : 900);
+  }
+  const adjustedMaxTokens = isAiDoc
+    ? Math.min(AIDOC_MAX_TOKENS, requestedMaxTokens ?? computedMaxTokens ?? AIDOC_MAX_TOKENS)
+    : Math.min(2048, requestedMaxTokens ?? computedMaxTokens ?? fallbackDefault);
+  const max_tokens = adjustedMaxTokens;
   const temperature = flags.study ? 0.4 : (flags.thinking ? 0.25 : 0.3);
 
   const upstream = await fetch(url, {

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -707,7 +707,7 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
   );
   const lang = prefs.lang;
   const allowHistory = prefs.allowHistory !== false && prefs.referenceChatHistory !== false;
-  const { t } = useI18n();
+  const { t, language: uiLanguage } = useI18n();
   const { active, setFromAnalysis, setFromChat, clear: clearContext } = useActiveContext();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [userText, setUserText] = useState('');
@@ -2693,6 +2693,8 @@ ${systemCommon}` + baseSys;
       if (activeHelper === 'study') qp.set('study', '1');
       if (activeHelper === 'thinking') qp.set('thinking', '1');
       if (activeModeTag) qp.set('mode', activeModeTag);
+      const languageParam = (uiLanguage || lang || '').trim();
+      if (languageParam) qp.set('lang', languageParam);
       const qs = qp.toString();
       const url = `/api/chat/stream${qs ? `?${qs}` : ''}`;
       mark('send');

--- a/lib/i18n/useI18n.ts
+++ b/lib/i18n/useI18n.ts
@@ -4,5 +4,5 @@ import { useT } from "@/components/hooks/useI18n";
 
 export function useI18n() {
   const t = useT();
-  return { t };
+  return { t, language: t.lang };
 }

--- a/lib/prompts/presets.ts
+++ b/lib/prompts/presets.ts
@@ -1,20 +1,27 @@
 export const STUDY_MODE_SYSTEM = `
-You are a precise, patient medical tutor.
-Explain step-by-step in clear language first, then (when relevant) add concise clinical detail.
-Prefer short sections with descriptive headings. Avoid fluffy filler. Cite concepts, not fake sources.
-When the user asks for formats (notes, flashcards, Q&A), structure accordingly.
-`;
+Act as a precise, patient medical tutor.
+Explain step-by-step with clear sections and concise clinical detail where relevant.
+Avoid inventing sources; if uncertain, say so briefly.
+When a study format is implied (notes, flashcards, Q&A), structure accordingly.
+`.trim();
 
 export const THINKING_MODE_HINT = `
-Prioritize careful reasoning. Avoid making claims you cannot support.
-Decompose problems, check assumptions, and state uncertainties briefly.
+Prioritize careful reasoning: decompose problems, check assumptions, and state uncertainties briefly.
 Be succinct but logically thorough.
-`;
+`.trim();
 
 export const STUDY_OUTPUT_GUIDE = `
-If the user does not specify a format, default to:
-- Key idea (2-3 bullets)
-- Step-by-step explanation (5-8 steps)
-- Quick checks/mnemonics (2-4 lines)
-- Caveats/contraindications where applicable
-`;
+Default structure if format is unspecified:
+- Key ideas (2–4 bullets)
+- Step-by-step explanation (5–8 short steps)
+- Quick checks/mnemonics (2–4 lines)
+- Caveats/contraindications if applicable
+`.trim();
+
+export function languageInstruction(lang: string) {
+  return `
+Respond entirely in "${lang}". Do not mix languages.
+If user input contains multiple languages, translate your output into "${lang}".
+Keep technical terms in "${lang}" unless the canonical term is universally used in another language.
+`.trim();
+}


### PR DESCRIPTION
## Summary
- add mode-aware query flags from the chat pane so study/thinking chips are sent with each request
- introduce shared study/thinking prompt presets and apply server-side gating plus prompt tuning

## Testing
- npm run lint *(fails: CLI prompts for ESLint configuration and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e264f76c84832fa9308eaa386dbfdd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added “Study” and “Thinking” modes that tailor prompts and outputs for learning and careful reasoning.
  - Mode-aware generation: adaptive temperature and token limits for improved responses.
  - Streaming now includes mode flags (research, study, thinking) and UI language so responses respect mode and locale.
  - Study output guidance and language-specific output enforcement to produce structured, localized results.
- Bug Fixes
  - Resets helper/mode hints after each message to prevent unintended carryover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->