### PR TITLE
Implement language-locked chat directives

### DIFF
--- a/app/api/chat/stream/route.ts
+++ b/app/api/chat/stream/route.ts
@@ -11,6 +11,13 @@ import { composeCalcPrelude } from '@/lib/medical/engine/prelude';
 // === [MEDX_CALC_ROUTE_IMPORTS_END] ===
 import { RESEARCH_BRIEF_STYLE } from '@/lib/styles';
 
+const SUPPORTED_LANGS = ['en', 'hi', 'es', 'fr', 'it', 'ar', 'de', 'zh'];
+
+function normalizeUILang(raw?: string | null): string {
+  const cleaned = (raw ?? SYSTEM_DEFAULT_LANG).toLowerCase().replace(/[^a-z-]/g, '');
+  return SUPPORTED_LANGS.includes(cleaned) ? cleaned : SYSTEM_DEFAULT_LANG;
+}
+
 function readIntEnv(name: string, fallback: number) {
   const raw = process.env[name];
   if (raw == null || raw.trim() === "") return fallback;
@@ -88,7 +95,7 @@ export async function POST(req: NextRequest) {
     (requestedLang && requestedLang.trim()) ||
     (headerLang && headerLang.trim()) ||
     SYSTEM_DEFAULT_LANG;
-  const lang = langTag.toLowerCase();
+  const lang = normalizeUILang(langTag);
   const helperDirectives: string[] = [];
   if (studyFlag) {
     helperDirectives.push(STUDY_MODE_SYSTEM, STUDY_OUTPUT_GUIDE);

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -2724,6 +2724,7 @@ ${systemCommon}` + baseSys;
         }
       }
       if (!res.ok || !res.body) throw new Error(`Chat API error ${res.status}`);
+      setActiveHelper(null);
 
       const reader = res.body.getReader();
       const decoder = new TextDecoder();

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -705,9 +705,9 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
       prefs.about,
     ],
   );
-  const lang = prefs.lang;
+  const { t, language } = useI18n();
+  const lang = language ?? prefs.lang ?? 'en';
   const allowHistory = prefs.allowHistory !== false && prefs.referenceChatHistory !== false;
-  const { t } = useI18n();
   const { active, setFromAnalysis, setFromChat, clear: clearContext } = useActiveContext();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [userText, setUserText] = useState('');
@@ -2680,9 +2680,15 @@ ${systemCommon}` + baseSys;
         ];
       }
 
-      const url = `/api/chat/stream${researchMode ? '?research=1' : ''}`;
+      const qp = new URLSearchParams();
+      if (activeHelper === 'study') qp.set('study', '1');
+      if (activeHelper === 'thinking') qp.set('thinking', '1');
+      if (mode) qp.set('mode', String(mode));
+      if (researchMode) qp.set('research', '1');
+      if (language) qp.set('lang', language);
+      const endpoint = `/api/chat/stream${qp.toString() ? `?${qp.toString()}` : ''}`;
       mark('send');
-      const res = await fetch(url, {
+      const res = await fetch(endpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/lib/i18n/useI18n.ts
+++ b/lib/i18n/useI18n.ts
@@ -4,5 +4,6 @@ import { useT } from "@/components/hooks/useI18n";
 
 export function useI18n() {
   const t = useT();
-  return { t };
+  const language = t.lang ?? "en";
+  return { t, language };
 }

--- a/lib/prompts/presets.ts
+++ b/lib/prompts/presets.ts
@@ -19,9 +19,10 @@ Default structure if format is unspecified:
 `.trim();
 
 export function languageInstruction(lang: string) {
+  const safe = JSON.stringify(lang);
   return `
-Respond entirely in "${lang}".
-Do not mix languages. If user input contains multiple languages, translate your output into "${lang}".
-Keep technical terms in "${lang}" unless the canonical term is universally used in another language (e.g., drug names).
+Respond entirely in ${safe}.
+Do not mix languages. If user input contains multiple languages, translate your output into ${safe}.
+Keep technical terms in ${safe} unless the canonical term is universally used in another language (e.g., drug names).
 `.trim();
 }

--- a/lib/prompts/presets.ts
+++ b/lib/prompts/presets.ts
@@ -1,0 +1,27 @@
+export const STUDY_MODE_SYSTEM = `
+Act as a precise, patient medical tutor.
+Explain step-by-step with clear sections and concise clinical detail where relevant.
+Avoid inventing sources; if uncertain, say so briefly.
+When a study format is implied (notes, flashcards, Q&A), structure accordingly.
+`.trim();
+
+export const THINKING_MODE_HINT = `
+Prioritize careful reasoning: decompose problems, check assumptions, and state uncertainties briefly.
+Be succinct but logically thorough.
+`.trim();
+
+export const STUDY_OUTPUT_GUIDE = `
+Default structure if format is unspecified:
+- Key ideas (2–4 bullets)
+- Step-by-step explanation (5–8 short steps)
+- Quick checks/mnemonics (2–4 lines)
+- Caveats/contraindications if applicable
+`.trim();
+
+export function languageInstruction(lang: string) {
+  return `
+Respond entirely in "${lang}".
+Do not mix languages. If user input contains multiple languages, translate your output into "${lang}".
+Keep technical terms in "${lang}" unless the canonical term is universally used in another language (e.g., drug names).
+`.trim();
+}


### PR DESCRIPTION
## Summary
- attach the active UI language to chat stream requests alongside existing helper flags
- add reusable study/thinking prompt helpers and a strict language instruction utility
- enforce the language lock server-side and append study/thinking guidance when requested

## Testing
- npm run lint *(blocked by interactive Next.js ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68e2665bead4832f9e5dfc813ecc43f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added Study and Thinking modes that guide tone, structure, and reasoning.
  * Improved language selection with a clear default and consistent, single-language replies.
  * Research mode can auto-fetch and include a summarized sources section.
  * Profile-aware and clinical context prompts produce more tailored answers.
  * Duplicate request protection prevents accidental double sends.

* Refactor
  * Stream endpoint now builds query parameters dynamically for mode, research, and language.
  * Localization hook now also exposes the active language for more reliable UI text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->