### PR TITLE
Improve language directives for non-English modes

### DIFF
--- a/lib/prompt/system.ts
+++ b/lib/prompt/system.ts
@@ -7,20 +7,24 @@ const DEFAULT_LOCALE = "en-IN";
 
 const LANGUAGE_NAMES: Record<string, string> = {
   ar: "Arabic",
+  de: "German",
   en: "English",
   es: "Spanish",
   fr: "French",
   hi: "Hindi",
   it: "Italian",
+  zh: "Chinese",
 };
 
 const LOCALE_MAP: Record<string, string> = {
   ar: "ar-AE",
+  de: "de-DE",
   en: "en-IN",
   es: "es-ES",
   fr: "fr-FR",
   hi: "hi-IN",
   it: "it-IT",
+  zh: "zh-CN",
 };
 
 const cap = (s: string, n: number) =>
@@ -79,7 +83,8 @@ export function resolveLocaleForLang(lang?: string): string {
 
 export const languageDirectiveFor = (lang: string = SYSTEM_DEFAULT_LANG): string => {
   const code = normalizeLang(lang);
-  return `Always answer in ${code}. If the user writes in another language, still answer in ${code}.`;
+  const label = languageNameFor(code);
+  return `Always answer in ${label} (${code}). If the user writes in another language, still answer in ${label} (${code}).`;
 };
 
 type BuildSystemPromptOptions = {

--- a/lib/prompts/presets.ts
+++ b/lib/prompts/presets.ts
@@ -1,4 +1,5 @@
 import { SUPPORTED_LANGS } from '@/lib/i18n/constants';
+import { languageNameFor } from '@/lib/prompt/system';
 
 export const STUDY_MODE_SYSTEM = `
 Act as a precise, patient medical tutor.
@@ -27,12 +28,13 @@ Default structure if format is unspecified:
 export function languageInstruction(lang: string) {
   const safe = (lang || 'en').toLowerCase().split('-')[0].replace(/[^a-z]/g, '');
   const target = (SUPPORTED_LANGS as readonly string[]).includes(safe) ? safe : 'en';
+  const label = languageNameFor(target);
 
   return `
-Respond entirely in "${target}".
-Do not mix languages. If user input mixes multiple languages, output must be in "${target}".
+Respond entirely in ${label} (${target}).
+Do not mix languages. If user input mixes multiple languages, output must stay in ${label} (${target}).
 Translate numeric headings, lists, and section titles.
 Preserve hyperlinks, file paths, and identifiers exactly as-is.
-Keep technical/medical terms in "${target}" unless no native equivalent exists.
+Keep technical/medical terms in ${label} (${target}) unless no native equivalent exists.
 `.trim();
 }


### PR DESCRIPTION
## Summary
- expand language name and locale mappings so non-English languages include explicit human-readable labels
- update server-side language directives to reference both the language name and code for clarity
- adjust streaming language instruction helper to use the descriptive language name alongside the code, improving compliance from clinical-mode responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2b8619efc832fb83056707b1bf409