### PR TITLE
Add format registry and persist chat format selection

### DIFF
--- a/lib/formats/build.ts
+++ b/lib/formats/build.ts
@@ -1,0 +1,23 @@
+import { Lang, Mode, FormatId } from './types';
+import { FORMATS, isFormatAllowed } from './registry';
+import { HEADING_MAP } from '@/lib/i18n/headingMap';
+
+export function buildFormatInstruction(lang: Lang, mode: Mode, formatId?: FormatId) {
+  if (!formatId) return '';
+  const meta = FORMATS.find(f => f.id === formatId);
+  if (!meta || !isFormatAllowed(formatId, mode)) return '';
+
+  const canonical = meta.canonicalHeading?.toLowerCase();
+  const localized = canonical ? HEADING_MAP[lang]?.[canonical] : undefined;
+
+  const localizedName = meta.label[lang] ?? meta.label['en'] ?? formatId;
+
+  return [
+    `# Output format: ${localizedName}`,
+    meta.systemHint,
+    meta.userGuide ? `User-guide: ${meta.userGuide}` : '',
+    localized ? `Preferred primary heading in ${lang}: "${localized}"` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}

--- a/lib/formats/registry.ts
+++ b/lib/formats/registry.ts
@@ -1,0 +1,61 @@
+import { FormatMeta, Mode } from './types';
+
+export const FORMATS: FormatMeta[] = [
+  {
+    id: 'essay',
+    label: { en: 'Essay', hi: 'निबंध', es: 'Ensayo', it: 'Saggio' },
+    allowedModes: ['wellness', 'therapy', 'wellness_research', 'clinical', 'clinical_research', 'aidoc'],
+    systemHint: `Write a cohesive, logically-structured essay with clear headings and short paragraphs.`,
+    userGuide: `Prefer plain language; avoid jargon unless requested.`,
+    canonicalHeading: 'what it is',
+  },
+  {
+    id: 'bullet_summary',
+    label: { en: 'Bulleted summary', hi: 'बुलेट सार', es: 'Resumen con viñetas', it: 'Riepilogo puntato' },
+    allowedModes: ['wellness', 'therapy', 'wellness_research', 'clinical', 'clinical_research'],
+    systemHint: `Summarize into concise bullet points with sub-bullets for details.`,
+  },
+  {
+    id: 'faq',
+    label: { en: 'FAQ', hi: 'अक्सर पूछे जाने वाले प्रश्न', es: 'Preguntas frecuentes', it: 'Domande frequenti' },
+    allowedModes: ['wellness', 'therapy', 'wellness_research', 'clinical'],
+    systemHint: `Produce a Q&A list. Each answer should be brief and actionable.`,
+  },
+  {
+    id: 'soap_note',
+    label: { en: 'SOAP note', hi: 'SOAP नोट', es: 'Nota SOAP', it: 'Nota SOAP' },
+    allowedModes: ['clinical', 'clinical_research'],
+    systemHint: `Structure as SOAP: Subjective, Objective, Assessment, Plan. Keep ICD/meds generic unless provided.`,
+  },
+  {
+    id: 'care_plan',
+    label: { en: 'Care plan', hi: 'केयर प्लान', es: 'Plan de cuidados', it: 'Piano di cura' },
+    allowedModes: ['clinical', 'clinical_research'],
+    systemHint: `Deliver a concise care plan: Goals, Interventions, Monitoring, Red flags.`,
+  },
+  {
+    id: 'abstract_imrad',
+    label: { en: 'Research abstract (IMRaD)', hi: 'संक्षेप (IMRaD)', es: 'Resumen IMRaD', it: 'Abstract IMRaD' },
+    allowedModes: ['wellness_research', 'clinical_research', 'aidoc'],
+    systemHint: `Use IMRaD headings: Introduction, Methods, Results, Discussion (and Limitations if relevant).`,
+    canonicalHeading: 'overview',
+  },
+  {
+    id: 'table_compare',
+    label: { en: 'Comparison table', hi: 'तुलनात्मक तालिका', es: 'Tabla comparativa', it: 'Tabella comparativa' },
+    allowedModes: ['wellness', 'clinical', 'wellness_research', 'clinical_research', 'aidoc'],
+    systemHint: `Return a simple markdown table with consistent columns and short cells.`,
+  },
+  {
+    id: 'json_structured',
+    label: { en: 'Structured JSON', hi: 'संरचित JSON', es: 'JSON estructurado', it: 'JSON strutturato' },
+    allowedModes: ['aidoc', 'clinical_research', 'wellness_research'],
+    systemHint: `Strictly return valid JSON matching the provided schema. Do not add commentary.`,
+  },
+  // add more as needed...
+];
+
+export function isFormatAllowed(id: FormatMeta['id'], mode: Mode) {
+  const f = FORMATS.find(x => x.id === id);
+  return !!f && f.allowedModes.includes(mode);
+}

--- a/lib/formats/types.ts
+++ b/lib/formats/types.ts
@@ -1,0 +1,32 @@
+export type Mode =
+  | 'wellness'
+  | 'clinical'
+  | 'therapy'
+  | 'wellness_research'
+  | 'clinical_research'
+  | 'aidoc';
+
+export type FormatId =
+  | 'essay'
+  | 'bullet_summary'
+  | 'faq'
+  | 'table_compare'
+  | 'step_by_step'
+  | 'soap_note'
+  | 'care_plan'
+  | 'patient_leaflet'
+  | 'abstract_imrad'
+  | 'json_structured'
+  | 'checklist'
+  | 'algorithm';
+
+export type Lang = 'en' | 'hi' | 'es' | 'it';
+
+export interface FormatMeta {
+  id: FormatId;
+  label: Partial<Record<Lang, string>>;
+  allowedModes: Mode[];
+  systemHint: string;
+  userGuide?: string;
+  canonicalHeading?: string;
+}


### PR DESCRIPTION
## Summary
- add a shared format type/registry with localized labels and mode constraints
- inject format-specific instructions into both chat streaming pipelines so outputs follow the chosen format
- persist the client-side format selection by mode and include it when calling the chat APIs

## Testing
- npm run lint *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b950ce1c832faa424de0f92481b5