### PR TITLE
Fix Markdown message renderer to support tables

### DIFF
--- a/components/chat/Message.tsx
+++ b/components/chat/Message.tsx
@@ -1,4 +1,4 @@
-import Markdown from "react-markdown";
+import ChatMarkdown from "@/components/ChatMarkdown";
 import FeedbackControls from "./FeedbackControls";
 
 type ChatMessage = {
@@ -35,7 +35,7 @@ export default function Message({ message }: MessageProps) {
 
   return (
     <div>
-      <Markdown>{message.content ?? ""}</Markdown>
+      <ChatMarkdown content={message.content ?? ""} />
       <div className="mt-2">
         <FeedbackControls messageId={message.id} />
       </div>


### PR DESCRIPTION
## Summary
- render chat messages with the shared ChatMarkdown component so GitHub-flavored tables are parsed consistently

## Testing
- not run (next lint prompts for configuration in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2ea6b0628832f857639b1fba77254