### PR TITLE
Preserve streamed text when stopping chat

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -872,6 +872,7 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     onContentUpdate: handlePendingContentUpdate,
     onFinalize: handlePendingFinalize,
   });
+  const showStopButton = queueActive || busy || Boolean(pendingAssistantState) || Boolean(abortRef.current);
 
   const sp = useSearchParams();
   const isAiDocMode = useIsAiDocMode();
@@ -4248,7 +4249,7 @@ ${systemCommon}` + baseSys;
                     }}
                   />
 
-                  {(queueActive || busy || abortRef.current) && (
+                  {showStopButton && (
                     <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center">
                       <StopButton
                         onClick={onStop}


### PR DESCRIPTION
## Summary
- store the latest streamed assistant text while a response is pending
- finalize stopped responses using the stored content when no accumulated stream is available
- clear the stored pending content once a message is finalized

## Testing
- not run (requires non-interactive lint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68e2f698a010832f8e775ad73cb0f4d7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures assistant messages finalize with the most recent content when a response is interrupted or canceled.
  * Reduces occurrences of blank or missing text after aborted streaming.
  * Improves consistency of displayed pending text, aligning it with the active locale.
  * Provides a reliable fallback to preserve visible content in edge cases during streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->