### PR TITLE
Adjust mobile chat composer helper chip layout

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -4263,32 +4263,32 @@ ${systemCommon}` + baseSys;
 
                 {activeHelper && (
                   <div className="order-4 flex w-full basis-full items-center gap-2 md:hidden">
-                    {([
-                      { id: 'study' as const, label: t('studyLearn'), Icon: GraduationCap },
-                      { id: 'thinking' as const, label: t('thinkingMode'), Icon: Brain },
-                    ]).map(
-                      ({ id, label, Icon }) => {
-                        const isActive = activeHelper === id;
-                        return (
-                          <button
-                            key={id}
-                            type="button"
-                            aria-pressed={isActive}
-                            onClick={() => {
-                              setActiveHelper(prev => (prev === id ? null : id));
-                              setPlusMenuOpen(false);
-                            }}
-                            className={`flex flex-1 items-center justify-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
-                              isActive
-                                ? 'border-blue-600 bg-blue-600 text-white shadow-sm focus-visible:outline-blue-600'
-                                : 'border-slate-300/70 bg-white/70 text-slate-600 hover:bg-slate-100 focus-visible:outline-blue-500 dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:bg-slate-800'
-                            }`}
-                          >
-                            <Icon className="h-4 w-4" aria-hidden="true" />
-                            <span>{label}</span>
-                          </button>
-                        );
-                      }
+                    {activeHelper === 'study' ? (
+                      <button
+                        type="button"
+                        aria-pressed={true}
+                        onClick={() => {
+                          setActiveHelper(prev => (prev === 'study' ? null : prev));
+                          setPlusMenuOpen(false);
+                        }}
+                        className="flex flex-1 items-center justify-center gap-1 rounded-full border border-blue-600 bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                      >
+                        <GraduationCap className="h-4 w-4" aria-hidden="true" />
+                        <span>{t('studyLearn')}</span>
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        aria-pressed={true}
+                        onClick={() => {
+                          setActiveHelper(prev => (prev === 'thinking' ? null : prev));
+                          setPlusMenuOpen(false);
+                        }}
+                        className="flex flex-1 items-center justify-center gap-1 rounded-full border border-blue-600 bg-blue-600 px-3 py-1 text-xs font-medium text-white shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                      >
+                        <Brain className="h-4 w-4" aria-hidden="true" />
+                        <span>{t('thinkingMode')}</span>
+                      </button>
                     )}
                   </div>
                 )}

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -4114,7 +4114,7 @@ ${systemCommon}` + baseSys;
                   e.preventDefault();
                   onSubmit();
                 }}
-                className="flex w-full items-end gap-3 rounded-2xl border border-slate-200/60 bg-white/90 px-3 py-2 dark:border-slate-700/60 dark:bg-slate-900/80"
+                className="flex w-full flex-wrap items-end gap-2 rounded-2xl border border-slate-200/60 bg-white/90 px-3 py-2 dark:border-slate-700/60 dark:bg-slate-900/80 md:flex-nowrap md:gap-3"
               >
                 <div ref={plusMenuRef} className="relative inline-flex items-center">
                   <button
@@ -4134,14 +4134,14 @@ ${systemCommon}` + baseSys;
 
                   {activeHelper && (
                     <span
-                      className="ml-2 inline-flex items-center gap-2 rounded-full border border-slate-300/70 bg-slate-50 px-3 py-1 text-sm text-foreground dark:border-slate-700/60 dark:bg-slate-900/60"
+                      className="order-3 inline-flex flex-shrink-0 items-center gap-1 rounded-full border border-slate-300/70 bg-slate-50 px-2 py-1 text-xs text-foreground dark:border-slate-700/60 dark:bg-slate-900/60 md:ml-2 md:gap-2 md:px-3 md:py-1 md:text-sm md:order-none"
                       aria-live="polite"
                     >
                       {activeHelper === 'study' ? t('studyLearn') : t('thinkingMode')}
                       <button
                         type="button"
                         aria-label={t('clearSelection')}
-                        className="opacity-70 hover:opacity-100"
+                        className="flex h-7 w-7 items-center justify-center rounded-full bg-slate-200/80 text-slate-600 transition hover:bg-slate-300 dark:bg-slate-800/70 dark:text-slate-200 dark:hover:bg-slate-700"
                         onClick={() => setActiveHelper(null)}
                       >
                         <X className="h-3.5 w-3.5" aria-hidden="true" />

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -4116,7 +4116,7 @@ ${systemCommon}` + baseSys;
                 }}
                 className="flex w-full flex-wrap items-end gap-2 rounded-2xl border border-slate-200/60 bg-white/90 px-3 py-2 dark:border-slate-700/60 dark:bg-slate-900/80 md:flex-nowrap md:gap-3"
               >
-                <div ref={plusMenuRef} className="relative inline-flex items-center">
+                <div ref={plusMenuRef} className="relative inline-flex flex-shrink-0 items-center">
                   <button
                     type="button"
                     aria-haspopup="menu"
@@ -4131,23 +4131,6 @@ ${systemCommon}` + baseSys;
                   >
                     <Plus className="h-5 w-5" aria-hidden="true" />
                   </button>
-
-                  {activeHelper && (
-                    <span
-                      className="order-3 inline-flex flex-shrink-0 items-center gap-1 rounded-full border border-slate-300/70 bg-slate-50 px-2 py-1 text-xs text-foreground dark:border-slate-700/60 dark:bg-slate-900/60 md:ml-2 md:gap-2 md:px-3 md:py-1 md:text-sm md:order-none"
-                      aria-live="polite"
-                    >
-                      {activeHelper === 'study' ? t('studyLearn') : t('thinkingMode')}
-                      <button
-                        type="button"
-                        aria-label={t('clearSelection')}
-                        className="flex h-7 w-7 items-center justify-center rounded-full bg-slate-200/80 text-slate-600 transition hover:bg-slate-300 dark:bg-slate-800/70 dark:text-slate-200 dark:hover:bg-slate-700"
-                        onClick={() => setActiveHelper(null)}
-                      >
-                        <X className="h-3.5 w-3.5" aria-hidden="true" />
-                      </button>
-                    </span>
-                  )}
 
                   {isPlusMenuOpen && (
                     <div
@@ -4197,6 +4180,23 @@ ${systemCommon}` + baseSys;
                   )}
                 </div>
 
+                {activeHelper && (
+                  <span
+                    className="order-3 inline-flex min-h-[2.25rem] basis-full items-center gap-1 rounded-full border border-slate-300/70 bg-slate-50 px-2 py-1 text-xs text-foreground dark:border-slate-700/60 dark:bg-slate-900/60 md:order-none md:ml-2 md:basis-auto md:gap-2 md:px-3 md:py-1 md:text-sm"
+                    aria-live="polite"
+                  >
+                    {activeHelper === 'study' ? t('studyLearn') : t('thinkingMode')}
+                    <button
+                      type="button"
+                      aria-label={t('clearSelection')}
+                      className="flex h-7 w-7 items-center justify-center rounded-full bg-slate-200/80 text-slate-600 transition hover:bg-slate-300 dark:bg-slate-800/70 dark:text-slate-200 dark:hover:bg-slate-700"
+                      onClick={() => setActiveHelper(null)}
+                    >
+                      <X className="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
+                  </span>
+                )}
+
                 <input
                   ref={fileInputRef}
                   type="file"
@@ -4209,7 +4209,7 @@ ${systemCommon}` + baseSys;
                     e.currentTarget.value = '';
                   }}
                 />
-                <div className="relative flex-1">
+                <div className="relative flex-1 basis-full min-w-0 md:basis-auto">
                   <textarea
                     ref={inputRef as unknown as RefObject<HTMLTextAreaElement>}
                     rows={1}

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -4182,7 +4182,7 @@ ${systemCommon}` + baseSys;
 
                 {activeHelper && (
                   <span
-                    className="order-3 inline-flex min-h-[2.25rem] basis-full items-center gap-1 rounded-full border border-slate-300/70 bg-slate-50 px-2 py-1 text-xs text-foreground dark:border-slate-700/60 dark:bg-slate-900/60 md:order-none md:ml-2 md:basis-auto md:gap-2 md:px-3 md:py-1 md:text-sm"
+                    className="order-3 hidden min-h-[2.25rem] basis-full items-center gap-1 rounded-full border border-slate-300/70 bg-slate-50 px-2 py-1 text-xs text-foreground dark:border-slate-700/60 dark:bg-slate-900/60 md:inline-flex md:order-none md:ml-2 md:basis-auto md:gap-2 md:px-3 md:py-1 md:text-sm"
                     aria-live="polite"
                   >
                     {activeHelper === 'study' ? t('studyLearn') : t('thinkingMode')}
@@ -4209,7 +4209,7 @@ ${systemCommon}` + baseSys;
                     e.currentTarget.value = '';
                   }}
                 />
-                <div className="relative flex-1 basis-full min-w-0 md:basis-auto">
+                <div className="relative order-2 flex-1 min-w-0 md:order-none md:basis-auto">
                   <textarea
                     ref={inputRef as unknown as RefObject<HTMLTextAreaElement>}
                     rows={1}
@@ -4251,7 +4251,7 @@ ${systemCommon}` + baseSys;
 
                 {!busy && (
                   <button
-                    className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:opacity-50"
+                    className="order-3 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 disabled:opacity-50 md:order-none"
                     type="submit"
                     disabled={pendingFiles.length === 0 && !userText.trim()}
                     aria-label="Send"
@@ -4260,6 +4260,36 @@ ${systemCommon}` + baseSys;
                     <Send size={16} />
                   </button>
                 )}
+
+                <div className="order-4 flex w-full basis-full items-center gap-2 md:hidden">
+                  {([
+                    { id: 'study' as const, label: t('studyLearn'), Icon: GraduationCap },
+                    { id: 'thinking' as const, label: t('thinkingMode'), Icon: Brain },
+                  ]).map(
+                    ({ id, label, Icon }) => {
+                      const isActive = activeHelper === id;
+                      return (
+                        <button
+                          key={id}
+                          type="button"
+                          aria-pressed={isActive}
+                          onClick={() => {
+                            setActiveHelper(prev => (prev === id ? null : id));
+                            setPlusMenuOpen(false);
+                          }}
+                          className={`flex flex-1 items-center justify-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+                            isActive
+                              ? 'border-blue-600 bg-blue-600 text-white shadow-sm focus-visible:outline-blue-600'
+                              : 'border-slate-300/70 bg-white/70 text-slate-600 hover:bg-slate-100 focus-visible:outline-blue-500 dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:bg-slate-800'
+                          }`}
+                        >
+                          <Icon className="h-4 w-4" aria-hidden="true" />
+                          <span>{label}</span>
+                        </button>
+                      );
+                    }
+                  )}
+                </div>
               </form>
             </div>
         </div>

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -4261,35 +4261,37 @@ ${systemCommon}` + baseSys;
                   </button>
                 )}
 
-                <div className="order-4 flex w-full basis-full items-center gap-2 md:hidden">
-                  {([
-                    { id: 'study' as const, label: t('studyLearn'), Icon: GraduationCap },
-                    { id: 'thinking' as const, label: t('thinkingMode'), Icon: Brain },
-                  ]).map(
-                    ({ id, label, Icon }) => {
-                      const isActive = activeHelper === id;
-                      return (
-                        <button
-                          key={id}
-                          type="button"
-                          aria-pressed={isActive}
-                          onClick={() => {
-                            setActiveHelper(prev => (prev === id ? null : id));
-                            setPlusMenuOpen(false);
-                          }}
-                          className={`flex flex-1 items-center justify-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
-                            isActive
-                              ? 'border-blue-600 bg-blue-600 text-white shadow-sm focus-visible:outline-blue-600'
-                              : 'border-slate-300/70 bg-white/70 text-slate-600 hover:bg-slate-100 focus-visible:outline-blue-500 dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:bg-slate-800'
-                          }`}
-                        >
-                          <Icon className="h-4 w-4" aria-hidden="true" />
-                          <span>{label}</span>
-                        </button>
-                      );
-                    }
-                  )}
-                </div>
+                {activeHelper && (
+                  <div className="order-4 flex w-full basis-full items-center gap-2 md:hidden">
+                    {([
+                      { id: 'study' as const, label: t('studyLearn'), Icon: GraduationCap },
+                      { id: 'thinking' as const, label: t('thinkingMode'), Icon: Brain },
+                    ]).map(
+                      ({ id, label, Icon }) => {
+                        const isActive = activeHelper === id;
+                        return (
+                          <button
+                            key={id}
+                            type="button"
+                            aria-pressed={isActive}
+                            onClick={() => {
+                              setActiveHelper(prev => (prev === id ? null : id));
+                              setPlusMenuOpen(false);
+                            }}
+                            className={`flex flex-1 items-center justify-center gap-1 rounded-full border px-3 py-1 text-xs font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+                              isActive
+                                ? 'border-blue-600 bg-blue-600 text-white shadow-sm focus-visible:outline-blue-600'
+                                : 'border-slate-300/70 bg-white/70 text-slate-600 hover:bg-slate-100 focus-visible:outline-blue-500 dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200 dark:hover:bg-slate-800'
+                            }`}
+                          >
+                            <Icon className="h-4 w-4" aria-hidden="true" />
+                            <span>{label}</span>
+                          </button>
+                        );
+                      }
+                    )}
+                  </div>
+                )}
               </form>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- allow the chat composer form to wrap on mobile so helper chips can drop below the textarea instead of squashing it
- reduce helper chip sizing on small screens while preserving the desktop treatment
- expand the helper chip dismiss control to a padded, finger-friendly target

## Testing
- npm run dev *(fails: Module not found: Can't resolve 'rehype-sanitize')*

------
https://chatgpt.com/codex/tasks/task_e_68e2f6313890832f9d6d2da6fc6e6e33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a mobile-only action bar with quick toggles for Study/Learn and Thinking Mode, including icons and active-state feedback.
- Style
  - Improved responsive layout of the composer row with better wrapping on small screens and tighter alignment on larger screens.
  - Prevented the plus-menu from shrinking in tight layouts.
  - Reintroduced a responsive helper badge with a clearer inline display and a close button, adjusting its placement across breakpoints.
  - Refined input and action ordering to maintain consistent behavior across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->