### PR TITLE
Ensure table requests override pinned formats

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -2348,14 +2348,14 @@ export default function ChatPane({ inputRef: externalInputRef }: { inputRef?: Re
     const resolvedMode = activeModeTag && isValidMode(activeModeTag) ? activeModeTag : undefined;
     if (!resolvedMode) return formatId;
 
-    const userPinnedFormat = formatMap[resolvedMode];
-    if (userPinnedFormat && isFormatAllowed(userPinnedFormat, resolvedMode)) {
-      return userPinnedFormat;
-    }
-
     const wantsTable = looksLikeTableIntent(messageText) || looksLikeComparisonIntent(messageText);
     if (wantsTable && isFormatAllowed('table_compare', resolvedMode)) {
       return 'table_compare';
+    }
+
+    const userPinnedFormat = formatMap[resolvedMode];
+    if (userPinnedFormat && isFormatAllowed(userPinnedFormat, resolvedMode)) {
+      return userPinnedFormat;
     }
 
     if (formatId && isFormatAllowed(formatId, resolvedMode)) {


### PR DESCRIPTION
## Summary
- allow the table/comparison intent detection to run before reading any stored format preference so that table responses are not blocked by a previously selected format

## Testing
- `npm run lint` *(fails: command prompts for ESLint config in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fd567394832f9b33a999e79f5489