### PR TITLE
Send format hints and respect pinned modes

### DIFF
--- a/app/api/chat/stream-final/route.ts
+++ b/app/api/chat/stream-final/route.ts
@@ -38,6 +38,14 @@ export async function POST(req: Request) {
   const formatId = rawFormat && FORMATS.some(f => f.id === rawFormat)
     ? (rawFormat as FormatId)
     : undefined;
+  const formatPinned: boolean = payload?.formatPinned === true;
+  const formatHintRaw: string | undefined = typeof payload?.formatHint === 'string' ? payload.formatHint : undefined;
+  const formatHint: FormatId | undefined = (() => {
+    if (!formatHintRaw) return undefined;
+    const normalized = formatHintRaw.trim().toLowerCase();
+    const match = FORMATS.find(f => f.id === normalized);
+    return match ? (match.id as FormatId) : undefined;
+  })();
   const rawModeTag = payload?.modeTag ?? mode;
   const normalizedModeTag = normalizeModeTag(rawModeTag);
   const resolvedMode: Mode = isValidMode(normalizedModeTag) ? normalizedModeTag : 'wellness';
@@ -50,8 +58,17 @@ export async function POST(req: Request) {
   const langTag = (requestedLang && requestedLang.trim()) || (headerLang && headerLang.trim()) || SYSTEM_DEFAULT_LANG;
   const lang = normalizeLangTag(langTag);
   const langDirective = languageDirectiveFor(lang);
+  const formatInstructionFor = (fid?: FormatId) => buildFormatInstruction(lang as any, resolvedMode, fid);
+  const effectiveFormatId = ((): FormatId | undefined => {
+    const isAllowed = (fid?: FormatId) => (fid ? Boolean(formatInstructionFor(fid)) : false);
+
+    if (formatPinned && isAllowed(formatId)) return formatId!;
+    if (!formatPinned && isAllowed(formatId)) return formatId!;
+    if (isAllowed(formatHint)) return formatHint!;
+    return undefined;
+  })();
   const formatInstruction = isValidLang(lang)
-    ? buildFormatInstruction(lang, resolvedMode, formatId)
+    ? formatInstructionFor(effectiveFormatId)
     : '';
 
   const lastUserMessage =
@@ -82,7 +99,7 @@ export async function POST(req: Request) {
   const modelMs = Date.now() - modelStart;
 
   const modeAllowed = Boolean(formatInstruction);
-  const shouldCoerceToTable = modeAllowed && needsTableCoercion(formatId);
+  const shouldCoerceToTable = modeAllowed && needsTableCoercion(effectiveFormatId);
 
   if (shouldCoerceToTable) {
     const rawSse = await upstream.text();


### PR DESCRIPTION
## Summary
- send the active modeTag along with a formatPinned flag and optional table format hint from the chat pane
- keep client format selection stable while surfacing table/comparison intent as a soft hint
- update both streaming endpoints to honor pinned formats, explicit requests, and hints via a single decision path

## Testing
- not run (next lint prompts for configuration in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e30f0432c8832f9f48c80832cb03fd