### PR TITLE
Allow comparison table format in therapy mode

### DIFF
--- a/lib/formats/registry.ts
+++ b/lib/formats/registry.ts
@@ -43,7 +43,7 @@ export const FORMATS: FormatMeta[] = [
   {
     id: 'table_compare',
     label: { en: 'Comparison table', hi: 'तुलनात्मक तालिका', es: 'Tabla comparativa', it: 'Tabella comparativa' },
-    allowedModes: ['wellness', 'clinical', 'wellness_research', 'clinical_research', 'aidoc'],
+    allowedModes: ['wellness', 'therapy', 'clinical', 'wellness_research', 'clinical_research', 'aidoc'],
     systemHint: [
       'Return a **single markdown table only** (no prose before or after).',
       'Columns (exact, in this order): Topic | Mechanism/How it works | Expected benefit | Limitations/Side effects | Notes/Evidence',

--- a/test/formats.tableCompare.test.ts
+++ b/test/formats.tableCompare.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isFormatAllowed } from '@/lib/formats/registry';
+import type { Mode } from '@/lib/formats/types';
+
+const TABLE_MODES: Mode[] = [
+  'wellness',
+  'therapy',
+  'clinical',
+  'wellness_research',
+  'clinical_research',
+  'aidoc',
+];
+
+describe('table_compare format availability', () => {
+  it('is enabled across all supported modes', () => {
+    TABLE_MODES.forEach(mode => {
+      expect(isFormatAllowed('table_compare', mode)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- allow the comparison table format to be used in therapy mode by expanding its allowed modes list
- add a unit test ensuring table_compare is enabled across all modes

## Testing
- npx vitest run test/formats.tableCompare.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e37d14d4dc832fa37a3c900314df0a