### PR TITLE
Add ads broker API endpoint with mock partner offers

### DIFF
--- a/app/api/ads/broker/route.ts
+++ b/app/api/ads/broker/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { broker } from '@/lib/ads/broker';
+import { AdContext } from '@/types/ads';
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(()=> ({}));
+  const ctx: AdContext = {
+    text: String(body.text ?? '').slice(0, 500),
+    region: String(body.region ?? process.env.ADS_REGION_DEFAULT ?? 'IN-DL'),
+    tier: (body.tier ?? 'free'),
+    zone: (body.zone ?? 'chat'),
+  };
+  const result = await broker(ctx);
+  return NextResponse.json(result, { status: 200 });
+}

--- a/lib/ads/broker.ts
+++ b/lib/ads/broker.ts
@@ -1,0 +1,31 @@
+import { AdContext, BrokerResult } from '@/types/ads';
+import { extractKeywords, chooseCategory } from './intent';
+import { getLabOffer } from './partners/labs';
+import { getOtcOffer } from './partners/otc';
+import { getClinicOffer } from './partners/clinic';
+
+function flag(name:string, def=''): string {
+  const v = process.env[name];
+  return (v===undefined || v===null) ? def : v;
+}
+function bool(name:string, def=false): boolean {
+  const v = flag(name);
+  return v ? ['1','true','yes','on'].includes(v.toLowerCase()) : def;
+}
+
+export async function broker(ctx: AdContext): Promise<BrokerResult> {
+  if (!bool('ADS_ENABLED')) return { reason: 'disabled' };
+  const noZones = flag('ADS_NO_ZONES','').split(',').map(s=>s.trim()).filter(Boolean);
+  if (noZones.includes(ctx.zone)) return { reason: 'zone_blocked' };
+  if (!(['free','100'] as const).includes(ctx.tier)) return { reason: 'disabled' };
+
+  const kws = extractKeywords(ctx.text);
+  const cat = chooseCategory(kws);
+  let card = null;
+  if (cat==='labs') card = await getLabOffer(ctx.region);
+  else if (cat==='otc') card = await getOtcOffer(ctx.region);
+  else card = await getClinicOffer(ctx.region);
+
+  if (!card) return { reason: 'no_fill' };
+  return { card };
+}

--- a/lib/ads/intent.ts
+++ b/lib/ads/intent.ts
@@ -1,0 +1,15 @@
+export function extractKeywords(msg: string): string[] {
+  const m = (msg||'').toLowerCase();
+  const kw = new Set<string>();
+  if (/\bldl|lipid|cholesterol\b/.test(m)) kw.add('lipid_profile');
+  if (/\bvitamin d|25-oh\b/.test(m)) kw.add('vitamin_d');
+  if (/\bcough|chest|wheeze\b/.test(m)) kw.add('respiratory');
+  if (kw.size===0 && /\btest|report|panel\b/.test(m)) kw.add('labs_generic');
+  return [...kw];
+}
+export function chooseCategory(k: string[]): 'labs'|'otc'|'clinic' {
+  if (k.includes('lipid_profile') || k.includes('labs_generic')) return 'labs';
+  if (k.includes('vitamin_d')) return 'otc';
+  if (k.includes('respiratory')) return 'clinic';
+  return 'labs';
+}

--- a/lib/ads/partners/clinic.ts
+++ b/lib/ads/partners/clinic.ts
@@ -1,0 +1,13 @@
+import { AdCard } from '@/types/ads';
+export async function getClinicOffer(region: string): Promise<AdCard|null> {
+  return {
+    slot: 'inline',
+    category: 'clinic',
+    title: 'Respiratory Specialist Consultation',
+    body: 'Video & in-person • Same-day slots',
+    cta: { label: 'Book Visit', url: 'https://example.com/respiratory?src=secondop' },
+    sponsor: { id: 'city_care', name: 'CityCare Pulmonology' },
+    labels: { sponsored: true, whyThis: 'For cough or breathing symptoms.' },
+    compliance: { contextualOnly: true, region }
+  };
+}

--- a/lib/ads/partners/labs.ts
+++ b/lib/ads/partners/labs.ts
@@ -1,0 +1,13 @@
+import { AdCard } from '@/types/ads';
+export async function getLabOffer(region: string): Promise<AdCard|null> {
+  return {
+    slot: 'inline',
+    category: 'labs',
+    title: 'Lipid Panel — Home Pickup',
+    body: 'NABL-certified • Delhi NCR',
+    cta: { label: 'Book Test', url: 'https://example.com/lipid?src=secondop' },
+    sponsor: { id: 'srl', name: 'SRL / Dr Lal' },
+    labels: { sponsored: true, whyThis: 'You asked about cholesterol.' },
+    compliance: { contextualOnly: true, region }
+  };
+}

--- a/lib/ads/partners/otc.ts
+++ b/lib/ads/partners/otc.ts
@@ -1,0 +1,13 @@
+import { AdCard } from '@/types/ads';
+export async function getOtcOffer(region: string): Promise<AdCard|null> {
+  return {
+    slot: 'inline',
+    category: 'otc',
+    title: 'Vitamin D3 Supplement — 60 Tabs',
+    body: 'Clinically dosed • Free shipping',
+    cta: { label: 'Buy Now', url: 'https://example.com/vitd?src=secondop' },
+    sponsor: { id: 'pharmacy_inc', name: 'Second Opinion Pharmacy' },
+    labels: { sponsored: true, whyThis: 'Mentioned low Vitamin D.' },
+    compliance: { contextualOnly: true, region }
+  };
+}

--- a/types/ads.ts
+++ b/types/ads.ts
@@ -1,0 +1,26 @@
+export type AdCategory = 'labs' | 'otc' | 'clinic';
+export type AdSlot = 'inline' | 'sidebar';
+export type UserTier = 'free'|'100'|'200'|'500';
+
+export interface AdContext {
+  text: string;  // last user/AI msg (server-side only)
+  region: string; // e.g., IN-DL
+  tier: UserTier;
+  zone: string;  // 'chat' | 'reports' | 'aidoc' | 'directory'
+}
+
+export interface AdCard {
+  slot: AdSlot;
+  category: AdCategory;
+  title: string;
+  body?: string;
+  cta: { label: string; url: string };
+  sponsor: { id: string; name: string };
+  labels: { sponsored: true; whyThis?: string };
+  compliance: { contextualOnly: true; region: string };
+}
+
+export interface BrokerResult {
+  card?: AdCard;
+  reason?: 'disabled'|'zone_blocked'|'freq_cap'|'no_fill';
+}


### PR DESCRIPTION
## Summary
- add shared ad type definitions for broker and partners
- implement deterministic keyword extraction and broker routing logic
- add mock partner adapters and expose Next.js API route for ads broker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e0782e68832f8724e52f4630abfa