### PR TITLE
Improve chat streaming performance

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -3,7 +3,6 @@ export const dynamic = "force-dynamic";
 export const preferredRegion = ["bom1", "sin1", "hnd1"];
 
 import { NextResponse } from "next/server";
-import { randomUUID } from "crypto";
 import { createParser } from "eventsource-parser";
 import { prisma } from "@/lib/prisma";
 import { appendMessage } from "@/lib/memory/store";
@@ -287,7 +286,7 @@ export async function POST(req: Request) {
   let conversationId = headers.get("x-conversation-id");
   let isNewChat = headers.get("x-new-chat") === "true";
   if (!conversationId) {
-    conversationId = randomUUID();
+    conversationId = generateConversationId();
     isNewChat = true;
     console.log("missing_conversation_id");
   }
@@ -662,4 +661,12 @@ export async function POST(req: Request) {
     maxTokens: 1200,
     persist: true,
   });
+}
+function generateConversationId() {
+  const globalCrypto = (globalThis as typeof globalThis & { crypto?: Crypto }).crypto;
+  if (globalCrypto?.randomUUID) {
+    return globalCrypto.randomUUID();
+  }
+  // Extremely unlikely fallback that keeps us working in older runtimes.
+  return `medx-${Math.random().toString(36).slice(2)}-${Date.now()}`;
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -61,6 +61,14 @@ type LogPayload =
   | { type: "persist_message"; data: { threadId: string; role: "user" | "assistant"; content: string } }
   | { type: "finalize_turn"; data: { threadId: string; assistant: string; summary?: string } };
 
+function randomId() {
+  const globalCrypto = (globalThis as typeof globalThis & { crypto?: Crypto }).crypto;
+  if (globalCrypto?.randomUUID) {
+    return globalCrypto.randomUUID();
+  }
+  return `${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
 async function postLog(origin: string, payload: LogPayload) {
   try {
     await fetch(`${origin}/api/log`, {
@@ -410,7 +418,7 @@ export async function POST(req: Request) {
   if (isNewChat) {
     console.log("new_chat_started", { conversationId });
     logChatEvent(origin, {
-      id: crypto.randomUUID(),
+      id: randomId(),
       kind: "chat_start",
       conversationId,
       userId: userId ?? null,
@@ -422,7 +430,7 @@ export async function POST(req: Request) {
     activeThreadId = conversationId;
     if (isNewChat) {
       logChatEvent(origin, {
-        id: crypto.randomUUID(),
+        id: randomId(),
         kind: "chat_thread_cleanup",
         threadId: activeThreadId,
       });
@@ -639,10 +647,10 @@ export async function POST(req: Request) {
   if (decision.action === "continue") {
     threadId = decision.threadId;
   } else if (decision.action === "newThread") {
-    const newId = crypto.randomUUID();
+    const newId = randomId();
     threadId = newId;
     logChatEvent(origin, {
-      id: crypto.randomUUID(),
+      id: randomId(),
       kind: "chat_thread_create",
       threadId: newId,
       userId: userId ?? null,
@@ -791,8 +799,8 @@ export async function POST(req: Request) {
 function generateConversationId() {
   const globalCrypto = (globalThis as typeof globalThis & { crypto?: Crypto }).crypto;
   if (globalCrypto?.randomUUID) {
-    return globalCrypto.randomUUID();
+    return randomId();
   }
   // Extremely unlikely fallback that keeps us working in older runtimes.
-  return `medx-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+  return `medx-${randomId()}`;
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -591,6 +591,7 @@ export async function POST(req: Request) {
       temperature: 0.25,
       maxTokens: 1200,
       persist: false,
+      origin,
     });
   }
 

--- a/app/api/chat/stream-final/route.ts
+++ b/app/api/chat/stream-final/route.ts
@@ -18,7 +18,7 @@ try {
   ({ computeAll } = require("@/lib/medical/engine/computeAll"));
 } catch {}
 
-export const runtime = "nodejs";
+export const runtime = "edge";
 export const dynamic = "force-dynamic";
 
 function normalizeLangTag(tag?: string | null) {
@@ -86,7 +86,7 @@ export async function POST(req: Request) {
   const modeAllowed = Boolean(formatInstruction);
   const shouldCoerceToTable = modeAllowed && needsTableCoercion(formatId);
 
-  const inlineTableCoercionEnabled = process.env.TABLE_COERCE_INLINE === "1";
+  const inlineTableCoercionEnabled = process.env.TABLE_COERCE_INLINE === "1"; // keep OFF in prod
 
   if (inlineTableCoercionEnabled && shouldCoerceToTable) {
     const rawSse = await upstream.text();

--- a/app/api/chat/stream-final/route.ts
+++ b/app/api/chat/stream-final/route.ts
@@ -9,7 +9,7 @@ import { needsTableCoercion } from "@/lib/formats/tableGuard";
 import { shapeToTable } from "@/lib/formats/tableShape";
 import type { FormatId, Mode } from "@/lib/formats/types";
 import { enforceLocale } from "@/lib/i18n/enforce";
-import { createParser } from "eventsource-parser";
+import { createParser, type ParsedEvent, type ReconnectInterval } from "eventsource-parser";
 import { polishText } from "@/lib/text/polish";
 import { selfCheck } from "@/lib/text/selfCheck";
 import { addEvidenceAnchorIfMedical } from "@/lib/text/medicalAnchor";
@@ -264,7 +264,7 @@ export async function POST(req: Request) {
         }
       }, heartbeatMs);
 
-      const parser = createParser((event) => {
+      const parser = createParser((event: ParsedEvent | ReconnectInterval) => {
         if (event.type !== "event") return;
         const data = event.data;
         if (data === "[DONE]") {

--- a/app/api/chat/stream-final/route.ts
+++ b/app/api/chat/stream-final/route.ts
@@ -1,14 +1,22 @@
 import { callOpenAIChat } from "@/lib/medx/providers";
 import { languageDirectiveFor, SYSTEM_DEFAULT_LANG } from "@/lib/prompt/system";
 import { SUPPORTED_LANGS } from "@/lib/i18n/constants";
-import { createLocaleEnforcedStream, enforceLocale } from "@/lib/i18n/enforce";
 import { normalizeModeTag } from "@/lib/i18n/normalize";
 import { buildFormatInstruction } from "@/lib/formats/build";
 import { FORMATS } from "@/lib/formats/registry";
 import { isValidLang, isValidMode } from "@/lib/formats/constants";
 import { needsTableCoercion } from "@/lib/formats/tableGuard";
-import { hasMarkdownTable, shapeToTable } from "@/lib/formats/tableShape";
+import { shapeToTable } from "@/lib/formats/tableShape";
 import type { FormatId, Mode } from "@/lib/formats/types";
+import { enforceLocale } from "@/lib/i18n/enforce";
+import { createParser } from "eventsource-parser";
+import { polishText } from "@/lib/text/polish";
+import { selfCheck } from "@/lib/text/selfCheck";
+import { addEvidenceAnchorIfMedical } from "@/lib/text/medicalAnchor";
+import { buildConstraintRecap } from "@/lib/text/recap";
+import { sanitizeLLM } from "@/lib/conversation/sanitize";
+import { finalReplyGuard } from "@/lib/conversation/finalReplyGuard";
+import { updateSummary } from "@/lib/memory/summary";
 
 // Optional calculator prelude (safe if engine absent)
 let composeCalcPrelude: any, extractAll: any, canonicalizeInputs: any, computeAll: any;
@@ -22,44 +30,101 @@ export const runtime = "edge";
 export const dynamic = "force-dynamic";
 
 function normalizeLangTag(tag?: string | null) {
-  if (!tag) return 'en';
-  const base = tag.toLowerCase().split('-')[0].replace(/[^a-z]/g, '');
-  return (SUPPORTED_LANGS as readonly string[]).includes(base as any) ? base : 'en';
+  if (!tag) return "en";
+  const base = tag.toLowerCase().split("-")[0].replace(/[^a-z]/g, "");
+  return (SUPPORTED_LANGS as readonly string[]).includes(base as any) ? base : "en";
+}
+
+type FinalizeContext = {
+  req: Request;
+  userText: string;
+  state?: any;
+  threadId?: string | null;
+  persist: boolean;
+  researchSources: any[];
+};
+
+function resolveBaseUrl(req: Request) {
+  const envBase = process.env.NEXT_PUBLIC_BASE_URL;
+  if (envBase) return envBase.replace(/\/$/, "");
+  const url = new URL(req.url);
+  const proto = req.headers.get("x-forwarded-proto") || url.protocol.replace(/:$/, "");
+  const host = req.headers.get("x-forwarded-host") || url.host;
+  return `${proto}://${host}`;
+}
+
+async function finalizeNonBlocking(raw: string, ctx: FinalizeContext) {
+  const trimmed = raw.trim();
+  if (!trimmed) return;
+
+  try {
+    let assistant = polished(trimmed, ctx);
+
+    if (ctx.persist && ctx.threadId) {
+      const prevSummary = typeof ctx.state?.runningSummary === "string" ? ctx.state.runningSummary : "";
+      const nextSummary = updateSummary(prevSummary, ctx.userText, assistant);
+      const expectedVersion = typeof ctx.state?.threadVersion === "number"
+        ? ctx.state.threadVersion
+        : typeof ctx.state?.version === "number"
+          ? ctx.state.version
+          : undefined;
+
+      await fetch(`${resolveBaseUrl(ctx.req)}/api/log`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          kind: "assistant_append_summary",
+          threadId: ctx.threadId,
+          assistantContent: assistant,
+          newSummary: nextSummary,
+          expectedVersion,
+        }),
+        keepalive: true,
+      }).catch(() => {});
+    }
+  } catch (err) {
+    console.error("[stream-final] finalize failed", err);
+  }
+}
+
+function polished(raw: string, ctx: Pick<FinalizeContext, "state" | "userText">) {
+  let assistant = raw;
+  assistant = polishText(assistant);
+  const check = selfCheck(assistant, ctx.state?.constraints, ctx.state?.entities);
+  assistant = check.fixed;
+  assistant = addEvidenceAnchorIfMedical(assistant);
+  const recap = buildConstraintRecap(ctx.state?.constraints);
+  if (recap) assistant += recap;
+  assistant = sanitizeLLM(assistant);
+  assistant = finalReplyGuard(ctx.userText, assistant);
+  return assistant;
 }
 
 export async function POST(req: Request) {
-  const t0 = Date.now();
-  // eslint-disable-next-line no-console
-  console.log("[stream-final] start", t0);
+  const startedAt = Date.now();
+  console.log("[stream-final] start", startedAt);
+
   const payload = await req.json();
   const { messages = [], mode } = payload ?? {};
-  const rawFormat = typeof payload?.formatId === 'string'
-    ? payload.formatId.trim().toLowerCase()
-    : '';
-  const formatId = rawFormat && FORMATS.some(f => f.id === rawFormat)
-    ? (rawFormat as FormatId)
-    : undefined;
+  const rawFormat = typeof payload?.formatId === "string" ? payload.formatId.trim().toLowerCase() : "";
+  const formatId = rawFormat && FORMATS.some((f) => f.id === rawFormat) ? (rawFormat as FormatId) : undefined;
   const rawModeTag = payload?.modeTag ?? mode;
   const normalizedModeTag = normalizeModeTag(rawModeTag);
-  const resolvedMode: Mode = isValidMode(normalizedModeTag) ? normalizedModeTag : 'wellness';
-  if (process.env.NODE_ENV !== 'production' && !payload?.modeTag) {
-    // eslint-disable-next-line no-console
-    console.warn('[medx] Missing modeTag in request body; falling back to legacy mode:', mode);
+  const resolvedMode: Mode = isValidMode(normalizedModeTag) ? normalizedModeTag : "wellness";
+  if (process.env.NODE_ENV !== "production" && !payload?.modeTag) {
+    console.warn("[medx] Missing modeTag in request body; falling back to legacy mode:", mode);
   }
-  const requestedLang = typeof payload?.lang === 'string' ? payload.lang : undefined;
-  const headerLang = req.headers.get('x-user-lang') || req.headers.get('x-lang') || undefined;
+
+  const requestedLang = typeof payload?.lang === "string" ? payload.lang : undefined;
+  const headerLang = req.headers.get("x-user-lang") || req.headers.get("x-lang") || undefined;
   const langTag = (requestedLang && requestedLang.trim()) || (headerLang && headerLang.trim()) || SYSTEM_DEFAULT_LANG;
   const lang = normalizeLangTag(langTag);
   const langDirective = languageDirectiveFor(lang);
-  const formatInstruction = isValidLang(lang)
-    ? buildFormatInstruction(lang, resolvedMode, formatId)
-    : '';
+  const formatInstruction = isValidLang(lang) ? buildFormatInstruction(lang, resolvedMode, formatId) : "";
 
   const lastUserMessage =
     messages.slice().reverse().find((m: any) => m.role === "user")?.content || "";
 
-  // This endpoint is explicitly the OpenAI (final say) stream for non-basic modes.
-  // Keep your current /api/chat/stream for Groq/basic.
   let system = "Validate all calculations and medical logic before answering. Correct any inconsistencies.";
   if ((process.env.CALC_AI_DISABLE || "0") !== "1") {
     try {
@@ -72,59 +137,90 @@ export async function POST(req: Request) {
   }
 
   const systemChunks = [langDirective, formatInstruction, system].filter(Boolean);
-  system = systemChunks.join('\n\n');
+  system = systemChunks.join("\n\n");
+
+  const userText = typeof payload?.userText === "string"
+    ? payload.userText
+    : messages.map((m: any) => (typeof m.content === "string" ? m.content : ""))
+        .filter(Boolean)
+        .slice(-1)[0] || lastUserMessage || "";
+
+  const abortSignal = typeof AbortSignal !== "undefined" && typeof AbortSignal.timeout === "function"
+    ? AbortSignal.timeout(30_000)
+    : undefined;
 
   const modelStart = Date.now();
   const upstream = await callOpenAIChat(
     [{ role: "system", content: system }, ...messages],
-    { stream: true },
+    { stream: true, signal: abortSignal },
   );
   const modelMs = Date.now() - modelStart;
-  // eslint-disable-next-line no-console
   console.log("[stream-final] upstream ready ms=", modelMs);
 
   const modeAllowed = Boolean(formatInstruction);
   const shouldCoerceToTable = modeAllowed && needsTableCoercion(formatId);
+  const inlineTableCoercionEnabled = process.env.TABLE_COERCE_INLINE === "1";
 
-  const inlineTableCoercionEnabled = process.env.TABLE_COERCE_INLINE === "1"; // keep OFF in prod
+  const conversationId =
+    (typeof payload?.conversationId === "string" && payload.conversationId) ||
+    req.headers.get("x-conversation-id") ||
+    undefined;
+
+  const persist = payload?.persist !== false;
+  const threadId = typeof payload?.threadId === "string" ? payload.threadId : payload?.threadId ?? undefined;
+  const state = payload?.state;
+  const researchSources = Array.isArray(payload?.researchSources) ? payload.researchSources : [];
+
+  const finalizeCtx: FinalizeContext = {
+    req,
+    userText,
+    state,
+    threadId,
+    persist,
+    researchSources,
+  };
 
   if (inlineTableCoercionEnabled && shouldCoerceToTable) {
     const rawSse = await upstream.text();
     if (!upstream.ok) {
-      return new Response(rawSse || 'OpenAI stream error', { status: upstream.status || 500 });
+      return new Response(rawSse || "OpenAI stream error", { status: upstream.status || 500 });
     }
 
     const fullText = rawSse
       .split(/\n\n/)
-      .map(line => line.replace(/^data:\s*/, ''))
+      .map((line) => line.replace(/^data:\s*/, ""))
       .filter(Boolean)
-      .filter(line => line !== '[DONE]')
-      .map(chunk => {
+      .filter((line) => line !== "[DONE]")
+      .map((chunk) => {
         try {
-          return JSON.parse(chunk)?.choices?.[0]?.delta?.content ?? '';
+          return JSON.parse(chunk)?.choices?.[0]?.delta?.content ?? "";
         } catch {
-          return '';
+          return "";
         }
       })
-      .join('');
+      .join("");
 
-    const subject = (lastUserMessage || '').split('\n')[0]?.trim() || 'Comparison';
+    const subject = (lastUserMessage || "").split("\n")[0]?.trim() || "Comparison";
     let table = shapeToTable(subject, fullText);
     table = enforceLocale(table, lang, { forbidEnglishHeadings: true });
-    const payload = {
-      choices: [{ delta: { content: table, medx_reset: true } }],
+    const payloadStream = {
+      choices: [{ delta: { content: table, medx_reset: true, medx_sources: researchSources } }],
     };
+
+    queueMicrotask(() => {
+      finalizeNonBlocking(table, finalizeCtx);
+    });
 
     const encoder = new TextEncoder();
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
-        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(payloadStream)}\n\n`));
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
         controller.close();
       },
     });
 
-    const totalMs = Date.now() - t0;
+    const totalMs = Date.now() - startedAt;
     const appMs = Math.max(0, totalMs - modelMs);
     const headers = new Headers({
       "Content-Type": "text/event-stream; charset=utf-8",
@@ -134,55 +230,134 @@ export async function POST(req: Request) {
       "Server-Timing": `app;dur=${appMs},model;dur=${modelMs}`,
       "x-medx-provider": "openai",
       "x-medx-model": process.env.OPENAI_TEXT_MODEL || "gpt-5",
+      "X-Accel-Buffering": "no",
     });
+    if (conversationId) headers.set("x-conversation-id", conversationId);
 
-    return new Response(stream, {
-      status: 200,
-      headers,
-    });
+    return new Response(stream, { status: 200, headers });
   }
 
   if (!upstream?.ok || !upstream.body) {
     const err = upstream ? await upstream.text().catch(() => "Upstream error") : "Upstream error";
-    return new Response(`OpenAI stream error: ${err}`, { status: 500 });
+    return new Response(`OpenAI stream error: ${err}`, { status: upstream?.status || 500 });
   }
 
-  const formatFinalizer = shouldCoerceToTable
-    ? (text: string) => {
-        if (hasMarkdownTable(text)) return text;
-        const subject = (lastUserMessage || '').split('\n')[0]?.trim() || 'Comparison';
-        return shapeToTable(subject, text);
-      }
-    : undefined;
-
-  const enforcedStream = createLocaleEnforcedStream(upstream.body, lang, {
-    forbidEnglishHeadings: true,
-    finalizer: formatFinalizer,
-  });
-
   const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  let aggregatedRaw = "";
+  let sanitizedSoFar = "";
+
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
-      controller.enqueue(encoder.encode(': ping\n\n'));
-      const reader = enforcedStream.getReader();
+      const heartbeatMs = 10_000;
+      controller.enqueue(encoder.encode(": ping\n\n"));
+      if (researchSources.length) {
+        const payload = { choices: [{ delta: { medx_sources: researchSources } }] };
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+      }
+
+      const heartbeat = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(": hb\n\n"));
+        } catch (err) {
+          clearInterval(heartbeat);
+        }
+      }, heartbeatMs);
+
+      const parser = createParser((event) => {
+        if (event.type !== "event") return;
+        const data = event.data;
+        if (data === "[DONE]") {
+          clearInterval(heartbeat);
+          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+          controller.close();
+          queueMicrotask(() => finalizeNonBlocking(sanitizedSoFar, finalizeCtx));
+          return;
+        }
+
+        let parsed: any;
+        try {
+          parsed = JSON.parse(data);
+        } catch {
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+          return;
+        }
+
+        const choices = Array.isArray(parsed?.choices) ? parsed.choices : [];
+        const primary = choices[0];
+        const delta = primary?.delta;
+        const content = typeof delta?.content === "string" ? delta.content : "";
+
+        if (content) {
+          aggregatedRaw += content;
+          const sanitized = enforceLocale(aggregatedRaw, lang, { forbidEnglishHeadings: true });
+          const previous = sanitizedSoFar;
+
+          if (!sanitized.startsWith(previous)) {
+            sanitizedSoFar = sanitized;
+            const nextPayload = {
+              ...parsed,
+              choices: choices.map((choice: any, index: number) =>
+                index === 0
+                  ? {
+                      ...choice,
+                      delta: {
+                        ...(choice?.delta || {}),
+                        content: sanitized,
+                        medx_reset: true,
+                      },
+                    }
+                  : choice,
+              ),
+            };
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(nextPayload)}\n\n`));
+            return;
+          }
+
+          const addition = sanitized.slice(previous.length);
+          sanitizedSoFar = sanitized;
+          if (addition) {
+            const nextPayload = {
+              ...parsed,
+              choices: choices.map((choice: any, index: number) =>
+                index === 0
+                  ? {
+                      ...choice,
+                      delta: {
+                        ...(choice?.delta || {}),
+                        content: addition,
+                      },
+                    }
+                  : choice,
+              ),
+            };
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(nextPayload)}\n\n`));
+            return;
+          }
+          return;
+        }
+
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(parsed)}\n\n`));
+      });
+
       (async () => {
         try {
+          const reader = upstream.body!.getReader();
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
-            if (value) controller.enqueue(value);
+            if (value) parser.feed(decoder.decode(value, { stream: true }));
           }
-          controller.close();
-        } catch (error) {
-          controller.error(error);
-        } finally {
-          reader.releaseLock();
+          clearInterval(heartbeat);
+        } catch (err) {
+          clearInterval(heartbeat);
+          controller.error(err);
         }
       })();
     },
   });
 
-  const totalMs = Date.now() - t0;
+  const totalMs = Date.now() - startedAt;
   const appMs = Math.max(0, totalMs - modelMs);
   const headers = new Headers({
     "Content-Type": "text/event-stream; charset=utf-8",
@@ -192,7 +367,9 @@ export async function POST(req: Request) {
     "Server-Timing": `app;dur=${appMs},model;dur=${modelMs}`,
     "x-medx-provider": "openai",
     "x-medx-model": process.env.OPENAI_TEXT_MODEL || "gpt-5",
+    "X-Accel-Buffering": "no",
   });
+  if (conversationId) headers.set("x-conversation-id", conversationId);
 
   return new Response(stream, {
     status: 200,

--- a/app/api/log/route.ts
+++ b/app/api/log/route.ts
@@ -73,8 +73,14 @@ export async function POST(req: Request) {
     if (!summaryCheck.success) {
       return NextResponse.json({ ok: false, error: "invalid_payload" }, { status: 400 });
     }
+    const { threadId, assistantContent, newSummary, expectedVersion } = summaryCheck.data;
     try {
-      await appendAssistantAndUpdateSummaryAtomic(summaryCheck.data);
+      await appendAssistantAndUpdateSummaryAtomic({
+        threadId,
+        assistantContent,
+        newSummary,
+        expectedVersion,
+      });
       return NextResponse.json({ ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/app/api/log/route.ts
+++ b/app/api/log/route.ts
@@ -116,7 +116,11 @@ async function persistMessage(data: z.infer<typeof persistMessageSchema>["data"]
     console.warn("[log] prisma message.create unavailable; skipping");
     return;
   }
-  await appendMessage(data);
+  await appendMessage({
+    threadId: data.threadId,
+    role: data.role,
+    content: data.content,
+  });
 }
 
 async function persistFinalizedTurn(data: z.infer<typeof finalizeTurnSchema>["data"]) {

--- a/app/api/log/route.ts
+++ b/app/api/log/route.ts
@@ -1,0 +1,19 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  try {
+    if (prisma && typeof (prisma as any).chatEvent?.create === "function") {
+      await (prisma as any).chatEvent.create({ data });
+    } else {
+      console.warn("[log] prisma chatEvent.create unavailable; skipping");
+    }
+  } catch (err) {
+    console.error("[log] failed to persist chat event", err);
+    return NextResponse.json({ ok: false, error: "failed_to_log" }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/log/route.ts
+++ b/app/api/log/route.ts
@@ -1,19 +1,165 @@
 export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
+import { appendMessage, setRunningSummary } from "@/lib/memory/store";
+import { embed } from "@/lib/memory/embeddings";
+
+const MAX_BYTES = 64 * 1024;
+
+const chatEventSchema = z.object({
+  type: z.literal("chat_event"),
+  event: z
+    .object({
+      id: z.string().min(1),
+      kind: z.string().min(1),
+      conversationId: z.string().optional(),
+      userId: z.string().optional(),
+      threadId: z.string().optional(),
+      metadata: z.record(z.unknown()).optional(),
+      createdAt: z.string().optional(),
+    })
+    .strict(),
+});
+
+const persistMessageSchema = z.object({
+  type: z.literal("persist_message"),
+  data: z
+    .object({
+      threadId: z.string().min(1),
+      role: z.enum(["user", "assistant"]),
+      content: z.string().min(1),
+    })
+    .strict(),
+});
+
+const finalizeTurnSchema = z.object({
+  type: z.literal("finalize_turn"),
+  data: z
+    .object({
+      threadId: z.string().min(1),
+      assistant: z.string().min(1),
+      summary: z.string().optional(),
+    })
+    .strict(),
+});
+
+const requestSchema = z.union([chatEventSchema, persistMessageSchema, finalizeTurnSchema]);
 
 export async function POST(req: Request) {
-  const data = await req.json();
+  const text = await readBody(req);
+  if (text === null) {
+    return NextResponse.json({ ok: false, error: "payload_too_large" }, { status: 413 });
+  }
+
+  let parsed: unknown;
   try {
-    if (prisma && typeof (prisma as any).chatEvent?.create === "function") {
-      await (prisma as any).chatEvent.create({ data });
-    } else {
-      console.warn("[log] prisma chatEvent.create unavailable; skipping");
+    parsed = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid_json" }, { status: 400 });
+  }
+
+  const validation = requestSchema.safeParse(parsed);
+  if (!validation.success) {
+    return NextResponse.json({ ok: false, error: "invalid_payload" }, { status: 400 });
+  }
+
+  const payload = validation.data;
+
+  try {
+    if (payload.type === "chat_event") {
+      await persistChatEvent(payload.event);
+      return NextResponse.json({ ok: true });
+    }
+
+    if (payload.type === "persist_message") {
+      await persistMessage(payload.data);
+      return NextResponse.json({ ok: true });
+    }
+
+    if (payload.type === "finalize_turn") {
+      await persistFinalizedTurn(payload.data);
+      return NextResponse.json({ ok: true });
     }
   } catch (err) {
-    console.error("[log] failed to persist chat event", err);
-    return NextResponse.json({ ok: false, error: "failed_to_log" }, { status: 500 });
+    console.error("[log] persistence failed", err);
+    return NextResponse.json({ ok: false, error: "persistence_failed" }, { status: 500 });
   }
-  return NextResponse.json({ ok: true });
+
+  return NextResponse.json({ ok: false, error: "unsupported" }, { status: 400 });
+}
+
+async function readBody(req: Request): Promise<string | null> {
+  const contentLengthHeader = req.headers.get("content-length");
+  if (contentLengthHeader && Number(contentLengthHeader) > MAX_BYTES) {
+    return null;
+  }
+
+  const buf = Buffer.from(await req.arrayBuffer());
+  if (buf.byteLength > MAX_BYTES) {
+    return null;
+  }
+  return buf.toString("utf8");
+}
+
+async function persistChatEvent(event: z.infer<typeof chatEventSchema>["event"]) {
+  if (!prisma || typeof (prisma as any).chatEvent?.create !== "function") {
+    console.warn("[log] prisma chatEvent.create unavailable; skipping");
+    return;
+  }
+  await (prisma as any).chatEvent.create({ data: event });
+}
+
+async function persistMessage(data: z.infer<typeof persistMessageSchema>["data"]) {
+  if (!prisma || typeof (prisma as any).message?.create !== "function") {
+    console.warn("[log] prisma message.create unavailable; skipping");
+    return;
+  }
+  await appendMessage(data);
+}
+
+async function persistFinalizedTurn(data: z.infer<typeof finalizeTurnSchema>["data"]) {
+  if (!prisma) {
+    console.warn("[log] prisma unavailable; skipping finalize turn");
+    return;
+  }
+
+  const summaryText = data.summary ?? "";
+
+  const prismaAny = prisma as any;
+  const messageModel = prismaAny.message;
+  const threadModel = prismaAny.chatThread;
+
+  if (typeof prismaAny.$transaction === "function" && messageModel?.create && threadModel?.update) {
+    const vector = await embed(data.assistant);
+    const embedding = Buffer.from(new Float32Array(vector).buffer);
+    await prismaAny.$transaction([
+      messageModel.create({
+        data: {
+          threadId: data.threadId,
+          role: "assistant",
+          content: data.assistant,
+          embedding,
+        },
+      }),
+      threadModel.update({
+        where: { id: data.threadId },
+        data: { runningSummary: summaryText },
+      }),
+    ]);
+    return;
+  }
+
+  if (messageModel?.create) {
+    await appendMessage({ threadId: data.threadId, role: "assistant", content: data.assistant });
+  } else {
+    console.warn("[log] prisma message.create unavailable; skipping assistant append");
+  }
+
+  if (threadModel?.update) {
+    await setRunningSummary(data.threadId, summaryText);
+  } else {
+    console.warn("[log] prisma chatThread.update unavailable; skipping summary update");
+  }
 }

--- a/app/api/threads/route.ts
+++ b/app/api/threads/route.ts
@@ -1,9 +1,8 @@
-import { randomUUID } from "crypto";
 import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
   const body = await request.json().catch(() => ({}));
   const title = typeof body?.titleHint === "string" ? body.titleHint : typeof body?.title === "string" ? body.title : "New chat";
-  const id = randomUUID();
+  const id = crypto.randomUUID();
   return NextResponse.json({ id, title });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,22 +11,25 @@ body * {
   transition: color 0.15s ease, border-color 0.15s ease;
 }
 
-/* Prevent any fallback face from flashing before Proxima Nova is ready */
-body.font-loading {
-  opacity: 0;
-}
-
-body.font-loading *,
-body.font-loading *::before,
-body.font-loading *::after {
-  transition: none !important;
-}
-
 /* === Base font: single source of truth via CSS variable with sensible fallbacks === */
 @layer base {
   html,
   body {
-    font-family: var(--font-proxima-nova, "Proxima Nova", "Proxima Nova Rg", "ProximaNova", "proxima-nova");
+    font-family: var(
+        --font-sans,
+        var(--font-proxima-nova, "Proxima Nova", "Proxima Nova Rg", "ProximaNova", "proxima-nova")
+      ),
+      "Proxima Nova",
+      "Proxima Nova Rg",
+      "ProximaNova",
+      "proxima-nova",
+      ui-sans-serif,
+      system-ui,
+      "Segoe UI",
+      Roboto,
+      "Helvetica Neue",
+      Arial,
+      sans-serif;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,30 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+  font-family: "Proxima";
+  src: url("/fonts/proxima/ProximaNova-Regular.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal;
+  font-display: block;
+}
+
+@font-face {
+  font-family: "Proxima";
+  src: url("/fonts/proxima/ProximaNova-Semibold.woff2") format("woff2");
+  font-weight: 600;
+  font-style: normal;
+  font-display: block;
+}
+
+@font-face {
+  font-family: "Proxima";
+  src: url("/fonts/proxima/ProximaNova-Bold.woff2") format("woff2");
+  font-weight: 700;
+  font-style: normal;
+  font-display: block;
+}
+
 /* smooth theme transitions without triggering scroll flicker */
 body {
   transition: background-color 0.15s ease, color 0.15s ease;
@@ -15,19 +39,18 @@ body * {
 @layer base {
   html,
   body {
-    font-family: var(
-        --font-sans,
-        var(--font-proxima-nova, "Proxima Nova", "Proxima Nova Rg", "ProximaNova", "proxima-nova")
-      ),
+    font-family:
+      "Proxima",
       "Proxima Nova",
       "Proxima Nova Rg",
       "ProximaNova",
       "proxima-nova",
-      ui-sans-serif,
-      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
       "Segoe UI",
       Roboto,
       "Helvetica Neue",
+      Helvetica,
       Arial,
       sans-serif;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,75 +13,29 @@ import MemorySnackbar from "@/components/memory/Snackbar";
 import UndoToast from "@/components/memory/UndoToast";
 import AppToastHost from "@/components/ui/AppToastHost";
 import dynamic from "next/dynamic";
-import Script from "next/script";
 import PreferencesProvider from "@/components/providers/PreferencesProvider";
 import LangDirEffect from "@/components/providers/LangDirEffect";
+import { Inter } from "next/font/google";
 
 // Mobile-only UI (loaded client-side)
 const MobileHeader = dynamic(() => import("@/components/mobile/MobileHeader"), { ssr: false });
 const MobileSidebarOverlay = dynamic(() => import("@/components/mobile/MobileSidebarOverlay"), { ssr: false });
 const MobileActionsSheet = dynamic(() => import("@/components/mobile/MobileActionsSheet"), { ssr: false });
 
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans", display: "swap" });
+
 export const metadata = { title: BRAND_NAME, description: "Global medical AI" };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html suppressHydrationWarning>
+    <html lang="en" className={`${inter.variable} ${inter.className}`} suppressHydrationWarning>
       <head>
         <link rel="dns-prefetch" href="https://api.openai.com" />
         <link rel="preconnect" href="https://api.openai.com" crossOrigin="anonymous" />
         <link rel="dns-prefetch" href="https://api.groq.com" />
         <link rel="preconnect" href="https://api.groq.com" crossOrigin="anonymous" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link rel="dns-prefetch" href="https://fonts.gstatic.com" />
-        <link rel="dns-prefetch" href="https://fonts.cdnfonts.com" />
-        <link rel="preconnect" href="https://fonts.cdnfonts.com" crossOrigin="anonymous" />
-        {/* Keep this ONLY if you still rely on the CDN font.
-           If you've migrated to a local/next-font, remove this link. */}
-        <link
-          rel="stylesheet"
-          href="https://fonts.cdnfonts.com/css/proxima-nova-2"
-        />
-        <noscript>
-          <style>{"body.font-loading{opacity:1 !important}"}</style>
-        </noscript>
       </head>
-      <body className="font-loading h-full bg-slate-100 text-slate-900 dark:bg-transparent dark:text-slate-100 font-sans antialiased">
-        <Script id="ensure-proxima-first" strategy="beforeInteractive">
-          {`
-            (function() {
-              var className = "font-loading";
-              var removeClass = function() {
-                var body = document.body;
-                if (!body || !body.classList.contains(className)) return;
-                body.classList.remove(className);
-                try {
-                  window.sessionStorage.setItem("proxima-font-loaded", "1");
-                } catch (e) {
-                  // ignore
-                }
-              };
-
-              try {
-                if (window.sessionStorage.getItem("proxima-font-loaded")) {
-                  removeClass();
-                  return;
-                }
-              } catch (e) {
-                // ignore
-              }
-
-              if (document.fonts && document.fonts.ready) {
-                document.fonts.ready.then(removeClass);
-                if (document.fonts.status === "loaded") {
-                  removeClass();
-                }
-              } else {
-                window.addEventListener("load", removeClass, { once: true });
-              }
-            })();
-          `}
-        </Script>
+      <body className="h-full bg-slate-100 text-slate-900 dark:bg-transparent dark:text-slate-100 font-sans antialiased">
         <PreferencesProvider>
           <LangDirEffect />
           <ThemeProvider

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,27 +15,45 @@ import AppToastHost from "@/components/ui/AppToastHost";
 import dynamic from "next/dynamic";
 import PreferencesProvider from "@/components/providers/PreferencesProvider";
 import LangDirEffect from "@/components/providers/LangDirEffect";
-import { Inter } from "next/font/google";
 
 // Mobile-only UI (loaded client-side)
 const MobileHeader = dynamic(() => import("@/components/mobile/MobileHeader"), { ssr: false });
 const MobileSidebarOverlay = dynamic(() => import("@/components/mobile/MobileSidebarOverlay"), { ssr: false });
 const MobileActionsSheet = dynamic(() => import("@/components/mobile/MobileActionsSheet"), { ssr: false });
 
-const inter = Inter({ subsets: ["latin"], variable: "--font-sans", display: "swap" });
-
 export const metadata = { title: BRAND_NAME, description: "Global medical AI" };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} ${inter.className}`} suppressHydrationWarning>
+    <html lang="en" className="font-sans" suppressHydrationWarning>
       <head>
         <link rel="dns-prefetch" href="https://api.openai.com" />
         <link rel="preconnect" href="https://api.openai.com" crossOrigin="anonymous" />
         <link rel="dns-prefetch" href="https://api.groq.com" />
         <link rel="preconnect" href="https://api.groq.com" crossOrigin="anonymous" />
+        <link
+          rel="preload"
+          href="/fonts/proxima/ProximaNova-Regular.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preload"
+          href="/fonts/proxima/ProximaNova-Semibold.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preload"
+          href="/fonts/proxima/ProximaNova-Bold.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin="anonymous"
+        />
       </head>
-      <body className="h-full bg-slate-100 text-slate-900 dark:bg-transparent dark:text-slate-100 font-sans antialiased">
+      <body className="font-sans h-full bg-slate-100 text-slate-900 dark:bg-transparent dark:text-slate-100 antialiased">
         <PreferencesProvider>
           <LangDirEffect />
           <ThemeProvider

--- a/components/ChatMarkdown.tsx
+++ b/components/ChatMarkdown.tsx
@@ -99,7 +99,7 @@ export default function ChatMarkdown({ content, formatId, userPrompt }: { conten
   return (
     <div
       className="
-        message-content prose prose-slate dark:prose-invert max-w-[72ch]
+        message-content prose prose-slate dark:prose-invert max-w-[72ch] font-sans
         prose-headings:font-semibold prose-headings:mb-2 prose-headings:mt-3
         prose-h3:text-lg prose-h4:text-base
         prose-p:my-2 prose-li:my-1 prose-strong:font-medium

--- a/components/chat/AssistantPendingMessage.tsx
+++ b/components/chat/AssistantPendingMessage.tsx
@@ -1,4 +1,3 @@
-import ChatMarkdown from "@/components/ChatMarkdown";
 import type { PendingAssistantStage } from "@/hooks/usePendingAssistantStages";
 import type { FormatId } from "@/lib/formats/types";
 
@@ -25,7 +24,9 @@ export function AssistantPendingMessage({ stage, analyzingPhrase, thinkingLabel,
   if (stage === "streaming") {
     return (
       <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl min-h-[64px]">
-        <ChatMarkdown content={content || ""} formatId={formatId} userPrompt={userPrompt} />
+        <pre className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-800 dark:text-slate-200">
+          {content || ""}
+        </pre>
       </div>
     );
   }

--- a/components/chat/AssistantPendingMessage.tsx
+++ b/components/chat/AssistantPendingMessage.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import type { PendingAssistantStage } from "@/hooks/usePendingAssistantStages";
 import type { FormatId } from "@/lib/formats/types";
+import ChatMarkdown from "@/components/ChatMarkdown";
 
 type Props = {
   stage: PendingAssistantStage;
@@ -8,6 +11,7 @@ type Props = {
   content: string;
   formatId?: FormatId;
   userPrompt?: string;
+  renderedContent?: string;
 };
 
 function stripTrailingEllipsis(value: string) {
@@ -17,16 +21,23 @@ function stripTrailingEllipsis(value: string) {
   return withoutEllipsis.length > 0 ? withoutEllipsis : trimmed;
 }
 
-export function AssistantPendingMessage({ stage, analyzingPhrase, thinkingLabel, content, formatId, userPrompt }: Props) {
+export function AssistantPendingMessage({
+  stage,
+  analyzingPhrase,
+  thinkingLabel,
+  content,
+  formatId,
+  userPrompt,
+  renderedContent,
+}: Props) {
   const fallbackLabel = stage === "reflecting" ? "Reflecting…" : "Analyzing";
   const label = thinkingLabel?.trim().length ? thinkingLabel : fallbackLabel;
 
   if (stage === "streaming") {
+    const streamContent = renderedContent ?? content;
     return (
       <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl min-h-[64px]">
-        <div className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-800 dark:text-slate-200 font-sans">
-          {content || ""}
-        </div>
+        <ChatMarkdown content={streamContent || ""} formatId={formatId} userPrompt={userPrompt} />
       </div>
     );
   }

--- a/components/chat/AssistantPendingMessage.tsx
+++ b/components/chat/AssistantPendingMessage.tsx
@@ -24,9 +24,9 @@ export function AssistantPendingMessage({ stage, analyzingPhrase, thinkingLabel,
   if (stage === "streaming") {
     return (
       <div className="rounded-2xl bg-white/90 dark:bg-zinc-900/60 p-4 text-left whitespace-normal max-w-3xl min-h-[64px]">
-        <pre className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-800 dark:text-slate-200">
+        <div className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-800 dark:text-slate-200 font-sans">
           {content || ""}
-        </pre>
+        </div>
       </div>
     );
   }

--- a/lib/db/threadWrites.ts
+++ b/lib/db/threadWrites.ts
@@ -1,0 +1,94 @@
+import { prisma } from "@/lib/prisma";
+import { embed } from "@/lib/memory/embeddings";
+
+type AppendParams = {
+  threadId: string;
+  assistantContent: string;
+  newSummary: string;
+  expectedVersion?: number;
+};
+
+export async function appendAssistantAndUpdateSummaryAtomic({
+  threadId,
+  assistantContent,
+  newSummary,
+  expectedVersion,
+}: AppendParams) {
+  if (!prisma) {
+    throw new Error("prisma_unavailable");
+  }
+
+  const prismaAny = prisma as any;
+  const messageModel = prismaAny?.message;
+  const threadModel = prismaAny?.chatThread;
+
+  if (!messageModel?.create || !threadModel?.update) {
+    throw new Error("prisma_models_missing");
+  }
+
+  const vector = await embed(assistantContent);
+  const embedding = Buffer.from(new Float32Array(vector).buffer);
+
+  const runAtomic = async (tx: any) => {
+    if (typeof expectedVersion === "number" && tx?.chatThread?.findUnique) {
+      const existing = await tx.chatThread.findUnique({
+        where: { id: threadId },
+        select: { version: true },
+      });
+      if (!existing || (typeof existing.version === "number" && existing.version !== expectedVersion)) {
+        throw new Error("version_conflict");
+      }
+    }
+
+    await tx.message.create({
+      data: {
+        threadId,
+        role: "assistant",
+        content: assistantContent,
+        embedding,
+      },
+    });
+
+    await tx.chatThread.update({
+      where: { id: threadId },
+      data: {
+        runningSummary: newSummary,
+        updatedAt: new Date(),
+      },
+    });
+  };
+
+  if (typeof prismaAny.$transaction === "function") {
+    await prismaAny.$transaction(async (tx: any) => {
+      await runAtomic(tx);
+    });
+    return;
+  }
+
+  if (typeof expectedVersion === "number" && threadModel?.findUnique) {
+    const current = await threadModel.findUnique({
+      where: { id: threadId },
+      select: { version: true },
+    });
+    if (!current || (typeof current.version === "number" && current.version !== expectedVersion)) {
+      throw new Error("version_conflict");
+    }
+  }
+
+  await messageModel.create({
+    data: {
+      threadId,
+      role: "assistant",
+      content: assistantContent,
+      embedding,
+    },
+  });
+
+  await threadModel.update({
+    where: { id: threadId },
+    data: {
+      runningSummary: newSummary,
+      updatedAt: new Date(),
+    },
+  });
+}

--- a/lib/medx/providers.ts
+++ b/lib/medx/providers.ts
@@ -25,15 +25,15 @@ export async function callGroqChat(messages: any[], options?: { temperature?: nu
 // Overloads: tell TS exactly what comes back
 export function callOpenAIChat(
   messages: any[],
-  options?: { stream?: false; temperature?: number }
+  options?: { stream?: false; temperature?: number; signal?: AbortSignal }
 ): Promise<string>;
 export function callOpenAIChat(
   messages: any[],
-  options: { stream: true; temperature?: number }
+  options: { stream: true; temperature?: number; signal?: AbortSignal }
 ): Promise<Response>;
 export async function callOpenAIChat(
   messages: any[],
-  { stream = false, temperature = 0.1 }: { stream?: boolean; temperature?: number } = {},
+  { stream = false, temperature = 0.1, signal }: { stream?: boolean; temperature?: number; signal?: AbortSignal } = {},
 ): Promise<string | Response> {
   const primary = process.env.OPENAI_TEXT_MODEL || "gpt-5";
   const fallbacks = (process.env.OPENAI_FALLBACK_MODELS || "gpt-4o,gpt-4o-mini")
@@ -69,7 +69,8 @@ export async function callOpenAIChat(
       fetch("https://api.openai.com/v1/chat/completions", {
         method: "POST",
         headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
-        body: JSON.stringify(payload)
+        body: JSON.stringify(payload),
+        signal,
       });
 
     let res = await post(withTemp);

--- a/lib/stream.ts
+++ b/lib/stream.ts
@@ -16,7 +16,7 @@ export async function streamChat(
   handlers: StreamHandlers,
   signal?: AbortSignal
 ): Promise<void> {
-  const res = await fetch("/api/chat", {
+  const res = await fetch("/api/chat/stream", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(req),

--- a/lib/trials/fetchCTRI.ts
+++ b/lib/trials/fetchCTRI.ts
@@ -1,58 +1,80 @@
+import { firstText, parseXml } from "./xml";
+
+const CTRI_URL = "https://ctri.nic.in/Clinicaltrials/services/Searchdata";
+
 export async function fetchCTRI(title?: string): Promise<any[]> {
-  const url = `https://ctri.nic.in/Clinicaltrials/services/Searchdata?trialno=&title=${encodeURIComponent(title || "")}`;
+  const url = `${CTRI_URL}?trialno=&title=${encodeURIComponent(title || "")}`;
   const res = await fetch(url, { next: { revalidate: 3600 } });
   const text = await res.text();
 
   try {
     const json = JSON.parse(text);
-    return Array.isArray(json) ? json.map(mapCtri) : [];
+    return Array.isArray(json) ? json.map(mapCtri).filter(filterValid) : [];
   } catch {
     return parseCtriXml(text);
   }
+}
 
-  function mapCtri(r: any) {
-    return {
-      id: r?.ctriNumber || r?.TrialNumber,
-      title: r?.PublicTitle || r?.ScientificTitle || r?.title,
-      url: r?.url || (r?.ctriNumber ? `https://ctri.nic.in/Clinicaltrials/pview2.php?trialid=${encodeURIComponent(r.ctriNumber)}` : undefined),
-      phase: r?.Phase,
-      status: r?.RecruitmentStatus,
-      country: "India",
-      source: "CTRI" as const,
-    };
-  }
+function mapCtri(record: any) {
+  const id = record?.ctriNumber || record?.TrialNumber || record?.trialno;
+  return {
+    id,
+    title: record?.PublicTitle || record?.ScientificTitle || record?.title,
+    url: id ? `https://ctri.nic.in/Clinicaltrials/pview2.php?trialid=${encodeURIComponent(id)}` : undefined,
+    phase: record?.Phase,
+    status: record?.RecruitmentStatus,
+    country: "India",
+    source: "CTRI" as const,
+  };
+}
 
-  function parseCtriXml(raw: string) {
-    if (typeof DOMParser === "undefined") return [] as any[];
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(raw, "application/xml");
-    if (doc.querySelector("parsererror")) {
-      return [] as any[];
-    }
+function parseCtriXml(raw: string) {
+  const xml = parseXml(raw);
+  if (!xml || typeof xml !== "object") return [];
 
-    const trials = Array.from(doc.getElementsByTagName("Trial"));
-    if (!trials.length) return [] as any[];
+  const trialsNode = xml.Trials ?? xml.trials ?? xml.Trial ?? xml.trial ?? xml;
+  const trialList = normalizeTrialArray(trialsNode, ["Trial", "trial"]);
 
-    const takeText = (node: Element, names: string[]): string | undefined => {
-      for (const name of names) {
-        const found = node.getElementsByTagName(name)[0];
-        const value = found?.textContent?.trim();
-        if (value) return value;
-      }
-      return undefined;
-    };
-
-    return trials.map((node) => {
-      const id = takeText(node, ["ctriNumber", "TrialNumber"]);
+  return trialList
+    .map((node) => {
+      const id = pick(node, ["ctriNumber", "TrialNumber", "trialno"]);
       return {
         id,
-        title: takeText(node, ["PublicTitle", "ScientificTitle", "title"]),
+        title: pick(node, ["PublicTitle", "ScientificTitle", "title"]),
         url: id ? `https://ctri.nic.in/Clinicaltrials/pview2.php?trialid=${encodeURIComponent(id)}` : undefined,
-        phase: takeText(node, ["Phase"]),
-        status: takeText(node, ["RecruitmentStatus"]),
+        phase: pick(node, ["Phase"]),
+        status: pick(node, ["RecruitmentStatus"]),
         country: "India",
         source: "CTRI" as const,
       };
-    }).filter((r) => r.id || r.title);
+    })
+    .filter(filterValid);
+}
+
+function normalizeTrialArray(root: any, childKeys: string[]) {
+  const direct = Array.isArray(root) ? root : root && typeof root === "object" ? [root] : [];
+  if (direct.length && typeof direct[0] === "object" && !childKeys.some((key) => key in direct[0])) {
+    return direct;
   }
+  for (const key of childKeys) {
+    const value = root?.[key];
+    if (value) {
+      return Array.isArray(value) ? value : [value];
+    }
+  }
+  return [];
+}
+
+function pick(record: any, keys: string[]): string | undefined {
+  if (!record || typeof record !== "object") return undefined;
+  for (const key of keys) {
+    const value = record[key];
+    const resolved = firstText(value);
+    if (resolved) return resolved;
+  }
+  return undefined;
+}
+
+function filterValid(trial: { id?: string; title?: string }) {
+  return Boolean(trial?.id || trial?.title);
 }

--- a/lib/trials/fetchEUCTR.ts
+++ b/lib/trials/fetchEUCTR.ts
@@ -1,5 +1,3 @@
-import { parseStringPromise } from "xml2js";
-
 export async function fetchEUCTR(query?: string): Promise<any[]> {
   const url = `https://www.clinicaltrialsregister.eu/ctr-search/rest/search?query=${encodeURIComponent(query||"")}`;
   const res = await fetch(url, { next: { revalidate: 3600 } });
@@ -9,9 +7,7 @@ export async function fetchEUCTR(query?: string): Promise<any[]> {
     const data = JSON.parse(text);
     return Array.isArray(data) ? data.map(mapEuctrJson) : [];
   } catch {
-    const xml = await parseStringPromise(text, { explicitArray: false });
-    const list = Array.isArray(xml?.result?.trial) ? xml.result.trial : (xml?.result?.trial ? [xml.result.trial] : []);
-    return list.map(mapEuctrXml);
+    return parseEuctrXml(text);
   }
 
   function mapEuctrJson(r:any) {
@@ -26,15 +22,41 @@ export async function fetchEUCTR(query?: string): Promise<any[]> {
     };
   }
 
-  function mapEuctrXml(r:any) {
-    return {
-      id: r?.eudractNumber || r?.trialNumber || r?.id || r?.EudraCTNumber,
-      title: r?.scientificTitle || r?.fullTitle || r?.title || r?.ScientificTitle,
-      url: r?.trialUrl || (r?.eudractNumber || r?.EudraCTNumber ? `https://www.clinicaltrialsregister.eu/ctr-search/trial/${r.eudractNumber || r.EudraCTNumber}` : undefined),
-      phase: r?.trialPhase || r?.phase || r?.TrialPhase,
-      status: r?.trialStatus || r?.status || r?.TrialStatus,
-      country: (r?.memberStatesConcerned || r?.countries || [])[0] || r?.Country,
-      source: "EUCTR" as const
+  function parseEuctrXml(raw: string) {
+    if (typeof DOMParser === "undefined") return [] as any[];
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(raw, "application/xml");
+    if (doc.querySelector("parsererror")) {
+      return [] as any[];
+    }
+
+    const trials = Array.from(doc.getElementsByTagName("trial"));
+    if (!trials.length) return [] as any[];
+
+    const takeText = (node: Element, names: string[]): string | undefined => {
+      for (const name of names) {
+        const found = node.getElementsByTagName(name)[0];
+        const value = found?.textContent?.trim();
+        if (value) return value;
+      }
+      return undefined;
     };
+
+    return trials.map((node) => {
+      const countries = Array.from(node.getElementsByTagName("country"))
+        .map((n) => n.textContent?.trim())
+        .filter(Boolean);
+      const id = takeText(node, ["eudractNumber", "trialNumber", "id", "EudraCTNumber"]);
+      const urlId = takeText(node, ["eudractNumber", "EudraCTNumber", "trialNumber", "id"]);
+      return {
+        id,
+        title: takeText(node, ["scientificTitle", "fullTitle", "title", "ScientificTitle"]),
+        url: urlId ? `https://www.clinicaltrialsregister.eu/ctr-search/trial/${urlId}` : undefined,
+        phase: takeText(node, ["trialPhase", "phase", "TrialPhase"]),
+        status: takeText(node, ["trialStatus", "status", "TrialStatus"]),
+        country: countries[0],
+        source: "EUCTR" as const,
+      };
+    }).filter((r) => r.id || r.title);
   }
 }

--- a/lib/trials/fetchEUCTR.ts
+++ b/lib/trials/fetchEUCTR.ts
@@ -1,62 +1,99 @@
+import { firstText, parseXml } from "./xml";
+
+const EUCTR_URL = "https://www.clinicaltrialsregister.eu/ctr-search/rest/search";
+
 export async function fetchEUCTR(query?: string): Promise<any[]> {
-  const url = `https://www.clinicaltrialsregister.eu/ctr-search/rest/search?query=${encodeURIComponent(query||"")}`;
+  const url = `${EUCTR_URL}?query=${encodeURIComponent(query || "")}`;
   const res = await fetch(url, { next: { revalidate: 3600 } });
   const text = await res.text();
 
   try {
     const data = JSON.parse(text);
-    return Array.isArray(data) ? data.map(mapEuctrJson) : [];
+    return Array.isArray(data) ? data.map(mapEuctrJson).filter(filterValid) : [];
   } catch {
     return parseEuctrXml(text);
   }
+}
 
-  function mapEuctrJson(r:any) {
-    return {
-      id: r?.eudractNumber || r?.trialNumber || r?.id,
-      title: r?.scientificTitle || r?.fullTitle || r?.title,
-      url: r?.trialUrl || (r?.eudractNumber ? `https://www.clinicaltrialsregister.eu/ctr-search/trial/${r.eudractNumber}` : undefined),
-      phase: r?.trialPhase || r?.phase,
-      status: r?.trialStatus || r?.status,
-      country: (r?.memberStatesConcerned || r?.countries || [])[0],
-      source: "EUCTR" as const
-    };
-  }
+function mapEuctrJson(record: any) {
+  const id = record?.eudractNumber || record?.trialNumber || record?.id;
+  const countries = normalizeCountryArray(record?.memberStatesConcerned || record?.countries);
+  return {
+    id,
+    title: record?.scientificTitle || record?.fullTitle || record?.title,
+    url: id ? `https://www.clinicaltrialsregister.eu/ctr-search/trial/${id}` : undefined,
+    phase: record?.trialPhase || record?.phase,
+    status: record?.trialStatus || record?.status,
+    country: countries[0],
+    source: "EUCTR" as const,
+  };
+}
 
-  function parseEuctrXml(raw: string) {
-    if (typeof DOMParser === "undefined") return [] as any[];
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(raw, "application/xml");
-    if (doc.querySelector("parsererror")) {
-      return [] as any[];
-    }
+function parseEuctrXml(raw: string) {
+  const xml = parseXml(raw);
+  if (!xml || typeof xml !== "object") return [];
 
-    const trials = Array.from(doc.getElementsByTagName("trial"));
-    if (!trials.length) return [] as any[];
+  const trialsNode = xml.result ?? xml.results ?? xml.trial ?? xml;
+  const trialList = normalizeTrialArray(trialsNode, ["trial", "Trial"]);
 
-    const takeText = (node: Element, names: string[]): string | undefined => {
-      for (const name of names) {
-        const found = node.getElementsByTagName(name)[0];
-        const value = found?.textContent?.trim();
-        if (value) return value;
-      }
-      return undefined;
-    };
-
-    return trials.map((node) => {
-      const countries = Array.from(node.getElementsByTagName("country"))
-        .map((n) => n.textContent?.trim())
-        .filter(Boolean);
-      const id = takeText(node, ["eudractNumber", "trialNumber", "id", "EudraCTNumber"]);
-      const urlId = takeText(node, ["eudractNumber", "EudraCTNumber", "trialNumber", "id"]);
+  return trialList
+    .map((node) => {
+      const id = pick(node, ["EudraCTNumber", "eudractNumber", "trialNumber", "id"]);
+      const countries = normalizeCountryArray(node?.country ?? node?.countries ?? node?.memberStatesConcerned);
+      const urlId = pick(node, ["EudraCTNumber", "eudractNumber", "trialNumber", "id"]);
       return {
         id,
-        title: takeText(node, ["scientificTitle", "fullTitle", "title", "ScientificTitle"]),
+        title: pick(node, ["scientificTitle", "ScientificTitle", "fullTitle", "title"]),
         url: urlId ? `https://www.clinicaltrialsregister.eu/ctr-search/trial/${urlId}` : undefined,
-        phase: takeText(node, ["trialPhase", "phase", "TrialPhase"]),
-        status: takeText(node, ["trialStatus", "status", "TrialStatus"]),
+        phase: pick(node, ["trialPhase", "TrialPhase", "phase"]),
+        status: pick(node, ["trialStatus", "TrialStatus", "status"]),
         country: countries[0],
         source: "EUCTR" as const,
       };
-    }).filter((r) => r.id || r.title);
+    })
+    .filter(filterValid);
+}
+
+function normalizeTrialArray(root: any, childKeys: string[]) {
+  const direct = Array.isArray(root) ? root : root && typeof root === "object" ? [root] : [];
+  if (direct.length && typeof direct[0] === "object" && !childKeys.some((key) => key in direct[0])) {
+    return direct;
   }
+  for (const key of childKeys) {
+    const value = root?.[key];
+    if (value) {
+      return Array.isArray(value) ? value : [value];
+    }
+  }
+  return [];
+}
+
+function normalizeCountryArray(value: any): string[] {
+  if (!value) return [];
+  if (typeof value === "string") return [value].filter(Boolean);
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => firstText(v))
+      .filter((v): v is string => Boolean(v));
+  }
+  if (typeof value === "object") {
+    return Object.values(value)
+      .flatMap((entry) => normalizeCountryArray(entry))
+      .filter((v): v is string => Boolean(v));
+  }
+  return [];
+}
+
+function pick(record: any, keys: string[]): string | undefined {
+  if (!record || typeof record !== "object") return undefined;
+  for (const key of keys) {
+    const value = record[key];
+    const resolved = firstText(value);
+    if (resolved) return resolved;
+  }
+  return undefined;
+}
+
+function filterValid(trial: { id?: string; title?: string }) {
+  return Boolean(trial?.id || trial?.title);
 }

--- a/lib/trials/search.ts
+++ b/lib/trials/search.ts
@@ -1,7 +1,6 @@
 // Add a Phase type that includes mixed values
 import { fetchEUCTR } from "./fetchEUCTR";
 import { fetchCTRI } from "./fetchCTRI";
-import { fetchISRCTNRecord } from "./fetchISRCTN";
 
 type PhaseStr = "1" | "2" | "3" | "4" | "1/2" | "2/3";
 

--- a/lib/trials/xml.ts
+++ b/lib/trials/xml.ts
@@ -1,0 +1,56 @@
+import { XMLParser } from "fast-xml-parser";
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "",
+  trimValues: true,
+  removeNSPrefix: true,
+});
+
+export function parseXml(raw: string): Record<string, any> | null {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return null;
+  }
+  try {
+    return parser.parse(raw);
+  } catch (err) {
+    console.warn("[xml] failed to parse payload", err);
+    return null;
+  }
+}
+
+export function firstText(value: any, depth = 0): string | undefined {
+  if (value == null || depth > 5) return undefined;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = firstText(item, depth + 1);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (typeof value === "object") {
+    if (typeof value.value === "string") {
+      return normalizeText(value.value);
+    }
+    if (typeof value["#text"] === "string") {
+      return normalizeText(value["#text"]);
+    }
+    for (const key of Object.keys(value)) {
+      const found = firstText(value[key], depth + 1);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (typeof value === "string") {
+    return normalizeText(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function normalizeText(input: string): string | undefined {
+  const trimmed = input.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@supabase/supabase-js": "^2.57.0",
         "@tanstack/react-query": "^5.89.0",
         "clsx": "^2.1.1",
+        "eventsource-parser": "^3.0.6",
         "framer-motion": "^12.23.12",
         "hast-util-sanitize": "^5.0.2",
         "html-to-image": "^1.11.11",
@@ -3443,6 +3444,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tanstack/react-query": "^5.89.0",
         "clsx": "^2.1.1",
         "eventsource-parser": "^3.0.6",
+        "fast-xml-parser": "^4.5.3",
         "framer-motion": "^12.23.12",
         "hast-util-sanitize": "^5.0.2",
         "html-to-image": "^1.11.11",
@@ -3521,6 +3522,24 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -8353,6 +8372,18 @@
     "node_modules/strip-literal/node_modules/js-tokens": {
       "version": "9.0.1",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/style-to-js": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@supabase/supabase-js": "^2.57.0",
     "@tanstack/react-query": "^5.89.0",
     "clsx": "^2.1.1",
+    "eventsource-parser": "^3.0.6",
     "framer-motion": "^12.23.12",
     "hast-util-sanitize": "^5.0.2",
     "html-to-image": "^1.11.11",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "^5.89.0",
     "clsx": "^2.1.1",
     "eventsource-parser": "^3.0.6",
+    "fast-xml-parser": "^4.5.3",
     "framer-motion": "^12.23.12",
     "hast-util-sanitize": "^5.0.2",
     "html-to-image": "^1.11.11",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,17 +16,19 @@ module.exports = {
       fontFamily: {
         // Used by className="font-sans"
         sans: [
-          "var(--font-sans)",
+          "Proxima",
           "Proxima Nova",
           "Proxima Nova Rg",
           "ProximaNova",
           "proxima-nova",
-          "ui-sans-serif",
-          "system-ui",
+          "-apple-system",
+          "BlinkMacSystemFont",
           "Segoe UI",
           "Roboto",
           "Helvetica Neue",
+          "Helvetica",
           "Arial",
+          "sans-serif",
         ],
       },
     },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,10 +16,17 @@ module.exports = {
       fontFamily: {
         // Used by className="font-sans"
         sans: [
+          "var(--font-sans)",
           "Proxima Nova",
           "Proxima Nova Rg",
           "ProximaNova",
           "proxima-nova",
+          "ui-sans-serif",
+          "system-ui",
+          "Segoe UI",
+          "Roboto",
+          "Helvetica Neue",
+          "Arial",
         ],
       },
     },


### PR DESCRIPTION
## Summary
- run the chat API on the edge runtime and stream Groq responses through a dedicated SSE helper
- buffer streamed client deltas, throttle scroll updates, and log first token/total timings while keeping pending content in sync
- render pending assistant text with a lightweight `<pre>` during streaming to defer full markdown work

## Testing
- npm run lint -- --max-warnings=0 *(prompts for configuration; existing setup prevents running non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ee91cd7c832f82568aa361c19d6e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buffered streaming assistant replies with incremental previews, citation delivery, non-blocking finalization, and conversation ID surfaced in responses.
  * Server-side logging endpoint to persist chat events and finalization logs.

* **Performance**
  * Debounced scrolling, buffered flushes, first-token timing and total streaming duration metrics.

* **Bug Fixes**
  * More resilient XML/JSON trial parsing and safer fallbacks for missing runtime crypto features.

* **Refactor**
  * Streaming and persistence flow consolidated; embedding generation moved to Web Crypto.

* **Chores**
  * Added event-stream and XML parser dependencies; enabled request abort/cancel support; updated local fonts and fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->