### PR TITLE
Block ads when therapy mode is active

### DIFF
--- a/__tests__/api.ads.broker.route.test.ts
+++ b/__tests__/api.ads.broker.route.test.ts
@@ -1,8 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { POST } from '@/app/api/ads/broker/route';
 import * as brokerMod from '@/lib/ads/broker';
 
-vi.spyOn(brokerMod, 'broker').mockResolvedValue({ reason: 'no_fill' } as any);
+const brokerSpy = vi.spyOn(brokerMod, 'broker').mockResolvedValue({ reason: 'no_fill' } as any);
+
+afterEach(() => {
+  brokerSpy.mockClear();
+  delete process.env.ADS_NO_ZONES;
+  delete process.env.ADS_ENABLED;
+});
 
 function req(body: any, headers?: Record<string, string>) {
   return new Request('http://test/api/ads/broker', {
@@ -34,5 +40,19 @@ describe('broker route', () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.card || json.reason).toBeTruthy();
+  });
+
+  it('blocks therapy zone via env flag', async () => {
+    process.env.ADS_ENABLED = 'true';
+    process.env.ADS_NO_ZONES = 'reports,aidoc,therapy';
+
+    const res = await POST(
+      req({ text: 'support', region: 'IN-DL', tier: 'free', zone: 'therapy' }) as any,
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.reason).toBe('zone_blocked');
+    expect(brokerSpy).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/lib.ads.kindFilter.test.ts
+++ b/__tests__/lib.ads.kindFilter.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { shouldFetchAdForMessage } from '@/lib/ads/kindFilter';
+
+describe('shouldFetchAdForMessage', () => {
+  it('rejects therapy assistant messages', () => {
+    const result = shouldFetchAdForMessage({
+      role: 'assistant',
+      kind: 'therapy',
+      id: '1',
+      pending: false,
+    } as any);
+
+    expect(result).toBe(false);
+  });
+});

--- a/app/api/ads/broker/route.ts
+++ b/app/api/ads/broker/route.ts
@@ -4,7 +4,7 @@ import type { AdContext } from '@/types/ads';
 import { broker } from '@/lib/ads/broker';
 
 const VALID_TIERS = ['free', '100', '200', '500'] as const;
-const VALID_ZONES = ['chat', 'reports', 'aidoc', 'directory'] as const;
+const VALID_ZONES = ['chat', 'reports', 'aidoc', 'directory', 'therapy'] as const;
 type Tier = typeof VALID_TIERS[number];
 type Zone = typeof VALID_ZONES[number];
 
@@ -42,6 +42,14 @@ export async function POST(req: Request) {
 
   const zoneRaw = String(body.zone ?? 'chat');
   const zone: Zone = (VALID_ZONES as readonly string[]).includes(zoneRaw) ? (zoneRaw as Zone) : 'chat';
+
+  const noZones = (process.env.ADS_NO_ZONES ?? '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  if (noZones.includes(zone)) {
+    return NextResponse.json({ reason: 'zone_blocked' }, { status: 200 });
+  }
 
   const ctx: AdContext = {
     text: sanitizeText(body.text),

--- a/types/ads.ts
+++ b/types/ads.ts
@@ -6,7 +6,7 @@ export interface AdContext {
   text: string;  // last user/AI msg (server-side only)
   region: string; // e.g., IN-DL
   tier: UserTier;
-  zone: string;  // 'chat' | 'reports' | 'aidoc' | 'directory'
+  zone: string;  // 'chat' | 'reports' | 'aidoc' | 'directory' | 'therapy'
 }
 
 export interface AdCard {


### PR DESCRIPTION
## Summary
- stop the chat pane from fetching or rendering inline ads when therapy mode is active and reset cached ads on mode changes
- add the therapy zone to the ad broker route allow-list and short-circuit requests when the zone is blocked via environment flags
- extend unit tests to cover therapy zone blocking and ensure therapy messages never trigger ad fetches

## Testing
- pnpm vitest run __tests__/api.ads.broker.route.test.ts
- pnpm vitest run __tests__/lib.ads.kindFilter.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e541d88d80832f99ecbcd165fb7f4d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “therapy” as a supported ad zone.
  - Ads are suppressed in therapy mode; sponsorship blocks won’t appear in therapy conversations.
  - Environment configuration can disable ad delivery for selected zones.
- Tests
  - Added tests verifying zone-level blocking via environment flags and ensuring no broker calls when blocked.
  - Added unit tests confirming ads are not fetched for therapy-related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->