### PR TITLE
Adjust desktop chat composer sizing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -311,7 +311,7 @@ body {
     --mobile-footer-base-height: 48px;
     --mobile-footer-safe-area: env(safe-area-inset-bottom);
     --mobile-footer-height: var(--mobile-footer-base-height);
-    --mobile-composer-height: 88px;
+    --mobile-composer-height: 104px;
     --mobile-composer-offset: 1.75rem;
     --mobile-composer-gap: calc(var(--mobile-composer-height) + var(--mobile-composer-offset));
   }
@@ -638,7 +638,11 @@ body {
     right: 0;
     bottom: calc(var(--mobile-footer-height, 0px) + var(--mobile-composer-offset, 0px));
     z-index: 45;
-    padding: 0.75rem 1rem;
+    display: flex;
+    justify-content: center;
+    padding: 1rem 0;
+    padding-left: max(env(safe-area-inset-left), 0px);
+    padding-right: max(env(safe-area-inset-right), 0px);
     background: var(--medx-panel);
     backdrop-filter: saturate(140%) blur(16px);
     border-top: 1px solid var(--medx-outline);

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -75,7 +75,7 @@ export function ChatInput({
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = "auto";
-    const minHeight = isDesktop ? 56 : 40;
+    const minHeight = isDesktop ? 56 : 48;
     const next = Math.min(Math.max(el.scrollHeight, minHeight), 160);
     el.style.height = `${next}px`;
   }, [text, isDesktop]);
@@ -162,7 +162,7 @@ export function ChatInput({
         e.preventDefault();
         onDropFiles(e.dataTransfer.files);
       }}
-      className="chat-input-container flex w-full items-end gap-2 rounded-2xl border border-[color:var(--medx-outline)] bg-[color:var(--medx-surface)] px-3 py-2 shadow-sm transition dark:border-white/10 dark:bg-[color:var(--medx-panel)] md:border-0 md:bg-transparent md:px-0 md:py-0 md:shadow-none"
+      className="chat-input-container mx-auto flex w-full max-w-3xl items-end gap-2 rounded-2xl border border-[color:var(--medx-outline)] bg-[color:var(--medx-surface)] px-4 py-3 shadow-sm transition dark:border-white/10 dark:bg-[color:var(--medx-panel)] md:border-0 md:bg-transparent md:px-0 md:py-0 md:shadow-none"
     >
       <div className="relative">
         <button
@@ -176,7 +176,7 @@ export function ChatInput({
               ? "Attach files is available before you start a new chat"
               : uploadText
           }
-          className="flex h-11 w-11 items-center justify-center rounded-full text-[color:var(--medx-text)] transition-colors hover:bg-black/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:text-[color:var(--medx-text)] dark:hover:bg-white/10 md:h-12 md:w-12"
+          className="flex h-12 w-12 items-center justify-center rounded-full text-[color:var(--medx-text)] transition-colors hover:bg-black/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:text-[color:var(--medx-text)] dark:hover:bg-white/10 md:h-12 md:w-12"
           onClick={() => {
             if (currentId) {
               return;
@@ -264,14 +264,14 @@ export function ChatInput({
             void handleSend();
           }
         }}
-        className="min-h-[40px] max-h-[160px] flex-1 resize-none bg-transparent text-base leading-snug text-[color:var(--medx-text)] placeholder:text-slate-400 focus:outline-none dark:text-[color:var(--medx-text)] dark:placeholder:text-slate-500 md:min-h-[56px]"
+        className="min-h-[48px] max-h-[160px] flex-1 resize-none bg-transparent text-base leading-snug text-[color:var(--medx-text)] placeholder:text-slate-400 focus:outline-none dark:text-[color:var(--medx-text)] dark:placeholder:text-slate-500 md:min-h-[56px]"
       />
       <button
         type="submit"
         aria-label={sendText}
         title={sendText}
         disabled={!text.trim() || isSending}
-        className="flex h-11 w-11 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-sky-500 dark:hover:bg-sky-400 md:h-12 md:w-12"
+        className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-sky-500 dark:hover:bg-sky-400 md:h-12 md:w-12"
       >
         <SendHorizontal className="h-5 w-5" />
       </button>

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -36,6 +36,7 @@ export function ChatInput({
   const { lang } = usePrefs();
   const openPrefs = useUIStore((state) => state.openPrefs);
   const [isUploadMenuOpen, setIsUploadMenuOpen] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
 
   const redirectToAccount = useCallback(() => {
     openPrefs("Account");
@@ -56,12 +57,28 @@ export function ChatInput({
   }, [currentId, draft.text]);
 
   useEffect(() => {
+    const query = window.matchMedia("(min-width: 768px)");
+    const update = (event: MediaQueryListEvent | MediaQueryList) => {
+      setIsDesktop(event.matches);
+    };
+    update(query);
+    const listener = (event: MediaQueryListEvent) => update(event);
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", listener);
+      return () => query.removeEventListener("change", listener);
+    }
+    query.addListener(listener);
+    return () => query.removeListener(listener);
+  }, []);
+
+  useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = "auto";
-    const next = Math.min(el.scrollHeight, 160);
+    const minHeight = isDesktop ? 56 : 40;
+    const next = Math.min(Math.max(el.scrollHeight, minHeight), 160);
     el.style.height = `${next}px`;
-  }, [text]);
+  }, [text, isDesktop]);
 
   const handleSend = async () => {
     if (isSending) return;
@@ -159,7 +176,7 @@ export function ChatInput({
               ? "Attach files is available before you start a new chat"
               : uploadText
           }
-          className="flex h-11 w-11 items-center justify-center rounded-full text-[color:var(--medx-text)] transition-colors hover:bg-black/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:text-[color:var(--medx-text)] dark:hover:bg-white/10"
+          className="flex h-11 w-11 items-center justify-center rounded-full text-[color:var(--medx-text)] transition-colors hover:bg-black/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-60 dark:text-[color:var(--medx-text)] dark:hover:bg-white/10 md:h-12 md:w-12"
           onClick={() => {
             if (currentId) {
               return;
@@ -247,14 +264,14 @@ export function ChatInput({
             void handleSend();
           }
         }}
-        className="min-h-[40px] max-h-[160px] flex-1 resize-none bg-transparent text-base leading-snug text-[color:var(--medx-text)] placeholder:text-slate-400 focus:outline-none dark:text-[color:var(--medx-text)] dark:placeholder:text-slate-500"
+        className="min-h-[40px] max-h-[160px] flex-1 resize-none bg-transparent text-base leading-snug text-[color:var(--medx-text)] placeholder:text-slate-400 focus:outline-none dark:text-[color:var(--medx-text)] dark:placeholder:text-slate-500 md:min-h-[56px]"
       />
       <button
         type="submit"
         aria-label={sendText}
         title={sendText}
         disabled={!text.trim() || isSending}
-        className="flex h-11 w-11 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-sky-500 dark:hover:bg-sky-400"
+        className="flex h-11 w-11 items-center justify-center rounded-full bg-blue-600 text-white transition hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-sky-500 dark:hover:bg-sky-400 md:h-12 md:w-12"
       >
         <SendHorizontal className="h-5 w-5" />
       </button>

--- a/components/ChatWindow.tsx
+++ b/components/ChatWindow.tsx
@@ -142,7 +142,7 @@ export function ChatWindow() {
 
     const updateMetrics = () => {
       const rect = composer.getBoundingClientRect();
-      const height = Math.max(64, Math.round(rect.height));
+      const height = Math.max(80, Math.round(rect.height));
       root.style.setProperty("--mobile-composer-height", `${height}px`);
     };
 

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -4284,7 +4284,7 @@ ${systemCommon}` + baseSys;
 
       <div className="mt-auto mobile-composer-region">
         <div className="px-6 pb-4 md:pb-6">
-          <div className="mx-auto max-w-3xl space-y-3 px-4 py-4">
+          <div className="mx-auto w-full max-w-3xl space-y-3 px-4 py-4 md:px-0">
               {((showDefaultSuggestions && showSuggestions) || showLiveSuggestions) && (
                 <div className="w-full">
                   {showDefaultSuggestions && showSuggestions && (

--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -4283,7 +4283,7 @@ ${systemCommon}` + baseSys;
       </div>
 
       <div className="mt-auto mobile-composer-region">
-        <div className="px-6 pb-4 md:pb-6">
+        <div className="px-4 pb-4 md:pb-6">
           <div className="mx-auto w-full max-w-3xl space-y-3 px-4 py-4 md:px-0">
               {((showDefaultSuggestions && showSuggestions) || showLiveSuggestions) && (
                 <div className="w-full">


### PR DESCRIPTION
## Summary
- align the desktop chat composer container width with the chat transcript column
- increase desktop button dimensions and textarea height to better match ChatGPT sizing
- ensure textarea resizing logic respects a larger desktop minimum height

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68e552405ea4832fbbe2ca63f74a9787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined mobile composer: taller input area, centered content, and safe-area-aware horizontal padding.
  * Improved desktop ergonomics: larger input field, buttons, and icons; increased hit targets and spacing; constrained max width for cleaner layout.
  * Smarter textarea sizing: responsive minimum heights (mobile vs. desktop) with a capped maximum height for readability.
  * Adjusted composer metrics to ensure a slightly taller baseline on mobile.
  * Tweaked Chat pane padding and responsive behavior for better alignment across viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->