### PR TITLE
Fix stop button alignment in chat composer

### DIFF
--- a/components/panels/ChatPane.tsx
+++ b/components/panels/ChatPane.tsx
@@ -4460,7 +4460,7 @@ ${systemCommon}` + baseSys;
                   />
 
                   {(queueActive || busy || abortRef.current) && (
-                    <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center">
+                    <div className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 flex items-center">
                       <StopButton
                         onClick={onStop}
                         className="pointer-events-auto"


### PR DESCRIPTION
## Summary
- adjust the stop button container positioning so the control stays vertically centered in the composer

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68e5e046727c832fb5a3b2fe650dca4e