### PR TITLE
Implement SSE streaming pipeline with client typewriter

### DIFF
--- a/lib/stream.ts
+++ b/lib/stream.ts
@@ -16,7 +16,7 @@ export async function streamChat(
   handlers: StreamHandlers,
   signal?: AbortSignal
 ): Promise<void> {
-  const res = await fetch("/api/chat", {
+  const res = await fetch("/api/chat/stream", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(req),


### PR DESCRIPTION
## Summary
- replace the stream-final API route with an Edge-native SSE proxy that streams OpenAI output with heartbeats and fallback handling
- move the streaming typewriter reveal into AssistantPendingMessage and simplify pending assistant stage management to feed raw text
- point the stream helper to the SSE endpoint so clients consume the new pipeline

## Testing
- npm run lint *(fails: command prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f50a20d0832fa89cfcdd990e90c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Progressive, typewriter-style rendering for assistant messages during streaming.
  * Support for request controls like temperature and max tokens.
* Performance
  * Migrated chat streaming to an edge runtime for faster, lower-latency responses.
  * Optimized streaming pipeline with incremental updates and keepalive heartbeats.
* Bug Fixes
  * More resilient upstream retries and model fallbacks reduce failed responses.
  * Clearer error surfaces for missing/invalid API keys and upstream errors.
* Documentation
  * Updated streaming endpoint usage to /api/chat/stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->